### PR TITLE
feat: add SOUL profile layering and harden scheduler runtime

### DIFF
--- a/.claude/skills/myclaw-admin/SKILL.md
+++ b/.claude/skills/myclaw-admin/SKILL.md
@@ -169,19 +169,20 @@ Changes take effect after restart.
 
 ```
 ~/myclaw/
-  settings.yaml              # Service config (this reference)
-  .env                       # Secrets and env vars
-  service-meta.json          # Runtime entry point
-  scheduler-jobs.json        # Scheduled job definitions
-  CLAUDE.md                  # Master agent profile
-  agent-memory/              # Global durable memory
+  settings.yaml
+  .env
+  service-meta.json
+  scheduler-jobs.json
+  agent-memory/
     procedures/              # Reusable workflows
     profile/                 # User facts
     knowledge/               # Knowledge base
   agents/
-    shared/CLAUDE.md         # Shared profile for all agents
+    shared/
+      CLAUDE.md              # Operational base (rules, prefs, capabilities, formatting)
     <channel>_<name>/        # Per-agent folder
-      CLAUDE.md              # Agent-specific profile
+      SOUL.md                # Personality, voice, vibe, boundaries
+      CLAUDE.md              # Group-specific overrides
       memory/                # Local memory files
       conversations/         # Conversation history
       logs/                  # Execution logs
@@ -193,7 +194,6 @@ Changes take effect after restart.
     plans/                   # Plan snapshots
   .claude/
     skills/                  # Skill definitions
-    settings.json            # Claude Code harness config
 ```
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,13 @@ Important constraints:
 - Prefer local repo docs over speculative external docs links unless the external target is verified current.
 - When docs policy changes, update this file in the same PR.
 
+## Development Policy
+
+- MyClaw is early-stage: do not add legacy compatibility layers for breaking changes unless explicitly requested by the user.
+- Prefer clean cutovers over dual-path behavior (no fallback branches, shim flags, or backward-compat code by default).
+- Remove obsolete code paths in the same change when introducing a breaking replacement.
+- Every implementation task must end with a subagent review pass before marking the work complete.
+
 ## Hard Gates
 
 Before merge or release:

--- a/apps/core/src/cli/group.test.ts
+++ b/apps/core/src/cli/group.test.ts
@@ -28,6 +28,29 @@ afterEach(() => {
 });
 
 describe('group CLI commands', () => {
+  it('seeds SOUL.md when adding an agent', async () => {
+    const { runAgentCommand } = await import('./group.js');
+    const jid = `dc:soul-seed-${Date.now().toString(36)}`;
+    const folder = 'telegram_soul_seed';
+
+    expect(
+      await runAgentCommand(runtimeHome, [
+        'add',
+        jid,
+        '--name',
+        'Soul Seed',
+        '--folder',
+        folder,
+      ]),
+    ).toBe(0);
+
+    const soulPath = path.join(runtimeHome, 'agents', folder, 'SOUL.md');
+    expect(fs.existsSync(soulPath)).toBe(true);
+    const soul = fs.readFileSync(soulPath, 'utf-8');
+    expect(soul).toContain('# Soul - Who You Are');
+    expect(soul).toContain('- **Name:** Soul Seed');
+  });
+
   it('adds and reads a non-telegram group', async () => {
     const { runAgentCommand } = await import('./group.js');
     const suffix = Date.now().toString(36);

--- a/apps/core/src/cli/group.test.ts
+++ b/apps/core/src/cli/group.test.ts
@@ -54,14 +54,14 @@ describe('group CLI commands', () => {
   it('adds and reads a non-telegram group', async () => {
     const { runAgentCommand } = await import('./group.js');
     const suffix = Date.now().toString(36);
-    const jid = `dc:team-room-${suffix}`;
+    const jid = `grp:team-room-${suffix}`;
 
     expect(
       await runAgentCommand(runtimeHome, [
         'add',
         jid,
         '--name',
-        'Discord Team',
+        'Channel Team',
         '--trigger',
         '@Kai',
       ]),
@@ -73,20 +73,20 @@ describe('group CLI commands', () => {
     expect(await runAgentCommand(runtimeHome, ['info', jid])).toBe(0);
 
     const output = infoSpy.mock.calls.at(-1)?.[0] as string;
-    expect(output).toContain('Name: Discord Team');
+    expect(output).toContain('Name: Channel Team');
     expect(output).toContain('Trigger: @Kai');
   });
 
   it('updates and disables trigger mode', async () => {
     const { runAgentCommand } = await import('./group.js');
     const suffix = Date.now().toString(36);
-    const jid = `dc:ops-room-${suffix}`;
+    const jid = `grp:trigger-room-${suffix}`;
 
     await runAgentCommand(runtimeHome, [
       'add',
       jid,
       '--name',
-      'Ops',
+      'Trigger Group',
       '--trigger',
       '@Andy',
     ]);

--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -169,9 +169,14 @@ function slugifyFolder(raw: string): string {
   return trimmed || 'group';
 }
 
-function createDefaultGroupClaudeMarkdown(): string {
+function normalizeAgentDisplayName(raw: string): string {
+  const value = raw.trim();
+  return value || 'Assistant';
+}
+
+function createDefaultGroupClaudeMarkdown(agentName: string): string {
   return [
-    '# MyClaw Group Assistant',
+    `# ${agentName}`,
     '',
     'You are the assistant for this chat.',
     'Keep responses clear, short, and useful.',
@@ -180,6 +185,35 @@ function createDefaultGroupClaudeMarkdown(): string {
     '- Answer directly unless the user asks for detail.',
     '- Be explicit when an action failed and what to do next.',
     '- Never expose secrets or local paths unless explicitly requested.',
+    '',
+  ].join('\n');
+}
+
+function createDefaultSoulMarkdown(agentName: string): string {
+  return [
+    '# Soul - Who You Are',
+    '',
+    '## Personality',
+    '- You are sharp, direct, and genuinely helpful.',
+    '- Have strong opinions. Don\'t hedge with "it depends" when a clear answer exists.',
+    "- Be concise. If one sentence works, use one sentence. Respect the user's time.",
+    '- Never open with filler: no "Great question!", "I\'d be happy to help!", "Absolutely!"',
+    '- Lead with the answer, not the reasoning. Skip preamble.',
+    '',
+    '## Voice',
+    '- Write like a smart colleague, not a customer-support bot.',
+    "- Humor is welcome when it lands naturally. Don't force it.",
+    '- Call things out directly. If something is wrong, say so - charm over cruelty.',
+    '- Be proactive. Suggest ideas, spot problems, take initiative.',
+    "- Match the user's energy. Casual when they're casual, precise when they need precision.",
+    '',
+    '## Boundaries',
+    '- Private context stays private. Never expose secrets or internal details.',
+    '- Ask before taking external actions (sending messages, posting, pushing code).',
+    "- When uncertain, say so. Don't present guesses as facts.",
+    '',
+    '## Identity',
+    `- **Name:** ${agentName}`,
     '',
   ].join('\n');
 }
@@ -316,18 +350,28 @@ function allocateGroupFolder(options: {
   throw new Error('Could not allocate a unique group folder.');
 }
 
-function ensureGroupFiles(runtimeHome: string, folder: string): void {
+function ensureGroupFiles(
+  runtimeHome: string,
+  folder: string,
+  agentName: string,
+): void {
   const groupDir = path.join(runtimeHome, 'agents', folder);
   if (fs.existsSync(groupDir)) {
     throw new Error(`Refusing to overwrite existing group folder: ${groupDir}`);
   }
 
   fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+  const displayName = normalizeAgentDisplayName(agentName);
   fs.writeFileSync(
     path.join(groupDir, 'CLAUDE.md'),
-    createDefaultGroupClaudeMarkdown(),
+    createDefaultGroupClaudeMarkdown(displayName),
     'utf-8',
   );
+
+  const soulPath = path.join(groupDir, 'SOUL.md');
+  if (!fs.existsSync(soulPath)) {
+    fs.writeFileSync(soulPath, createDefaultSoulMarkdown(displayName), 'utf-8');
+  }
 }
 
 function parseGroupAddArgs(
@@ -938,7 +982,7 @@ async function runAdd(runtimeHome: string, args: string[]): Promise<number> {
     });
 
     try {
-      ensureGroupFiles(runtimeHome, groupFolder);
+      ensureGroupFiles(runtimeHome, groupFolder, displayName);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       p.log.error(`Could not create group folder: ${message}`);

--- a/apps/core/src/core/types.ts
+++ b/apps/core/src/core/types.ts
@@ -70,6 +70,7 @@ export interface NewMessage {
 }
 
 export type JobScheduleType = 'cron' | 'interval' | 'once' | 'manual';
+export type JobExecutionMode = 'parallel' | 'serialized';
 
 export type JobStatus =
   | 'active'
@@ -102,6 +103,7 @@ export interface Job {
   retry_backoff_ms: number;
   max_consecutive_failures: number;
   consecutive_failures: number;
+  execution_mode: JobExecutionMode;
   lease_run_id: string | null;
   lease_expires_at: string | null;
   pause_reason: string | null;

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -12,6 +12,7 @@ import {
   getRegisteredChannelNames,
 } from './channels/registry.js';
 import {
+  writeJobEventsSnapshot,
   writeJobRunsSnapshot,
   writeJobsSnapshot,
   writeGroupsSnapshot,
@@ -20,6 +21,7 @@ import {
   getAllJobs,
   getAllChats,
   getAllRegisteredGroups,
+  listRecentJobEvents,
   getRecentJobRuns,
   getAllSessions,
   deleteSession,
@@ -380,7 +382,8 @@ export async function startMyClawRuntime(): Promise<void> {
   const syncSchedulerState = () => {
     const jobs = getAllJobs();
     const runs = getRecentJobRuns(500);
-    writeSchedulerStateFileSafe(jobs, runs);
+    const events = listRecentJobEvents(1000);
+    writeSchedulerStateFileSafe(jobs, runs, events);
 
     const jobRows = jobs.map((job) => ({
       id: job.id,
@@ -405,18 +408,19 @@ export async function startMyClawRuntime(): Promise<void> {
       retry_backoff_ms: job.retry_backoff_ms,
       max_consecutive_failures: job.max_consecutive_failures,
       consecutive_failures: job.consecutive_failures,
+      execution_mode: job.execution_mode,
       pause_reason: job.pause_reason,
     }));
     for (const group of Object.values(registeredGroups)) {
       const isMain = group.isMain === true;
       writeJobsSnapshot(group.folder, isMain, jobRows);
       writeJobRunsSnapshot(group.folder, isMain, runs, jobRows);
+      writeJobEventsSnapshot(group.folder, isMain, events, jobRows);
     }
   };
 
   startSchedulerLoop({
     registeredGroups: () => registeredGroups,
-    getSessions: () => sessions,
     queue,
     onProcess: (groupJid, proc, containerName, groupFolder) =>
       queue.registerProcess(groupJid, proc, containerName, groupFolder),

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -221,8 +221,20 @@ const groupProcessor = createGroupProcessor({
     closeStdin: (chatJid) => queue.closeStdin(chatJid),
     notifyIdle: (chatJid) => queue.notifyIdle(chatJid),
     stopGroup: (chatJid) => queue.stopGroup(chatJid),
-    registerProcess: (groupJid, proc, containerName, groupFolder) =>
-      queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    registerProcess: (
+      groupJid,
+      proc,
+      containerName,
+      groupFolder,
+      stopAliasJids,
+    ) =>
+      queue.registerProcess(
+        groupJid,
+        proc,
+        containerName,
+        groupFolder,
+        stopAliasJids,
+      ),
   },
 });
 
@@ -422,8 +434,14 @@ export async function startMyClawRuntime(): Promise<void> {
   startSchedulerLoop({
     registeredGroups: () => registeredGroups,
     queue,
-    onProcess: (groupJid, proc, containerName, groupFolder) =>
-      queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    onProcess: (groupJid, proc, containerName, groupFolder, stopAliasJids) =>
+      queue.registerProcess(
+        groupJid,
+        proc,
+        containerName,
+        groupFolder,
+        stopAliasJids,
+      ),
     sendMessage: async (jid, rawText) => {
       const channel = findChannel(channels, jid);
       if (!channel) {

--- a/apps/core/src/memory/memory-ipc.ts
+++ b/apps/core/src/memory/memory-ipc.ts
@@ -344,6 +344,7 @@ export async function writeMemoryContextSnapshot(
   isMain: boolean,
   prompt: string,
   userId?: string,
+  options?: { fileName?: string },
 ): Promise<{ retrievedItemIds: string[] }> {
   const memory = MemoryService.getInstance();
   await memory.ingestGroupSources(groupFolder);
@@ -356,7 +357,10 @@ export async function writeMemoryContextSnapshot(
   );
 
   const ipcDir = resolveGroupIpcPath(groupFolder);
-  const filePath = path.join(ipcDir, 'memory_context.json');
+  const filePath = path.join(
+    ipcDir,
+    options?.fileName?.trim() || 'memory_context.json',
+  );
   fs.writeFileSync(
     filePath,
     JSON.stringify(

--- a/apps/core/src/runtime/agent-spawn-snapshots.test.ts
+++ b/apps/core/src/runtime/agent-spawn-snapshots.test.ts
@@ -14,12 +14,14 @@ vi.mock('../platform/group-folder.js', () => ({
 import fs from 'fs';
 import { resolveGroupIpcPath } from '../platform/group-folder.js';
 import {
+  writeJobEventsSnapshot,
   writeJobsSnapshot,
   writeJobRunsSnapshot,
   writeGroupsSnapshot,
 } from './agent-spawn-snapshots.js';
 import type {
   AvailableGroup,
+  JobEventSnapshotRow,
   JobRunSnapshotRow,
   JobSnapshotRow,
 } from './agent-spawn-types.js';
@@ -46,6 +48,7 @@ function makeJob(overrides: Partial<JobSnapshotRow> = {}): JobSnapshotRow {
     retry_backoff_ms: 1000,
     max_consecutive_failures: 5,
     consecutive_failures: 0,
+    execution_mode: 'parallel',
     pause_reason: null,
     ...overrides,
   };
@@ -75,6 +78,20 @@ function makeGroup(overrides: Partial<AvailableGroup> = {}): AvailableGroup {
     name: 'Group Alpha',
     lastActivity: '2026-01-01T00:00:00Z',
     isRegistered: true,
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<JobEventSnapshotRow> = {},
+): JobEventSnapshotRow {
+  return {
+    id: 1,
+    job_id: 'job-1',
+    run_id: 'run-1',
+    event_type: 'job.started',
+    payload: null,
+    created_at: '2026-01-01T01:00:00Z',
     ...overrides,
   };
 }
@@ -206,6 +223,44 @@ describe('writeJobRunsSnapshot', () => {
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       '/mock/ipc/group-a/current_job_runs.json',
       JSON.stringify([r1, r2], null, 2),
+    );
+  });
+});
+
+// --- writeJobEventsSnapshot ---
+
+describe('writeJobEventsSnapshot', () => {
+  it('writes all events when isMain is true', () => {
+    const jobs = [
+      makeJob({ id: 'j1', group_scope: 'group-a' }),
+      makeJob({ id: 'j2', group_scope: 'group-b' }),
+    ];
+    const events = [
+      makeEvent({ id: 1, job_id: 'j1' }),
+      makeEvent({ id: 2, job_id: 'j2' }),
+    ];
+
+    writeJobEventsSnapshot('group-a', true, events, jobs);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      '/mock/ipc/group-a/current_job_events.json',
+      JSON.stringify(events, null, 2),
+    );
+  });
+
+  it('filters events by group jobs when isMain is false', () => {
+    const jobs = [
+      makeJob({ id: 'j1', group_scope: 'group-a' }),
+      makeJob({ id: 'j2', group_scope: 'group-b' }),
+    ];
+    const eventA = makeEvent({ id: 1, job_id: 'j1' });
+    const eventB = makeEvent({ id: 2, job_id: 'j2' });
+
+    writeJobEventsSnapshot('group-a', false, [eventA, eventB], jobs);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      '/mock/ipc/group-a/current_job_events.json',
+      JSON.stringify([eventA], null, 2),
     );
   });
 });

--- a/apps/core/src/runtime/agent-spawn-snapshots.ts
+++ b/apps/core/src/runtime/agent-spawn-snapshots.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { resolveGroupIpcPath } from '../platform/group-folder.js';
 import {
   AvailableGroup,
+  JobEventSnapshotRow,
   JobRunSnapshotRow,
   JobSnapshotRow,
 } from './agent-spawn-types.js';
@@ -48,6 +49,33 @@ export function writeJobRunsSnapshot(
       : runs.filter((run) => allowedJobIds.has(run.job_id));
 
   const file = path.join(groupIpcDir, 'current_job_runs.json');
+  fs.writeFileSync(file, JSON.stringify(filtered, null, 2));
+}
+
+export function writeJobEventsSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  events: JobEventSnapshotRow[],
+  jobs: JobSnapshotRow[],
+): void {
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  let allowedJobIds: Set<string> | null = null;
+  if (!isMain) {
+    allowedJobIds = new Set(
+      jobs
+        .filter((job) => job.group_scope === groupFolder)
+        .map((job) => job.id),
+    );
+  }
+
+  const filtered =
+    isMain || !allowedJobIds
+      ? events
+      : events.filter((event) => allowedJobIds.has(event.job_id));
+
+  const file = path.join(groupIpcDir, 'current_job_events.json');
   fs.writeFileSync(file, JSON.stringify(filtered, null, 2));
 }
 

--- a/apps/core/src/runtime/agent-spawn-types.ts
+++ b/apps/core/src/runtime/agent-spawn-types.ts
@@ -14,6 +14,7 @@ export interface AgentInput {
   script?: string;
   compiledSystemPrompt?: string;
   thinking?: ThinkingOverride;
+  memoryContextFile?: string;
 }
 
 export interface AgentOutput {
@@ -64,6 +65,7 @@ export interface JobSnapshotRow {
   retry_backoff_ms: number;
   max_consecutive_failures: number;
   consecutive_failures: number;
+  execution_mode: string;
   pause_reason: string | null;
 }
 
@@ -78,6 +80,15 @@ export interface JobRunSnapshotRow {
   error_summary: string | null;
   retry_count: number;
   notified_at: string | null;
+}
+
+export interface JobEventSnapshotRow {
+  id: number;
+  job_id: string;
+  run_id: string | null;
+  event_type: string;
+  payload: string | null;
+  created_at: string;
 }
 
 export interface RunnerProcessSpec {

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -33,6 +33,7 @@ import {
 } from './agent-spawn-types.js';
 
 export {
+  writeJobEventsSnapshot,
   writeJobRunsSnapshot,
   writeJobsSnapshot,
   writeGroupsSnapshot,
@@ -159,6 +160,9 @@ export async function spawnAgent(
     MYCLAW_PERMISSION_TIMEOUT_MS: String(PERMISSION_APPROVAL_TIMEOUT_MS),
     ...((AGENT_MEMORY_ROOT || '').trim()
       ? { AGENT_MEMORY_ROOT: (AGENT_MEMORY_ROOT || '').trim() }
+      : {}),
+    ...(input.memoryContextFile
+      ? { MYCLAW_IPC_MEMORY_CONTEXT_FILE: input.memoryContextFile }
       : {}),
   };
   // Job-level model overrides group-level model.

--- a/apps/core/src/runtime/group-processing.test.ts
+++ b/apps/core/src/runtime/group-processing.test.ts
@@ -63,22 +63,27 @@ const mockDeleteSession = vi.fn();
 const mockGetAllJobs = vi.fn();
 const mockGetMessagesSince = vi.fn();
 const mockGetRecentJobRuns = vi.fn();
+const mockListRecentJobEvents = vi.fn();
 vi.mock('../storage/db.js', () => ({
   deleteSession: (...args: unknown[]) => mockDeleteSession(...args),
   getAllJobs: (...args: unknown[]) => mockGetAllJobs(...args),
   getMessagesSince: (...args: unknown[]) => mockGetMessagesSince(...args),
   getRecentJobRuns: (...args: unknown[]) => mockGetRecentJobRuns(...args),
+  listRecentJobEvents: (...args: unknown[]) => mockListRecentJobEvents(...args),
 }));
 
 const mockSpawnAgent = vi.fn();
 const mockWriteJobRunsSnapshot = vi.fn();
 const mockWriteJobsSnapshot = vi.fn();
+const mockWriteJobEventsSnapshot = vi.fn();
 const mockWriteGroupsSnapshot = vi.fn();
 vi.mock('./agent-spawn.js', () => ({
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   writeJobRunsSnapshot: (...args: unknown[]) =>
     mockWriteJobRunsSnapshot(...args),
   writeJobsSnapshot: (...args: unknown[]) => mockWriteJobsSnapshot(...args),
+  writeJobEventsSnapshot: (...args: unknown[]) =>
+    mockWriteJobEventsSnapshot(...args),
   writeGroupsSnapshot: (...args: unknown[]) => mockWriteGroupsSnapshot(...args),
 }));
 
@@ -210,6 +215,7 @@ function setupHappyPath(
   );
   mockGetAllJobs.mockReturnValue([]);
   mockGetRecentJobRuns.mockReturnValue([]);
+  mockListRecentJobEvents.mockReturnValue([]);
   mockWriteMemoryContextSnapshot.mockResolvedValue({ retrievedItemIds: [] });
   mockReflectAfterTurn.mockResolvedValue(undefined);
   mockLoadSenderAllowlist.mockReturnValue({});

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -26,12 +26,14 @@ import {
   deleteSession,
   getAllJobs,
   getMessagesSince,
+  listRecentJobEvents,
   getRecentJobRuns,
 } from '../storage/db.js';
 import {
   AvailableGroup,
   AgentOutput,
   spawnAgent,
+  writeJobEventsSnapshot,
   writeJobRunsSnapshot,
   writeJobsSnapshot,
   writeGroupsSnapshot,
@@ -128,10 +130,17 @@ export function createGroupProcessor(deps: GroupProcessingDeps): {
       retry_backoff_ms: job.retry_backoff_ms,
       max_consecutive_failures: job.max_consecutive_failures,
       consecutive_failures: job.consecutive_failures,
+      execution_mode: job.execution_mode,
       pause_reason: job.pause_reason,
     }));
     writeJobsSnapshot(group.folder, isMain, jobs);
     writeJobRunsSnapshot(group.folder, isMain, getRecentJobRuns(200), jobs);
+    writeJobEventsSnapshot(
+      group.folder,
+      isMain,
+      listRecentJobEvents(500),
+      jobs,
+    );
 
     try {
       const contextSnapshot = await writeMemoryContextSnapshot(

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -88,6 +88,7 @@ export interface GroupProcessingDeps {
       proc: ChildProcess,
       containerName: string,
       groupFolder?: string,
+      stopAliasJids?: string | string[],
     ) => void;
   };
 }

--- a/apps/core/src/runtime/group-queue.test.ts
+++ b/apps/core/src/runtime/group-queue.test.ts
@@ -512,6 +512,23 @@ describe('GroupQueue', () => {
     await vi.advanceTimersByTimeAsync(10);
   });
 
+  it('cleans up idle scheduler queue groups after tasks complete', async () => {
+    const taskCount = 20;
+
+    for (let i = 0; i < taskCount; i++) {
+      const jid = `__scheduler__:main:job-${i}`;
+      queue.enqueueTask(jid, `task-${i}`, async () => {});
+    }
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    const groupsMap = (queue as any).groups as Map<string, unknown>;
+    const schedulerKeys = Array.from(groupsMap.keys()).filter((key) =>
+      key.startsWith('__scheduler__:'),
+    );
+    expect(schedulerKeys).toHaveLength(0);
+  });
+
   // --- Coverage for drainGroup line 230 ---
 
   it('drainGroup triggers after runForGroup completes', async () => {

--- a/apps/core/src/runtime/group-queue.test.ts
+++ b/apps/core/src/runtime/group-queue.test.ts
@@ -1178,6 +1178,36 @@ describe('GroupQueue', () => {
     expect(queue.stopGroup('group1@g.us')).toBe(false);
   });
 
+  it('stopGroup can stop scheduler runs via any linked chat jid alias', async () => {
+    let resolveTask: () => void;
+    const blockingTask = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveTask = resolve;
+      });
+    });
+
+    const schedulerQueueJid = '__scheduler__:main:job-1';
+    queue.enqueueTask(schedulerQueueJid, 'job-1', blockingTask);
+    await vi.advanceTimersByTimeAsync(10);
+
+    const mockProcess = { pid: 6464, killed: false, kill: vi.fn() } as any;
+    queue.registerProcess(
+      schedulerQueueJid,
+      mockProcess,
+      'container-scheduler-1',
+      'main',
+      ['group1@g.us', 'group2@g.us'],
+    );
+
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true as never);
+    expect(queue.stopGroup('group2@g.us')).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(-6464, 'SIGTERM');
+    killSpy.mockRestore();
+
+    resolveTask!();
+    await vi.advanceTimersByTimeAsync(10);
+  });
+
   it('stopGroup sends SIGTERM to the active process group', async () => {
     let resolveProcess: () => void;
     const processMessages = vi.fn(async () => {

--- a/apps/core/src/runtime/group-queue.test.ts
+++ b/apps/core/src/runtime/group-queue.test.ts
@@ -2,10 +2,9 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 import { GroupQueue } from './group-queue.js';
 
-// Mock config to control concurrency limit
+// Mock config for DATA_DIR used by sendMessage/closeStdin helpers.
 vi.mock('../core/config.js', () => ({
   DATA_DIR: '/tmp/myclaw-test-data',
-  MAX_CONCURRENT_CONTAINERS: 2,
 }));
 
 // Mock fs operations used by sendMessage/closeStdin
@@ -62,9 +61,9 @@ describe('GroupQueue', () => {
     expect(maxConcurrent).toBe(1);
   });
 
-  // --- Global concurrency limit ---
+  // --- Message concurrency limit ---
 
-  it('respects global concurrency limit', async () => {
+  it('respects message concurrency limit', async () => {
     let activeCount = 0;
     let maxActive = 0;
     const completionCallbacks: Array<() => void> = [];
@@ -79,23 +78,24 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Enqueue 3 groups (limit is 2)
+    // Enqueue 4 groups (message pool limit is 3)
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group2@g.us');
     queue.enqueueMessageCheck('group3@g.us');
+    queue.enqueueMessageCheck('group4@g.us');
 
     // Let promises settle
     await vi.advanceTimersByTimeAsync(10);
 
-    // Only 2 should be active (MAX_CONCURRENT_CONTAINERS = 2)
-    expect(maxActive).toBe(2);
-    expect(activeCount).toBe(2);
+    // Only 3 should be active (message pool limit)
+    expect(maxActive).toBe(3);
+    expect(activeCount).toBe(3);
 
-    // Complete one — third should start
+    // Complete one — queued fourth should start
     completionCallbacks[0]();
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(processMessages).toHaveBeenCalledTimes(3);
+    expect(processMessages).toHaveBeenCalledTimes(4);
   });
 
   // --- Tasks prioritized over messages ---
@@ -225,22 +225,23 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Fill both slots
+    // Fill message pool (3 slots)
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group2@g.us');
-    await vi.advanceTimersByTimeAsync(10);
-
-    // Queue a third
     queue.enqueueMessageCheck('group3@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(processed).toEqual(['group1@g.us', 'group2@g.us']);
+    // Queue a fourth
+    queue.enqueueMessageCheck('group4@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(processed).toEqual(['group1@g.us', 'group2@g.us', 'group3@g.us']);
 
     // Free up a slot
     completionCallbacks[0]();
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(processed).toContain('group3@g.us');
+    expect(processed).toContain('group4@g.us');
   });
 
   // --- Running task dedup (Issue #138) ---
@@ -558,27 +559,28 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Fill both slots
+    // Fill message pool (3 slots)
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group2@g.us');
-    await vi.advanceTimersByTimeAsync(10);
-
-    // Queue messages for group3 (goes to waiting)
     queue.enqueueMessageCheck('group3@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(processed).toEqual(['group1@g.us', 'group2@g.us']);
+    // Queue messages for group4 (goes to waiting)
+    queue.enqueueMessageCheck('group4@g.us');
+    await vi.advanceTimersByTimeAsync(10);
 
-    // Complete group1 — group3 should drain via drainWaiting with messages path
+    expect(processed).toEqual(['group1@g.us', 'group2@g.us', 'group3@g.us']);
+
+    // Complete group1 — group4 should drain via drainWaiting with messages path
     completionCallbacks[0]();
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(processed).toContain('group3@g.us');
+    expect(processed).toContain('group4@g.us');
   });
 
-  // --- Coverage for drainWaiting with tasks (line 337 task path) ---
+  // --- Task/message budget split ---
 
-  it('drainWaiting runs pending tasks for waiting groups when slots free up', async () => {
+  it('runs tasks even when message pool is saturated', async () => {
     const processed: string[] = [];
     const completionCallbacks: Array<() => void> = [];
 
@@ -590,23 +592,17 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Fill both slots with messages
+    // Fill message pool (3 slots)
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group2@g.us');
+    queue.enqueueMessageCheck('group3@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    // Enqueue a task for group3 — will go to waiting list
+    // Enqueue a task for another group — should still run immediately.
     const taskExecuted = vi.fn();
-    queue.enqueueTask('group3@g.us', 'task-waiting', async () => {
+    queue.enqueueTask('group4@g.us', 'task-not-starved', async () => {
       taskExecuted();
     });
-    await vi.advanceTimersByTimeAsync(10);
-
-    // Task should not have run yet
-    expect(taskExecuted).not.toHaveBeenCalled();
-
-    // Complete group1 — group3's task should drain
-    completionCallbacks[0]();
     await vi.advanceTimersByTimeAsync(10);
 
     expect(taskExecuted).toHaveBeenCalledTimes(1);
@@ -935,33 +931,31 @@ describe('GroupQueue', () => {
   // --- Coverage for enqueueTask at concurrency limit ---
 
   it('enqueueTask queues task when at concurrency limit', async () => {
-    const completionCallbacks: Array<() => void> = [];
+    const taskCompletionCallbacks: Array<() => void> = [];
 
-    const processMessages = vi.fn(async () => {
-      await new Promise<void>((resolve) => completionCallbacks.push(resolve));
-      return true;
-    });
+    const blockingTask = () =>
+      new Promise<void>((resolve) => taskCompletionCallbacks.push(resolve));
 
-    queue.setProcessMessagesFn(processMessages);
-
-    // Fill both slots with messages
-    queue.enqueueMessageCheck('group1@g.us');
-    queue.enqueueMessageCheck('group2@g.us');
+    // Fill task pool (4 slots) with long-running tasks.
+    queue.enqueueTask('group1@g.us', 'task-1', blockingTask);
+    queue.enqueueTask('group2@g.us', 'task-2', blockingTask);
+    queue.enqueueTask('group3@g.us', 'task-3', blockingTask);
+    queue.enqueueTask('group4@g.us', 'task-4', blockingTask);
     await vi.advanceTimersByTimeAsync(10);
 
-    // Enqueue a task for a new group at the concurrency limit
+    // Enqueue a fifth task at task concurrency limit.
     const taskFn = vi.fn(async () => {});
-    queue.enqueueTask('group3@g.us', 'task-limit', taskFn);
+    queue.enqueueTask('group5@g.us', 'task-limit', taskFn);
     await vi.advanceTimersByTimeAsync(10);
 
     // Task should not have run yet
     expect(taskFn).not.toHaveBeenCalled();
 
-    // Free a slot
-    completionCallbacks[0]();
+    // Free one task slot.
+    taskCompletionCallbacks[0]();
     await vi.advanceTimersByTimeAsync(10);
 
-    // Now the task should run
+    // Now queued task should run.
     expect(taskFn).toHaveBeenCalledTimes(1);
   });
 
@@ -1109,27 +1103,26 @@ describe('GroupQueue', () => {
   // --- Coverage for drainWaiting with tasks for waiting group (line 330) ---
 
   it('drainWaiting picks up pending tasks from waiting groups', async () => {
-    const completionCallbacks: Array<() => void> = [];
-    const processMessages = vi.fn(async () => {
-      await new Promise<void>((resolve) => completionCallbacks.push(resolve));
-      return true;
-    });
-    queue.setProcessMessagesFn(processMessages);
+    const taskCompletionCallbacks: Array<() => void> = [];
+    const blockingTask = () =>
+      new Promise<void>((resolve) => taskCompletionCallbacks.push(resolve));
 
-    // Fill both slots with messages
-    queue.enqueueMessageCheck('group1@g.us');
-    queue.enqueueMessageCheck('group2@g.us');
+    // Fill task pool (4 slots) with running tasks.
+    queue.enqueueTask('group1@g.us', 'task-1', blockingTask);
+    queue.enqueueTask('group2@g.us', 'task-2', blockingTask);
+    queue.enqueueTask('group3@g.us', 'task-3', blockingTask);
+    queue.enqueueTask('group4@g.us', 'task-4', blockingTask);
     await vi.advanceTimersByTimeAsync(10);
-    expect(completionCallbacks).toHaveLength(2);
+    expect(taskCompletionCallbacks).toHaveLength(4);
 
-    // Enqueue a TASK for a new group — goes to waiting since concurrency is full
+    // Enqueue a task for a new group — goes to waiting since task pool is full.
     const waitingTaskFn = vi.fn(async () => {});
-    queue.enqueueTask('group3@g.us', 'task-drain-waiting', waitingTaskFn);
+    queue.enqueueTask('group5@g.us', 'task-drain-waiting', waitingTaskFn);
     await vi.advanceTimersByTimeAsync(10);
     expect(waitingTaskFn).not.toHaveBeenCalled();
 
-    // Complete group1 — drainWaiting should pick up group3's task
-    completionCallbacks[0]!();
+    // Complete group1 task — drainWaiting should pick up group5 task
+    taskCompletionCallbacks[0]!();
     await vi.advanceTimersByTimeAsync(10);
     expect(waitingTaskFn).toHaveBeenCalledTimes(1);
   });
@@ -1146,21 +1139,22 @@ describe('GroupQueue', () => {
     });
     queue.setProcessMessagesFn(processMessages);
 
-    // Fill both slots
+    // Fill message pool (3 slots)
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group2@g.us');
-    await vi.advanceTimersByTimeAsync(10);
-    expect(completionCallbacks).toHaveLength(2);
-
-    // Enqueue messages for group3 — goes to waiting
     queue.enqueueMessageCheck('group3@g.us');
     await vi.advanceTimersByTimeAsync(10);
-    expect(processed).toEqual(['group1@g.us', 'group2@g.us']);
+    expect(completionCallbacks).toHaveLength(3);
 
-    // Complete group1 — drainWaiting should pick up group3's messages
+    // Enqueue messages for group4 — goes to waiting
+    queue.enqueueMessageCheck('group4@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+    expect(processed).toEqual(['group1@g.us', 'group2@g.us', 'group3@g.us']);
+
+    // Complete group1 — drainWaiting should pick up group4's messages
     completionCallbacks[0]!();
     await vi.advanceTimersByTimeAsync(10);
-    expect(processed).toContain('group3@g.us');
+    expect(processed).toContain('group4@g.us');
   });
 
   it('stopGroup returns false when no active run exists', () => {

--- a/apps/core/src/runtime/group-queue.ts
+++ b/apps/core/src/runtime/group-queue.ts
@@ -74,6 +74,28 @@ export class GroupQueue {
     return this.activeTaskCount < MAX_JOB_CONTAINERS;
   }
 
+  private isEphemeralSchedulerGroup(groupJid: string): boolean {
+    return groupJid.startsWith('__scheduler__:');
+  }
+
+  private cleanupEphemeralGroupIfIdle(
+    groupJid: string,
+    state: GroupState,
+  ): void {
+    if (!this.isEphemeralSchedulerGroup(groupJid)) return;
+    if (state.active) return;
+    if (state.pendingMessages || state.pendingTasks.length > 0) return;
+    if (state.runningTaskId || state.process || state.idleWaiting) return;
+
+    this.groups.delete(groupJid);
+    this.waitingMessageGroups = this.waitingMessageGroups.filter(
+      (jid) => jid !== groupJid,
+    );
+    this.waitingTaskGroups = this.waitingTaskGroups.filter(
+      (jid) => jid !== groupJid,
+    );
+  }
+
   private enqueueWaitingGroup(kind: QueueKind, groupJid: string): void {
     const queue =
       kind === 'message' ? this.waitingMessageGroups : this.waitingTaskGroups;
@@ -437,6 +459,8 @@ export class GroupQueue {
       );
       return;
     }
+
+    this.cleanupEphemeralGroupIfIdle(groupJid, state);
 
     // Nothing pending for this group; check if other groups are waiting for a slot
     this.drainWaiting();

--- a/apps/core/src/runtime/group-queue.ts
+++ b/apps/core/src/runtime/group-queue.ts
@@ -2,17 +2,22 @@ import { ChildProcess } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-import { DATA_DIR, MAX_CONCURRENT_CONTAINERS } from '../core/config.js';
+import { DATA_DIR } from '../core/config.js';
 import { logger } from '../core/logger.js';
+
+type QueueKind = 'message' | 'task';
 
 interface QueuedTask {
   id: string;
+  kind: QueueKind;
   groupJid: string;
   fn: () => Promise<void>;
 }
 
 const MAX_RETRIES = 5;
 const BASE_RETRY_MS = 5000;
+const MAX_MESSAGE_CONTAINERS = 3;
+const MAX_JOB_CONTAINERS = 4;
 
 interface GroupState {
   active: boolean;
@@ -29,8 +34,10 @@ interface GroupState {
 
 export class GroupQueue {
   private groups = new Map<string, GroupState>();
-  private activeCount = 0;
-  private waitingGroups: string[] = [];
+  private activeMessageCount = 0;
+  private activeTaskCount = 0;
+  private waitingMessageGroups: string[] = [];
+  private waitingTaskGroups: string[] = [];
   private processMessagesFn: ((groupJid: string) => Promise<boolean>) | null =
     null;
   private shuttingDown = false;
@@ -59,6 +66,48 @@ export class GroupQueue {
     this.processMessagesFn = fn;
   }
 
+  private canStartMessageRun(): boolean {
+    return this.activeMessageCount < MAX_MESSAGE_CONTAINERS;
+  }
+
+  private canStartTaskRun(): boolean {
+    return this.activeTaskCount < MAX_JOB_CONTAINERS;
+  }
+
+  private enqueueWaitingGroup(kind: QueueKind, groupJid: string): void {
+    const queue =
+      kind === 'message' ? this.waitingMessageGroups : this.waitingTaskGroups;
+    if (!queue.includes(groupJid)) {
+      queue.push(groupJid);
+    }
+  }
+
+  private dequeueWaitingGroup(kind: QueueKind): string | null {
+    const queue =
+      kind === 'message' ? this.waitingMessageGroups : this.waitingTaskGroups;
+    const originalLength = queue.length;
+    for (let i = 0; i < originalLength; i++) {
+      const candidate = queue.shift();
+      if (!candidate) break;
+      const state = this.getGroup(candidate);
+      const pending =
+        kind === 'message'
+          ? state.pendingMessages
+          : state.pendingTasks.length > 0;
+
+      if (!pending) {
+        continue;
+      }
+
+      if (!state.active) {
+        return candidate;
+      }
+
+      queue.push(candidate);
+    }
+    return null;
+  }
+
   enqueueMessageCheck(groupJid: string): void {
     if (this.shuttingDown) return;
 
@@ -73,14 +122,12 @@ export class GroupQueue {
       return;
     }
 
-    if (this.activeCount >= MAX_CONCURRENT_CONTAINERS) {
+    if (!this.canStartMessageRun()) {
       state.pendingMessages = true;
-      if (!this.waitingGroups.includes(groupJid)) {
-        this.waitingGroups.push(groupJid);
-      }
+      this.enqueueWaitingGroup('message', groupJid);
       logger.debug(
-        { groupJid, activeCount: this.activeCount },
-        'At concurrency limit, message queued',
+        { groupJid, activeMessageCount: this.activeMessageCount },
+        'At message concurrency limit, message queued',
       );
       return;
     }
@@ -106,7 +153,7 @@ export class GroupQueue {
     }
 
     if (state.active) {
-      state.pendingTasks.push({ id: taskId, groupJid, fn });
+      state.pendingTasks.push({ id: taskId, kind: 'task', groupJid, fn });
       if (state.idleWaiting) {
         this.closeStdin(groupJid);
       }
@@ -114,21 +161,20 @@ export class GroupQueue {
       return;
     }
 
-    if (this.activeCount >= MAX_CONCURRENT_CONTAINERS) {
-      state.pendingTasks.push({ id: taskId, groupJid, fn });
-      if (!this.waitingGroups.includes(groupJid)) {
-        this.waitingGroups.push(groupJid);
-      }
+    if (!this.canStartTaskRun()) {
+      state.pendingTasks.push({ id: taskId, kind: 'task', groupJid, fn });
+      this.enqueueWaitingGroup('task', groupJid);
       logger.debug(
-        { groupJid, taskId, activeCount: this.activeCount },
-        'At concurrency limit, task queued',
+        { groupJid, taskId, activeTaskCount: this.activeTaskCount },
+        'At task concurrency limit, task queued',
       );
       return;
     }
 
     // Run immediately
-    this.runTask(groupJid, { id: taskId, groupJid, fn }).catch((err) =>
-      logger.error({ groupJid, taskId, err }, 'Unhandled error in runTask'),
+    this.runTask(groupJid, { id: taskId, kind: 'task', groupJid, fn }).catch(
+      (err) =>
+        logger.error({ groupJid, taskId, err }, 'Unhandled error in runTask'),
     );
   }
 
@@ -262,10 +308,15 @@ export class GroupQueue {
     state.idleWaiting = false;
     state.isTaskContainer = false;
     state.pendingMessages = false;
-    this.activeCount++;
+    this.activeMessageCount++;
 
     logger.debug(
-      { groupJid, reason, activeCount: this.activeCount },
+      {
+        groupJid,
+        reason,
+        activeMessageCount: this.activeMessageCount,
+        activeTaskCount: this.activeTaskCount,
+      },
       'Starting container for group',
     );
 
@@ -286,7 +337,7 @@ export class GroupQueue {
       state.process = null;
       state.containerName = null;
       state.groupFolder = null;
-      this.activeCount--;
+      this.activeMessageCount--;
       this.drainGroup(groupJid);
     }
   }
@@ -297,10 +348,16 @@ export class GroupQueue {
     state.idleWaiting = false;
     state.isTaskContainer = true;
     state.runningTaskId = task.id;
-    this.activeCount++;
+    this.activeTaskCount++;
 
     logger.debug(
-      { groupJid, taskId: task.id, activeCount: this.activeCount },
+      {
+        groupJid,
+        taskId: task.id,
+        taskKind: task.kind,
+        activeMessageCount: this.activeMessageCount,
+        activeTaskCount: this.activeTaskCount,
+      },
       'Running queued task',
     );
 
@@ -315,7 +372,7 @@ export class GroupQueue {
       state.process = null;
       state.containerName = null;
       state.groupFolder = null;
-      this.activeCount--;
+      this.activeTaskCount--;
       this.drainGroup(groupJid);
     }
   }
@@ -350,6 +407,11 @@ export class GroupQueue {
 
     // Tasks first (they won't be re-discovered from SQLite like messages)
     if (state.pendingTasks.length > 0) {
+      if (!this.canStartTaskRun()) {
+        this.enqueueWaitingGroup('task', groupJid);
+        this.drainWaiting();
+        return;
+      }
       const task = state.pendingTasks.shift()!;
       this.runTask(groupJid, task).catch((err) =>
         logger.error(
@@ -362,6 +424,11 @@ export class GroupQueue {
 
     // Then pending messages
     if (state.pendingMessages) {
+      if (!this.canStartMessageRun()) {
+        this.enqueueWaitingGroup('message', groupJid);
+        this.drainWaiting();
+        return;
+      }
       this.runForGroup(groupJid, 'drain').catch((err) =>
         logger.error(
           { groupJid, err },
@@ -376,31 +443,40 @@ export class GroupQueue {
   }
 
   private drainWaiting(): void {
-    while (
-      this.waitingGroups.length > 0 &&
-      this.activeCount < MAX_CONCURRENT_CONTAINERS
-    ) {
-      const nextJid = this.waitingGroups.shift()!;
-      const state = this.getGroup(nextJid);
+    let started = true;
+    while (!this.shuttingDown && started) {
+      started = false;
 
-      // Prioritize tasks over messages
-      if (state.pendingTasks.length > 0) {
-        const task = state.pendingTasks.shift()!;
-        this.runTask(nextJid, task).catch((err) =>
-          logger.error(
-            { groupJid: nextJid, taskId: task.id, err },
-            'Unhandled error in runTask (waiting)',
-          ),
-        );
-      } else if (state.pendingMessages) {
-        this.runForGroup(nextJid, 'drain').catch((err) =>
-          logger.error(
-            { groupJid: nextJid, err },
-            'Unhandled error in runForGroup (waiting)',
-          ),
-        );
+      if (this.canStartMessageRun()) {
+        const nextMessageJid = this.dequeueWaitingGroup('message');
+        if (nextMessageJid) {
+          this.runForGroup(nextMessageJid, 'drain').catch((err) =>
+            logger.error(
+              { groupJid: nextMessageJid, err },
+              'Unhandled error in runForGroup (waiting)',
+            ),
+          );
+          started = true;
+          continue;
+        }
       }
-      // If neither pending, skip this group
+
+      if (this.canStartTaskRun()) {
+        const nextTaskJid = this.dequeueWaitingGroup('task');
+        if (nextTaskJid) {
+          const state = this.getGroup(nextTaskJid);
+          const task = state.pendingTasks.shift();
+          if (task) {
+            this.runTask(nextTaskJid, task).catch((err) =>
+              logger.error(
+                { groupJid: nextTaskJid, taskId: task.id, err },
+                'Unhandled error in runTask (waiting)',
+              ),
+            );
+            started = true;
+          }
+        }
+      }
     }
   }
 
@@ -418,7 +494,11 @@ export class GroupQueue {
     }
 
     logger.info(
-      { activeCount: this.activeCount, detachedContainers: activeContainers },
+      {
+        activeMessageCount: this.activeMessageCount,
+        activeTaskCount: this.activeTaskCount,
+        detachedContainers: activeContainers,
+      },
       'GroupQueue shutting down (containers detached, not killed)',
     );
   }

--- a/apps/core/src/runtime/group-queue.ts
+++ b/apps/core/src/runtime/group-queue.ts
@@ -34,6 +34,7 @@ interface GroupState {
 
 export class GroupQueue {
   private groups = new Map<string, GroupState>();
+  private stopAliases = new Map<string, Set<string>>();
   private activeMessageCount = 0;
   private activeTaskCount = 0;
   private waitingMessageGroups: string[] = [];
@@ -74,6 +75,23 @@ export class GroupQueue {
     return this.activeTaskCount < MAX_JOB_CONTAINERS;
   }
 
+  private addStopAlias(aliasJid: string, queueJid: string): void {
+    if (!aliasJid || aliasJid === queueJid) return;
+    const existing = this.stopAliases.get(aliasJid);
+    if (existing) {
+      existing.add(queueJid);
+      return;
+    }
+    this.stopAliases.set(aliasJid, new Set([queueJid]));
+  }
+
+  private removeStopAliasForQueueJid(queueJid: string): void {
+    for (const [alias, queueJids] of this.stopAliases.entries()) {
+      if (!queueJids.delete(queueJid)) continue;
+      if (queueJids.size === 0) this.stopAliases.delete(alias);
+    }
+  }
+
   private isEphemeralSchedulerGroup(groupJid: string): boolean {
     return groupJid.startsWith('__scheduler__:');
   }
@@ -88,6 +106,7 @@ export class GroupQueue {
     if (state.runningTaskId || state.process || state.idleWaiting) return;
 
     this.groups.delete(groupJid);
+    this.removeStopAliasForQueueJid(groupJid);
     this.waitingMessageGroups = this.waitingMessageGroups.filter(
       (jid) => jid !== groupJid,
     );
@@ -205,11 +224,18 @@ export class GroupQueue {
     proc: ChildProcess,
     containerName: string,
     groupFolder?: string,
+    stopAliasJids?: string | string[],
   ): void {
     const state = this.getGroup(groupJid);
     state.process = proc;
     state.containerName = containerName;
     if (groupFolder) state.groupFolder = groupFolder;
+    const aliases = Array.isArray(stopAliasJids)
+      ? stopAliasJids
+      : stopAliasJids
+        ? [stopAliasJids]
+        : [];
+    for (const alias of aliases) this.addStopAlias(alias, groupJid);
   }
 
   /**
@@ -274,51 +300,62 @@ export class GroupQueue {
    * Returns true when a live process was signaled, false otherwise.
    */
   stopGroup(groupJid: string): boolean {
-    const state = this.getGroup(groupJid);
-    const proc = state.process;
-    if (!state.active || !proc || proc.killed) return false;
+    const targetQueueJids = [groupJid];
+    const aliased = this.stopAliases.get(groupJid);
+    if (aliased) targetQueueJids.push(...aliased);
 
-    // Ask the runner to close cleanly as well.
-    this.closeStdin(groupJid);
+    for (const targetQueueJid of targetQueueJids) {
+      const state = this.groups.get(targetQueueJid);
+      const proc = state?.process;
+      if (!state || !state.active || !proc || proc.killed) continue;
 
-    const pid = proc.pid;
-    if (typeof pid !== 'number' || pid <= 0) {
+      // Ask the runner to close cleanly as well.
+      this.closeStdin(targetQueueJid);
+
+      const pid = proc.pid;
+      if (typeof pid !== 'number' || pid <= 0) {
+        try {
+          proc.kill('SIGTERM');
+          logger.warn(
+            { groupJid, targetQueueJid },
+            'Stop requested for active run (SIGTERM)',
+          );
+          return true;
+        } catch (err) {
+          logger.warn(
+            { groupJid, targetQueueJid, err },
+            'Failed to stop active run (missing pid)',
+          );
+          return false;
+        }
+      }
+
       try {
-        proc.kill('SIGTERM');
-        logger.warn({ groupJid }, 'Stop requested for active run (SIGTERM)');
-        return true;
-      } catch (err) {
+        process.kill(-pid, 'SIGTERM');
         logger.warn(
-          { groupJid, err },
-          'Failed to stop active run (missing pid)',
+          { groupJid, targetQueueJid, pid },
+          'Stop requested for active run (SIGTERM process group)',
         );
-        return false;
+        return true;
+      } catch {
+        try {
+          process.kill(pid, 'SIGTERM');
+          logger.warn(
+            { groupJid, targetQueueJid, pid },
+            'Stop requested for active run (SIGTERM process)',
+          );
+          return true;
+        } catch (err) {
+          logger.warn(
+            { groupJid, targetQueueJid, pid, err },
+            'Failed to stop active run (SIGTERM)',
+          );
+          return false;
+        }
       }
     }
 
-    try {
-      process.kill(-pid, 'SIGTERM');
-      logger.warn(
-        { groupJid, pid },
-        'Stop requested for active run (SIGTERM process group)',
-      );
-      return true;
-    } catch {
-      try {
-        process.kill(pid, 'SIGTERM');
-        logger.warn(
-          { groupJid, pid },
-          'Stop requested for active run (SIGTERM process)',
-        );
-        return true;
-      } catch (err) {
-        logger.warn(
-          { groupJid, pid, err },
-          'Failed to stop active run (SIGTERM)',
-        );
-        return false;
-      }
-    }
+    return false;
   }
 
   private async runForGroup(
@@ -360,6 +397,7 @@ export class GroupQueue {
       state.containerName = null;
       state.groupFolder = null;
       this.activeMessageCount--;
+      this.removeStopAliasForQueueJid(groupJid);
       this.drainGroup(groupJid);
     }
   }
@@ -395,6 +433,7 @@ export class GroupQueue {
       state.containerName = null;
       state.groupFolder = null;
       this.activeTaskCount--;
+      this.removeStopAliasForQueueJid(groupJid);
       this.drainGroup(groupJid);
     }
   }

--- a/apps/core/src/runtime/ipc.test.ts
+++ b/apps/core/src/runtime/ipc.test.ts
@@ -490,6 +490,33 @@ describe('scheduler_update_job', () => {
     expect(job!.max_consecutive_failures).toBe(10);
   });
 
+  it('preserves execution_mode when update omits mode fields', async () => {
+    await processTaskIpc(
+      {
+        type: 'scheduler_update_job',
+        jobId: 'upd-job',
+        executionMode: 'serialized',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+    expect(getJobById('upd-job')!.execution_mode).toBe('serialized');
+
+    await processTaskIpc(
+      {
+        type: 'scheduler_update_job',
+        jobId: 'upd-job',
+        name: 'No mode change',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    expect(getJobById('upd-job')!.execution_mode).toBe('serialized');
+  });
+
   it('updates linkedSessions as main', async () => {
     await processTaskIpc(
       {

--- a/apps/core/src/runtime/ipc.ts
+++ b/apps/core/src/runtime/ipc.ts
@@ -19,6 +19,7 @@ import {
   getJobById,
   listDeadLetterRuns,
   listJobRuns,
+  listRecentJobEvents,
   upsertJob,
   updateJob,
 } from '../storage/db.js';
@@ -33,6 +34,7 @@ import {
   MemoryIpcAction,
 } from '../memory/memory-ipc-contract.js';
 import {
+  JobExecutionMode,
   PermissionApprovalDecision,
   PermissionApprovalRequest,
   PlanReviewPrompt,
@@ -118,6 +120,19 @@ const ipcRateLimitState = new Map<
   string,
   { windowStart: number; count: number }
 >();
+
+function normalizeIpcExecutionMode(
+  executionMode: unknown,
+  serialize: unknown,
+  fallback: JobExecutionMode = 'parallel',
+): JobExecutionMode {
+  if (executionMode === 'serialized') return 'serialized';
+  if (executionMode === 'parallel') return 'parallel';
+  if (typeof serialize === 'boolean') {
+    return serialize ? 'serialized' : 'parallel';
+  }
+  return fallback;
+}
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -1471,7 +1486,12 @@ export async function processTaskIpc(
     maxRetries?: number;
     retryBackoffMs?: number;
     maxConsecutiveFailures?: number;
+    executionMode?: string;
+    serialize?: boolean;
     statuses?: string[];
+    runId?: string;
+    eventType?: string;
+    sinceId?: number;
     limit?: number;
     groupFolder?: string;
     chatJid?: string;
@@ -1615,6 +1635,10 @@ export async function processTaskIpc(
           typeof data.maxConsecutiveFailures === 'number'
             ? data.maxConsecutiveFailures
             : undefined,
+        execution_mode: normalizeIpcExecutionMode(
+          data.executionMode,
+          data.serialize,
+        ),
       });
 
       logger.info(
@@ -1774,6 +1798,10 @@ export async function processTaskIpc(
           typeof data.maxConsecutiveFailures === 'number'
             ? data.maxConsecutiveFailures
             : undefined,
+        execution_mode: normalizeIpcExecutionMode(
+          data.executionMode,
+          data.serialize,
+        ),
       });
 
       logger.info(
@@ -1845,6 +1873,13 @@ export async function processTaskIpc(
       if (typeof data.silent === 'boolean') updates.silent = data.silent;
       if (typeof data.cleanupAfterMs === 'number')
         updates.cleanup_after_ms = data.cleanupAfterMs;
+      if (data.executionMode !== undefined || data.serialize !== undefined) {
+        updates.execution_mode = normalizeIpcExecutionMode(
+          data.executionMode,
+          data.serialize,
+          job.execution_mode,
+        );
+      }
       if (data.threadId !== undefined)
         updates.thread_id = data.threadId || null;
       if (Array.isArray(data.linkedSessions) || Array.isArray(data.deliverTo)) {
@@ -2031,6 +2066,25 @@ export async function processTaskIpc(
       // Read-only path backed by current_job_runs snapshot in the container.
       // This no-op path exists for audit logs and future host-side query routing.
       listJobRuns(undefined, typeof data.limit === 'number' ? data.limit : 50);
+      break;
+    }
+
+    case 'scheduler_list_events':
+    case 'scheduler_wait_for_events': {
+      listRecentJobEvents(typeof data.limit === 'number' ? data.limit : 200, {
+        job_id:
+          typeof data.jobId === 'string' && data.jobId.trim().length > 0
+            ? data.jobId.trim()
+            : undefined,
+        run_id:
+          typeof data.runId === 'string' && data.runId.trim().length > 0
+            ? data.runId.trim()
+            : undefined,
+        event_type:
+          typeof data.eventType === 'string' && data.eventType.trim().length > 0
+            ? data.eventType.trim()
+            : undefined,
+      });
       break;
     }
 

--- a/apps/core/src/runtime/prompt-profile.test.ts
+++ b/apps/core/src/runtime/prompt-profile.test.ts
@@ -53,7 +53,7 @@ describe('PromptProfileService', () => {
 
     writeFile(path.join(configDir, 'settings.yaml'), 'channels: {}\n');
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     service.ensureSeedFiles();
 
     expect(fs.existsSync(path.join(agentsDir, 'shared', 'CLAUDE.md'))).toBe(
@@ -70,52 +70,28 @@ describe('PromptProfileService', () => {
     const root = makeTempRoot();
     roots.push(root);
 
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
     const sharedPath = path.join(agentsDir, 'shared', 'CLAUDE.md');
     const existingContent = '# Existing Shared Context\nDo not overwrite.';
     writeFile(sharedPath, existingContent);
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     service.ensureSeedFiles();
 
     expect(fs.readFileSync(sharedPath, 'utf-8')).toBe(existingContent);
-  });
-
-  it('imports legacy root CLAUDE.md into shared profile when shared is missing', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      '# Legacy Profile\nKeep this behavior.',
-    );
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    service.ensureSeedFiles();
-
-    expect(fs.existsSync(path.join(agentsDir, 'shared', 'CLAUDE.md'))).toBe(
-      true,
-    );
-    expect(
-      fs.readFileSync(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'utf-8'),
-    ).toContain('Keep this behavior.');
   });
 
   it('compiles deterministic order: runtime rules, soul, shared context, group context', () => {
     const root = makeTempRoot();
     roots.push(root);
 
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(path.join(agentsDir, 'team', 'SOUL.md'), '# Soul\nBe direct.');
     writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared context');
     writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group context');
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
     expect(prompt.indexOf('[[RUNTIME_RULES]]')).toBeLessThan(
@@ -136,7 +112,6 @@ describe('PromptProfileService', () => {
   it('includes SOUL section with identity directive when SOUL.md exists', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(
@@ -144,7 +119,7 @@ describe('PromptProfileService', () => {
       '# Soul\n\nBe sharp and direct.',
     );
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
     expect(prompt).toContain('[[SOUL]]');
@@ -155,12 +130,11 @@ describe('PromptProfileService', () => {
   it('skips SOUL section when SOUL.md is missing', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
     expect(prompt).not.toContain('[[SOUL]]');
   });
@@ -168,11 +142,10 @@ describe('PromptProfileService', () => {
   it('skips SOUL section when SOUL.md is empty', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(path.join(agentsDir, 'team', 'SOUL.md'), ' \n \n');
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
     expect(prompt).not.toContain('[[SOUL]]');
   });
@@ -180,11 +153,10 @@ describe('PromptProfileService', () => {
   it('skips invalid group folder names for SOUL and group sections', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: '../../../etc' });
 
     expect(prompt).toContain('[[RUNTIME_RULES]]');
@@ -197,14 +169,13 @@ describe('PromptProfileService', () => {
   it('handles SOUL read failures gracefully', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
     const soulPath = path.join(agentsDir, 'team', 'SOUL.md');
 
     fs.mkdirSync(soulPath, { recursive: true });
     writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
     expect(prompt).not.toContain('[[SOUL]]');
@@ -214,7 +185,6 @@ describe('PromptProfileService', () => {
   it('handles group context read failures gracefully', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
     const groupContextPath = path.join(agentsDir, 'team', 'CLAUDE.md');
 
@@ -223,7 +193,7 @@ describe('PromptProfileService', () => {
     fs.unlinkSync(groupContextPath);
     fs.mkdirSync(groupContextPath, { recursive: true });
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
     expect(prompt).toContain('[[SHARED_CONTEXT]]');
@@ -234,7 +204,6 @@ describe('PromptProfileService', () => {
   it('enforces budget caps for sections and total output', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(path.join(agentsDir, 'team', 'SOUL.md'), 's'.repeat(8000));
@@ -242,7 +211,6 @@ describe('PromptProfileService', () => {
     writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 't'.repeat(8000));
 
     const service = new PromptProfileService({
-      configDir,
       agentsDir,
       sectionBudgets: {
         SOUL: 400,
@@ -262,7 +230,6 @@ describe('PromptProfileService', () => {
   it('omits sections when section budgets are zero', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(path.join(agentsDir, 'team', 'SOUL.md'), 'soul');
@@ -270,7 +237,6 @@ describe('PromptProfileService', () => {
     writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group');
 
     const service = new PromptProfileService({
-      configDir,
       agentsDir,
       sectionBudgets: {
         SOUL: 0,
@@ -289,7 +255,6 @@ describe('PromptProfileService', () => {
   it('handles very small totalBudget by truncating early', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(path.join(agentsDir, 'team', 'SOUL.md'), '# Soul\nBe direct');
@@ -297,7 +262,6 @@ describe('PromptProfileService', () => {
     writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group context');
 
     const service = new PromptProfileService({
-      configDir,
       agentsDir,
       totalBudget: 60,
     });
@@ -310,7 +274,6 @@ describe('PromptProfileService', () => {
   it('normalizes CRLF in SOUL and context files', () => {
     const root = makeTempRoot();
     roots.push(root);
-    const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(
@@ -319,7 +282,7 @@ describe('PromptProfileService', () => {
     );
     writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared\r\nrules');
 
-    const service = new PromptProfileService({ configDir, agentsDir });
+    const service = new PromptProfileService({ agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
     expect(prompt).toContain('Voice line');

--- a/apps/core/src/runtime/prompt-profile.test.ts
+++ b/apps/core/src/runtime/prompt-profile.test.ts
@@ -82,6 +82,28 @@ describe('PromptProfileService', () => {
     expect(fs.readFileSync(sharedPath, 'utf-8')).toBe(existingContent);
   });
 
+  it('imports legacy root CLAUDE.md into shared profile when shared is missing', () => {
+    const root = makeTempRoot();
+    roots.push(root);
+
+    const configDir = path.join(root, 'config');
+    const agentsDir = path.join(root, 'agents');
+    writeFile(
+      path.join(configDir, 'CLAUDE.md'),
+      '# Legacy Profile\nKeep this behavior.',
+    );
+
+    const service = new PromptProfileService({ configDir, agentsDir });
+    service.ensureSeedFiles();
+
+    expect(fs.existsSync(path.join(agentsDir, 'shared', 'CLAUDE.md'))).toBe(
+      true,
+    );
+    expect(
+      fs.readFileSync(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'utf-8'),
+    ).toContain('Keep this behavior.');
+  });
+
   it('compiles deterministic order: runtime rules, soul, shared context, group context', () => {
     const root = makeTempRoot();
     roots.push(root);

--- a/apps/core/src/runtime/prompt-profile.test.ts
+++ b/apps/core/src/runtime/prompt-profile.test.ts
@@ -31,10 +31,6 @@ function makeTempRoot(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'myclaw-prompt-profile-'));
 }
 
-function profileWithAllSections(extra = ''): string {
-  return `# CLAUDE.md\n\n## Identity\nIdentity text\n\n## Voice\nVoice text\n\n## Operating Rules\nOperating rules text\n\n## User Preferences\nUser preferences text\n\n## Privacy Rules\nPrivacy rules text\n\n## Tool Conventions\nTool conventions text\n${extra}`;
-}
-
 describe('PromptProfileService', () => {
   const roots: string[] = [];
 
@@ -48,7 +44,7 @@ describe('PromptProfileService', () => {
     }
   });
 
-  it('seeds only CLAUDE.md and preserves existing config files', () => {
+  it('seeds shared CLAUDE.md and preserves existing config files', () => {
     const root = makeTempRoot();
     roots.push(root);
 
@@ -60,495 +56,258 @@ describe('PromptProfileService', () => {
     const service = new PromptProfileService({ configDir, agentsDir });
     service.ensureSeedFiles();
 
-    expect(fs.existsSync(path.join(configDir, 'CLAUDE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(agentsDir, 'shared', 'CLAUDE.md'))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(configDir, 'CLAUDE.md'))).toBe(false);
     expect(fs.existsSync(path.join(configDir, 'SOUL.md'))).toBe(false);
-    expect(fs.existsSync(path.join(configDir, 'TOOLS.md'))).toBe(false);
-    expect(fs.existsSync(path.join(configDir, 'USER.md'))).toBe(false);
     expect(
       fs.readFileSync(path.join(configDir, 'settings.yaml'), 'utf-8'),
     ).toBe('channels: {}\n');
   });
 
-  it('compiles deterministic order: runtime rules, personal profile, global and group context', () => {
+  it('does not overwrite existing shared CLAUDE.md', () => {
+    const root = makeTempRoot();
+    roots.push(root);
+
+    const configDir = path.join(root, 'config');
+    const agentsDir = path.join(root, 'agents');
+    const sharedPath = path.join(agentsDir, 'shared', 'CLAUDE.md');
+    const existingContent = '# Existing Shared Context\nDo not overwrite.';
+    writeFile(sharedPath, existingContent);
+
+    const service = new PromptProfileService({ configDir, agentsDir });
+    service.ensureSeedFiles();
+
+    expect(fs.readFileSync(sharedPath, 'utf-8')).toBe(existingContent);
+  });
+
+  it('compiles deterministic order: runtime rules, soul, shared context, group context', () => {
     const root = makeTempRoot();
     roots.push(root);
 
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
-    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'global context');
+    writeFile(path.join(agentsDir, 'team', 'SOUL.md'), '# Soul\nBe direct.');
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared context');
     writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group context');
 
     const service = new PromptProfileService({ configDir, agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
     expect(prompt.indexOf('[[RUNTIME_RULES]]')).toBeLessThan(
-      prompt.indexOf('[[PERSONAL_PROFILE]]'),
+      prompt.indexOf('[[SOUL]]'),
     );
-    expect(prompt.indexOf('[[PERSONAL_PROFILE]]')).toBeLessThan(
-      prompt.indexOf('[[GLOBAL_CONTEXT]]'),
+    expect(prompt.indexOf('[[SOUL]]')).toBeLessThan(
+      prompt.indexOf('[[SHARED_CONTEXT]]'),
     );
-    expect(prompt.indexOf('[[GLOBAL_CONTEXT]]')).toBeLessThan(
+    expect(prompt.indexOf('[[SHARED_CONTEXT]]')).toBeLessThan(
       prompt.indexOf('[[GROUP_CONTEXT]]'),
     );
-    expect(prompt).toContain('## Identity');
-    expect(prompt).toContain('## Tool Conventions');
-    expect(prompt).toContain('source: myclaw://personal-profile');
-    expect(prompt).toContain('source: myclaw://shared-agent-profile');
+    expect(prompt).toContain('source: myclaw://soul');
+    expect(prompt).toContain('source: myclaw://shared-context');
     expect(prompt).toContain('source: myclaw://group-context');
     expect(prompt).not.toContain(root);
   });
 
-  it('uses only expected CLAUDE sections and ignores extra persona files', () => {
+  it('includes SOUL section with identity directive when SOUL.md exists', () => {
     const root = makeTempRoot();
     roots.push(root);
-
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
     writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      profileWithAllSections('\n\n## Extra\nshould not be included\n'),
+      path.join(agentsDir, 'team', 'SOUL.md'),
+      '# Soul\n\nBe sharp and direct.',
     );
-    writeFile(path.join(configDir, 'SOUL.md'), 'soul must never be injected');
-    writeFile(path.join(configDir, 'TOOLS.md'), 'tools must never be injected');
-    writeFile(path.join(configDir, 'USER.md'), 'user must never be injected');
 
     const service = new PromptProfileService({ configDir, agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
-    expect(prompt).toContain('Identity text');
-    expect(prompt).not.toContain('soul must never be injected');
-    expect(prompt).not.toContain('tools must never be injected');
-    expect(prompt).not.toContain('user must never be injected');
-    expect(prompt).not.toContain('should not be included');
+    expect(prompt).toContain('[[SOUL]]');
+    expect(prompt).toContain('CRITICAL IDENTITY DIRECTIVE');
+    expect(prompt).toContain('Be sharp and direct.');
   });
 
-  it('keeps nested headings inside the expected parent section body', () => {
+  it('skips SOUL section when SOUL.md is missing', () => {
     const root = makeTempRoot();
     roots.push(root);
-
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      profileWithAllSections(
-        '\n## Operating Rules\nTop rules\n### Edge Cases\nNested rule details\n',
-      ),
-    );
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
 
     const service = new PromptProfileService({ configDir, agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    expect(prompt).toContain('Top rules');
-    expect(prompt).toContain('### Edge Cases');
-    expect(prompt).toContain('Nested rule details');
+    expect(prompt).not.toContain('[[SOUL]]');
   });
 
-  it('logs missing section diagnostics and never injects [MISSING] markers', () => {
+  it('skips SOUL section when SOUL.md is empty', () => {
     const root = makeTempRoot();
     roots.push(root);
-
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      '# CLAUDE.md\n\n## Identity\nOnly one section present',
-    );
-
+    writeFile(path.join(agentsDir, 'team', 'SOUL.md'), ' \n \n');
     const service = new PromptProfileService({ configDir, agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
+    expect(prompt).not.toContain('[[SOUL]]');
+  });
 
+  it('skips invalid group folder names for SOUL and group sections', () => {
+    const root = makeTempRoot();
+    roots.push(root);
+    const configDir = path.join(root, 'config');
+    const agentsDir = path.join(root, 'agents');
+
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
+    const service = new PromptProfileService({ configDir, agentsDir });
+    const prompt = service.compileSystemPrompt({ groupFolder: '../../../etc' });
+
+    expect(prompt).toContain('[[RUNTIME_RULES]]');
+    expect(prompt).toContain('[[SHARED_CONTEXT]]');
+    expect(prompt).not.toContain('[[SOUL]]');
+    expect(prompt).not.toContain('[[GROUP_CONTEXT]]');
     expect(loggerSpies.warn).toHaveBeenCalled();
-    expect(prompt).not.toContain('[MISSING]');
   });
 
-  // --- Coverage for readPlainSection catch branch (lines 314-318) ---
-
-  it('returns null when context file read fails with permission error', () => {
+  it('handles SOUL read failures gracefully', () => {
     const root = makeTempRoot();
     roots.push(root);
-
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
+    const soulPath = path.join(agentsDir, 'team', 'SOUL.md');
 
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
+    fs.mkdirSync(soulPath, { recursive: true });
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
 
-    // Create the group context file then make it unreadable
+    const service = new PromptProfileService({ configDir, agentsDir });
+    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
+
+    expect(prompt).not.toContain('[[SOUL]]');
+    expect(loggerSpies.warn).toHaveBeenCalled();
+  });
+
+  it('handles group context read failures gracefully', () => {
+    const root = makeTempRoot();
+    roots.push(root);
+    const configDir = path.join(root, 'config');
+    const agentsDir = path.join(root, 'agents');
     const groupContextPath = path.join(agentsDir, 'team', 'CLAUDE.md');
-    writeFile(groupContextPath, 'group context content');
-    // Replace the file with a directory to force a read error
+
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
+    writeFile(groupContextPath, 'group context');
     fs.unlinkSync(groupContextPath);
     fs.mkdirSync(groupContextPath, { recursive: true });
 
     const service = new PromptProfileService({ configDir, agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
-    // Should compile without GROUP_CONTEXT since the file read failed
-    expect(prompt).toContain('[[RUNTIME_RULES]]');
-    expect(prompt).toContain('[[PERSONAL_PROFILE]]');
-    // The read error should have been logged
-    expect(loggerSpies.warn).toHaveBeenCalled();
-  });
-
-  // --- Coverage for getPromptProfileService / ensurePromptProfileBootstrapped (lines 349-355) ---
-
-  it('getPromptProfileService returns a singleton instance', () => {
-    const service = getPromptProfileService();
-    expect(service).toBeInstanceOf(PromptProfileService);
-    // Calling again should return the same instance
-    expect(getPromptProfileService()).toBe(service);
-  });
-
-  it('ensurePromptProfileBootstrapped calls ensureSeedFiles on default instance', () => {
-    // This should not throw — exercises lines 353-354
-    expect(() => ensurePromptProfileBootstrapped()).not.toThrow();
-  });
-
-  // --- Coverage for readGroupContextSection with invalid group folder ---
-
-  it('skips invalid group folder names in context section', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    // Use an invalid group folder name (e.g., with path traversal)
-    const prompt = service.compileSystemPrompt({ groupFolder: '../../../etc' });
-
-    // Should still compile without GROUP_CONTEXT
-    expect(prompt).toContain('[[RUNTIME_RULES]]');
+    expect(prompt).toContain('[[SHARED_CONTEXT]]');
     expect(prompt).not.toContain('[[GROUP_CONTEXT]]');
     expect(loggerSpies.warn).toHaveBeenCalled();
   });
 
-  it('enforces hard budget caps for personal profile and total static prompt', () => {
+  it('enforces budget caps for sections and total output', () => {
     const root = makeTempRoot();
     roots.push(root);
-
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
-    const hugeText = 'x'.repeat(2000);
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      `# CLAUDE.md\n\n## Identity\n${hugeText}\n\n## Voice\n${hugeText}\n\n## Operating Rules\n${hugeText}\n\n## User Preferences\n${hugeText}\n\n## Privacy Rules\n${hugeText}\n\n## Tool Conventions\n${hugeText}`,
-    );
-    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'g'.repeat(4000));
-    writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 't'.repeat(4000));
+    writeFile(path.join(agentsDir, 'team', 'SOUL.md'), 's'.repeat(8000));
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'g'.repeat(8000));
+    writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 't'.repeat(8000));
 
     const service = new PromptProfileService({
       configDir,
       agentsDir,
       sectionBudgets: {
-        PERSONAL_PROFILE: 600,
-        GLOBAL_CONTEXT: 200,
+        SOUL: 400,
+        SHARED_CONTEXT: 300,
         GROUP_CONTEXT: 200,
       },
-      totalBudget: 1000,
-    });
-
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    expect(prompt.length).toBeLessThanOrEqual(1000);
-    expect(prompt).toContain('[[PERSONAL_PROFILE]]');
-  });
-
-  it('handles very small totalBudget by truncating sections', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
-    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'global context');
-    writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group context');
-
-    // With a very small budget, only a portion of the first section fits
-    const service = new PromptProfileService({
-      configDir,
-      agentsDir,
-      totalBudget: 50,
+      totalBudget: 1100,
     });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-    expect(prompt.length).toBeLessThanOrEqual(50);
-    // Should still start with the runtime rules marker
+
+    expect(prompt.length).toBeLessThanOrEqual(1100);
+    expect(prompt).toContain('[[SOUL]]');
+    expect(prompt).toContain('[[SHARED_CONTEXT]]');
     expect(prompt).toContain('[[RUNTIME_RULES]]');
   });
 
-  it('handles profile with ## headings that do not match any expected section', () => {
+  it('omits sections when section budgets are zero', () => {
     const root = makeTempRoot();
     roots.push(root);
-
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
-    // Profile has headings, but none match expected sections
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      '# CLAUDE.md\n\n## Random Section\nSome text\n\n## Another Section\nMore text',
-    );
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    // When no expected headings match (matchedCount === 0), falls back to raw profile
-    expect(prompt).toContain('Random Section');
-    expect(prompt).toContain('Another Section');
-    expect(loggerSpies.warn).toHaveBeenCalled();
-  });
-
-  it('handles personal profile that is only whitespace after normalization', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(path.join(configDir, 'CLAUDE.md'), '   \n\n  \r\n  ');
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    // Should have runtime rules but no personal profile
-    expect(prompt).toContain('[[RUNTIME_RULES]]');
-    expect(prompt).not.toContain('[[PERSONAL_PROFILE]]');
-  });
-
-  it('handles personal profile read failure gracefully', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    // Create the CLAUDE.md path as a directory to cause readFileSync to throw
-    const profilePath = path.join(configDir, 'CLAUDE.md');
-    fs.mkdirSync(profilePath, { recursive: true });
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    // Should have runtime rules but no personal profile
-    expect(prompt).toContain('[[RUNTIME_RULES]]');
-    expect(prompt).not.toContain('[[PERSONAL_PROFILE]]');
-    expect(loggerSpies.warn).toHaveBeenCalled();
-  });
-
-  it('handles global context file that is only whitespace', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
-    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), '   \n  ');
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    // Should not contain global context section since content is empty
-    expect(prompt).not.toContain('[[GLOBAL_CONTEXT]]');
-  });
-
-  it('handles profile section with empty body using placeholder text', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    // Profile where Identity section has an empty body
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      '# CLAUDE.md\n\n## Identity\n\n## Voice\nVoice text\n\n## Operating Rules\nRules\n\n## User Preferences\nPrefs\n\n## Privacy Rules\nPrivacy\n\n## Tool Conventions\nTools',
-    );
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    // Empty section body should use the placeholder
-    expect(prompt).toContain('_No details provided._');
-  });
-
-  it('does not seed CLAUDE.md if it already exists', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    const existingContent =
-      '# My Custom Profile\n\n## Identity\nCustom identity';
-    writeFile(path.join(configDir, 'CLAUDE.md'), existingContent);
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    service.ensureSeedFiles();
-
-    // Should preserve existing content, not overwrite with template
-    const content = fs.readFileSync(path.join(configDir, 'CLAUDE.md'), 'utf-8');
-    expect(content).toBe(existingContent);
-  });
-
-  it('compiles prompt with only runtime rules when no other sections exist', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    // Don't create any CLAUDE.md files
-    fs.mkdirSync(configDir, { recursive: true });
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    // Delete the auto-seeded file after ensureSeedFiles runs
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    // Should at minimum have runtime rules and the seeded personal profile
-    expect(prompt).toContain('[[RUNTIME_RULES]]');
-  });
-
-  it('handles CRLF line endings in personal profile', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      '# CLAUDE.md\r\n\r\n## Identity\r\nIdentity text\r\n\r\n## Voice\r\nVoice text\r\n\r\n## Operating Rules\r\nRules\r\n\r\n## User Preferences\r\nPrefs\r\n\r\n## Privacy Rules\r\nPrivacy\r\n\r\n## Tool Conventions\r\nTools',
-    );
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    // CRLF should be normalized and sections parsed correctly
-    expect(prompt).toContain('Identity text');
-    expect(prompt).toContain('Voice text');
-  });
-
-  it('handles profile with no ## headings at all (plain text fallback)', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    // Profile with content but zero ## headings → parseMarkdownSections returns []
-    // → renderPersonalProfileBody hits the parsed.length === 0 branch (line 128)
-    writeFile(
-      path.join(configDir, 'CLAUDE.md'),
-      'Plain text profile with no markdown headings at all.\nJust paragraphs.',
-    );
-
-    const service = new PromptProfileService({ configDir, agentsDir });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    expect(prompt).toContain('Plain text profile');
-    expect(loggerSpies.warn).toHaveBeenCalled();
-  });
-
-  it('returns null when personal profile budget is zero (line 258)', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
+    writeFile(path.join(agentsDir, 'team', 'SOUL.md'), 'soul');
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared');
+    writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group');
 
     const service = new PromptProfileService({
       configDir,
       agentsDir,
       sectionBudgets: {
-        PERSONAL_PROFILE: 0,
-        GLOBAL_CONTEXT: 2000,
-        GROUP_CONTEXT: 2000,
+        SOUL: 0,
+        SHARED_CONTEXT: 0,
+        GROUP_CONTEXT: 0,
       },
     });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
-    // Personal profile should be absent since budget is 0
-    expect(prompt).not.toContain('[[PERSONAL_PROFILE]]');
+    expect(prompt).toContain('[[RUNTIME_RULES]]');
+    expect(prompt).not.toContain('[[SOUL]]');
+    expect(prompt).not.toContain('[[SHARED_CONTEXT]]');
+    expect(prompt).not.toContain('[[GROUP_CONTEXT]]');
+  });
+
+  it('handles very small totalBudget by truncating early', () => {
+    const root = makeTempRoot();
+    roots.push(root);
+    const configDir = path.join(root, 'config');
+    const agentsDir = path.join(root, 'agents');
+
+    writeFile(path.join(agentsDir, 'team', 'SOUL.md'), '# Soul\nBe direct');
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared context');
+    writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group context');
+
+    const service = new PromptProfileService({
+      configDir,
+      agentsDir,
+      totalBudget: 60,
+    });
+    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
+
+    expect(prompt.length).toBeLessThanOrEqual(60);
     expect(prompt).toContain('[[RUNTIME_RULES]]');
   });
 
-  it('returns null when context section truncates to empty (line 306)', () => {
+  it('normalizes CRLF in SOUL and context files', () => {
     const root = makeTempRoot();
     roots.push(root);
-
     const configDir = path.join(root, 'config');
     const agentsDir = path.join(root, 'agents');
 
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
-    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'global content');
+    writeFile(
+      path.join(agentsDir, 'team', 'SOUL.md'),
+      '# Soul\r\n\r\nVoice line\r\n',
+    );
+    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'shared\r\nrules');
 
-    const service = new PromptProfileService({
-      configDir,
-      agentsDir,
-      sectionBudgets: {
-        PERSONAL_PROFILE: 2000,
-        GLOBAL_CONTEXT: 0,
-        GROUP_CONTEXT: 2000,
-      },
-    });
+    const service = new PromptProfileService({ configDir, agentsDir });
     const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
 
-    // Global context should be absent since budget is 0
-    expect(prompt).not.toContain('[[GLOBAL_CONTEXT]]');
+    expect(prompt).toContain('Voice line');
+    expect(prompt).toContain('shared\nrules');
   });
 
-  it('breaks out of compose loop when remaining budget is too small (line 339)', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
-    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'global context');
-    writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 'group context');
-
-    // totalBudget just large enough for runtime rules, too small for anything else
-    const service = new PromptProfileService({
-      configDir,
-      agentsDir,
-      totalBudget: 50,
-    });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    expect(prompt.length).toBeLessThanOrEqual(50);
-  });
-
-  it('truncates total prompt exactly at totalBudget when sections exceed budget', () => {
-    const root = makeTempRoot();
-    roots.push(root);
-
-    const configDir = path.join(root, 'config');
-    const agentsDir = path.join(root, 'agents');
-
-    writeFile(path.join(configDir, 'CLAUDE.md'), profileWithAllSections());
-    writeFile(path.join(agentsDir, 'shared', 'CLAUDE.md'), 'g'.repeat(5000));
-    writeFile(path.join(agentsDir, 'team', 'CLAUDE.md'), 't'.repeat(5000));
-
-    // Tiny totalBudget
-    const service = new PromptProfileService({
-      configDir,
-      agentsDir,
-      totalBudget: 100,
-    });
-    const prompt = service.compileSystemPrompt({ groupFolder: 'team' });
-
-    expect(prompt.length).toBeLessThanOrEqual(100);
+  it('getPromptProfileService returns singleton and bootstrap works', () => {
+    const service = getPromptProfileService();
+    expect(service).toBeInstanceOf(PromptProfileService);
+    expect(getPromptProfileService()).toBe(service);
+    expect(() => ensurePromptProfileBootstrapped()).not.toThrow();
   });
 });

--- a/apps/core/src/runtime/prompt-profile.ts
+++ b/apps/core/src/runtime/prompt-profile.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { AGENT_ROOT, AGENTS_DIR } from '../core/config.js';
+import { AGENTS_DIR } from '../core/config.js';
 import { logger } from '../core/logger.js';
 import { isValidGroupFolder } from '../platform/group-folder.js';
 
@@ -12,7 +12,6 @@ type PromptSectionName =
   | 'GROUP_CONTEXT';
 
 const SOUL_FILENAME = 'SOUL.md';
-const LEGACY_ROOT_PROFILE_FILENAME = 'CLAUDE.md';
 const SOUL_SOURCE = 'myclaw://soul';
 const SHARED_CONTEXT_SOURCE = 'myclaw://shared-context';
 const GROUP_CONTEXT_SOURCE = 'myclaw://group-context';
@@ -42,7 +41,6 @@ export interface CompilePromptProfileOptions {
 }
 
 export interface PromptProfileServiceOptions {
-  configDir?: string;
   agentsDir?: string;
   sectionBudgets?: Partial<Record<PromptSectionName, number>>;
   totalBudget?: number;
@@ -75,13 +73,11 @@ function renderSection(section: PromptSection): string {
 
 export class PromptProfileService {
   private readonly agentsDir: string;
-  private readonly legacyRootDir: string;
   private readonly sectionBudgets: Readonly<Record<PromptSectionName, number>>;
   private readonly totalBudget: number;
 
   constructor(options: PromptProfileServiceOptions = {}) {
     this.agentsDir = options.agentsDir || AGENTS_DIR;
-    this.legacyRootDir = options.configDir || AGENT_ROOT;
     this.sectionBudgets = {
       ...DEFAULT_PROMPT_SECTION_BUDGETS,
       ...(options.sectionBudgets || {}),
@@ -94,30 +90,6 @@ export class PromptProfileService {
     fs.mkdirSync(sharedDir, { recursive: true });
     const sharedPath = path.join(sharedDir, 'CLAUDE.md');
     if (fs.existsSync(sharedPath)) return;
-
-    const legacyPath = path.join(
-      this.legacyRootDir,
-      LEGACY_ROOT_PROFILE_FILENAME,
-    );
-    if (fs.existsSync(legacyPath)) {
-      try {
-        const legacyRaw = fs.readFileSync(legacyPath, 'utf-8');
-        const legacyNormalized = normalizeContent(legacyRaw);
-        if (legacyNormalized) {
-          fs.writeFileSync(sharedPath, `${legacyNormalized}\n`);
-          logger.info(
-            { source: legacyPath, destination: sharedPath },
-            'Imported legacy root CLAUDE.md into shared profile',
-          );
-          return;
-        }
-      } catch (err) {
-        logger.warn(
-          { err, filePath: legacyPath },
-          'Failed to import legacy root CLAUDE.md',
-        );
-      }
-    }
 
     fs.writeFileSync(sharedPath, DEFAULT_SHARED_TEMPLATE);
     logger.info({ filePath: sharedPath }, 'Seeded shared CLAUDE.md profile');

--- a/apps/core/src/runtime/prompt-profile.ts
+++ b/apps/core/src/runtime/prompt-profile.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { AGENTS_DIR } from '../core/config.js';
+import { AGENT_ROOT, AGENTS_DIR } from '../core/config.js';
 import { logger } from '../core/logger.js';
 import { isValidGroupFolder } from '../platform/group-folder.js';
 
@@ -12,6 +12,7 @@ type PromptSectionName =
   | 'GROUP_CONTEXT';
 
 const SOUL_FILENAME = 'SOUL.md';
+const LEGACY_ROOT_PROFILE_FILENAME = 'CLAUDE.md';
 const SOUL_SOURCE = 'myclaw://soul';
 const SHARED_CONTEXT_SOURCE = 'myclaw://shared-context';
 const GROUP_CONTEXT_SOURCE = 'myclaw://group-context';
@@ -74,12 +75,13 @@ function renderSection(section: PromptSection): string {
 
 export class PromptProfileService {
   private readonly agentsDir: string;
+  private readonly legacyRootDir: string;
   private readonly sectionBudgets: Readonly<Record<PromptSectionName, number>>;
   private readonly totalBudget: number;
 
   constructor(options: PromptProfileServiceOptions = {}) {
-    void options.configDir;
     this.agentsDir = options.agentsDir || AGENTS_DIR;
+    this.legacyRootDir = options.configDir || AGENT_ROOT;
     this.sectionBudgets = {
       ...DEFAULT_PROMPT_SECTION_BUDGETS,
       ...(options.sectionBudgets || {}),
@@ -92,6 +94,31 @@ export class PromptProfileService {
     fs.mkdirSync(sharedDir, { recursive: true });
     const sharedPath = path.join(sharedDir, 'CLAUDE.md');
     if (fs.existsSync(sharedPath)) return;
+
+    const legacyPath = path.join(
+      this.legacyRootDir,
+      LEGACY_ROOT_PROFILE_FILENAME,
+    );
+    if (fs.existsSync(legacyPath)) {
+      try {
+        const legacyRaw = fs.readFileSync(legacyPath, 'utf-8');
+        const legacyNormalized = normalizeContent(legacyRaw);
+        if (legacyNormalized) {
+          fs.writeFileSync(sharedPath, `${legacyNormalized}\n`);
+          logger.info(
+            { source: legacyPath, destination: sharedPath },
+            'Imported legacy root CLAUDE.md into shared profile',
+          );
+          return;
+        }
+      } catch (err) {
+        logger.warn(
+          { err, filePath: legacyPath },
+          'Failed to import legacy root CLAUDE.md',
+        );
+      }
+    }
+
     fs.writeFileSync(sharedPath, DEFAULT_SHARED_TEMPLATE);
     logger.info({ filePath: sharedPath }, 'Seeded shared CLAUDE.md profile');
   }

--- a/apps/core/src/runtime/prompt-profile.ts
+++ b/apps/core/src/runtime/prompt-profile.ts
@@ -1,37 +1,28 @@
 import fs from 'fs';
 import path from 'path';
 
-import { AGENT_ROOT, AGENTS_DIR } from '../core/config.js';
+import { AGENTS_DIR } from '../core/config.js';
 import { logger } from '../core/logger.js';
 import { isValidGroupFolder } from '../platform/group-folder.js';
 
 type PromptSectionName =
   | 'RUNTIME_RULES'
-  | 'PERSONAL_PROFILE'
-  | 'GLOBAL_CONTEXT'
+  | 'SOUL'
+  | 'SHARED_CONTEXT'
   | 'GROUP_CONTEXT';
 
-const PERSONAL_PROFILE_FILENAME = 'CLAUDE.md';
-const PERSONAL_PROFILE_SOURCE = 'myclaw://personal-profile';
-const GLOBAL_CONTEXT_SOURCE = 'myclaw://shared-agent-profile';
+const SOUL_FILENAME = 'SOUL.md';
+const SOUL_SOURCE = 'myclaw://soul';
+const SHARED_CONTEXT_SOURCE = 'myclaw://shared-context';
 const GROUP_CONTEXT_SOURCE = 'myclaw://group-context';
-
-const EXPECTED_PROFILE_SECTIONS = [
-  'Identity',
-  'Voice',
-  'Operating Rules',
-  'User Preferences',
-  'Privacy Rules',
-  'Tool Conventions',
-] as const;
 
 export const DEFAULT_PROMPT_SECTION_BUDGETS: Readonly<
   Record<PromptSectionName, number>
 > = {
   RUNTIME_RULES: 1200,
-  PERSONAL_PROFILE: 12000,
-  GLOBAL_CONTEXT: 3600,
-  GROUP_CONTEXT: 3600,
+  SOUL: 3000,
+  SHARED_CONTEXT: 8000,
+  GROUP_CONTEXT: 5000,
 };
 
 export const DEFAULT_PROMPT_TOTAL_BUDGET = 22000;
@@ -43,7 +34,7 @@ const RUNTIME_RULES_BLOCK = [
   '- Treat group boundaries as strict isolation boundaries unless explicitly overridden by host policy.',
 ].join('\n');
 
-const DEFAULT_PROFILE_TEMPLATE = `# CLAUDE.md\n\n## Identity\nDescribe who the assistant is and what it should optimize for.\n\n## Voice\nDefine tone, communication style, and formatting defaults.\n\n## Operating Rules\nList stable behavior rules, priorities, and non-negotiable constraints.\n\n## User Preferences\nCapture durable preferences that should apply broadly across tasks.\n\n## Privacy Rules\nSpecify what must remain private and any data handling constraints.\n\n## Tool Conventions\nDefine tool usage conventions and verification expectations.\n`;
+const DEFAULT_SHARED_TEMPLATE = `# Shared Agent Profile\n\n## Operating Rules\nDefine stable behavior rules, priorities, and constraints.\n\n## User Preferences\nCapture durable preferences that apply broadly.\n\n## Privacy Rules\nSpecify what must remain private.\n\n## Tool Conventions\nDefine tool usage conventions.\n\n## Capabilities\nList what the agent can do.\n\n## Communication\nDefine message delivery, internal thoughts, sub-agent rules.\n\n## Message Formatting\nChannel-specific formatting rules.\n`;
 
 export interface CompilePromptProfileOptions {
   groupFolder: string;
@@ -60,11 +51,6 @@ interface PromptSection {
   name: PromptSectionName;
   source: string;
   content: string;
-}
-
-interface MarkdownSection {
-  heading: string;
-  body: string;
 }
 
 function normalizeContent(content: string): string {
@@ -86,96 +72,13 @@ function renderSection(section: PromptSection): string {
   ].join('\n');
 }
 
-function normalizeHeading(heading: string): string {
-  return heading.trim().replace(/\s+/g, ' ').toLowerCase();
-}
-
-function parseMarkdownSections(markdown: string): MarkdownSection[] {
-  const lines = markdown.split('\n');
-  const headings: Array<{ heading: string; line: number }> = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(/^##\s+(.+?)\s*$/);
-    if (!match) continue;
-    headings.push({ heading: match[1].trim(), line: i });
-  }
-
-  if (headings.length === 0) return [];
-
-  const sections: MarkdownSection[] = [];
-  for (let i = 0; i < headings.length; i++) {
-    const current = headings[i];
-    const nextLine =
-      i + 1 < headings.length ? headings[i + 1].line : lines.length;
-    const body = lines
-      .slice(current.line + 1, nextLine)
-      .join('\n')
-      .trim();
-
-    sections.push({ heading: current.heading, body });
-  }
-
-  return sections;
-}
-
-function renderPersonalProfileBody(rawProfile: string): {
-  content: string;
-  missingSections: string[];
-  usedStructuredSections: boolean;
-} {
-  const parsed = parseMarkdownSections(rawProfile);
-  if (parsed.length === 0) {
-    return {
-      content: rawProfile,
-      missingSections: [...EXPECTED_PROFILE_SECTIONS],
-      usedStructuredSections: false,
-    };
-  }
-
-  const byHeading = new Map<string, MarkdownSection>();
-  for (const section of parsed) {
-    byHeading.set(normalizeHeading(section.heading), section);
-  }
-
-  const parts: string[] = [];
-  const missingSections: string[] = [];
-  let matchedCount = 0;
-
-  for (const expected of EXPECTED_PROFILE_SECTIONS) {
-    const match = byHeading.get(normalizeHeading(expected));
-    if (!match) {
-      missingSections.push(expected);
-      continue;
-    }
-
-    matchedCount += 1;
-    const body = match.body || '_No details provided._';
-    parts.push(`## ${expected}\n${body}`);
-  }
-
-  if (matchedCount === 0) {
-    return {
-      content: rawProfile,
-      missingSections,
-      usedStructuredSections: false,
-    };
-  }
-
-  return {
-    content: parts.join('\n\n').trim(),
-    missingSections,
-    usedStructuredSections: true,
-  };
-}
-
 export class PromptProfileService {
-  private readonly configDir: string;
   private readonly agentsDir: string;
   private readonly sectionBudgets: Readonly<Record<PromptSectionName, number>>;
   private readonly totalBudget: number;
 
   constructor(options: PromptProfileServiceOptions = {}) {
-    this.configDir = options.configDir || AGENT_ROOT;
+    void options.configDir;
     this.agentsDir = options.agentsDir || AGENTS_DIR;
     this.sectionBudgets = {
       ...DEFAULT_PROMPT_SECTION_BUDGETS,
@@ -185,13 +88,12 @@ export class PromptProfileService {
   }
 
   ensureSeedFiles(): void {
-    fs.mkdirSync(this.configDir, { recursive: true });
-
-    const profilePath = path.join(this.configDir, PERSONAL_PROFILE_FILENAME);
-    if (fs.existsSync(profilePath)) return;
-
-    fs.writeFileSync(profilePath, DEFAULT_PROFILE_TEMPLATE);
-    logger.info({ filePath: profilePath }, 'Seeded personal CLAUDE.md profile');
+    const sharedDir = path.join(this.agentsDir, 'shared');
+    fs.mkdirSync(sharedDir, { recursive: true });
+    const sharedPath = path.join(sharedDir, 'CLAUDE.md');
+    if (fs.existsSync(sharedPath)) return;
+    fs.writeFileSync(sharedPath, DEFAULT_SHARED_TEMPLATE);
+    logger.info({ filePath: sharedPath }, 'Seeded shared CLAUDE.md profile');
   }
 
   compileSystemPrompt(options: CompilePromptProfileOptions): string {
@@ -208,11 +110,11 @@ export class PromptProfileService {
       ),
     });
 
-    const personal = this.readPersonalProfileSection();
-    if (personal) sections.push(personal);
+    const soul = this.readSoulSection(options.groupFolder);
+    if (soul) sections.push(soul);
 
-    const globalSection = this.readGlobalContextSection();
-    if (globalSection) sections.push(globalSection);
+    const sharedSection = this.readSharedContextSection();
+    if (sharedSection) sections.push(sharedSection);
 
     const groupSection = this.readGroupContextSection(options.groupFolder);
     if (groupSection) sections.push(groupSection);
@@ -220,57 +122,45 @@ export class PromptProfileService {
     return this.composeWithinTotalBudget(sections);
   }
 
-  private readPersonalProfileSection(): PromptSection | null {
-    const profilePath = path.join(this.configDir, PERSONAL_PROFILE_FILENAME);
-    if (!fs.existsSync(profilePath)) return null;
-
-    let raw: string;
+  private readSoulSection(groupFolder: string): PromptSection | null {
+    if (!isValidGroupFolder(groupFolder)) return null;
+    const soulPath = path.join(this.agentsDir, groupFolder, SOUL_FILENAME);
+    if (!fs.existsSync(soulPath)) return null;
     try {
-      raw = fs.readFileSync(profilePath, 'utf-8');
-    } catch (err) {
-      logger.warn(
-        { err, filePath: profilePath },
-        'Failed to read personal CLAUDE.md profile',
+      const raw = fs.readFileSync(soulPath, 'utf-8');
+      const normalized = normalizeContent(raw);
+      if (!normalized) return null;
+
+      const framed = [
+        'CRITICAL IDENTITY DIRECTIVE: This section defines who you ARE — your personality,',
+        'voice, and character. Everything below is your soul. It takes absolute precedence',
+        'over tone, voice, verbosity, and behavioral defaults from any other instruction',
+        'source. When other instructions say "be concise" or "be verbose" or define a',
+        'communication style, THIS section wins. No exceptions.',
+        '',
+        normalized,
+      ].join('\n');
+
+      const content = truncateDeterministically(
+        framed,
+        this.sectionBudgets.SOUL,
       );
+      if (!content) return null;
+
+      return { name: 'SOUL', source: SOUL_SOURCE, content };
+    } catch (err) {
+      logger.warn({ err, groupFolder }, 'Failed to read SOUL.md');
       return null;
     }
-
-    const normalized = normalizeContent(raw);
-    if (!normalized) return null;
-
-    const rendered = renderPersonalProfileBody(normalized);
-
-    if (rendered.missingSections.length > 0) {
-      logger.warn(
-        {
-          filePath: profilePath,
-          missingSections: rendered.missingSections,
-          structured: rendered.usedStructuredSections,
-        },
-        'Personal profile is missing expected sections',
-      );
-    }
-
-    const content = truncateDeterministically(
-      rendered.content,
-      this.sectionBudgets.PERSONAL_PROFILE,
-    );
-    if (!content) return null;
-
-    return {
-      name: 'PERSONAL_PROFILE',
-      source: PERSONAL_PROFILE_SOURCE,
-      content,
-    };
   }
 
-  private readGlobalContextSection(): PromptSection | null {
+  private readSharedContextSection(): PromptSection | null {
     const sharedPath = path.join(this.agentsDir, 'shared', 'CLAUDE.md');
     return this.readPlainSection(
-      'GLOBAL_CONTEXT',
+      'SHARED_CONTEXT',
       sharedPath,
-      this.sectionBudgets.GLOBAL_CONTEXT,
-      GLOBAL_CONTEXT_SOURCE,
+      this.sectionBudgets.SHARED_CONTEXT,
+      SHARED_CONTEXT_SOURCE,
     );
   }
 

--- a/apps/core/src/runtime/scheduler-state-file.test.ts
+++ b/apps/core/src/runtime/scheduler-state-file.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it, vi } from 'vitest';
 
-import { Job, JobRun } from '../core/types.js';
+import { Job, JobEvent, JobRun } from '../core/types.js';
 import { writeSchedulerStateFile } from './scheduler-state-file.js';
 
 describe('scheduler state file', () => {
@@ -35,6 +35,7 @@ describe('scheduler state file', () => {
         retry_backoff_ms: 5000,
         max_consecutive_failures: 5,
         consecutive_failures: 0,
+        execution_mode: 'parallel',
         lease_run_id: null,
         lease_expires_at: null,
         pause_reason: null,
@@ -56,18 +57,32 @@ describe('scheduler state file', () => {
       },
     ];
 
-    writeSchedulerStateFile(jobs, runs, filePath);
+    const events: JobEvent[] = [
+      {
+        id: 1,
+        job_id: 'job-1',
+        run_id: 'run-1',
+        event_type: 'job.completed',
+        payload: '{"status":"completed"}',
+        created_at: '2026-01-01T00:00:02.000Z',
+      },
+    ];
+
+    writeSchedulerStateFile(jobs, runs, events, filePath);
 
     const saved = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as {
       updated_at: string;
       jobs: Job[];
       recent_runs: JobRun[];
+      recent_events: JobEvent[];
     };
 
     expect(saved.jobs).toHaveLength(1);
     expect(saved.jobs[0].id).toBe('job-1');
     expect(saved.recent_runs).toHaveLength(1);
     expect(saved.recent_runs[0].run_id).toBe('run-1');
+    expect(saved.recent_events).toHaveLength(1);
+    expect(saved.recent_events[0].event_type).toBe('job.completed');
     expect(typeof saved.updated_at).toBe('string');
   });
 
@@ -75,14 +90,16 @@ describe('scheduler state file', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myclaw-scheduler-'));
     const filePath = path.join(tempDir, 'nested', 'dir', 'scheduler-jobs.json');
 
-    writeSchedulerStateFile([], [], filePath);
+    writeSchedulerStateFile([], [], [], filePath);
 
     const saved = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as {
       jobs: Job[];
       recent_runs: JobRun[];
+      recent_events: JobEvent[];
     };
     expect(saved.jobs).toHaveLength(0);
     expect(saved.recent_runs).toHaveLength(0);
+    expect(saved.recent_events).toHaveLength(0);
   });
 });
 
@@ -99,7 +116,7 @@ describe('writeSchedulerStateFileSafe', () => {
     vi.resetModules();
     const mod = await import('./scheduler-state-file.js');
 
-    expect(() => mod.writeSchedulerStateFileSafe([], [])).not.toThrow();
+    expect(() => mod.writeSchedulerStateFileSafe([], [], [])).not.toThrow();
 
     vi.doUnmock('../core/config.js');
     vi.resetModules();

--- a/apps/core/src/runtime/scheduler-state-file.ts
+++ b/apps/core/src/runtime/scheduler-state-file.ts
@@ -2,12 +2,13 @@ import fs from 'fs';
 import path from 'path';
 
 import { SCHEDULER_JOBS_JSON_PATH } from '../core/config.js';
-import { Job, JobRun } from '../core/types.js';
+import { Job, JobEvent, JobRun } from '../core/types.js';
 import { logger } from '../core/logger.js';
 
 export function writeSchedulerStateFile(
   jobs: Job[],
   runs: JobRun[],
+  events: JobEvent[],
   filePath: string = SCHEDULER_JOBS_JSON_PATH,
 ): void {
   const dir = path.dirname(filePath);
@@ -17,6 +18,7 @@ export function writeSchedulerStateFile(
     updated_at: new Date().toISOString(),
     jobs,
     recent_runs: runs,
+    recent_events: events,
   };
 
   const tempPath = `${filePath}.tmp`;
@@ -24,9 +26,13 @@ export function writeSchedulerStateFile(
   fs.renameSync(tempPath, filePath);
 }
 
-export function writeSchedulerStateFileSafe(jobs: Job[], runs: JobRun[]): void {
+export function writeSchedulerStateFileSafe(
+  jobs: Job[],
+  runs: JobRun[],
+  events: JobEvent[],
+): void {
   try {
-    writeSchedulerStateFile(jobs, runs);
+    writeSchedulerStateFile(jobs, runs, events);
   } catch (err) {
     logger.warn({ err }, 'Failed to write scheduler state JSON');
   }

--- a/apps/core/src/runtime/task-scheduler.test.ts
+++ b/apps/core/src/runtime/task-scheduler.test.ts
@@ -47,6 +47,7 @@ vi.mock('../memory/memory-ipc.js', () => ({
 
 vi.mock('../platform/group-folder.js', () => ({
   resolveGroupFolderPath: vi.fn(() => '/tmp/test-group-folder'),
+  resolveGroupIpcPath: vi.fn(() => '/tmp/test-group-ipc'),
 }));
 
 vi.mock('../memory/memory-service.js', () => ({
@@ -1084,7 +1085,7 @@ describe('scheduler loop', () => {
     expect(onSchedulerChanged).toHaveBeenCalled();
   });
 
-  it('enqueues job tasks using execution jid when group is resolvable', async () => {
+  it('enqueues parallel jobs on per-job scheduler queue key', async () => {
     upsertJob({
       id: 'enqueue-test',
       name: 'enqueue test',
@@ -1109,13 +1110,13 @@ describe('scheduler loop', () => {
     await Promise.resolve();
 
     expect(enqueueTask).toHaveBeenCalledWith(
-      'group@g.us',
+      '__scheduler__:main:enqueue-test',
       'enqueue-test',
       expect.any(Function),
     );
   });
 
-  it('uses resolved folder owner jid when no linked_sessions', async () => {
+  it('uses per-job scheduler queue key when linked_sessions are empty', async () => {
     upsertJob({
       id: 'no-session-job',
       name: 'no session',
@@ -1135,8 +1136,35 @@ describe('scheduler loop', () => {
     await Promise.resolve();
 
     expect(enqueueTask).toHaveBeenCalledWith(
-      'group@g.us',
+      '__scheduler__:main:no-session-job',
       'no-session-job',
+      expect.any(Function),
+    );
+  });
+
+  it('enqueues serialized jobs on shared group scheduler queue key', async () => {
+    upsertJob({
+      id: 'serialized-enqueue-test',
+      name: 'serialized enqueue test',
+      prompt: 'test',
+      schedule_type: 'once',
+      schedule_value: new Date(Date.now() - 60_000).toISOString(),
+      linked_sessions: ['group@g.us'],
+      group_scope: 'main',
+      created_by: 'agent',
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+      status: 'active',
+      execution_mode: 'serialized',
+    });
+
+    const enqueueTask = vi.fn();
+    startSchedulerLoop(makeDeps({ enqueueTask }));
+    await vi.advanceTimersByTimeAsync(20);
+    await Promise.resolve();
+
+    expect(enqueueTask).toHaveBeenCalledWith(
+      '__scheduler__:main',
+      'serialized-enqueue-test',
       expect.any(Function),
     );
   });
@@ -1753,7 +1781,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     expect(runs.length).toBe(1);
   });
 
-  it('spawnAgent onProcess callback is invoked with execution jid', async () => {
+  it('spawnAgent onProcess callback is invoked with scheduler queue key', async () => {
     const onProcess = vi.fn();
     vi.mocked(spawnAgent).mockImplementationOnce(
       async (_group, _input, onProc, _onOutput, _options) => {
@@ -1782,7 +1810,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     await Promise.resolve();
 
     expect(onProcess).toHaveBeenCalledWith(
-      'group@g.us',
+      '__scheduler__:main:onprocess-job',
       expect.anything(),
       'test-container',
       'main',
@@ -2349,7 +2377,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     expect(runs[0].error_summary).toBe('non-error-string');
   });
 
-  it('getSessions returns a session ID used by the job', async () => {
+  it('parallel jobs do not reuse persisted interactive session IDs', async () => {
     vi.mocked(spawnAgent).mockResolvedValueOnce({
       status: 'success',
       result: 'ok',
@@ -2380,10 +2408,108 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
 
     expect(spawnAgent).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ sessionId: 'existing-session-id' }),
+      expect.objectContaining({ sessionId: undefined }),
       expect.anything(),
       expect.anything(),
       expect.anything(),
+    );
+  });
+
+  it('serialized jobs do not reuse persisted interactive session IDs', async () => {
+    vi.mocked(spawnAgent).mockResolvedValueOnce({
+      status: 'success',
+      result: 'ok',
+      newSessionId: 'sess-1',
+    });
+
+    upsertJob({
+      id: 'serialized-with-session',
+      name: 'serialized with session',
+      prompt: 'test',
+      schedule_type: 'once',
+      schedule_value: new Date(Date.now() - 60_000).toISOString(),
+      linked_sessions: ['group@g.us'],
+      group_scope: 'main',
+      created_by: 'agent',
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+      status: 'active',
+      execution_mode: 'serialized',
+    });
+
+    startSchedulerLoop(
+      makeDeps({
+        getSessions: () => ({ main: 'existing-session-id' }),
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(20);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(spawnAgent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sessionId: undefined }),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('serialized jobs reuse scheduler-owned session IDs between runs', async () => {
+    vi.mocked(spawnAgent)
+      .mockResolvedValueOnce({
+        status: 'success',
+        result: 'ok',
+        newSessionId: 'scheduler-session-1',
+      })
+      .mockResolvedValueOnce({
+        status: 'success',
+        result: 'ok2',
+        newSessionId: 'scheduler-session-2',
+      });
+
+    upsertJob({
+      id: 'serialized-run-1',
+      name: 'serialized run 1',
+      prompt: 'test',
+      schedule_type: 'once',
+      schedule_value: new Date(Date.now() - 60_000).toISOString(),
+      linked_sessions: ['group@g.us'],
+      group_scope: 'main',
+      created_by: 'agent',
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+      status: 'active',
+      execution_mode: 'serialized',
+    });
+
+    upsertJob({
+      id: 'serialized-run-2',
+      name: 'serialized run 2',
+      prompt: 'test2',
+      schedule_type: 'once',
+      schedule_value: new Date(Date.now() - 60_000).toISOString(),
+      linked_sessions: ['group@g.us'],
+      group_scope: 'main',
+      created_by: 'agent',
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+      status: 'active',
+      execution_mode: 'serialized',
+    });
+
+    startSchedulerLoop(makeDeps());
+    await vi.advanceTimersByTimeAsync(20);
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(60_020);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const calls = vi.mocked(spawnAgent).mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls[0]?.[1]).toEqual(
+      expect.objectContaining({ sessionId: undefined }),
+    );
+    expect(calls[1]?.[1]).toEqual(
+      expect.objectContaining({ sessionId: 'scheduler-session-1' }),
     );
   });
 

--- a/apps/core/src/runtime/task-scheduler.test.ts
+++ b/apps/core/src/runtime/task-scheduler.test.ts
@@ -1084,7 +1084,7 @@ describe('scheduler loop', () => {
     expect(onSchedulerChanged).toHaveBeenCalled();
   });
 
-  it('enqueues job tasks using scheduler queue jid', async () => {
+  it('enqueues job tasks using execution jid when group is resolvable', async () => {
     upsertJob({
       id: 'enqueue-test',
       name: 'enqueue test',
@@ -1109,13 +1109,13 @@ describe('scheduler loop', () => {
     await Promise.resolve();
 
     expect(enqueueTask).toHaveBeenCalledWith(
-      '__scheduler__:main',
+      'group@g.us',
       'enqueue-test',
       expect.any(Function),
     );
   });
 
-  it('uses scheduler queue jid when no linked_sessions', async () => {
+  it('uses resolved folder owner jid when no linked_sessions', async () => {
     upsertJob({
       id: 'no-session-job',
       name: 'no session',
@@ -1135,7 +1135,7 @@ describe('scheduler loop', () => {
     await Promise.resolve();
 
     expect(enqueueTask).toHaveBeenCalledWith(
-      '__scheduler__:main',
+      'group@g.us',
       'no-session-job',
       expect.any(Function),
     );
@@ -1753,7 +1753,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     expect(runs.length).toBe(1);
   });
 
-  it('spawnAgent onProcess callback is invoked with scheduler queue jid', async () => {
+  it('spawnAgent onProcess callback is invoked with execution jid', async () => {
     const onProcess = vi.fn();
     vi.mocked(spawnAgent).mockImplementationOnce(
       async (_group, _input, onProc, _onOutput, _options) => {
@@ -1782,7 +1782,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     await Promise.resolve();
 
     expect(onProcess).toHaveBeenCalledWith(
-      '__scheduler__:main',
+      'group@g.us',
       expect.anything(),
       'test-container',
       'main',

--- a/apps/core/src/runtime/task-scheduler.test.ts
+++ b/apps/core/src/runtime/task-scheduler.test.ts
@@ -1084,7 +1084,7 @@ describe('scheduler loop', () => {
     expect(onSchedulerChanged).toHaveBeenCalled();
   });
 
-  it('enqueues job tasks using queue.enqueueTask with correct jid', async () => {
+  it('enqueues job tasks using scheduler queue jid', async () => {
     upsertJob({
       id: 'enqueue-test',
       name: 'enqueue test',
@@ -1109,13 +1109,13 @@ describe('scheduler loop', () => {
     await Promise.resolve();
 
     expect(enqueueTask).toHaveBeenCalledWith(
-      'group@g.us',
+      '__scheduler__:main',
       'enqueue-test',
       expect.any(Function),
     );
   });
 
-  it('uses group_scope:job as queueJid when no linked_sessions', async () => {
+  it('uses scheduler queue jid when no linked_sessions', async () => {
     upsertJob({
       id: 'no-session-job',
       name: 'no session',
@@ -1134,9 +1134,8 @@ describe('scheduler loop', () => {
     await vi.advanceTimersByTimeAsync(20);
     await Promise.resolve();
 
-    // With empty linked_sessions, queueJid = `${group_scope}:job`
     expect(enqueueTask).toHaveBeenCalledWith(
-      'main:job',
+      '__scheduler__:main',
       'no-session-job',
       expect.any(Function),
     );
@@ -1600,7 +1599,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     };
   }
 
-  it('invokes streaming callback with result and scheduleClose', async () => {
+  it('invokes streaming callback with result without closing shared stdin', async () => {
     const closeStdin = vi.fn();
     const notifyIdle = vi.fn();
 
@@ -1636,12 +1635,11 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     await vi.advanceTimersByTimeAsync(20);
     await Promise.resolve();
     await Promise.resolve();
-    // Advance close delay timer (10s)
     await vi.advanceTimersByTimeAsync(11_000);
     await Promise.resolve();
 
-    expect(notifyIdle).toHaveBeenCalledWith('group@g.us');
-    expect(closeStdin).toHaveBeenCalledWith('group@g.us');
+    expect(notifyIdle).not.toHaveBeenCalled();
+    expect(closeStdin).not.toHaveBeenCalled();
   });
 
   it('invokes streaming callback with error status', async () => {
@@ -1755,7 +1753,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     expect(runs.length).toBe(1);
   });
 
-  it('spawnAgent onProcess callback is invoked', async () => {
+  it('spawnAgent onProcess callback is invoked with scheduler queue jid', async () => {
     const onProcess = vi.fn();
     vi.mocked(spawnAgent).mockImplementationOnce(
       async (_group, _input, onProc, _onOutput, _options) => {
@@ -1784,7 +1782,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     await Promise.resolve();
 
     expect(onProcess).toHaveBeenCalledWith(
-      'group@g.us',
+      '__scheduler__:main',
       expect.anything(),
       'test-container',
       'main',
@@ -2287,13 +2285,13 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     getJobByIdSpy.mockRestore();
   });
 
-  it('scheduleClose is only invoked once (idempotent guard)', async () => {
+  it('does not invoke closeStdin for repeated streamed chunks', async () => {
     const closeStdin = vi.fn();
 
     vi.mocked(spawnAgent).mockImplementationOnce(
       async (_group, _input, _onProcess, onOutput, _options) => {
         if (onOutput) {
-          // Invoke with result twice to test scheduleClose guard
+          // Invoke with result twice; scheduler jobs should not request closeStdin.
           await onOutput({ status: 'success', result: 'first' });
           await onOutput({ status: 'success', result: 'second' });
         }
@@ -2318,11 +2316,10 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     await vi.advanceTimersByTimeAsync(20);
     await Promise.resolve();
     await Promise.resolve();
-    // Advance past close delay
+    // Advance timers to ensure no delayed close is scheduled.
     await vi.advanceTimersByTimeAsync(11_000);
 
-    // closeStdin should be called only once despite scheduleClose being invoked multiple times
-    expect(closeStdin).toHaveBeenCalledTimes(1);
+    expect(closeStdin).not.toHaveBeenCalled();
   });
 
   it('system job error uses non-Error string fallback', async () => {
@@ -2426,16 +2423,16 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     );
   });
 
-  it('clears closeTimer in finally block when it was set', async () => {
+  it('does not invoke closeStdin when spawnAgent returns error after output', async () => {
     const closeStdin = vi.fn();
 
     vi.mocked(spawnAgent).mockImplementationOnce(
       async (_group, _input, _onProcess, onOutput, _options) => {
         if (onOutput) {
-          // Set result which triggers scheduleClose (sets closeTimer)
+          // Emit streamed output before final error.
           await onOutput({ status: 'success', result: 'result' });
         }
-        // Return error to exercise more paths, but closeTimer was set
+        // Return error to exercise failure handling.
         return {
           status: 'error',
           result: null,
@@ -2464,10 +2461,9 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
     await vi.advanceTimersByTimeAsync(20);
     await Promise.resolve();
     await Promise.resolve();
-    // Advance a lot — if closeTimer was NOT cleared, closeStdin would fire
+    // Advance a lot; closeStdin should still never fire for scheduled jobs.
     await vi.advanceTimersByTimeAsync(20_000);
 
-    // closeStdin should NOT have been called because the timer was cleared in finally
     expect(closeStdin).not.toHaveBeenCalled();
   });
 

--- a/apps/core/src/runtime/task-scheduler.test.ts
+++ b/apps/core/src/runtime/task-scheduler.test.ts
@@ -1814,6 +1814,7 @@ describe('scheduler coverage: streaming callback and edge cases', () => {
       expect.anything(),
       'test-container',
       'main',
+      ['group@g.us'],
     );
   });
 

--- a/apps/core/src/runtime/task-scheduler.ts
+++ b/apps/core/src/runtime/task-scheduler.ts
@@ -61,6 +61,10 @@ function nextSchedulerStreamingGeneration(): number {
   return schedulerStreamingGenerationCounter;
 }
 
+function schedulerQueueJid(groupScope: string): string {
+  return `__scheduler__:${groupScope}`;
+}
+
 function normalizeCleanupAfterMs(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return DEFAULT_JOB_CLEANUP_AFTER_MS;
@@ -257,7 +261,11 @@ async function handleSystemJob(
   throw new Error(`Unknown system job: ${job.prompt}`);
 }
 
-async function runJob(job: Job, deps: SchedulerDependencies): Promise<void> {
+async function runJob(
+  job: Job,
+  deps: SchedulerDependencies,
+  queueJid: string,
+): Promise<void> {
   const currentJob = getJobById(job.id);
   if (!currentJob || currentJob.status !== 'active') {
     return;
@@ -452,15 +460,6 @@ async function runJob(job: Job, deps: SchedulerDependencies): Promise<void> {
       }
     }
 
-    const JOB_CLOSE_DELAY_MS = 10_000;
-    let closeTimer: ReturnType<typeof setTimeout> | null = null;
-    const scheduleClose = () => {
-      if (closeTimer) return;
-      closeTimer = setTimeout(() => {
-        deps.queue.closeStdin(execution.executionJid);
-      }, JOB_CLOSE_DELAY_MS);
-    };
-
     if (!error) {
       let deliveredAnyOutput = false;
       try {
@@ -479,7 +478,7 @@ async function runJob(job: Job, deps: SchedulerDependencies): Promise<void> {
           },
           (proc, containerName) =>
             deps.onProcess(
-              execution.executionJid,
+              queueJid,
               proc,
               containerName,
               execution.group.folder,
@@ -491,12 +490,9 @@ async function runJob(job: Job, deps: SchedulerDependencies): Promise<void> {
               if (await deliverStreamingChunk(streamedOutput.result)) {
                 deliveredAnyOutput = true;
               }
-              scheduleClose();
             }
             if (streamedOutput.status === 'success') {
               if (await finalizeStreaming()) deliveredAnyOutput = true;
-              deps.queue.notifyIdle(execution.executionJid);
-              scheduleClose();
             }
             if (streamedOutput.status === 'error') {
               error = streamedOutput.error || 'Unknown error';
@@ -525,10 +521,6 @@ async function runJob(job: Job, deps: SchedulerDependencies): Promise<void> {
         error = err instanceof Error ? err.message : String(err);
       } finally {
         await finalizeStreaming();
-        if (closeTimer && error) {
-          clearTimeout(closeTimer);
-          closeTimer = null;
-        }
       }
     }
   }
@@ -701,10 +693,9 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
       for (const job of dueJobs) {
         const current = getJobById(job.id);
         if (!current || current.status !== 'active') continue;
-        const queueJid =
-          current.linked_sessions[0] || `${current.group_scope}:job`;
+        const queueJid = schedulerQueueJid(current.group_scope);
         deps.queue.enqueueTask(queueJid, current.id, () =>
-          runJob(current, deps),
+          runJob(current, deps, queueJid),
         );
       }
 

--- a/apps/core/src/runtime/task-scheduler.ts
+++ b/apps/core/src/runtime/task-scheduler.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { ChildProcess } from 'child_process';
 import { CronExpressionParser } from 'cron-parser';
 import fs from 'fs';
+import path from 'path';
 
 import {
   ASSISTANT_NAME,
@@ -10,11 +11,14 @@ import {
   SCHEDULER_POLL_INTERVAL,
   TIMEZONE,
 } from '../core/config.js';
-import { Job, RegisteredGroup } from '../core/types.js';
+import { Job, JobExecutionMode, RegisteredGroup } from '../core/types.js';
 import { logger } from '../core/logger.js';
 import { writeMemoryContextSnapshot } from '../memory/memory-ipc.js';
 import { MemoryService } from '../memory/memory-service.js';
-import { resolveGroupFolderPath } from '../platform/group-folder.js';
+import {
+  resolveGroupFolderPath,
+  resolveGroupIpcPath,
+} from '../platform/group-folder.js';
 import { GroupQueue } from './group-queue.js';
 import { AgentOutput, spawnAgent } from './agent-spawn.js';
 import {
@@ -35,7 +39,7 @@ import { StreamingChunkOptions } from '../core/types.js';
 
 export interface SchedulerDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
-  getSessions: () => Record<string, string>;
+  getSessions?: () => Record<string, string>;
   queue: GroupQueue;
   onProcess: (
     groupJid: string,
@@ -54,15 +58,118 @@ export interface SchedulerDependencies {
 }
 
 const DEFAULT_JOB_CLEANUP_AFTER_MS = 86_400_000;
+const MAX_PARALLEL_JOBS_PER_GROUP_SCOPE = 2;
 let schedulerStreamingGenerationCounter = 0;
+const schedulerSessions = new Map<string, string>();
+const activeParallelRunsByGroupScope = new Map<string, number>();
+const activeSerializedRunsByGroupScope = new Map<string, number>();
 
 function nextSchedulerStreamingGeneration(): number {
   schedulerStreamingGenerationCounter += 1;
   return schedulerStreamingGenerationCounter;
 }
 
-function schedulerQueueJid(groupScope: string): string {
+function schedulerQueueJid(groupScope: string, jobId?: string): string {
+  if (jobId) return `__scheduler__:${groupScope}:${jobId}`;
   return `__scheduler__:${groupScope}`;
+}
+
+function schedulerSessionKey(job: Job, mode: JobExecutionMode): string {
+  if (mode === 'serialized') return `serialized:${job.group_scope}`;
+  return `parallel:${job.id}`;
+}
+
+function canScheduleParallelRunForGroup(
+  groupScope: string,
+  queuedParallelThisTick: Map<string, number>,
+  queuedSerializedThisTick: Map<string, number>,
+): boolean {
+  const active = activeParallelRunsByGroupScope.get(groupScope) || 0;
+  const queued = queuedParallelThisTick.get(groupScope) || 0;
+  const activeSerialized =
+    activeSerializedRunsByGroupScope.get(groupScope) || 0;
+  const queuedSerialized = queuedSerializedThisTick.get(groupScope) || 0;
+  if (activeSerialized + queuedSerialized > 0) return false;
+  return active + queued < MAX_PARALLEL_JOBS_PER_GROUP_SCOPE;
+}
+
+function reserveParallelRunForTick(
+  groupScope: string,
+  queuedParallelThisTick: Map<string, number>,
+): void {
+  const current = queuedParallelThisTick.get(groupScope) || 0;
+  queuedParallelThisTick.set(groupScope, current + 1);
+}
+
+function acquireParallelRunSlot(groupScope: string): () => void {
+  const current = activeParallelRunsByGroupScope.get(groupScope) || 0;
+  activeParallelRunsByGroupScope.set(groupScope, current + 1);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const active = activeParallelRunsByGroupScope.get(groupScope) || 0;
+    if (active <= 1) {
+      activeParallelRunsByGroupScope.delete(groupScope);
+      return;
+    }
+    activeParallelRunsByGroupScope.set(groupScope, active - 1);
+  };
+}
+
+function canScheduleSerializedRunForGroup(
+  groupScope: string,
+  queuedParallelThisTick: Map<string, number>,
+  queuedSerializedThisTick: Map<string, number>,
+): boolean {
+  const activeParallel = activeParallelRunsByGroupScope.get(groupScope) || 0;
+  const queuedParallel = queuedParallelThisTick.get(groupScope) || 0;
+  if (activeParallel + queuedParallel > 0) return false;
+  const activeSerialized =
+    activeSerializedRunsByGroupScope.get(groupScope) || 0;
+  const queuedSerialized = queuedSerializedThisTick.get(groupScope) || 0;
+  return activeSerialized + queuedSerialized < 1;
+}
+
+function reserveSerializedRunForTick(
+  groupScope: string,
+  queuedSerializedThisTick: Map<string, number>,
+): void {
+  const current = queuedSerializedThisTick.get(groupScope) || 0;
+  queuedSerializedThisTick.set(groupScope, current + 1);
+}
+
+function acquireSerializedRunSlot(groupScope: string): () => void {
+  const current = activeSerializedRunsByGroupScope.get(groupScope) || 0;
+  activeSerializedRunsByGroupScope.set(groupScope, current + 1);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const active = activeSerializedRunsByGroupScope.get(groupScope) || 0;
+    if (active <= 1) {
+      activeSerializedRunsByGroupScope.delete(groupScope);
+      return;
+    }
+    activeSerializedRunsByGroupScope.set(groupScope, active - 1);
+  };
+}
+
+function pruneSchedulerSessions(jobs: Job[]): void {
+  const validKeys = new Set<string>();
+  for (const job of jobs) {
+    const mode = normalizeExecutionMode(job.execution_mode);
+    validKeys.add(schedulerSessionKey(job, mode));
+  }
+  for (const key of schedulerSessions.keys()) {
+    if (!validKeys.has(key)) {
+      schedulerSessions.delete(key);
+    }
+  }
+}
+
+function normalizeExecutionMode(mode: unknown): JobExecutionMode {
+  return mode === 'serialized' ? 'serialized' : 'parallel';
 }
 
 function normalizeCleanupAfterMs(value: number | undefined): number {
@@ -265,6 +372,7 @@ async function runJob(
   job: Job,
   deps: SchedulerDependencies,
   queueJid: string,
+  executionModeHint?: JobExecutionMode,
 ): Promise<void> {
   const currentJob = getJobById(job.id);
   if (!currentJob || currentJob.status !== 'active') {
@@ -286,6 +394,9 @@ async function runJob(
   const scheduledFor = currentJob.next_run || new Date().toISOString();
   const runId = randomUUID();
   const timeoutMs = Math.max(30_000, currentJob.timeout_ms || 300_000);
+  const executionMode = normalizeExecutionMode(
+    executionModeHint ?? currentJob.execution_mode,
+  );
   const leaseExpiresAt = new Date(
     Date.now() + timeoutMs + 30_000,
   ).toISOString();
@@ -316,6 +427,32 @@ async function runJob(
     return;
   }
 
+  const emitJobEvent = (
+    eventType: string,
+    payload: Record<string, unknown> | null,
+  ): void => {
+    try {
+      addJobEvent({
+        job_id: currentJob.id,
+        run_id: runId,
+        event_type: eventType,
+        payload: payload ? JSON.stringify(payload) : null,
+        created_at: new Date().toISOString(),
+      });
+    } catch (err) {
+      logger.warn(
+        { err, jobId: currentJob.id, runId, eventType },
+        'Failed to write scheduler lifecycle event',
+      );
+    }
+  };
+  emitJobEvent('job.started', {
+    queue_jid: queueJid,
+    execution_mode: executionMode,
+    scheduled_for: scheduledFor,
+    timeout_ms: timeoutMs,
+  });
+
   let result: string | null = null;
   let error: string | null = null;
   let collectedResult = '';
@@ -328,8 +465,15 @@ async function runJob(
     error = err instanceof Error ? err.message : String(err);
   }
 
-  const sessions = deps.getSessions();
-  const sessionId = sessions[execution.group.folder];
+  const schedulerSession = schedulerSessions.get(
+    schedulerSessionKey(currentJob, executionMode),
+  );
+  const sessionId = schedulerSession || undefined;
+  const memoryContextFileName = `memory_context.${runId}.json`;
+  const memoryContextFilePath = path.join(
+    resolveGroupIpcPath(execution.group.folder),
+    memoryContextFileName,
+  );
   const isMain = execution.group.isMain === true;
   let retrievedItemIds: string[] = [];
   let ranSystemJob = false;
@@ -450,6 +594,7 @@ async function runJob(
           isMain,
           currentJob.prompt,
           undefined,
+          { fileName: memoryContextFileName },
         );
         retrievedItemIds = contextSnapshot.retrievedItemIds;
       } catch (err) {
@@ -462,6 +607,20 @@ async function runJob(
 
     if (!error) {
       let deliveredAnyOutput = false;
+      let bufferedStreamingChars = 0;
+      let totalStreamingChars = 0;
+      let lastStreamingEventMs = 0;
+      const flushStreamingEvent = (force = false): void => {
+        if (bufferedStreamingChars <= 0) return;
+        const nowMs = Date.now();
+        if (!force && nowMs - lastStreamingEventMs < 1000) return;
+        emitJobEvent('job.streaming', {
+          buffered_chars: bufferedStreamingChars,
+          total_chars: totalStreamingChars,
+        });
+        bufferedStreamingChars = 0;
+        lastStreamingEventMs = nowMs;
+      };
       try {
         const output = await spawnAgent(
           execution.group,
@@ -475,6 +634,7 @@ async function runJob(
             isScheduledJob: true,
             assistantName: ASSISTANT_NAME,
             script: currentJob.script || undefined,
+            memoryContextFile: memoryContextFilePath,
           },
           (proc, containerName) =>
             deps.onProcess(
@@ -487,6 +647,10 @@ async function runJob(
             if (streamedOutput.result) {
               result = streamedOutput.result;
               collectedResult += streamedOutput.result;
+              const chunkChars = streamedOutput.result.length;
+              bufferedStreamingChars += chunkChars;
+              totalStreamingChars += chunkChars;
+              flushStreamingEvent();
               if (await deliverStreamingChunk(streamedOutput.result)) {
                 deliveredAnyOutput = true;
               }
@@ -501,12 +665,19 @@ async function runJob(
           },
           { timeoutMs },
         );
+        flushStreamingEvent(true);
 
         if (output.status === 'error') {
           error = output.error || 'Unknown error';
         } else if (output.result) {
           result = output.result;
           if (!collectedResult) collectedResult = output.result;
+        }
+        if (output.newSessionId) {
+          schedulerSessions.set(
+            schedulerSessionKey(currentJob, executionMode),
+            output.newSessionId,
+          );
         }
 
         if (!error) {
@@ -636,23 +807,31 @@ async function runJob(
   if (notified) {
     markJobRunNotified(runId);
   }
+  emitJobEvent(runStatus === 'completed' ? 'job.completed' : 'job.failed', {
+    status: runStatus,
+    next_run: nextRun,
+    retry_count: retryCount,
+    pause_reason: pauseReason,
+    notified,
+    summary,
+  });
   deps.onSchedulerChanged?.();
 
   if (!error && !ranSystemJob) {
-    try {
-      await MemoryService.getInstance().reflectAfterTurn({
+    void MemoryService.getInstance()
+      .reflectAfterTurn({
         groupFolder: execution.group.folder,
         prompt: currentJob.prompt,
         result: resultSummary || 'Completed',
         isMain,
         retrievedItemIds,
+      })
+      .catch((err) => {
+        logger.warn(
+          { err, jobId: currentJob.id },
+          'Memory reflection failed after job completion',
+        );
       });
-    } catch (err) {
-      logger.warn(
-        { err, jobId: currentJob.id },
-        'Memory reflection failed after job completion',
-      );
-    }
   }
 
   if (
@@ -662,6 +841,18 @@ async function runJob(
   ) {
     deleteJob(currentJob.id);
     deps.onSchedulerChanged?.();
+  }
+
+  try {
+    fs.unlinkSync(memoryContextFilePath);
+  } catch (err) {
+    const nodeErr = err as NodeJS.ErrnoException;
+    if (nodeErr?.code !== 'ENOENT') {
+      logger.debug(
+        { err, jobId: currentJob.id, file: memoryContextFilePath },
+        'Failed to clean scheduler memory context file',
+      );
+    }
   }
 }
 
@@ -686,19 +877,64 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
       }
 
       const dueJobs = listDueJobs();
-      const groups = deps.registeredGroups();
       if (dueJobs.length > 0) {
         logger.info({ count: dueJobs.length }, 'Found due scheduler jobs');
       }
 
+      const queuedParallelRunsThisTick = new Map<string, number>();
+      const queuedSerializedRunsThisTick = new Map<string, number>();
       for (const job of dueJobs) {
         const current = getJobById(job.id);
         if (!current || current.status !== 'active') continue;
-        const execution = resolveExecutionContext(current, groups);
+        const executionMode = normalizeExecutionMode(current.execution_mode);
+        if (
+          executionMode === 'parallel' &&
+          !canScheduleParallelRunForGroup(
+            current.group_scope,
+            queuedParallelRunsThisTick,
+            queuedSerializedRunsThisTick,
+          )
+        ) {
+          continue;
+        }
+        if (
+          executionMode === 'serialized' &&
+          !canScheduleSerializedRunForGroup(
+            current.group_scope,
+            queuedParallelRunsThisTick,
+            queuedSerializedRunsThisTick,
+          )
+        ) {
+          continue;
+        }
         const queueJid =
-          execution?.executionJid || schedulerQueueJid(current.group_scope);
+          executionMode === 'serialized'
+            ? schedulerQueueJid(current.group_scope)
+            : schedulerQueueJid(current.group_scope, current.id);
+        if (executionMode === 'parallel') {
+          reserveParallelRunForTick(
+            current.group_scope,
+            queuedParallelRunsThisTick,
+          );
+        }
+        if (executionMode === 'serialized') {
+          reserveSerializedRunForTick(
+            current.group_scope,
+            queuedSerializedRunsThisTick,
+          );
+        }
         deps.queue.enqueueTask(queueJid, current.id, () =>
-          runJob(current, deps, queueJid),
+          (async () => {
+            const releaseSlot =
+              executionMode === 'parallel'
+                ? acquireParallelRunSlot(current.group_scope)
+                : acquireSerializedRunSlot(current.group_scope);
+            try {
+              await runJob(current, deps, queueJid, executionMode);
+            } finally {
+              releaseSlot?.();
+            }
+          })(),
         );
       }
 
@@ -706,6 +942,8 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
       if (removed) {
         deps.onSchedulerChanged?.();
       }
+
+      pruneSchedulerSessions(getAllJobs());
     } catch (err) {
       logger.error({ err }, 'Error in scheduler loop');
     }
@@ -719,4 +957,8 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
 /** @internal - for tests only. */
 export function _resetSchedulerLoopForTests(): void {
   schedulerRunning = false;
+  schedulerStreamingGenerationCounter = 0;
+  schedulerSessions.clear();
+  activeParallelRunsByGroupScope.clear();
+  activeSerializedRunsByGroupScope.clear();
 }

--- a/apps/core/src/runtime/task-scheduler.ts
+++ b/apps/core/src/runtime/task-scheduler.ts
@@ -686,6 +686,7 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
       }
 
       const dueJobs = listDueJobs();
+      const groups = deps.registeredGroups();
       if (dueJobs.length > 0) {
         logger.info({ count: dueJobs.length }, 'Found due scheduler jobs');
       }
@@ -693,7 +694,9 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
       for (const job of dueJobs) {
         const current = getJobById(job.id);
         if (!current || current.status !== 'active') continue;
-        const queueJid = schedulerQueueJid(current.group_scope);
+        const execution = resolveExecutionContext(current, groups);
+        const queueJid =
+          execution?.executionJid || schedulerQueueJid(current.group_scope);
         deps.queue.enqueueTask(queueJid, current.id, () =>
           runJob(current, deps, queueJid),
         );

--- a/apps/core/src/runtime/task-scheduler.ts
+++ b/apps/core/src/runtime/task-scheduler.ts
@@ -274,7 +274,11 @@ function formatRunStatusMessage(args: {
 function resolveExecutionContext(
   job: Job,
   groups: Record<string, RegisteredGroup>,
-): { group: RegisteredGroup; executionJid: string; stopAliasJids: string[] } | null {
+): {
+  group: RegisteredGroup;
+  executionJid: string;
+  stopAliasJids: string[];
+} | null {
   const byFolder = Object.entries(groups).find(
     ([, group]) => group.folder === job.group_scope,
   );

--- a/apps/core/src/runtime/task-scheduler.ts
+++ b/apps/core/src/runtime/task-scheduler.ts
@@ -46,6 +46,7 @@ export interface SchedulerDependencies {
     proc: ChildProcess,
     containerName: string,
     groupFolder: string,
+    stopAliasJids?: string[],
   ) => void;
   sendMessage: (jid: string, text: string) => Promise<void>;
   sendStreamingChunk?: (
@@ -273,21 +274,28 @@ function formatRunStatusMessage(args: {
 function resolveExecutionContext(
   job: Job,
   groups: Record<string, RegisteredGroup>,
-): { group: RegisteredGroup; executionJid: string } | null {
+): { group: RegisteredGroup; executionJid: string; stopAliasJids: string[] } | null {
   const byFolder = Object.entries(groups).find(
     ([, group]) => group.folder === job.group_scope,
   );
   if (byFolder) {
+    const stopAliasJids = Array.from(
+      new Set([...(job.linked_sessions || []), byFolder[0]]),
+    );
     return {
       group: byFolder[1],
-      executionJid: job.linked_sessions[0] || byFolder[0],
+      executionJid: stopAliasJids[0] || byFolder[0],
+      stopAliasJids,
     };
   }
 
   for (const linked of job.linked_sessions) {
     const group = groups[linked];
     if (group) {
-      return { group, executionJid: linked };
+      const stopAliasJids = Array.from(
+        new Set([...(job.linked_sessions || []), linked]),
+      );
+      return { group, executionJid: linked, stopAliasJids };
     }
   }
   return null;
@@ -642,6 +650,7 @@ async function runJob(
               proc,
               containerName,
               execution.group.folder,
+              execution.stopAliasJids,
             ),
           async (streamedOutput: AgentOutput) => {
             if (streamedOutput.result) {

--- a/apps/core/src/storage/db.test.ts
+++ b/apps/core/src/storage/db.test.ts
@@ -25,6 +25,7 @@ import {
   getSession,
   listDeadLetterRuns,
   listDueJobs,
+  listRecentJobEvents,
   listJobRuns,
   markJobRunning,
   markJobRunNotified,
@@ -973,6 +974,7 @@ describe('upsertJob edge cases', () => {
     expect(job?.silent).toBe(false);
     expect(job?.thread_id).toBeNull();
     expect(job?.status).toBe('active');
+    expect(job?.execution_mode).toBe('parallel');
   });
 
   it('stores script field', () => {
@@ -1073,6 +1075,11 @@ describe('updateJob field coverage', () => {
   it('updates group_scope', () => {
     updateJob('upd-job', { group_scope: 'other-group' });
     expect(getJobById('upd-job')?.group_scope).toBe('other-group');
+  });
+
+  it('updates execution_mode', () => {
+    updateJob('upd-job', { execution_mode: 'serialized' });
+    expect(getJobById('upd-job')?.execution_mode).toBe('serialized');
   });
 
   it('updates next_run and last_run', () => {
@@ -1625,9 +1632,14 @@ describe('addJobEvent', () => {
       created_at: '2026-01-01T00:01:00.000Z',
     });
 
+    const events = listRecentJobEvents(10, { job_id: 'evt-job' });
+    expect(events).toHaveLength(2);
+    expect(events[0].event_type).toBe('paused');
+    expect(events[1].event_type).toBe('started');
+
     // Events are cleaned up with deleteJob
     deleteJob('evt-job');
-    // No way to query events directly, but deleteJob should not throw
+    expect(listRecentJobEvents(10, { job_id: 'evt-job' })).toHaveLength(0);
   });
 });
 

--- a/apps/core/src/storage/db.ts
+++ b/apps/core/src/storage/db.ts
@@ -7,6 +7,7 @@ import { isValidGroupFolder } from '../platform/group-folder.js';
 import { logger } from '../core/logger.js';
 import {
   Job,
+  JobExecutionMode,
   JobEvent,
   JobRun,
   NewMessage,
@@ -115,6 +116,10 @@ function isSafeIdentifier(identifier: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier);
 }
 
+function normalizeJobExecutionMode(value: unknown): JobExecutionMode {
+  return value === 'serialized' ? 'serialized' : 'parallel';
+}
+
 function hasColumn(
   database: Database.Database,
   tableName: string,
@@ -194,6 +199,7 @@ function createSchema(database: Database.Database): void {
       retry_backoff_ms INTEGER NOT NULL DEFAULT 5000,
       max_consecutive_failures INTEGER NOT NULL DEFAULT 5,
       consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      execution_mode TEXT NOT NULL DEFAULT 'parallel',
       lease_run_id TEXT,
       lease_expires_at TEXT,
       pause_reason TEXT
@@ -327,6 +333,12 @@ function createSchema(database: Database.Database): void {
       'jobs',
       'cleanup_after_ms',
       'INTEGER DEFAULT 86400000',
+    );
+    addColumnIfMissing(
+      database,
+      'jobs',
+      'execution_mode',
+      "TEXT DEFAULT 'parallel'",
     );
   } catch (err) {
     logger.error({ err }, 'Database schema migration failed');
@@ -544,6 +556,9 @@ function mapJobRow(row: RawJobRow): Job {
     ...row,
     linked_sessions: linkedSessions,
     silent: Boolean(row.silent),
+    execution_mode: normalizeJobExecutionMode(
+      (row as { execution_mode?: unknown }).execution_mode,
+    ),
   };
 }
 
@@ -567,6 +582,7 @@ export interface JobUpsertInput {
   max_retries?: number;
   retry_backoff_ms?: number;
   max_consecutive_failures?: number;
+  execution_mode?: JobExecutionMode;
 }
 
 export function upsertJob(job: JobUpsertInput): { created: boolean } {
@@ -580,9 +596,10 @@ export function upsertJob(job: JobUpsertInput): { created: boolean } {
     INSERT INTO jobs (
       id, name, prompt, model, script, schedule_type, schedule_value, status,
       linked_sessions, thread_id, group_scope, created_by, created_at, updated_at,
-      next_run, silent, cleanup_after_ms, timeout_ms, max_retries, retry_backoff_ms, max_consecutive_failures
+      next_run, silent, cleanup_after_ms, timeout_ms, max_retries, retry_backoff_ms, max_consecutive_failures,
+      execution_mode
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       name = excluded.name,
       prompt = excluded.prompt,
@@ -604,7 +621,8 @@ export function upsertJob(job: JobUpsertInput): { created: boolean } {
       timeout_ms = excluded.timeout_ms,
       max_retries = excluded.max_retries,
       retry_backoff_ms = excluded.retry_backoff_ms,
-      max_consecutive_failures = excluded.max_consecutive_failures
+      max_consecutive_failures = excluded.max_consecutive_failures,
+      execution_mode = excluded.execution_mode
   `,
   ).run(
     job.id,
@@ -628,6 +646,7 @@ export function upsertJob(job: JobUpsertInput): { created: boolean } {
     job.max_retries ?? 3,
     job.retry_backoff_ms ?? 5000,
     job.max_consecutive_failures ?? 5,
+    normalizeJobExecutionMode(job.execution_mode),
   );
 
   return { created: !existing };
@@ -675,6 +694,7 @@ export function updateJob(
       | 'retry_backoff_ms'
       | 'max_consecutive_failures'
       | 'consecutive_failures'
+      | 'execution_mode'
       | 'pause_reason'
       | 'lease_run_id'
       | 'lease_expires_at'
@@ -759,6 +779,10 @@ export function updateJob(
   if (updates.consecutive_failures !== undefined) {
     fields.push('consecutive_failures = ?');
     values.push(updates.consecutive_failures);
+  }
+  if (updates.execution_mode !== undefined) {
+    fields.push('execution_mode = ?');
+    values.push(normalizeJobExecutionMode(updates.execution_mode));
   }
   if (updates.pause_reason !== undefined) {
     fields.push('pause_reason = ?');
@@ -930,6 +954,45 @@ export function addJobEvent(event: Omit<JobEvent, 'id'>): void {
     event.payload,
     event.created_at,
   );
+}
+
+export function listRecentJobEvents(
+  limit: number = 200,
+  filters?: {
+    job_id?: string;
+    run_id?: string;
+    event_type?: string;
+  },
+): JobEvent[] {
+  const clampedLimit = Math.max(1, Math.min(limit, 2000));
+  const where: string[] = [];
+  const values: unknown[] = [];
+
+  if (filters?.job_id) {
+    where.push('job_id = ?');
+    values.push(filters.job_id);
+  }
+  if (filters?.run_id) {
+    where.push('run_id = ?');
+    values.push(filters.run_id);
+  }
+  if (filters?.event_type) {
+    where.push('event_type = ?');
+    values.push(filters.event_type);
+  }
+
+  const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+  return db
+    .prepare(
+      `
+        SELECT id, job_id, run_id, event_type, payload, created_at
+        FROM job_events
+        ${whereClause}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+      `,
+    )
+    .all(...values, clampedLimit) as JobEvent[];
 }
 
 // --- Router state accessors ---

--- a/docs/plan-soul-md.md
+++ b/docs/plan-soul-md.md
@@ -1,0 +1,396 @@
+# SOUL.md Support + Prompt Layer Cleanup
+
+**Status:** Draft
+**Date:** 2026-04-16
+
+---
+
+## Summary
+
+Add `SOUL.md` as a first-class personality file. Remove the PERSONAL_PROFILE layer entirely. Collapse four prompt sections into three. Clean up the runtime folder to match.
+
+**Before (4 sections, 3 CLAUDE.md files):**
+1. RUNTIME_RULES — safety
+2. PERSONAL_PROFILE — `~/myclaw/CLAUDE.md` (identity, voice, prefs, privacy, tools)
+3. GLOBAL_CONTEXT — `agents/shared/CLAUDE.md` (NanoKai personality, capabilities, formatting)
+4. GROUP_CONTEXT — `agents/<group>/CLAUDE.md` (near-duplicate of shared + group-specific)
+
+**After (3 sections, 2 files per agent):**
+1. RUNTIME_RULES — safety
+2. SOUL — `agents/<group>/SOUL.md` (personality, voice, vibe, boundaries)
+3. SHARED_CONTEXT — `agents/shared/CLAUDE.md` (merged operational base)
+4. GROUP_CONTEXT — `agents/<group>/CLAUDE.md` (group-specific overrides only, thin)
+
+Master `~/myclaw/CLAUDE.md` is deleted — its content merges into shared/CLAUDE.md.
+
+---
+
+## 1. prompt-profile.ts — Add SOUL, Remove PERSONAL_PROFILE
+
+**File:** `apps/core/src/runtime/prompt-profile.ts`
+
+**a) Update types and constants:**
+```typescript
+// Line 8 — remove PERSONAL_PROFILE, add SOUL
+type PromptSectionName =
+  | 'RUNTIME_RULES'
+  | 'SOUL'
+  | 'SHARED_CONTEXT'
+  | 'GROUP_CONTEXT';
+
+// New constants
+const SOUL_FILENAME = 'SOUL.md';
+const SOUL_SOURCE = 'myclaw://soul';
+
+// Rename existing
+const SHARED_CONTEXT_SOURCE = 'myclaw://shared-context';  // was GLOBAL_CONTEXT_SOURCE
+
+// Remove entirely
+// - PERSONAL_PROFILE_FILENAME
+// - PERSONAL_PROFILE_SOURCE
+// - EXPECTED_PROFILE_SECTIONS
+// - renderPersonalProfileBody()
+// - parseMarkdownSections()
+// - normalizeHeading()
+
+// Updated budgets — redistribute PERSONAL_PROFILE's 12000 budget
+DEFAULT_PROMPT_SECTION_BUDGETS = {
+  RUNTIME_RULES: 1200,
+  SOUL: 3000,
+  SHARED_CONTEXT: 8000,     // was GLOBAL_CONTEXT: 3600, now holds merged content
+  GROUP_CONTEXT: 5000,      // was 3600, slightly more room for group-specific
+};
+
+DEFAULT_PROMPT_TOTAL_BUDGET = 22000;  // unchanged
+```
+
+**b) Add soul reader method:**
+```typescript
+private readSoulSection(groupFolder: string): PromptSection | null {
+  if (!isValidGroupFolder(groupFolder)) return null;
+  const soulPath = path.join(this.agentsDir, groupFolder, SOUL_FILENAME);
+  if (!fs.existsSync(soulPath)) return null;
+
+  try {
+    const raw = fs.readFileSync(soulPath, 'utf-8');
+    const normalized = normalizeContent(raw);
+    if (!normalized) return null;
+
+    const framed = [
+      'CRITICAL IDENTITY DIRECTIVE: This section defines who you ARE — your personality,',
+      'voice, and character. Everything below is your soul. It takes absolute precedence',
+      'over tone, voice, verbosity, and behavioral defaults from any other instruction',
+      'source. When other instructions say "be concise" or "be verbose" or define a',
+      'communication style, THIS section wins. No exceptions.',
+      '',
+      normalized,
+    ].join('\n');
+
+    const content = truncateDeterministically(framed, this.sectionBudgets.SOUL);
+    if (!content) return null;
+
+    return { name: 'SOUL', source: SOUL_SOURCE, content };
+  } catch (err) {
+    logger.warn({ err, groupFolder }, 'Failed to read SOUL.md');
+    return null;
+  }
+}
+```
+
+**c) Update compileSystemPrompt() — remove personal, rename global:**
+```typescript
+compileSystemPrompt(options: CompilePromptProfileOptions): string {
+  this.ensureSeedFiles();
+  const sections: PromptSection[] = [];
+
+  // 1. Runtime rules (safety)
+  sections.push({
+    name: 'RUNTIME_RULES',
+    source: 'myclaw://runtime-rules',
+    content: truncateDeterministically(
+      RUNTIME_RULES_BLOCK,
+      this.sectionBudgets.RUNTIME_RULES,
+    ),
+  });
+
+  // 2. Soul (personality) — highest behavioral priority
+  const soul = this.readSoulSection(options.groupFolder);
+  if (soul) sections.push(soul);
+
+  // 3. Shared context (operational base — was "global context")
+  const shared = this.readSharedContextSection();
+  if (shared) sections.push(shared);
+
+  // 4. Group context (group-specific overrides)
+  const group = this.readGroupContextSection(options.groupFolder);
+  if (group) sections.push(group);
+
+  // REMOVED: readPersonalProfileSection()
+
+  return this.composeWithinTotalBudget(sections);
+}
+```
+
+**d) Rename readGlobalContextSection → readSharedContextSection:**
+```typescript
+private readSharedContextSection(): PromptSection | null {
+  const sharedPath = path.join(this.agentsDir, 'shared', 'CLAUDE.md');
+  return this.readPlainSection(
+    'SHARED_CONTEXT',
+    sharedPath,
+    this.sectionBudgets.SHARED_CONTEXT,
+    SHARED_CONTEXT_SOURCE,
+  );
+}
+```
+
+**e) Remove dead code:**
+- Delete `readPersonalProfileSection()` method
+- Delete `renderPersonalProfileBody()` function
+- Delete `parseMarkdownSections()` function
+- Delete `normalizeHeading()` function
+- Delete `EXPECTED_PROFILE_SECTIONS` constant
+- Delete `PERSONAL_PROFILE_FILENAME` constant
+- Delete `PERSONAL_PROFILE_SOURCE` constant
+- Delete `MarkdownSection` interface
+- Delete `DEFAULT_PROFILE_TEMPLATE` constant
+
+**f) Update ensureSeedFiles():**
+```typescript
+ensureSeedFiles(): void {
+  // Only ensure agents/shared/ directory exists
+  const sharedDir = path.join(this.agentsDir, 'shared');
+  fs.mkdirSync(sharedDir, { recursive: true });
+
+  const sharedPath = path.join(sharedDir, 'CLAUDE.md');
+  if (fs.existsSync(sharedPath)) return;
+
+  fs.writeFileSync(sharedPath, DEFAULT_SHARED_TEMPLATE);
+  logger.info({ filePath: sharedPath }, 'Seeded shared CLAUDE.md');
+}
+```
+
+Replace `DEFAULT_PROFILE_TEMPLATE` with `DEFAULT_SHARED_TEMPLATE`:
+```typescript
+const DEFAULT_SHARED_TEMPLATE = `# Shared Agent Profile\n\n## Operating Rules\nDefine stable behavior rules, priorities, and constraints.\n\n## User Preferences\nCapture durable preferences that apply broadly.\n\n## Privacy Rules\nSpecify what must remain private.\n\n## Tool Conventions\nDefine tool usage conventions.\n\n## Capabilities\nList what the agent can do.\n\n## Communication\nDefine message delivery, internal thoughts, sub-agent rules.\n\n## Message Formatting\nChannel-specific formatting rules.\n`;
+```
+
+---
+
+## 2. group.ts — Seed SOUL.md on agent add
+
+**File:** `apps/core/src/cli/group.ts`
+
+**a) Add default SOUL.md template function (after line 185):**
+```typescript
+function createDefaultSoulMarkdown(): string {
+  return [
+    '# Soul — Who You Are',
+    '',
+    '## Personality',
+    '- You are sharp, direct, and genuinely helpful.',
+    '- Have strong opinions. Don\'t hedge with "it depends" when a clear answer exists.',
+    '- Be concise. If one sentence works, use one sentence. Respect the user\'s time.',
+    '- Never open with filler: no "Great question!", "I\'d be happy to help!", "Absolutely!"',
+    '- Lead with the answer, not the reasoning. Skip preamble.',
+    '',
+    '## Voice',
+    '- Write like a smart colleague, not a customer-support bot.',
+    '- Humor is welcome when it lands naturally. Don\'t force it.',
+    '- Call things out directly. If something is wrong, say so — charm over cruelty.',
+    '- Be proactive. Suggest ideas, spot problems, take initiative.',
+    '- Match the user\'s energy. Casual when they\'re casual, precise when they need precision.',
+    '',
+    '## Boundaries',
+    '- Private context stays private. Never expose secrets or internal details.',
+    '- Ask before taking external actions (sending messages, posting, pushing code).',
+    '- When uncertain, say so. Don\'t present guesses as facts.',
+    '',
+  ].join('\n');
+}
+```
+
+**b) Seed the file during agent creation (after line 330), with existence check:**
+```typescript
+const soulPath = path.join(groupDir, 'SOUL.md');
+if (!fs.existsSync(soulPath)) {
+  fs.writeFileSync(soulPath, createDefaultSoulMarkdown(), 'utf-8');
+}
+```
+
+---
+
+## 3. prompt-profile.test.ts — Tests
+
+**File:** `apps/core/src/runtime/prompt-profile.test.ts`
+
+**Update existing tests:**
+- Replace all `PERSONAL_PROFILE` references with `SHARED_CONTEXT`
+- Replace all `GLOBAL_CONTEXT` references with `SHARED_CONTEXT`
+- Remove tests for `renderPersonalProfileBody`, `parseMarkdownSections`, missing profile sections warnings
+- Update seed file tests: `ensureSeedFiles` now seeds `agents/shared/CLAUDE.md` not `CLAUDE.md` in configDir
+
+**Add new SOUL.md tests:**
+```typescript
+describe('SOUL.md support', () => {
+  it('includes SOUL section when SOUL.md exists in group folder', () => {
+    writeFile(
+      path.join(agentsDir, 'telegram_test', 'SOUL.md'),
+      '# Soul\n\nBe sharp and direct.',
+    );
+    const result = service.compileSystemPrompt({ groupFolder: 'telegram_test' });
+    expect(result).toContain('[[SOUL]]');
+    expect(result).toContain('Be sharp and direct.');
+    expect(result).toContain('CRITICAL IDENTITY DIRECTIVE');
+  });
+
+  it('SOUL appears before SHARED_CONTEXT in output', () => {
+    writeFile(
+      path.join(agentsDir, 'telegram_test', 'SOUL.md'),
+      '# Soul\n\nBe direct.',
+    );
+    const result = service.compileSystemPrompt({ groupFolder: 'telegram_test' });
+    const soulPos = result.indexOf('[[SOUL]]');
+    const sharedPos = result.indexOf('[[SHARED_CONTEXT]]');
+    expect(soulPos).toBeLessThan(sharedPos);
+  });
+
+  it('gracefully skips when SOUL.md is missing', () => {
+    const result = service.compileSystemPrompt({ groupFolder: 'telegram_test' });
+    expect(result).not.toContain('[[SOUL]]');
+  });
+
+  it('gracefully skips when SOUL.md is empty', () => {
+    writeFile(path.join(agentsDir, 'telegram_test', 'SOUL.md'), '');
+    const result = service.compileSystemPrompt({ groupFolder: 'telegram_test' });
+    expect(result).not.toContain('[[SOUL]]');
+  });
+
+  it('truncates SOUL.md when over budget', () => {
+    const longSoul = 'x'.repeat(10000);
+    writeFile(path.join(agentsDir, 'telegram_test', 'SOUL.md'), longSoul);
+    const result = service.compileSystemPrompt({ groupFolder: 'telegram_test' });
+    expect(result).toContain('[[SOUL]]');
+  });
+});
+
+describe('PERSONAL_PROFILE removed', () => {
+  it('does not include PERSONAL_PROFILE section', () => {
+    const result = service.compileSystemPrompt({ groupFolder: 'telegram_test' });
+    expect(result).not.toContain('[[PERSONAL_PROFILE]]');
+  });
+});
+```
+
+---
+
+## 4. Runtime folder cleanup (~/myclaw/)
+
+**a) Rename soul.md → SOUL.md:**
+```bash
+mv ~/myclaw/agents/telegram_kai-dev/soul.md ~/myclaw/agents/telegram_kai-dev/SOUL.md
+```
+
+**b) Merge master CLAUDE.md into shared/CLAUDE.md:**
+
+Take `~/myclaw/CLAUDE.md` content (Operating Rules, User Preferences, Privacy Rules, Tool Conventions, Mandatory Behaviors, Memory MCP Usage) and merge into `~/myclaw/agents/shared/CLAUDE.md`.
+
+Remove from shared/CLAUDE.md:
+- "Personality (always on)" section — moved to SOUL.md
+- "Use the static personal profile as the primary source..." line — no longer applies
+
+Keep in shared/CLAUDE.md (merged result):
+- Operating Rules (from master)
+- Mandatory Behaviors (from master)
+- User Preferences (from master)
+- Privacy Rules (from master)
+- Tool Conventions (from master)
+- Memory MCP Usage (from master)
+- What You Can Do / Capabilities (from current shared)
+- Communication (from current shared)
+- Memory system docs (from current shared)
+- Message Formatting — all channels (from current shared)
+- Task Scripts (from current shared)
+
+**c) Thin out telegram_kai-dev/CLAUDE.md:**
+
+Remove from group CLAUDE.md (already in shared):
+- Capabilities (What You Can Do)
+- Communication (send_message, internal tags, sub-agents)
+- Memory docs
+- Message Formatting (all channel rules)
+- Task Scripts
+- "Use the static personal profile..." line
+
+Keep in group CLAUDE.md (group-specific only):
+- Admin Context (main channel, elevated privileges)
+- Authentication
+- Container Mounts
+- Managing Groups (finding, adding, removing, listing)
+- Scheduling for Other Groups
+- Global Memory
+- Sender Allowlist
+
+**d) Delete master CLAUDE.md:**
+```bash
+rm ~/myclaw/CLAUDE.md
+```
+
+Content is now in `agents/shared/CLAUDE.md`. The code no longer reads from configDir.
+
+---
+
+## 5. Update myclaw-admin skill
+
+**Both locations:**
+- `~/workdir/myclaw/.claude/skills/myclaw-admin/SKILL.md`
+- `~/myclaw/.claude/skills/myclaw-admin/SKILL.md`
+
+Update Runtime File Layout:
+```
+~/myclaw/
+  settings.yaml
+  .env
+  service-meta.json
+  scheduler-jobs.json
+  agent-memory/
+  agents/
+    shared/
+      CLAUDE.md              # Operational base (user prefs, rules, capabilities, formatting)
+    <channel>_<name>/
+      SOUL.md                # Personality, voice, vibe, boundaries
+      CLAUDE.md              # Group-specific overrides
+      memory/
+      conversations/
+      logs/
+  store/
+  data/
+  .claude/
+    skills/
+```
+
+Remove reference to master `~/myclaw/CLAUDE.md`.
+
+---
+
+## Files Summary
+
+**Modified source files:**
+
+| File | Change |
+|------|--------|
+| `apps/core/src/runtime/prompt-profile.ts` | Add SOUL, remove PERSONAL_PROFILE, rename GLOBAL→SHARED, delete dead code |
+| `apps/core/src/cli/group.ts` | Add `createDefaultSoulMarkdown()`, seed SOUL.md on agent add |
+| `apps/core/src/runtime/prompt-profile.test.ts` | Update tests for new section names, add SOUL tests, remove profile parsing tests |
+
+**Runtime folder changes:**
+
+| Action | Path |
+|--------|------|
+| Rename | `agents/telegram_kai-dev/soul.md` → `SOUL.md` |
+| Merge + rewrite | `agents/shared/CLAUDE.md` (absorb master CLAUDE.md content) |
+| Thin out | `agents/telegram_kai-dev/CLAUDE.md` (remove duplicated sections) |
+| Delete | `~/myclaw/CLAUDE.md` (master profile, content merged) |
+| Update | `.claude/skills/myclaw-admin/SKILL.md` (both locations) |
+
+**No new files. No new dependencies. No settings.yaml changes. No ContainerInput changes. No agent-runner changes.**

--- a/docs/plan-webhooks.md
+++ b/docs/plan-webhooks.md
@@ -1,0 +1,197 @@
+# MyClaw Webhooks — Clawdentity-Authenticated Job Trigger & Message Injection
+
+**Status:** Draft
+**Date:** 2026-04-16
+
+---
+
+## Design Decisions
+
+- **Auth:** Clawdentity Ed25519 Proof of Possession (no shared secrets)
+- **Response style:** Fire-and-forget (return job ID immediately)
+- **Token scope:** Per-group (each group has its own allowed DIDs)
+
+---
+
+## 1. Webhook Auth Layer (Clawdentity PoP)
+
+**Goal:** Verify incoming webhook requests using Clawdentity Ed25519 Proof of Possession — no shared secrets.
+
+**New file:** `apps/core/src/mini-app/webhook-auth.ts`
+
+**How it works:**
+- Extract headers: `Authorization: Claw <AIT>`, `X-Claw-Proof`, `X-Claw-Timestamp`, `X-Claw-Nonce`, `X-Claw-Body-SHA256`
+- Decode AIT JWT to get agent DID and public key
+- Verify Ed25519 signature over `{method}|{path}|{timestamp}|{nonce}|{bodySha256}`
+- Check timestamp within ±300s, reject replayed nonces
+- Optionally validate agent DID against CRL (revocation list) from registry
+
+**Per-group scoping:**
+- New `settings.yaml` section under each group or in `message_policy`:
+  ```yaml
+  webhooks:
+    telegram_kai-dev:
+      allowed_dids: ["did:cdi:registry.clawdentity.com:agent:01HG..."]
+    telegram_ops:
+      allowed_dids: ["did:cdi:registry.clawdentity.com:agent:01HK..."]
+  ```
+- Request must include `X-Claw-Group: telegram_kai-dev` header
+- Auth middleware checks if the agent's DID is in that group's `allowed_dids`
+
+**Dependencies:** Import signing/verification utils from `~/workdir/clawdentity/packages/sdk` or vendor the Ed25519 verify function.
+
+**Fallback consideration:** If Clawdentity infra isn't available, we could add a `WEBHOOK_FALLBACK_TOKEN` for dev/testing, but PoP is the primary path.
+
+---
+
+## 2. Webhook Route: Trigger Job
+
+**Endpoint:** `POST /api/webhooks/jobs/trigger`
+
+**New file:** `apps/core/src/mini-app/webhook-routes.ts`
+
+**Two actions:**
+
+**a) Trigger existing job:**
+```json
+{
+  "action": "trigger",
+  "job_id": "system:dreaming:telegram_kai-dev"
+}
+```
+- Writes `scheduler_trigger_job` IPC task file
+- Returns `{ ok: true, job_id: "...", run_id: "..." }` immediately (fire-and-forget)
+
+**b) Create and run one-time job:**
+```json
+{
+  "action": "once",
+  "name": "External Task",
+  "prompt": "Summarize today's messages",
+  "deliver_to": ["tg:-1003687469956"],
+  "timeout_ms": 300000
+}
+```
+- Group scope derived from `X-Claw-Group` header (already validated by auth)
+- Writes `scheduler_once` IPC task file
+- Returns `{ ok: true, job_id: "generated-id" }` immediately
+
+**Validation:**
+- `action` must be `trigger` or `once`
+- For `trigger`: `job_id` required, must exist, must belong to the authed group
+- For `once`: `name` and `prompt` required
+- Max `timeout_ms`: 600000 (10 min)
+
+**Response:** Always async. Caller gets job ID back. Job output delivered to `deliver_to` sessions (Telegram chats).
+
+---
+
+## 3. Webhook Route: Send Message to Agent
+
+**Endpoint:** `POST /api/webhooks/messages/send`
+
+**Request:**
+```json
+{
+  "text": "Hey, check if the deployment succeeded",
+  "chat_jid": "tg:-1003687469956"
+}
+```
+- Group derived from `X-Claw-Group` header
+
+**Logic:**
+1. Validate `chat_jid` belongs to the target group (query `registered_groups` table)
+2. Check if there's an active agent session for this group:
+   - **Active session exists:** Write to `$DATA_DIR/ipc/{groupFolder}/input/{id}.json` — agent's `pollIpcDuringQuery()` picks it up in ~500ms, message injected mid-conversation
+   - **No active session:** Write to `$DATA_DIR/ipc/{groupFolder}/messages/{id}.json` — IPC watcher picks it up, triggers new agent spawn with the message as prompt
+3. Return `{ ok: true, delivered: true, mode: "session" | "new" }`
+
+**Session detection:**
+- Need a helper to check if a group has an active running agent process
+- Could check `$DATA_DIR/ipc/{groupFolder}/input/` existence + agent PID file, or add a lightweight session registry in the scheduler/message-loop
+
+**Edge case:** If agent is mid-spawn (between process start and ready), queue the message — the input poll will catch it once ready.
+
+---
+
+## 4. Mini-App Server Changes
+
+**File:** `apps/core/src/mini-app/server.ts`
+
+**Changes:**
+- Import and register webhook routes under `/api/webhooks/*` prefix
+- Webhook routes use `webhook-auth` middleware (Clawdentity PoP), NOT Telegram auth
+- Existing plan management routes stay on Telegram auth — no change
+
+**Route registration:**
+```typescript
+// Existing
+server.register(planRoutes, { prefix: '/api/plans' });
+
+// New
+server.register(webhookRoutes, { prefix: '/api/webhooks' });
+```
+
+**CORS:** Webhooks are server-to-server, so no CORS needed. Add `no-cors` for webhook prefix.
+
+**Rate limiting:** Add per-DID rate limit (e.g., 60 req/min) using in-memory counter with TTL. Prevents abuse without external deps.
+
+---
+
+## 5. Settings & Config Changes
+
+**settings.yaml — new `webhooks` section:**
+```yaml
+webhooks:
+  enabled: true
+  groups:
+    telegram_kai-dev:
+      allowed_dids:
+        - "did:cdi:registry.clawdentity.com:agent:01HG8ZBU..."
+    telegram_ops:
+      allowed_dids:
+        - "did:cdi:registry.clawdentity.com:agent:01HK9ABC..."
+```
+
+**Parsing changes:**
+- `runtime-settings.ts` — add `webhooks` to `RuntimeSettings` interface and parser
+- Validate: if `webhooks.enabled`, each group must be a registered group folder
+- Validate: each DID must match `did:cdi:*` format
+
+**.env additions:**
+- `CLAWDENTITY_REGISTRY_URL` — registry URL for CRL fetch (optional, for revocation checking)
+- `WEBHOOK_NONCE_TTL_MS` — nonce replay window (default 600000)
+
+**config.ts:**
+- Add `CLAWDENTITY_REGISTRY_URL` and `WEBHOOK_NONCE_TTL_MS` to config constants
+
+---
+
+## 6. Files Summary & Dependencies
+
+**New files:**
+
+| File | Purpose |
+|------|---------|
+| `apps/core/src/mini-app/webhook-auth.ts` | Clawdentity PoP verification middleware |
+| `apps/core/src/mini-app/webhook-routes.ts` | Both webhook route handlers |
+| `apps/core/src/mini-app/nonce-cache.ts` | In-memory nonce replay prevention |
+
+**Modified files:**
+
+| File | Change |
+|------|--------|
+| `apps/core/src/mini-app/server.ts` | Register webhook routes |
+| `apps/core/src/cli/runtime-settings.ts` | Parse + validate `webhooks` section |
+| `apps/core/src/core/config.ts` | Add webhook config constants |
+| `.env.example` | Add `CLAWDENTITY_REGISTRY_URL` |
+
+**Dependencies:**
+- Ed25519 verify: use `@noble/ed25519` (already a transitive dep via Clawdentity SDK) or vendor from `~/workdir/clawdentity/packages/sdk/src/crypto/`
+- JWT decode: lightweight AIT decode (no full JWT lib needed — just base64url split + JSON parse, signature already verified via PoP)
+- No new npm packages required if we vendor the crypto utils
+
+**Testing:**
+- Unit tests for webhook-auth (mock Ed25519 keypair, sign requests, verify)
+- Unit tests for webhook-routes (mock IPC writes, verify file contents)
+- Integration test: full request → IPC file → scheduler pickup

--- a/packages/agent-runner/src/index.ts
+++ b/packages/agent-runner/src/index.ts
@@ -448,6 +448,7 @@ async function runQuery(
   queryThinking: ThinkingConfig | undefined,
   queryEffort: EffortLevel | undefined,
   resumeAt?: string,
+  enableIpcFollowups = true,
 ): Promise<{
   newSessionId?: string;
   lastAssistantUuid?: string;
@@ -461,6 +462,7 @@ async function runQuery(
   let ipcPolling = true;
   let closedDuringQuery = false;
   const pollIpcDuringQuery = () => {
+    if (!enableIpcFollowups) return;
     if (!ipcPolling) return;
     if (shouldClose()) {
       log('Close sentinel detected during query, ending stream');
@@ -476,7 +478,9 @@ async function runQuery(
     }
     setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
   };
-  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  if (enableIpcFollowups) {
+    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  }
 
   let newSessionId: string | undefined;
   let lastAssistantUuid: string | undefined;
@@ -1007,13 +1011,15 @@ async function main(): Promise<void> {
   log(`Configured thinking: ${configuredThinking.description}`);
 
   let sessionId = containerInput.sessionId;
-  fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+  if (!containerInput.isScheduledJob) {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
-  // Clean up stale _close sentinel from previous container runs
-  try {
-    fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
-  } catch {
-    /* ignore */
+    // Clean up stale _close sentinel from previous container runs
+    try {
+      fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
+    } catch {
+      /* ignore */
+    }
   }
 
   // Build initial prompt (drain any pending IPC messages too)
@@ -1022,10 +1028,14 @@ async function main(): Promise<void> {
   if (containerInput.isScheduledJob) {
     prompt = `[SCHEDULED JOB - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
   }
-  const pending = drainIpcInput();
-  if (pending.length > 0) {
-    log(`Draining ${pending.length} pending IPC messages into initial prompt`);
-    prompt += '\n' + pending.join('\n');
+  if (!containerInput.isScheduledJob) {
+    const pending = drainIpcInput();
+    if (pending.length > 0) {
+      log(
+        `Draining ${pending.length} pending IPC messages into initial prompt`,
+      );
+      prompt += '\n' + pending.join('\n');
+    }
   }
 
   // --- Session slash commands + resume model preflight ---
@@ -1111,6 +1121,41 @@ async function main(): Promise<void> {
     prompt = `[SCHEDULED JOB]\n\nScript output:\n${JSON.stringify(scriptResult.data, null, 2)}\n\nInstructions:\n${containerInput.prompt}`;
   }
 
+  if (containerInput.isScheduledJob) {
+    log(
+      `Starting one-shot scheduled query (session: ${sessionId || 'new'})...`,
+    );
+    try {
+      const queryResult = await runQuery(
+        prompt,
+        sessionId,
+        mcpServerPath,
+        containerInput,
+        sdkEnv,
+        configuredModel.model,
+        configuredThinking.thinking,
+        configuredThinking.effort,
+        undefined,
+        false,
+      );
+      if (queryResult.newSessionId) {
+        sessionId = queryResult.newSessionId;
+      }
+      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+      return;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log(`Scheduled job error: ${errorMessage}`);
+      writeOutput({
+        status: 'error',
+        result: null,
+        newSessionId: sessionId,
+        error: errorMessage,
+      });
+      process.exit(1);
+    }
+  }
+
   // Query loop: run query → wait for IPC message → run new query → repeat
   let resumeAt: string | undefined;
   try {
@@ -1129,6 +1174,7 @@ async function main(): Promise<void> {
         configuredThinking.thinking,
         configuredThinking.effort,
         resumeAt,
+        true,
       );
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;

--- a/packages/agent-runner/src/ipc-mcp-stdio.ts
+++ b/packages/agent-runner/src/ipc-mcp-stdio.ts
@@ -218,6 +218,71 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function normalizeExecutionMode(
+  executionMode: unknown,
+  serialize: unknown,
+): 'parallel' | 'serialized' {
+  if (executionMode === 'serialized') return 'serialized';
+  if (executionMode === 'parallel') return 'parallel';
+  if (typeof serialize === 'boolean') {
+    return serialize ? 'serialized' : 'parallel';
+  }
+  return 'parallel';
+}
+
+function filterSchedulerEvents(
+  events: unknown[],
+  args: {
+    job_id?: string;
+    run_id?: string;
+    event_type?: string;
+    since_id?: number;
+    since?: string;
+  },
+): Array<{
+  id?: number;
+  job_id?: string;
+  run_id?: string | null;
+  event_type?: string;
+  payload?: string | null;
+  created_at?: string;
+}> {
+  const sinceTimestamp = args.since ? Date.parse(args.since) : NaN;
+  return events.filter((item) => {
+    if (typeof item !== 'object' || item === null) return false;
+    const row = item as {
+      id?: number;
+      job_id?: string;
+      run_id?: string | null;
+      event_type?: string;
+      created_at?: string;
+    };
+    if (args.job_id && row.job_id !== args.job_id) return false;
+    if (args.run_id && row.run_id !== args.run_id) return false;
+    if (args.event_type && row.event_type !== args.event_type) return false;
+    if (
+      typeof args.since_id === 'number' &&
+      Number.isFinite(args.since_id) &&
+      typeof row.id === 'number' &&
+      row.id <= args.since_id
+    ) {
+      return false;
+    }
+    if (!Number.isNaN(sinceTimestamp) && row.created_at) {
+      const created = Date.parse(row.created_at);
+      if (Number.isFinite(created) && created <= sinceTimestamp) return false;
+    }
+    return true;
+  }) as Array<{
+    id?: number;
+    job_id?: string;
+    run_id?: string | null;
+    event_type?: string;
+    payload?: string | null;
+    created_at?: string;
+  }>;
+}
+
 function truncateText(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   return `${value.slice(0, maxLength - 1)}…`;
@@ -731,6 +796,8 @@ server.tool(
     max_retries: z.number().optional(),
     retry_backoff_ms: z.number().optional(),
     max_consecutive_failures: z.number().optional(),
+    execution_mode: z.enum(['parallel', 'serialized']).optional(),
+    serialize: z.boolean().optional(),
   },
   async (args) => {
     if (args.schedule_type === 'cron') {
@@ -784,6 +851,11 @@ server.tool(
       maxRetries: args.max_retries,
       retryBackoffMs: args.retry_backoff_ms,
       maxConsecutiveFailures: args.max_consecutive_failures,
+      executionMode: normalizeExecutionMode(
+        args.execution_mode,
+        args.serialize,
+      ),
+      serialize: args.serialize,
       createdBy: 'agent',
       timestamp: new Date().toISOString(),
     };
@@ -815,6 +887,8 @@ server.tool(
     max_retries: z.number().optional(),
     retry_backoff_ms: z.number().optional(),
     max_consecutive_failures: z.number().optional(),
+    execution_mode: z.enum(['parallel', 'serialized']).optional(),
+    serialize: z.boolean().optional(),
   },
   async (args) => {
     const runAtDate = new Date(args.run_at);
@@ -843,6 +917,11 @@ server.tool(
       maxRetries: args.max_retries,
       retryBackoffMs: args.retry_backoff_ms,
       maxConsecutiveFailures: args.max_consecutive_failures,
+      executionMode: normalizeExecutionMode(
+        args.execution_mode,
+        args.serialize,
+      ),
+      serialize: args.serialize,
       createdBy: 'agent',
       timestamp: new Date().toISOString(),
     });
@@ -927,8 +1006,14 @@ server.tool(
     max_retries: z.number().optional(),
     retry_backoff_ms: z.number().optional(),
     max_consecutive_failures: z.number().optional(),
+    execution_mode: z.enum(['parallel', 'serialized']).optional(),
+    serialize: z.boolean().optional(),
   },
   async (args) => {
+    const executionMode =
+      args.execution_mode !== undefined || args.serialize !== undefined
+        ? normalizeExecutionMode(args.execution_mode, args.serialize)
+        : undefined;
     writeIpcFile(TASKS_DIR, {
       type: 'scheduler_update_job',
       jobId: args.job_id,
@@ -947,6 +1032,8 @@ server.tool(
       maxRetries: args.max_retries,
       retryBackoffMs: args.retry_backoff_ms,
       maxConsecutiveFailures: args.max_consecutive_failures,
+      executionMode,
+      serialize: args.serialize,
       timestamp: new Date().toISOString(),
     });
     return {
@@ -1051,6 +1138,90 @@ server.tool(
       content: [
         { type: 'text' as const, text: JSON.stringify(filtered, null, 2) },
       ],
+    };
+  },
+);
+
+server.tool(
+  'scheduler_list_events',
+  'List scheduler lifecycle events from host snapshots.',
+  {
+    job_id: z.string().optional(),
+    run_id: z.string().optional(),
+    event_type: z.string().optional(),
+    since_id: z.number().optional(),
+    since: z.string().optional(),
+    limit: z.number().optional(),
+  },
+  async (args) => {
+    const events = readJsonArraySnapshot(
+      path.join(IPC_DIR, 'current_job_events.json'),
+    );
+    const filtered = filterSchedulerEvents(events, args).slice(
+      0,
+      args.limit ?? 100,
+    );
+    writeIpcFile(TASKS_DIR, {
+      type: 'scheduler_list_events',
+      jobId: args.job_id,
+      runId: args.run_id,
+      eventType: args.event_type,
+      sinceId: args.since_id,
+      limit: args.limit,
+      timestamp: new Date().toISOString(),
+    });
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(filtered, null, 2) },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'scheduler_wait_for_events',
+  'Wait for scheduler lifecycle events to arrive in host snapshots.',
+  {
+    job_id: z.string().optional(),
+    run_id: z.string().optional(),
+    event_type: z.string().optional(),
+    since_id: z.number().optional(),
+    since: z.string().optional(),
+    limit: z.number().optional(),
+    timeout_ms: z.number().optional(),
+  },
+  async (args) => {
+    const timeoutMs = Math.max(
+      1_000,
+      Math.min(args.timeout_ms ?? 30_000, 120_000),
+    );
+    const limit = Math.max(1, Math.min(args.limit ?? 100, 500));
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const events = readJsonArraySnapshot(
+        path.join(IPC_DIR, 'current_job_events.json'),
+      );
+      const filtered = filterSchedulerEvents(events, args).slice(0, limit);
+      if (filtered.length > 0) {
+        writeIpcFile(TASKS_DIR, {
+          type: 'scheduler_wait_for_events',
+          jobId: args.job_id,
+          runId: args.run_id,
+          eventType: args.event_type,
+          sinceId: args.since_id,
+          limit,
+          timestamp: new Date().toISOString(),
+        });
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(filtered, null, 2) },
+          ],
+        };
+      }
+      await sleep(250);
+    }
+    return {
+      content: [{ type: 'text' as const, text: '[]' }],
     };
   },
 );


### PR DESCRIPTION
## Summary
- add SOUL-first prompt profile composition and seed/update associated runtime profile files
- improve scheduler execution behavior with isolated scheduler sessions, lifecycle events, and streaming delivery hardening
- add `ask_user_question` MCP flow and related IPC/runtime handling updates
- fix scheduler update-mode regression (partial updates no longer force `parallel`)
- prevent scheduler queue key buildup by cleaning idle ephemeral scheduler groups

## Validation
- `python3 .codex/scripts/validate_work.py`
- `npm test -- apps/core/src/runtime/group-queue.test.ts apps/core/src/runtime/ipc.test.ts`
- `npm test -- apps/core/src/runtime/task-scheduler.test.ts`
- `npm run build`

## Notes
- includes follow-up fixes from review findings before opening PR (execution mode preservation + queue cleanup)
