### PR TITLE
A0.3: add architecture fitness checks to Codex verify harness

### DIFF
--- a/.claude/skills/myclaw-admin/SKILL.md
+++ b/.claude/skills/myclaw-admin/SKILL.md
@@ -92,7 +92,7 @@ Complete reference for managing the MyClaw runtime. The CLI binary is `myclaw` a
 - `MINI_APP_PORT` — Mini App port (default: 3100)
 - `ASSISTANT_NAME` — Assistant display name
 - `AGENT_ROOT` — Runtime home directory
-- `AGENT_RUNTIME` — `container` (default) or `host`
+- Runtime mode — Host runtime is the only supported mode.
 
 ### Channel Connection
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -12,3 +12,5 @@ This folder owns factory prompts, hook wiring, agent prompt contracts, and tests
 - Avoid prompt duplication. If a rule belongs in a shared checklist, put it in `prompts/self-check.md` and reference it from other prompts.
 - When adding prompt policy, add or update tests under `.codex/scripts/tests/` so the contract does not silently drift.
 - Do not let prompt changes invent new product behavior or bypass the existing PR-ready review gates.
+- Deterministic verify includes an architecture phase (`python3 .codex/scripts/check_architecture.py`) before typecheck/tests.
+- Architecture exceptions belong in `.codex/architecture-exceptions.json`, must include owner/reason/expiry, and should be temporary caps instead of permanent waivers.

--- a/.codex/architecture-exceptions.json
+++ b/.codex/architecture-exceptions.json
@@ -1,0 +1,221 @@
+{
+  "version": 1,
+  "exceptions": [
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/channels/slack.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 1712,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/channels/telegram.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 2089,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/cli/doctor.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 581,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/cli/group.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 1443,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/cli/runtime-settings.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 655,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/cli/service-manager.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 603,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/cli/setup-flow.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 947,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/cli/slack.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 537,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/core/config.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 678,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/index.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 596,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/memory/memory-provider.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 403,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/memory/memory-service.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 1056,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/memory/memory-store.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 1341,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/mini-app/plan-store.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 417,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/mini-app/server.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 561,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/runtime/agent-spawn-process.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 407,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/runtime/group-processing.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 726,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/runtime/group-queue.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 568,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/runtime/ipc.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 2489,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/runtime/task-scheduler.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 977,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/session/session-commands.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 432,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "apps/core/src/storage/db.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 1206,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "packages/agent-runner/src/index.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 1222,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    },
+    {
+      "rule": "file_size_budget",
+      "target": "packages/agent-runner/src/ipc-mcp-stdio.ts",
+      "owner": "A0.3",
+      "reason": "Pre-existing oversized production module; split in a follow-up refactor task.",
+      "expires_on": "2026-09-30",
+      "max_lines": 1927,
+      "delete_after": "File is split into production modules at or below 400 LOC."
+    }
+  ]
+}

--- a/.codex/scripts/architecture_rules.py
+++ b/.codex/scripts/architecture_rules.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import date
+from pathlib import Path
+
+FILE_SIZE_LIMIT = 400
+FILE_SIZE_RULE = "file_size_budget"
+REQUIRED_EXCEPTION_FIELDS = ("rule", "target", "owner", "reason", "expires_on")
+
+ACTIVE_DOC_FILES = (
+    "README.md",
+    "AGENTS.md",
+    "WORKFLOW.md",
+    "CONTRIBUTING.md",
+    "docs/FACTORY.md",
+    "docs/QUALITY.md",
+    "docs/SECURITY.md",
+)
+
+FORBIDDEN_IMPORT_RULES = (
+    (
+        "apps/core/src/core",
+        (
+            "apps/core/src/runtime",
+            "apps/core/src/channels",
+            "apps/core/src/cli",
+            "apps/core/src/storage",
+            "apps/core/src/session",
+            "apps/core/src/memory",
+            "apps/core/src/mini-app",
+        ),
+    ),
+    (
+        "apps/core/src/platform",
+        (
+            "apps/core/src/runtime",
+            "apps/core/src/channels",
+            "apps/core/src/cli",
+            "apps/core/src/storage",
+            "apps/core/src/session",
+            "apps/core/src/memory",
+            "apps/core/src/mini-app",
+        ),
+    ),
+    (
+        "apps/core/src/storage",
+        (
+            "apps/core/src/runtime",
+            "apps/core/src/channels",
+            "apps/core/src/cli",
+            "apps/core/src/session",
+            "apps/core/src/memory",
+            "apps/core/src/mini-app",
+        ),
+    ),
+    (
+        "apps/core/src/runtime",
+        (
+            "apps/core/src/channels",
+            "apps/core/src/cli",
+            "apps/core/src/mini-app",
+        ),
+    ),
+    ("apps/core/src/channels", ("apps/core/src/cli",)),
+    ("apps/mini-app/src", ("apps/core/src",)),
+    ("packages/agent-runner/src", ("apps/core/src",)),
+)
+
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+IMPORT_FROM_RE = re.compile(r"(?:^|\n)\s*(?:import|export)\b[^;]*?\bfrom\s*['\"]([^'\"]+)['\"]", re.MULTILINE)
+SIDE_EFFECT_IMPORT_RE = re.compile(r"(?:^|\n)\s*import\s*['\"]([^'\"]+)['\"]", re.MULTILINE)
+
+RECOGNIZED_CODE_PATH_EXTENSIONS = {
+    ".md",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".json",
+    ".toml",
+    ".yaml",
+    ".yml",
+    ".py",
+    ".sh",
+}
+
+ROOT_FILE_REFERENCES = {
+    "README.md",
+    "AGENTS.md",
+    "WORKFLOW.md",
+    "CONTRIBUTING.md",
+    "CHANGELOG.md",
+    "CLAUDE.md",
+}
+
+
+def repo_root_from_git() -> Path:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(proc.stdout.strip())
+
+
+def path_in_repo(root: Path, path: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def is_production_source(rel_path: Path) -> bool:
+    rel_text = rel_path.as_posix()
+    lower = rel_text.lower()
+    if rel_path.suffix not in {".ts", ".tsx"}:
+        return False
+    if "/src/" not in rel_text:
+        return False
+    if ".d.ts" in lower:
+        return False
+    if any(token in lower for token in ("/__tests__/", "/test/", "/tests/", ".test.", ".spec.", ".generated.")):
+        return False
+    if any(part.lower() in {"node_modules", "dist", "coverage", "generated", "__generated__"} for part in rel_path.parts):
+        return False
+    return rel_text.startswith("apps/") or rel_text.startswith("packages/")
+
+
+def iter_production_sources(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for top in ("apps", "packages"):
+        base = root / top
+        if not base.exists():
+            continue
+        for glob in ("*.ts", "*.tsx"):
+            for file_path in base.rglob(glob):
+                rel_path = file_path.relative_to(root)
+                if is_production_source(rel_path):
+                    files.append(file_path)
+    return sorted(set(files))
+
+
+def load_exceptions(exceptions_path: Path) -> tuple[dict[str, object] | None, list[str]]:
+    if not exceptions_path.exists():
+        return None, [f"Missing exceptions file: {exceptions_path.as_posix()}"]
+    try:
+        payload = json.loads(exceptions_path.read_text())
+    except json.JSONDecodeError as exc:
+        return None, [f"Invalid JSON in {exceptions_path.as_posix()}: {exc}"]
+    if not isinstance(payload, dict):
+        return None, [f"{exceptions_path.as_posix()} must be a JSON object."]
+    return payload, []
+
+
+def normalize_repo_relative(path_value: str) -> str:
+    return Path(path_value).as_posix()
+
+
+def validate_exceptions(
+    root: Path,
+    exceptions_path: Path,
+    production_files: set[str],
+    today: date,
+) -> tuple[dict[str, dict[str, object]], list[str]]:
+    payload, issues = load_exceptions(exceptions_path)
+    if payload is None:
+        return {}, issues
+
+    version = payload.get("version")
+    if version != 1:
+        issues.append("Exceptions file must set `version` to 1.")
+
+    raw_exceptions = payload.get("exceptions")
+    if not isinstance(raw_exceptions, list):
+        issues.append("Exceptions file must include an `exceptions` array.")
+        return {}, sorted(issues)
+
+    by_target: dict[str, dict[str, object]] = {}
+    seen: set[tuple[str, str]] = set()
+    for index, item in enumerate(raw_exceptions):
+        prefix = f"exceptions[{index}]"
+        if not isinstance(item, dict):
+            issues.append(f"{prefix} must be an object.")
+            continue
+
+        item_issues: list[str] = []
+        missing = [field for field in REQUIRED_EXCEPTION_FIELDS if not str(item.get(field, "")).strip()]
+        if missing:
+            item_issues.append(f"{prefix} is missing required fields: {', '.join(missing)}")
+
+        rule = str(item.get("rule", "")).strip()
+        target = normalize_repo_relative(str(item.get("target", "")).strip())
+        expires_on = str(item.get("expires_on", "")).strip()
+
+        if Path(target).is_absolute():
+            item_issues.append(f"{prefix} target must be repo-relative: {target}")
+        if rule != FILE_SIZE_RULE:
+            item_issues.append(f"{prefix} has unsupported rule `{rule}`.")
+
+        target_path = root / target
+        if not target:
+            item_issues.append(f"{prefix} target must be non-empty.")
+        elif not target_path.exists():
+            item_issues.append(f"{prefix} points to a missing target: {target}")
+
+        if target and target not in production_files:
+            item_issues.append(f"{prefix} target is not a production source file: {target}")
+
+        try:
+            expiry = date.fromisoformat(expires_on)
+        except ValueError:
+            item_issues.append(f"{prefix} has invalid `expires_on` date: {expires_on}")
+        else:
+            if expiry < today:
+                item_issues.append(f"{prefix} is expired on {expires_on}.")
+
+        max_lines = item.get("max_lines")
+        if not isinstance(max_lines, int) or max_lines <= FILE_SIZE_LIMIT:
+            item_issues.append(f"{prefix} must include integer `max_lines` greater than {FILE_SIZE_LIMIT}.")
+
+        key = (rule, target)
+        if key in seen:
+            item_issues.append(f"{prefix} duplicates rule/target pair `{rule}:{target}`.")
+        seen.add(key)
+
+        if item_issues:
+            issues.extend(item_issues)
+            continue
+
+        by_target[target] = item
+
+    return by_target, sorted(issues)
+
+
+def count_lines(path: Path) -> int:
+    return len(path.read_text().splitlines())
+
+
+def check_file_size_budget(production_files: list[Path], root: Path, exceptions: dict[str, dict[str, object]]) -> list[str]:
+    issues: list[str] = []
+    over_budget: set[str] = set()
+    for file_path in production_files:
+        rel = file_path.relative_to(root).as_posix()
+        line_count = count_lines(file_path)
+        if line_count <= FILE_SIZE_LIMIT:
+            continue
+        over_budget.add(rel)
+        exception = exceptions.get(rel)
+        if exception is None:
+            issues.append(f"{rel} has {line_count} lines (limit {FILE_SIZE_LIMIT}) and no exception.")
+            continue
+        max_lines = int(exception["max_lines"])
+        if line_count > max_lines:
+            issues.append(f"{rel} has {line_count} lines but exception max_lines is {max_lines}.")
+
+    for target in sorted(exceptions):
+        if target not in over_budget:
+            issues.append(f"{target} has an exception but is now within {FILE_SIZE_LIMIT} lines; remove it.")
+    return sorted(issues)
+
+
+def extract_import_specifiers(source_text: str) -> list[str]:
+    specs = IMPORT_FROM_RE.findall(source_text)
+    specs.extend(SIDE_EFFECT_IMPORT_RE.findall(source_text))
+    return specs
+
+
+def resolve_import_target(root: Path, source_file: Path, specifier: str) -> str | None:
+    if specifier.startswith("."):
+        base = (source_file.parent / specifier).resolve()
+    elif specifier.startswith(("apps/", "packages/")):
+        base = (root / specifier).resolve()
+    else:
+        return None
+
+    if not path_in_repo(root, base):
+        return None
+
+    candidates = [base]
+    if not base.suffix:
+        candidates.extend(
+            [
+                base.with_suffix(".ts"),
+                base.with_suffix(".tsx"),
+                base.with_suffix(".d.ts"),
+                base.with_suffix(".js"),
+                base / "index.ts",
+                base / "index.tsx",
+                base / "index.js",
+            ]
+        )
+
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file() and path_in_repo(root, candidate):
+            return candidate.relative_to(root).as_posix()
+    return None
+
+
+def path_matches_prefix(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def check_forbidden_import_edges(production_files: list[Path], root: Path) -> list[str]:
+    violations: set[str] = set()
+    for source_file in production_files:
+        source_rel = source_file.relative_to(root).as_posix()
+        source_text = source_file.read_text()
+        for specifier in extract_import_specifiers(source_text):
+            target_rel = resolve_import_target(root, source_file, specifier)
+            if target_rel is None:
+                continue
+            for source_prefix, forbidden_prefixes in FORBIDDEN_IMPORT_RULES:
+                if not path_matches_prefix(source_rel, source_prefix):
+                    continue
+                for forbidden_prefix in forbidden_prefixes:
+                    if path_matches_prefix(target_rel, forbidden_prefix):
+                        violations.add(
+                            f"{source_rel} imports {target_rel} via `{specifier}` "
+                            f"(forbidden {source_prefix} -> {forbidden_prefix})."
+                        )
+    return sorted(violations)
+
+
+def active_docs(root: Path) -> list[Path]:
+    docs: list[Path] = []
+    for rel in ACTIVE_DOC_FILES:
+        path = root / rel
+        if path.exists():
+            docs.append(path)
+    for folder in ("docs/product", "docs/architecture", "docs/decisions"):
+        base = root / folder
+        if not base.exists():
+            continue
+        docs.extend(path for path in sorted(base.rglob("*.md")) if not path.name.startswith("plan-"))
+    unique = {path.relative_to(root).as_posix(): path for path in docs}
+    return [unique[key] for key in sorted(unique)]
+
+
+def should_ignore_markdown_target(target: str) -> bool:
+    normalized = target.strip()
+    if not normalized or normalized.startswith("#") or normalized.startswith("/"):
+        return True
+    if normalized.startswith("~/") or "://" in normalized:
+        return True
+    if normalized.lower().startswith(("mailto:", "tel:")):
+        return True
+    return any(ch in normalized for ch in ("*", "{", "}"))
+
+
+def resolve_doc_target(root: Path, source_doc: Path, target: str) -> Path | None:
+    if target.startswith(("./", "../")):
+        candidate = (source_doc.parent / target).resolve()
+    else:
+        candidate = (root / target).resolve()
+    return candidate if path_in_repo(root, candidate) else None
+
+
+def looks_like_local_file_reference(token: str) -> bool:
+    if " " in token:
+        return False
+    if token.startswith(("/", "~/", "-", "http://", "https://")) or "://" in token:
+        return False
+    if any(ch in token for ch in ("*", "{", "}", "$")) or token.endswith("/"):
+        return False
+    if token.startswith(".factory/"):
+        return False
+    if token in ROOT_FILE_REFERENCES:
+        return True
+    suffix = Path(token).suffix.lower()
+    return suffix in RECOGNIZED_CODE_PATH_EXTENSIONS and "/" in token
+
+
+def check_doc_references(root: Path) -> list[str]:
+    missing: set[str] = set()
+    for doc in active_docs(root):
+        rel_doc = doc.relative_to(root).as_posix()
+        text = doc.read_text()
+        for raw_target in MARKDOWN_LINK_RE.findall(text):
+            target = raw_target.strip().split()[0].strip("<>").split("#", 1)[0]
+            if should_ignore_markdown_target(target):
+                continue
+            resolved = resolve_doc_target(root, doc, target)
+            if resolved is None or not resolved.exists():
+                missing.add(f"{rel_doc} -> {target}")
+        for token in INLINE_CODE_RE.findall(text):
+            if not looks_like_local_file_reference(token):
+                continue
+            resolved = resolve_doc_target(root, doc, token)
+            if resolved is None or not resolved.exists():
+                missing.add(f"{rel_doc} -> {token}")
+    return sorted(missing)

--- a/.codex/scripts/check_architecture.py
+++ b/.codex/scripts/check_architecture.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+
+from architecture_rules import (
+    check_doc_references,
+    check_file_size_budget,
+    check_forbidden_import_edges,
+    iter_production_sources,
+    repo_root_from_git,
+    validate_exceptions,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run architecture fitness checks.")
+    parser.add_argument("--root", help="Repository root path. Defaults to `git rev-parse --show-toplevel`.")
+    parser.add_argument(
+        "--exceptions",
+        default=".codex/architecture-exceptions.json",
+        help="Path to architecture exceptions JSON (absolute or relative to --root).",
+    )
+    return parser.parse_args()
+
+
+def print_grouped_failures(issues: dict[str, list[str]]) -> None:
+    print("Architecture checks failed.")
+    groups = (
+        ("exception_hygiene", "Exception Hygiene"),
+        ("file_size_budget", "File Size Budget"),
+        ("forbidden_import_edges", "Forbidden Import Edges"),
+        ("doc_references", "Active Doc References"),
+    )
+    for key, label in groups:
+        entries = issues.get(key, [])
+        if not entries:
+            continue
+        print(f"\n[{label}]")
+        for entry in entries:
+            print(f"- {entry}")
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve() if args.root else repo_root_from_git()
+    exceptions_path = Path(args.exceptions)
+    if not exceptions_path.is_absolute():
+        exceptions_path = (root / exceptions_path).resolve()
+
+    production_files = iter_production_sources(root)
+    production_rel_paths = {path.relative_to(root).as_posix() for path in production_files}
+    exceptions, exception_hygiene = validate_exceptions(root, exceptions_path, production_rel_paths, date.today())
+
+    grouped_issues = {
+        "exception_hygiene": exception_hygiene,
+        "file_size_budget": check_file_size_budget(production_files, root, exceptions),
+        "forbidden_import_edges": check_forbidden_import_edges(production_files, root),
+        "doc_references": check_doc_references(root),
+    }
+
+    if any(grouped_issues.values()):
+        print_grouped_failures(grouped_issues)
+        return 1
+
+    print("Architecture checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/scripts/tests/test_check_architecture.py
+++ b/.codex/scripts/tests/test_check_architecture.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECK_SCRIPT = SCRIPTS_DIR / "check_architecture.py"
+VERIFY_SCRIPT = SCRIPTS_DIR / "verify.py"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def write_json(path: Path, payload: object) -> None:
+    write_text(path, json.dumps(payload, indent=2) + "\n")
+
+
+def write_lines(path: Path, count: int) -> None:
+    body = "\n".join(f"const line_{index} = {index};" for index in range(count))
+    write_text(path, body + "\n")
+
+
+def make_base_fixture(root: Path) -> Path:
+    write_text(root / "README.md", "# Fixture\n")
+    write_lines(root / "apps/core/src/core/ok.ts", 10)
+    write_json(
+        root / ".codex/architecture-exceptions.json",
+        {"version": 1, "exceptions": []},
+    )
+    return root
+
+
+def run_architecture_check(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECK_SCRIPT),
+            "--root",
+            str(root),
+            "--exceptions",
+            ".codex/architecture-exceptions.json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+class CheckArchitectureTests(unittest.TestCase):
+    def test_clean_fixture_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertIn("Architecture checks passed.", result.stdout)
+
+    def test_over_budget_file_fails_without_exception(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_lines(root / "apps/core/src/core/oversized.ts", 401)
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[File Size Budget]", result.stdout)
+            self.assertIn("apps/core/src/core/oversized.ts has 401 lines", result.stdout)
+
+    def test_valid_and_expired_exception_behavior(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_lines(root / "apps/core/src/core/oversized.ts", 401)
+            write_json(
+                root / ".codex/architecture-exceptions.json",
+                {
+                    "version": 1,
+                    "exceptions": [
+                        {
+                            "rule": "file_size_budget",
+                            "target": "apps/core/src/core/oversized.ts",
+                            "owner": "TEST-1",
+                            "reason": "Fixture baseline",
+                            "expires_on": "2099-12-31",
+                            "max_lines": 401,
+                        }
+                    ],
+                },
+            )
+            passing = run_architecture_check(root)
+            self.assertEqual(passing.returncode, 0, msg=passing.stdout + passing.stderr)
+
+            write_json(
+                root / ".codex/architecture-exceptions.json",
+                {
+                    "version": 1,
+                    "exceptions": [
+                        {
+                            "rule": "file_size_budget",
+                            "target": "apps/core/src/core/oversized.ts",
+                            "owner": "TEST-1",
+                            "reason": "Fixture baseline",
+                            "expires_on": "2000-01-01",
+                            "max_lines": 401,
+                        }
+                    ],
+                },
+            )
+            expired = run_architecture_check(root)
+            self.assertEqual(expired.returncode, 1)
+            self.assertIn("[Exception Hygiene]", expired.stdout)
+            self.assertIn("expired on 2000-01-01", expired.stdout)
+
+    def test_excepted_file_growth_beyond_max_lines_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_lines(root / "apps/core/src/core/oversized.ts", 402)
+            write_json(
+                root / ".codex/architecture-exceptions.json",
+                {
+                    "version": 1,
+                    "exceptions": [
+                        {
+                            "rule": "file_size_budget",
+                            "target": "apps/core/src/core/oversized.ts",
+                            "owner": "TEST-1",
+                            "reason": "Fixture baseline",
+                            "expires_on": "2099-12-31",
+                            "max_lines": 401,
+                        }
+                    ],
+                },
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("max_lines is 401", result.stdout)
+
+    def test_forbidden_import_edge_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_lines(root / "apps/core/src/runtime/worker.ts", 5)
+            write_text(
+                root / "apps/core/src/core/boundary-break.ts",
+                'import { run } from "../runtime/worker";\nexport const value = run;\n',
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Forbidden Import Edges]", result.stdout)
+            self.assertIn("apps/core/src/core/boundary-break.ts imports apps/core/src/runtime/worker.ts", result.stdout)
+
+    def test_stale_doc_reference_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(root / "README.md", "[Missing](docs/not-real.md)\n")
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Active Doc References]", result.stdout)
+            self.assertIn("README.md -> docs/not-real.md", result.stdout)
+
+    def test_malformed_exception_missing_owner_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_lines(root / "apps/core/src/core/oversized.ts", 401)
+            write_json(
+                root / ".codex/architecture-exceptions.json",
+                {
+                    "version": 1,
+                    "exceptions": [
+                        {
+                            "rule": "file_size_budget",
+                            "target": "apps/core/src/core/oversized.ts",
+                            "reason": "Fixture baseline",
+                            "expires_on": "2099-12-31",
+                            "max_lines": 401,
+                        }
+                    ],
+                },
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Exception Hygiene]", result.stdout)
+            self.assertIn("missing required fields: owner", result.stdout)
+
+
+class VerifyContractTests(unittest.TestCase):
+    def test_verify_print_only_includes_architecture_phase(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(VERIFY_SCRIPT), "--print-only"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        phases = [line.split(":", 1)[0] for line in result.stdout.splitlines() if ":" in line]
+        self.assertIn("architecture", phases)
+        self.assertLess(phases.index("structural"), phases.index("architecture"))
+        self.assertLess(phases.index("architecture"), phases.index("typecheck"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.codex/scripts/verify.py
+++ b/.codex/scripts/verify.py
@@ -17,6 +17,11 @@ commands = [
         os.environ.get("FACTORY_STRUCTURAL_CMD")
         or "npm run format:check",
     ),
+    (
+        "architecture",
+        os.environ.get("FACTORY_ARCHITECTURE_CMD")
+        or "python3 .codex/scripts/check_architecture.py",
+    ),
     ("typecheck", os.environ.get("FACTORY_TYPECHECK_CMD") or "npm run typecheck"),
     ("tests", os.environ.get("FACTORY_TEST_CMD") or "npm test"),
 ]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For guided changes, run `/customize`.
 
 Contributions should keep the core runtime small and maintainable. Bug fixes, simplifications, docs improvements, and reusable skills are good fits. Broad feature creep in the default runtime is not.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution policy and [docs/skills-as-branches.md](docs/skills-as-branches.md) for the branch-based skill model.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution policy and branch-based skill model.
 
 ## Documentation
 

--- a/apps/core/src/cli/doctor.ts
+++ b/apps/core/src/cli/doctor.ts
@@ -235,13 +235,6 @@ export function runDoctor(
     });
   }
 
-  add(checks, {
-    id: 'runtime-mode',
-    title: 'Runtime Mode',
-    status: 'pass',
-    message: 'Host runtime is active and officially supported.',
-  });
-
   const settingsResult = loadSettingsForDoctor(runtimeHome);
   const settings = settingsResult.settings;
   const telegramEnabled = settings?.channels.telegram.enabled ?? false;

--- a/apps/core/src/cli/platform.ts
+++ b/apps/core/src/cli/platform.ts
@@ -55,19 +55,6 @@ export function getNodeMajorVersion(): number {
   return Number.isFinite(major) ? major : 0;
 }
 
-export function hasDocker(): boolean {
-  return commandExists('docker');
-}
-
-export function isDockerRunning(): boolean {
-  if (!hasDocker()) return false;
-  return tryExec('docker', ['info']).ok;
-}
-
-export function hasAppleContainer(): boolean {
-  return commandExists('container');
-}
-
 export function hasSystemdUser(): boolean {
   if (detectPlatform() !== 'linux') return false;
   if (!commandExists('systemctl')) return false;

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -4,7 +4,7 @@
 
 Every change must pass five independent checks:
 1. automated tests
-2. deterministic verify
+2. deterministic verify (structural, architecture, typecheck, tests)
 3. quality review
 4. performance review
 5. security review

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -27,6 +27,8 @@ There is no active container isolation boundary in the current runtime.
 - outside project root
 - not writable by runtime agents by default
 
+In host runtime, this allowlist controls what paths are exposed to the agent runner. It is a policy boundary, not a kernel isolation boundary.
+
 **Default Blocked Patterns:**
 ```
 .ssh, .gnupg, .aws, .azure, .gcloud, .kube, .docker,
@@ -59,6 +61,17 @@ Messages and scheduler operations are verified against group identity:
 | View all jobs | ✓ | Own only |
 | Manage other groups | ✓ | ✗ |
 
+## Privilege Comparison (Host Runtime)
+
+| Capability | Main Group | Non-Main Group |
+|------------|------------|----------------|
+| Project root access | Allowed by configured mounts | Not granted by default |
+| Group folder | Own group (rw) | Own group (rw) |
+| Global memory access | Read/write | Read-only (when mounted) |
+| Additional mounts | Configurable by admin policy | Read-only unless policy allows write |
+| Scheduler control scope | All groups | Own group only |
+| Session commands (`/new`, `/model`, `/runtime`) | Allowed | Admin/trusted sender only |
+
 ### 5. Credential Isolation (OneCLI Agent Vault)
 
 Credentials should be provided through OneCLI and runtime environment controls.
@@ -78,3 +91,28 @@ The following names still exist in code/schema and are tracked for cleanup:
 - `AdditionalMount.containerPath`
 
 These are naming artifacts, not evidence of active container runtime support.
+
+## Security Architecture (Host Runtime)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        UNTRUSTED INPUT                           │
+│  Incoming channel messages (prompt-injection risk)               │
+└────────────────────────────────┬─────────────────────────────────┘
+                                 │
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                     HOST ORCHESTRATOR                            │
+│  • message routing and authorization checks                      │
+│  • scheduler and IPC policy enforcement                          │
+│  • mount/path allowlist validation                               │
+└────────────────────────────────┬─────────────────────────────────┘
+                                 │
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                  HOST AGENT RUNTIME PROCESS                      │
+│  • per-group working dirs and session state                      │
+│  • tools and file operations scoped by runtime policy            │
+│  • outbound credentials via OneCLI/environment policy            │
+└──────────────────────────────────────────────────────────────────┘
+```

--- a/docs/decisions/2026-04-16-runtime-truth-host-first.md
+++ b/docs/decisions/2026-04-16-runtime-truth-host-first.md
@@ -4,9 +4,7 @@
 
 MyClaw currently has one working runtime implementation in production code: host execution.
 
-Several active docs and scripts still described a container-first dual-mode model (`AGENT_RUNTIME=container|host`) and referenced missing files such as:
-- `apps/core/src/runtime/container-runner.ts`
-- `apps/core/src/runtime/container-runtime.ts`
+Several active docs and scripts still described a container-first dual-mode model (`AGENT_RUNTIME=container|host`) and referenced now-removed runtime files such as `container-runner.ts` and `container-runtime.ts`.
 
 This created a half-real supported mode: users were told container runtime was first-class even though host runtime is the only complete and maintained execution path in this repository.
 

--- a/docs/decisions/2026-04-16-runtime-truth-host-first.md
+++ b/docs/decisions/2026-04-16-runtime-truth-host-first.md
@@ -43,6 +43,8 @@ Decision details:
 
 - Rollback path: if a real container runtime implementation ships later, create a follow-up ADR to define supported dual-mode behavior and required validation/doctor surfaces.
 - Migration for existing users: remove use of `AGENT_RUNTIME`, `npm run dev:container`, and `npm run start:container`; use `npm run dev` / `npm start`.
+- Runtime-truth search gate must include docs, runtime surfaces, and skills:
+  - `rg -n "AGENT_RUNTIME|start:container|dev:container|container-runner|container-runtime|SETUP_CONTAINER|container mode|container-first|Container-first" README.md AGENTS.md CLAUDE.md CONTRIBUTING.md docs .claude apps/core package.json`
 - Follow-up cleanup backlog (separate tasks):
   - rename `container_config` to `agent_config` with schema migration
   - rename `containerName` to runtime-process naming


### PR DESCRIPTION
## Summary
- add `.codex/scripts/check_architecture.py` with deterministic architecture checks for file-size budgets, import boundaries, and active doc references
- add `.codex/architecture-exceptions.json` with explicit expiring `file_size_budget` baselines for current oversized production files
- integrate architecture as a first-class verify phase in `.codex/scripts/verify.py` (with `FACTORY_ARCHITECTURE_CMD` override)
- add fixture-based coverage in `.codex/scripts/tests/test_check_architecture.py`
- document the new deterministic verify phase and exception policy in `.codex/AGENTS.md` and `docs/QUALITY.md`
- fix stale active-doc references that would otherwise fail the new checker

## Validation
- `python3 .codex/scripts/check_architecture.py`
- `python3 .codex/scripts/tests/test_check_architecture.py`
- `python3 -m unittest discover .codex/scripts/tests`
- `python3 .codex/scripts/verify.py --print-only`
- `python3 .codex/scripts/verify.py`
- `python3 .codex/scripts/validate_work.py --check-only`
- `python3 .codex/scripts/validate_work.py`
- `npm run build`
- `python3 .codex/scripts/validate_artifacts.py --allow-missing-run`
