### PR TITLE
Single-cut maintainability/provider modernization and agent capabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ Personal AI assistant runtime. See [README.md](README.md) for philosophy and set
 
 ## Quick Context
 
-Single Node.js process with skill-based channel system. Channels (WhatsApp, Telegram, Slack, Discord, Gmail) are skills that self-register at startup. Messages route to Claude Agent SDK via host runtime processes. Each group has isolated filesystem and memory boundaries.
+Single Node.js process with skill-based channel provider system. Built-in providers (Telegram, Slack) are registered through `apps/core/src/channels/register-builtins.ts`; additional providers can be added through skills. Messages route to the Claude Agent SDK via host runtime processes. Each group has isolated filesystem and memory boundaries.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
 | `apps/core/src/index.ts` | Orchestrator: state, message loop, agent invocation |
-| `apps/core/src/channels/registry.ts` | Channel registry (self-registration at startup) |
+| `apps/core/src/channels/provider-registry.ts` | Channel provider registry |
 | `apps/core/src/runtime/ipc.ts` | IPC watcher and task processing |
 | `apps/core/src/messaging/router.ts` | Message formatting and outbound routing |
 | `apps/core/src/core/config.ts` | Trigger pattern, paths, intervals |
@@ -81,4 +81,4 @@ Available gstack skills: `/office-hours`, `/plan-ceo-review`, `/plan-eng-review`
 
 ## Agent Runner Build Cache
 
-If you add or update the agent runner, rebuild from the repo root with `npm run build` so both the app and `packages/agent-runner` stay in sync.
+If you add or update the agent runner, rebuild from the repo root with `npm run build` so `apps/core/src/runner` and emitted dist artifacts stay in sync.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## What MyClaw Is
 
-MyClaw is a single-process Node.js assistant runtime. Messages come in from one or more channels, get stored in SQLite, and are routed to Codex-driven agents through a host runtime process.
+MyClaw is a single-process Node.js assistant runtime. Messages come in from one or more channels, get stored in SQLite, and are routed to host-managed agents through a host runtime process.
 
 The project is intentionally small. The goal is not to be a framework with every feature built in. The goal is to give one person a secure, understandable base they can shape to fit their own workflow.
 
@@ -46,7 +46,7 @@ Defaults in v1:
 - memory provider: `sqlite` by default; `qmd` adds a markdown audit mirror
 - embeddings: off (unless OpenAI key is provided and enabled)
 - dreaming: off
-- sender allowlist: `channels.telegram.sender_allowlist` / `channels.slack.sender_allowlist` in `settings.yaml`
+- sender allowlist: `channels.<provider>.sender_allowlist` in `settings.yaml`
 
 Canonical memory settings live in `~/myclaw/settings.yaml`:
 
@@ -85,7 +85,7 @@ Notes:
 - Secure by explicit trust boundaries. The current runtime executes on host, so security depends on host controls, scoped mounts, and clear operational safeguards.
 - Customized in code. If you want different behavior, change the code instead of stacking on configuration.
 - Skills over core bloat. Reusable capabilities should be delivered as skills or narrowly scoped branches, not piled into the default runtime.
-- AI-native operations. Setup, debugging, and maintenance should be easy to drive from Claude Code or Codex.
+- AI-native operations. Setup, debugging, and maintenance should be easy to drive from Claude Code.
 
 ## What It Supports
 

--- a/apps/core/src/core/datetime.ts
+++ b/apps/core/src/core/datetime.ts
@@ -1,0 +1,75 @@
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration.js';
+import utc from 'dayjs/plugin/utc.js';
+
+dayjs.extend(duration);
+dayjs.extend(utc);
+
+export interface Clock {
+  now: () => Date;
+  nowMs: () => number;
+}
+
+export const systemClock: Clock = {
+  now: () => new Date(),
+  nowMs: () => Date.now(),
+};
+
+export function fixedClock(input: Date | number | string): Clock {
+  const fixed = toDate(input);
+  const fixedMs = fixed.getTime();
+  return {
+    now: () => new Date(fixedMs),
+    nowMs: () => fixedMs,
+  };
+}
+
+export function nowIso(clock: Clock = systemClock): string {
+  return dayjs(clock.nowMs()).utc().toISOString();
+}
+
+export function nowMs(clock: Clock = systemClock): number {
+  return clock.nowMs();
+}
+
+export function toIso(input: Date | number | string): string {
+  return dayjs(toDate(input)).utc().toISOString();
+}
+
+export function parseIso(value: string): Date | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = dayjs(trimmed);
+  if (!parsed.isValid()) return undefined;
+  return parsed.toDate();
+}
+
+export function formatDurationMs(durationMs: number): string {
+  if (!Number.isFinite(durationMs)) return '0ms';
+  const sign = durationMs < 0 ? '-' : '';
+  const abs = Math.abs(Math.round(durationMs));
+  const d = dayjs.duration(abs);
+  const parts: string[] = [];
+  const hours = Math.floor(d.asHours());
+  const minutes = d.minutes();
+  const seconds = d.seconds();
+  const milliseconds = d.milliseconds();
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0 || hours > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || minutes > 0 || hours > 0) parts.push(`${seconds}s`);
+  parts.push(`${milliseconds}ms`);
+  return `${sign}${parts.join(' ')}`;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toDate(input: Date | number | string): Date {
+  const parsed = dayjs(input);
+  if (!parsed.isValid()) {
+    throw new Error(`Invalid date input: ${String(input)}`);
+  }
+  return parsed.toDate();
+}

--- a/apps/core/src/core/fs-paths.ts
+++ b/apps/core/src/core/fs-paths.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+import { nowMs } from './datetime.js';
+
+export function safeRealpathSync(targetPath: string): string {
+  try {
+    return fs.realpathSync(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+export function resolvePathWithRealParent(targetPath: string): string {
+  const resolved = path.resolve(targetPath);
+  let existingParent = path.dirname(resolved);
+  while (!fs.existsSync(existingParent)) {
+    const parent = path.dirname(existingParent);
+    if (parent === existingParent) break;
+    existingParent = parent;
+  }
+  const parentReal = safeRealpathSync(existingParent);
+  const tail = path.relative(existingParent, resolved);
+  return path.resolve(parentReal, tail);
+}
+
+export function isPathInside(rootDir: string, candidatePath: string): boolean {
+  const rootResolved = safeRealpathSync(rootDir);
+  const candidateResolved = resolvePathWithRealParent(candidatePath);
+  const relative = path.relative(rootResolved, candidateResolved);
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
+  );
+}
+
+export function writeFileAtomic(
+  filePath: string,
+  content: string | Buffer,
+  opts: { mode?: number } = {},
+): void {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const tmpPath = path.join(
+    dir,
+    `.${path.basename(filePath)}.${process.pid}.${nowMs()}.tmp`,
+  );
+  fs.writeFileSync(tmpPath, content, {
+    mode: opts.mode ?? 0o600,
+  });
+  fs.renameSync(tmpPath, filePath);
+}

--- a/apps/core/src/core/index.ts
+++ b/apps/core/src/core/index.ts
@@ -1,4 +1,7 @@
 export * from './config.js';
+export * from './datetime.js';
+export * from './fs-paths.js';
 export * from './logger.js';
+export * from './object.js';
 export * from './timezone.js';
 export * from './types.js';

--- a/apps/core/src/core/logger.ts
+++ b/apps/core/src/core/logger.ts
@@ -1,81 +1,198 @@
-const LEVELS = { debug: 20, info: 30, warn: 40, error: 50, fatal: 60 } as const;
-type Level = keyof typeof LEVELS;
+import { Clock, nowIso, systemClock, toIso } from './datetime.js';
+import { isPlainObject } from './object.js';
 
-const COLORS: Record<Level, string> = {
-  debug: '\x1b[34m',
-  info: '\x1b[32m',
-  warn: '\x1b[33m',
-  error: '\x1b[31m',
-  fatal: '\x1b[41m\x1b[37m',
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
 };
-const KEY_COLOR = '\x1b[35m';
-const MSG_COLOR = '\x1b[36m';
-const RESET = '\x1b[39m';
-const FULL_RESET = '\x1b[0m';
+
+export interface LogRecord {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  pid: number;
+  context?: Record<string, unknown>;
+}
+
+export interface LogSink {
+  write: (record: LogRecord) => void;
+}
+
+export interface Logger {
+  debug: (dataOrMsg: Record<string, unknown> | string, msg?: string) => void;
+  info: (dataOrMsg: Record<string, unknown> | string, msg?: string) => void;
+  warn: (dataOrMsg: Record<string, unknown> | string, msg?: string) => void;
+  error: (dataOrMsg: Record<string, unknown> | string, msg?: string) => void;
+  fatal: (dataOrMsg: Record<string, unknown> | string, msg?: string) => void;
+  child: (context: Record<string, unknown>) => Logger;
+}
+
+export interface CreateLoggerOptions {
+  level?: LogLevel;
+  sink?: LogSink;
+  format?: 'json' | 'text';
+  clock?: Clock;
+  context?: Record<string, unknown>;
+  redact?: (value: unknown) => unknown;
+}
+
+const DEFAULT_REDACT_KEY_PATTERN =
+  /(token|secret|password|credential|api[_-]?key|authorization|auth)/i;
 const LOGGER_HANDLER_MARK = Symbol.for('myclaw.logger.handler');
 
-const threshold =
-  LEVELS[(process.env.LOG_LEVEL as Level) || 'info'] ?? LEVELS.info;
-
-function formatErr(err: unknown): string {
-  if (err instanceof Error) {
-    return `{\n      "type": "${err.constructor.name}",\n      "message": "${err.message}",\n      "stack":\n          ${err.stack}\n    }`;
-  }
-  return JSON.stringify(err);
+function sanitizeError(err: Error): Record<string, unknown> {
+  return {
+    type: err.constructor.name,
+    message: err.message,
+    stack: err.stack,
+  };
 }
 
-function formatData(data: Record<string, unknown>): string {
-  let out = '';
-  for (const [k, v] of Object.entries(data)) {
-    if (k === 'err') {
-      out += `\n    ${KEY_COLOR}err${RESET}: ${formatErr(v)}`;
-    } else {
-      out += `\n    ${KEY_COLOR}${k}${RESET}: ${JSON.stringify(v)}`;
+function defaultRedact(value: unknown): unknown {
+  return redactValue(value, 0);
+}
+
+function redactValue(value: unknown, depth: number): unknown {
+  if (depth > 6) return '[TRUNCATED_DEPTH]';
+  if (value instanceof Error) return sanitizeError(value);
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry, depth + 1));
+  }
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (DEFAULT_REDACT_KEY_PATTERN.test(key)) {
+        out[key] = '[REDACTED]';
+        continue;
+      }
+      out[key] = redactValue(entry, depth + 1);
     }
+    return out;
   }
-  return out;
+  return value;
 }
 
-function ts(): string {
-  const d = new Date();
-  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}.${String(d.getMilliseconds()).padStart(3, '0')}`;
+function createTextSink(opts: { stderrOnly?: boolean }): LogSink {
+  return {
+    write(record) {
+      const forceStderr = opts.stderrOnly === true;
+      const stream =
+        forceStderr ||
+        LOG_LEVEL_PRIORITY[record.level] >= LOG_LEVEL_PRIORITY.warn
+          ? process.stderr
+          : process.stdout;
+      if (!record.context || Object.keys(record.context).length === 0) {
+        stream.write(
+          `[${record.timestamp}] ${record.level.toUpperCase()} (${record.pid}): ${record.message}\n`,
+        );
+        return;
+      }
+      stream.write(
+        `[${record.timestamp}] ${record.level.toUpperCase()} (${record.pid}): ${record.message} ${JSON.stringify(record.context)}\n`,
+      );
+    },
+  };
 }
 
-function log(
-  level: Level,
-  dataOrMsg: Record<string, unknown> | string,
-  msg?: string,
-): void {
-  if (LEVELS[level] < threshold) return;
-  const tag = `${COLORS[level]}${level.toUpperCase()}${level === 'fatal' ? FULL_RESET : RESET}`;
-  const forceStderr = process.env.MYCLAW_LOG_STDERR === '1';
-  const stream =
-    forceStderr || LEVELS[level] >= LEVELS.warn
-      ? process.stderr
-      : process.stdout;
-  if (typeof dataOrMsg === 'string') {
-    stream.write(
-      `[${ts()}] ${tag} (${process.pid}): ${MSG_COLOR}${dataOrMsg}${RESET}\n`,
-    );
-  } else {
-    stream.write(
-      `[${ts()}] ${tag} (${process.pid}): ${MSG_COLOR}${msg}${RESET}${formatData(dataOrMsg)}\n`,
-    );
+function createJsonSink(opts: { stderrOnly?: boolean }): LogSink {
+  return {
+    write(record) {
+      const forceStderr = opts.stderrOnly === true;
+      const stream =
+        forceStderr ||
+        LOG_LEVEL_PRIORITY[record.level] >= LOG_LEVEL_PRIORITY.warn
+          ? process.stderr
+          : process.stdout;
+      stream.write(`${JSON.stringify(record)}\n`);
+    },
+  };
+}
+
+function mergeContexts(
+  left?: Record<string, unknown>,
+  right?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!left && !right) return undefined;
+  return {
+    ...(left || {}),
+    ...(right || {}),
+  };
+}
+
+function normalizeLevel(raw?: string): LogLevel {
+  const value = (raw || '').trim().toLowerCase();
+  if (
+    value === 'debug' ||
+    value === 'info' ||
+    value === 'warn' ||
+    value === 'error' ||
+    value === 'fatal'
+  ) {
+    return value;
   }
+  return 'info';
 }
 
-export const logger = {
-  debug: (dataOrMsg: Record<string, unknown> | string, msg?: string) =>
-    log('debug', dataOrMsg, msg),
-  info: (dataOrMsg: Record<string, unknown> | string, msg?: string) =>
-    log('info', dataOrMsg, msg),
-  warn: (dataOrMsg: Record<string, unknown> | string, msg?: string) =>
-    log('warn', dataOrMsg, msg),
-  error: (dataOrMsg: Record<string, unknown> | string, msg?: string) =>
-    log('error', dataOrMsg, msg),
-  fatal: (dataOrMsg: Record<string, unknown> | string, msg?: string) =>
-    log('fatal', dataOrMsg, msg),
-};
+export function createLogger(options: CreateLoggerOptions = {}): Logger {
+  const level = options.level || normalizeLevel(process.env.LOG_LEVEL);
+  const clock = options.clock || systemClock;
+  const redact = options.redact || defaultRedact;
+  const baseContext = options.context;
+  const stderrOnly = process.env.MYCLAW_LOG_STDERR === '1';
+  const sink =
+    options.sink ||
+    (options.format === 'json'
+      ? createJsonSink({ stderrOnly })
+      : createTextSink({ stderrOnly }));
+
+  const log = (
+    currentLevel: LogLevel,
+    dataOrMsg: Record<string, unknown> | string,
+    msg?: string,
+    childContext?: Record<string, unknown>,
+  ) => {
+    if (LOG_LEVEL_PRIORITY[currentLevel] < LOG_LEVEL_PRIORITY[level]) return;
+    const record: LogRecord = {
+      timestamp: nowIso(clock),
+      level: currentLevel,
+      message: typeof dataOrMsg === 'string' ? dataOrMsg : msg || '',
+      pid: process.pid,
+      ...(() => {
+        if (typeof dataOrMsg === 'string') {
+          const context = mergeContexts(baseContext, childContext);
+          return context ? { context } : {};
+        }
+        const context = mergeContexts(
+          mergeContexts(baseContext, childContext),
+          redact(dataOrMsg) as Record<string, unknown>,
+        );
+        return context ? { context } : {};
+      })(),
+    };
+    sink.write(record);
+  };
+
+  const makeChildLogger = (childContext?: Record<string, unknown>): Logger => ({
+    debug: (dataOrMsg, msg) => log('debug', dataOrMsg, msg, childContext),
+    info: (dataOrMsg, msg) => log('info', dataOrMsg, msg, childContext),
+    warn: (dataOrMsg, msg) => log('warn', dataOrMsg, msg, childContext),
+    error: (dataOrMsg, msg) => log('error', dataOrMsg, msg, childContext),
+    fatal: (dataOrMsg, msg) => log('fatal', dataOrMsg, msg, childContext),
+    child: (nextContext) =>
+      makeChildLogger(mergeContexts(childContext, nextContext)),
+  });
+
+  return makeChildLogger();
+}
+
+export const logger = createLogger({
+  format: process.env.LOG_FORMAT === 'json' ? 'json' : 'text',
+});
 
 type MarkedUncaughtExceptionHandler = ((err: Error) => void) & {
   [LOGGER_HANDLER_MARK]?: true;
@@ -101,7 +218,6 @@ function removeMarkedProcessListeners(
     }
     return;
   }
-
   for (const listener of process.listeners(
     event,
   ) as MarkedUnhandledRejectionHandler[]) {
@@ -111,21 +227,43 @@ function removeMarkedProcessListeners(
   }
 }
 
-const uncaughtExceptionHandler = ((err: Error) => {
-  logger.fatal({ err }, 'Uncaught exception');
-  process.exit(1);
-}) as MarkedUncaughtExceptionHandler;
-uncaughtExceptionHandler[LOGGER_HANDLER_MARK] = true;
+export function installGlobalErrorHandlers(
+  target: Logger = logger,
+): () => void {
+  removeMarkedProcessListeners('uncaughtException');
+  removeMarkedProcessListeners('unhandledRejection');
 
-const unhandledRejectionHandler = ((reason: unknown) => {
-  logger.error({ err: reason }, 'Unhandled rejection');
-}) as MarkedUnhandledRejectionHandler;
-unhandledRejectionHandler[LOGGER_HANDLER_MARK] = true;
+  const uncaughtExceptionHandler = ((err: Error) => {
+    target.fatal({ err }, 'Uncaught exception');
+    process.exit(1);
+  }) as MarkedUncaughtExceptionHandler;
+  uncaughtExceptionHandler[LOGGER_HANDLER_MARK] = true;
 
-// Route uncaught errors through logger so they get timestamps in stderr.
-// De-duplicate handlers because test module reloads can otherwise attach
-// unbounded listeners and eventually stall CI.
-removeMarkedProcessListeners('uncaughtException');
-removeMarkedProcessListeners('unhandledRejection');
-process.on('uncaughtException', uncaughtExceptionHandler);
-process.on('unhandledRejection', unhandledRejectionHandler);
+  const unhandledRejectionHandler = ((reason: unknown) => {
+    target.error({ err: reason }, 'Unhandled rejection');
+  }) as MarkedUnhandledRejectionHandler;
+  unhandledRejectionHandler[LOGGER_HANDLER_MARK] = true;
+
+  process.on('uncaughtException', uncaughtExceptionHandler);
+  process.on('unhandledRejection', unhandledRejectionHandler);
+
+  return () => {
+    process.removeListener('uncaughtException', uncaughtExceptionHandler);
+    process.removeListener('unhandledRejection', unhandledRejectionHandler);
+  };
+}
+
+export function createLogRecord(
+  level: LogLevel,
+  message: string,
+  context?: Record<string, unknown>,
+  clock: Clock = systemClock,
+): LogRecord {
+  return {
+    level,
+    message,
+    pid: process.pid,
+    timestamp: toIso(clock.now()),
+    ...(context ? { context } : {}),
+  };
+}

--- a/apps/core/src/core/object.ts
+++ b/apps/core/src/core/object.ts
@@ -1,0 +1,16 @@
+export function isPlainObject(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function toTrimmedString(
+  value: unknown,
+  opts: { maxLen?: number; allowEmpty?: boolean } = {},
+): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!opts.allowEmpty && trimmed.length === 0) return undefined;
+  if (opts.maxLen && trimmed.length > opts.maxLen) return undefined;
+  return trimmed;
+}

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -1,4 +1,4 @@
-import { logger } from './core/logger.js';
+import { installGlobalErrorHandlers, logger } from './core/logger.js';
 import { createChannelWiring } from './bootstrap/channel-wiring.js';
 import { getDefaultRuntimeApp } from './bootstrap/runtime-app.js';
 import { startRuntimeServices } from './bootstrap/runtime-services.js';
@@ -55,6 +55,7 @@ const isDirectRun =
     new URL(`file://${process.argv[1]}`).pathname;
 
 if (isDirectRun) {
+  installGlobalErrorHandlers(logger);
   startMyClawRuntime().catch((err) => {
     logger.error({ err }, 'Failed to start MyClaw');
     process.exit(1);

--- a/apps/core/src/memory/cleanup-job.ts
+++ b/apps/core/src/memory/cleanup-job.ts
@@ -10,6 +10,8 @@ import {
   MEMORY_JOURNAL_DELETE_DAYS,
   MEMORY_JOURNAL_GZIP_DAYS,
 } from '../core/config.js';
+import { isPathInside } from '../core/fs-paths.js';
+import { nowIso } from '../core/datetime.js';
 import { MemoryRootService } from './memory-root.js';
 
 export interface MemoryCleanupResult {
@@ -73,44 +75,11 @@ function sqlQuote(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
-function safeRealpathSync(targetPath: string): string | null {
-  try {
-    return fs.realpathSync(targetPath);
-  } catch {
-    return null;
-  }
-}
-
-function resolvePathWithRealParent(targetPath: string): string | null {
-  const resolved = path.resolve(targetPath);
-  let existingParent = path.dirname(resolved);
-  while (!fs.existsSync(existingParent)) {
-    const parent = path.dirname(existingParent);
-    if (parent === existingParent) break;
-    existingParent = parent;
-  }
-  const parentReal = safeRealpathSync(existingParent);
-  if (!parentReal) return null;
-  const tail = path.relative(existingParent, resolved);
-  return path.resolve(parentReal, tail);
-}
-
-function isInsideRoot(root: string, candidatePath: string): boolean {
-  const rootResolved = safeRealpathSync(root);
-  const candidateResolved = resolvePathWithRealParent(candidatePath);
-  if (!rootResolved || !candidateResolved) return false;
-  const relative = path.relative(rootResolved, candidateResolved);
-  return (
-    relative === '' ||
-    (!relative.startsWith('..') && !path.isAbsolute(relative))
-  );
-}
-
 function isSafeManagedFileDelete(
   managedRoot: string,
   candidatePath: string,
 ): boolean {
-  if (!isInsideRoot(managedRoot, candidatePath)) return false;
+  if (!isPathInside(managedRoot, candidatePath)) return false;
   try {
     const stat = fs.lstatSync(candidatePath);
     return stat.isFile() && !stat.isSymbolicLink();
@@ -178,7 +147,7 @@ function createDailyCheckpoint(
 } {
   const checkpointsDir = path.join(journalDir, 'checkpoints');
   fs.mkdirSync(checkpointsDir, { recursive: true, mode: 0o700 });
-  const iso = new Date().toISOString();
+  const iso = nowIso();
   const stamp = `${iso.slice(0, 10).replace(/-/g, '')}-${iso
     .slice(11, 19)
     .replace(/:/g, '')}`;

--- a/apps/core/src/memory/extractor-llm.ts
+++ b/apps/core/src/memory/extractor-llm.ts
@@ -4,6 +4,7 @@ import {
   MEMORY_EXTRACTOR_MIN_CONFIDENCE,
 } from '../core/config.js';
 import { logger } from '../core/logger.js';
+import { sleep } from '../core/datetime.js';
 import {
   MEMORY_EXTRACTION_FEW_SHOTS,
   MEMORY_EXTRACTION_SYSTEM_PROMPT,
@@ -310,12 +311,6 @@ function isTransientExtractorError(err: unknown): boolean {
     );
   }
   return false;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 export class LlmMemoryExtractionProvider implements MemoryExtractionProvider {

--- a/apps/core/src/memory/memory-ipc.ts
+++ b/apps/core/src/memory/memory-ipc.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { MemoryIpcRequest, MemoryIpcResponse } from '@myclaw/contracts';
 
 import { logger } from '../core/logger.js';
+import { isPlainObject } from '../core/object.js';
 import { resolveGroupIpcPath } from '../platform/group-folder.js';
 import { MemoryService } from './memory-service.js';
 import {
@@ -13,10 +14,6 @@ import {
 } from './memory-types.js';
 
 const MEMORY_IPC_REQUEST_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function parseOptionalString(
   value: unknown,

--- a/apps/core/src/memory/memory-service.ts
+++ b/apps/core/src/memory/memory-service.ts
@@ -34,6 +34,7 @@ import {
   MEMORY_TEMPORAL_DECAY_HALFLIFE_DAYS,
   RUNTIME_MEMORY_DREAMING_ENABLED,
 } from '../core/config.js';
+import { isPathInside, writeFileAtomic } from '../core/fs-paths.js';
 import { logger } from '../core/logger.js';
 import {
   createEmbeddingProvider,
@@ -1613,7 +1614,7 @@ export class MemoryService {
       managedSubdir === '.'
         ? memoryStorageDir
         : path.join(memoryStorageDir, managedSubdir);
-    if (!isInsideRoot(managedRoot, filePath)) return;
+    if (!isPathInside(managedRoot, filePath)) return;
     try {
       const stat = fs.lstatSync(filePath);
       if (!stat.isFile() || stat.isSymbolicLink()) return;
@@ -1675,50 +1676,8 @@ function yamlSafe(value: string): string {
   return JSON.stringify(value);
 }
 
-function writeFileAtomic(filePath: string, content: string): void {
-  const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  const tmpPath = path.join(
-    dir,
-    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`,
-  );
-  fs.writeFileSync(tmpPath, content, { mode: 0o600 });
-  fs.renameSync(tmpPath, filePath);
-}
-
 function sha256(content: string): string {
   return createHash('sha256').update(content).digest('hex');
-}
-
-function safeRealpathSync(targetPath: string): string {
-  try {
-    return fs.realpathSync(targetPath);
-  } catch {
-    return path.resolve(targetPath);
-  }
-}
-
-function resolvePathWithRealParent(targetPath: string): string {
-  const resolved = path.resolve(targetPath);
-  let existingParent = path.dirname(resolved);
-  while (!fs.existsSync(existingParent)) {
-    const parent = path.dirname(existingParent);
-    if (parent === existingParent) break;
-    existingParent = parent;
-  }
-  const parentReal = safeRealpathSync(existingParent);
-  const tail = path.relative(existingParent, resolved);
-  return path.resolve(parentReal, tail);
-}
-
-function isInsideRoot(rootDir: string, candidatePath: string): boolean {
-  const rootResolved = safeRealpathSync(rootDir);
-  const candidateResolved = resolvePathWithRealParent(candidatePath);
-  const relative = path.relative(rootResolved, candidateResolved);
-  return (
-    relative === '' ||
-    (!relative.startsWith('..') && !path.isAbsolute(relative))
-  );
 }
 
 function fingerprintSensitiveToken(value: string): string {

--- a/apps/core/src/runner/agent-capabilities.ts
+++ b/apps/core/src/runner/agent-capabilities.ts
@@ -1,0 +1,142 @@
+export interface AgentCapabilityContext {
+  mcpServerPath: string;
+  chatJid: string;
+  groupFolder: string;
+  isMain: boolean;
+  ipcDir?: string;
+  ipcAuthToken?: string;
+}
+
+export interface AgentCapabilityProfile {
+  allowedTools: readonly string[];
+  mcpServers: Record<
+    string,
+    {
+      command: string;
+      args: string[];
+      env: Record<string, string>;
+    }
+  >;
+  permissionMode: 'default' | 'bypassPermissions';
+  alwaysAllowedTools: readonly string[];
+}
+
+export interface AgentCapabilityProvider {
+  id: string;
+  provide: (ctx: AgentCapabilityContext) => Partial<AgentCapabilityProfile>;
+}
+
+const DEFAULT_ALLOWED_TOOLS = [
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'WebFetch',
+  'Task',
+  'TaskOutput',
+  'TaskStop',
+  'TeamCreate',
+  'TeamDelete',
+  'SendMessage',
+  'TodoWrite',
+  'ToolSearch',
+  'Skill',
+  'NotebookEdit',
+  'Config',
+  'EnterWorktree',
+  'ExitWorktree',
+  'mcp__myclaw__*',
+] as const;
+
+const ALWAYS_ALLOWED_TOOLS = [
+  'Config',
+  'EnterWorktree',
+  'ExitWorktree',
+] as const;
+
+const sdkToolsProvider: AgentCapabilityProvider = {
+  id: 'sdk-tools',
+  provide: () => ({
+    allowedTools: DEFAULT_ALLOWED_TOOLS,
+  }),
+};
+
+const permissionProvider: AgentCapabilityProvider = {
+  id: 'permissions',
+  provide: () => ({
+    permissionMode: 'default',
+    alwaysAllowedTools: ALWAYS_ALLOWED_TOOLS,
+  }),
+};
+
+const myclawMcpProvider: AgentCapabilityProvider = {
+  id: 'myclaw-mcp',
+  provide: (ctx) => ({
+    mcpServers: {
+      myclaw: {
+        command: 'node',
+        args: [ctx.mcpServerPath],
+        env: {
+          MYCLAW_CHAT_JID: ctx.chatJid,
+          MYCLAW_GROUP_FOLDER: ctx.groupFolder,
+          MYCLAW_IS_MAIN: ctx.isMain ? '1' : '0',
+          ...(ctx.ipcDir ? { MYCLAW_IPC_DIR: ctx.ipcDir } : {}),
+          ...(ctx.ipcAuthToken
+            ? { MYCLAW_IPC_AUTH_TOKEN: ctx.ipcAuthToken }
+            : {}),
+        },
+      },
+    },
+  }),
+};
+
+export const BUILTIN_AGENT_CAPABILITY_PROVIDERS: readonly AgentCapabilityProvider[] =
+  [sdkToolsProvider, permissionProvider, myclawMcpProvider];
+
+function mergeUnique(
+  base: readonly string[],
+  next: readonly string[],
+): string[] {
+  const out = new Set<string>(base);
+  for (const item of next) out.add(item);
+  return [...out];
+}
+
+export function composeAgentCapabilities(
+  ctx: AgentCapabilityContext,
+  providers: readonly AgentCapabilityProvider[] = BUILTIN_AGENT_CAPABILITY_PROVIDERS,
+): AgentCapabilityProfile {
+  let allowedTools: readonly string[] = [];
+  let mcpServers: AgentCapabilityProfile['mcpServers'] = {};
+  let permissionMode: AgentCapabilityProfile['permissionMode'] = 'default';
+  let alwaysAllowedTools: readonly string[] = [];
+
+  for (const provider of providers) {
+    const partial = provider.provide(ctx);
+    if (partial.allowedTools) {
+      allowedTools = mergeUnique(allowedTools, partial.allowedTools);
+    }
+    if (partial.mcpServers) {
+      mcpServers = { ...mcpServers, ...partial.mcpServers };
+    }
+    if (partial.permissionMode) {
+      permissionMode = partial.permissionMode;
+    }
+    if (partial.alwaysAllowedTools) {
+      alwaysAllowedTools = mergeUnique(
+        alwaysAllowedTools,
+        partial.alwaysAllowedTools,
+      );
+    }
+  }
+
+  return {
+    allowedTools,
+    mcpServers,
+    permissionMode,
+    alwaysAllowedTools,
+  };
+}

--- a/apps/core/src/runner/index.ts
+++ b/apps/core/src/runner/index.ts
@@ -24,6 +24,9 @@ import {
   type ThinkingConfig,
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
+import { nowIso, nowMs, sleep } from '../core/datetime.js';
+import { isPlainObject } from '../core/object.js';
+import { composeAgentCapabilities } from './agent-capabilities.js';
 
 interface AgentRunnerInput {
   prompt: string;
@@ -90,10 +93,6 @@ function resolveGroupIpcDir(groupFolder: string): string {
     return IPC_BASE_DIR;
   }
   return path.join(IPC_BASE_DIR, groupFolder);
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function buildSystemPrompt(append?: string):
@@ -359,7 +358,7 @@ async function requestPermissionApproval(options: {
     );
     fs.mkdirSync(permissionRequestsDir, { recursive: true });
     fs.mkdirSync(permissionResponsesDir, { recursive: true });
-    const requestId = `perm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const requestId = `perm-${nowMs()}-${Math.random().toString(36).slice(2, 8)}`;
     const requestPath = path.join(permissionRequestsDir, `${requestId}.json`);
     const requestTmpPath = `${requestPath}.tmp`;
     const envelope = {
@@ -377,14 +376,14 @@ async function requestPermissionApproval(options: {
         ? { toolInput: options.toolInput }
         : {}),
       ...(IPC_AUTH_TOKEN ? { authToken: IPC_AUTH_TOKEN } : {}),
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     };
     fs.writeFileSync(requestTmpPath, JSON.stringify(envelope, null, 2));
     fs.renameSync(requestTmpPath, requestPath);
 
     const responsePath = path.join(permissionResponsesDir, `${requestId}.json`);
-    const deadline = Date.now() + PERMISSION_REQUEST_TIMEOUT_MS;
-    while (Date.now() < deadline) {
+    const deadline = nowMs() + PERMISSION_REQUEST_TIMEOUT_MS;
+    while (nowMs() < deadline) {
       if (fs.existsSync(responsePath)) {
         try {
           const raw = JSON.parse(fs.readFileSync(responsePath, 'utf-8'));
@@ -417,7 +416,7 @@ async function requestPermissionApproval(options: {
           };
         }
       }
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await sleep(100);
     }
     return {
       approved: false,
@@ -507,6 +506,15 @@ async function runQuery(
     log(`Additional directories: ${extraDirs.join(', ')}`);
   }
 
+  const capabilities = composeAgentCapabilities({
+    mcpServerPath,
+    chatJid: agentInput.chatJid,
+    groupFolder: agentInput.groupFolder,
+    isMain: agentInput.isMain,
+    ipcDir: process.env.MYCLAW_IPC_DIR,
+    ipcAuthToken: process.env.MYCLAW_IPC_AUTH_TOKEN,
+  });
+
   for await (const message of query({
     prompt: stream,
     options: {
@@ -518,38 +526,11 @@ async function runQuery(
       resume: sessionId,
       resumeSessionAt: resumeAt,
       systemPrompt,
-      allowedTools: [
-        'Bash',
-        'Read',
-        'Write',
-        'Edit',
-        'Glob',
-        'Grep',
-        'WebSearch',
-        'WebFetch',
-        'Task',
-        'TaskOutput',
-        'TaskStop',
-        'TeamCreate',
-        'TeamDelete',
-        'SendMessage',
-        'TodoWrite',
-        'ToolSearch',
-        'Skill',
-        'NotebookEdit',
-        'Config',
-        'EnterWorktree',
-        'ExitWorktree',
-        'mcp__myclaw__*',
-      ],
+      allowedTools: [...capabilities.allowedTools],
       env: sdkEnv,
-      permissionMode: 'default',
+      permissionMode: capabilities.permissionMode,
       canUseTool: async (toolName, input, permissionOpts) => {
-        if (
-          toolName === 'Config' ||
-          toolName === 'EnterWorktree' ||
-          toolName === 'ExitWorktree'
-        ) {
+        if (capabilities.alwaysAllowedTools.includes(toolName)) {
           return { behavior: 'allow' as const, updatedInput: input };
         }
 
@@ -584,25 +565,7 @@ async function runQuery(
         };
       },
       settingSources: ['user'],
-      mcpServers: {
-        myclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            MYCLAW_CHAT_JID: agentInput.chatJid,
-            MYCLAW_GROUP_FOLDER: agentInput.groupFolder,
-            MYCLAW_IS_MAIN: agentInput.isMain ? '1' : '0',
-            ...(process.env.MYCLAW_IPC_DIR
-              ? { MYCLAW_IPC_DIR: process.env.MYCLAW_IPC_DIR }
-              : {}),
-            ...(process.env.MYCLAW_IPC_AUTH_TOKEN
-              ? {
-                  MYCLAW_IPC_AUTH_TOKEN: process.env.MYCLAW_IPC_AUTH_TOKEN,
-                }
-              : {}),
-          },
-        },
-      },
+      mcpServers: capabilities.mcpServers,
       includePartialMessages: true,
     },
   })) {

--- a/apps/core/src/runner/ipc-mcp-stdio.ts
+++ b/apps/core/src/runner/ipc-mcp-stdio.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
+import { nowIso, nowMs, parseIso, sleep } from '../core/datetime.js';
 import {
   formatMemoryTimeoutError,
   getMemoryActionTimeoutMs,
@@ -46,7 +47,7 @@ const isMain = process.env.MYCLAW_IS_MAIN === '1';
 function writeIpcFile(dir: string, data: object): string {
   fs.mkdirSync(dir, { recursive: true });
 
-  const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`;
+  const filename = `${nowMs()}-${Math.random().toString(36).slice(2, 8)}.json`;
   const filepath = path.join(dir, filename);
 
   // Atomic write: temp file then rename
@@ -78,7 +79,7 @@ async function requestMemoryAction(
   fs.mkdirSync(MEMORY_REQUESTS_DIR, { recursive: true });
   fs.mkdirSync(MEMORY_RESPONSES_DIR, { recursive: true });
 
-  const requestId = `mem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const requestId = `mem-${nowMs()}-${Math.random().toString(36).slice(2, 8)}`;
   const reqPath = path.join(MEMORY_REQUESTS_DIR, `${requestId}.json`);
   const tmpReqPath = `${reqPath}.tmp`;
   fs.writeFileSync(
@@ -97,10 +98,10 @@ async function requestMemoryAction(
   fs.renameSync(tmpReqPath, reqPath);
 
   const timeoutMs = getMemoryActionTimeoutMs(action);
-  const deadline = Date.now() + timeoutMs;
+  const deadline = nowMs() + timeoutMs;
   const responsePath = path.join(MEMORY_RESPONSES_DIR, `${requestId}.json`);
 
-  while (Date.now() < deadline) {
+  while (nowMs() < deadline) {
     if (fs.existsSync(responsePath)) {
       try {
         const data = JSON.parse(fs.readFileSync(responsePath, 'utf-8')) as {
@@ -138,7 +139,7 @@ async function requestBrowserAction(
   fs.mkdirSync(BROWSER_REQUESTS_DIR, { recursive: true });
   fs.mkdirSync(BROWSER_RESPONSES_DIR, { recursive: true });
 
-  const requestId = `browser-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const requestId = `browser-${nowMs()}-${Math.random().toString(36).slice(2, 8)}`;
   const reqPath = path.join(BROWSER_REQUESTS_DIR, `${requestId}.json`);
   const tmpReqPath = `${reqPath}.tmp`;
 
@@ -157,10 +158,10 @@ async function requestBrowserAction(
   );
   fs.renameSync(tmpReqPath, reqPath);
 
-  const deadline = Date.now() + 30_000;
+  const deadline = nowMs() + 30_000;
   const responsePath = path.join(BROWSER_RESPONSES_DIR, `${requestId}.json`);
 
-  while (Date.now() < deadline) {
+  while (nowMs() < deadline) {
     if (fs.existsSync(responsePath)) {
       try {
         const data = JSON.parse(fs.readFileSync(responsePath, 'utf-8')) as {
@@ -213,10 +214,6 @@ function formatBrowserToolResponse(response: { data?: unknown }): string {
     return JSON.stringify(response.data, null, 2);
   }
   return JSON.stringify({ data: response.data }, null, 2);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function normalizeExecutionMode(
@@ -350,8 +347,8 @@ async function waitForTaskResponse(
 ): Promise<TaskResponseEnvelope | null> {
   fs.mkdirSync(TASK_RESPONSES_DIR, { recursive: true });
   const responsePath = path.join(TASK_RESPONSES_DIR, `task-${taskId}.json`);
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  const deadline = nowMs() + timeoutMs;
+  while (nowMs() < deadline) {
     if (fs.existsSync(responsePath)) {
       try {
         const parsed = parseTaskResponseEnvelope(
@@ -416,7 +413,7 @@ server.tool(
       text: args.text,
       sender: args.sender || undefined,
       groupFolder,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     };
 
     writeIpcFile(MESSAGES_DIR, data);
@@ -468,7 +465,7 @@ server.tool(
     fs.mkdirSync(userQuestionRequestsDir, { recursive: true });
     fs.mkdirSync(userQuestionResponsesDir, { recursive: true });
 
-    const requestId = `userq-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const requestId = `userq-${nowMs()}-${Math.random().toString(36).slice(2, 8)}`;
     const requestPath = path.join(userQuestionRequestsDir, `${requestId}.json`);
     const responsePath = path.join(
       userQuestionResponsesDir,
@@ -481,14 +478,14 @@ server.tool(
       sourceGroup: groupFolder,
       questions: args.questions,
       ...(IPC_AUTH_TOKEN ? { authToken: IPC_AUTH_TOKEN } : {}),
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     };
 
     fs.writeFileSync(tmpPath, JSON.stringify(envelope, null, 2));
     fs.renameSync(tmpPath, requestPath);
 
-    const deadline = Date.now() + USER_QUESTION_TIMEOUT_MS;
-    while (Date.now() < deadline) {
+    const deadline = nowMs() + USER_QUESTION_TIMEOUT_MS;
+    while (nowMs() < deadline) {
       if (context?.signal?.aborted) {
         return {
           content: [
@@ -612,8 +609,8 @@ server.tool(
       }
     }
     if (args.schedule_type === 'once') {
-      const date = new Date(args.schedule_value);
-      if (isNaN(date.getTime())) {
+      const date = parseIso(args.schedule_value);
+      if (!date) {
         return {
           content: [{ type: 'text' as const, text: 'Invalid once timestamp.' }],
           isError: true,
@@ -645,7 +642,7 @@ server.tool(
       ),
       serialize: args.serialize,
       createdBy: 'agent',
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     };
     writeIpcFile(TASKS_DIR, data);
     return {
@@ -756,7 +753,7 @@ server.tool(
       maxConsecutiveFailures: args.max_consecutive_failures,
       executionMode,
       serialize: args.serialize,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     });
     return {
       content: [
@@ -774,7 +771,7 @@ server.tool(
     writeIpcFile(TASKS_DIR, {
       type: 'scheduler_delete_job',
       jobId: args.job_id,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     });
     return {
       content: [
@@ -792,7 +789,7 @@ server.tool(
     writeIpcFile(TASKS_DIR, {
       type: 'scheduler_pause_job',
       jobId: args.job_id,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     });
     return {
       content: [
@@ -810,7 +807,7 @@ server.tool(
     writeIpcFile(TASKS_DIR, {
       type: 'scheduler_resume_job',
       jobId: args.job_id,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     });
     return {
       content: [
@@ -872,7 +869,7 @@ server.tool(
       eventType: args.event_type,
       sinceId: args.since_id,
       limit: args.limit,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     });
     return {
       content: [
@@ -900,8 +897,8 @@ server.tool(
       Math.min(args.timeout_ms ?? 30_000, 120_000),
     );
     const limit = Math.max(1, Math.min(args.limit ?? 100, 500));
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
+    const deadline = nowMs() + timeoutMs;
+    while (nowMs() < deadline) {
       const events = readJsonArraySnapshot(
         path.join(IPC_DIR, 'current_job_events.json'),
       );
@@ -914,7 +911,7 @@ server.tool(
           eventType: args.event_type,
           sinceId: args.since_id,
           limit,
-          timestamp: new Date().toISOString(),
+          timestamp: nowIso(),
         });
         return {
           content: [
@@ -1265,11 +1262,11 @@ server.tool(
       };
     }
 
-    const taskId = `service-restart-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const taskId = `service-restart-${nowMs()}-${Math.random().toString(36).slice(2, 8)}`;
     writeIpcFile(TASKS_DIR, {
       type: 'service_restart',
       taskId,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     });
 
     const response = await waitForTaskResponse(taskId, 20_000);
@@ -1345,7 +1342,7 @@ Use available_groups.json to find the JID for a group. The folder name must be c
       };
     }
 
-    const taskId = `register-agent-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const taskId = `register-agent-${nowMs()}-${Math.random().toString(36).slice(2, 8)}`;
     const data = {
       type: 'register_agent',
       taskId,
@@ -1354,7 +1351,7 @@ Use available_groups.json to find the JID for a group. The folder name must be c
       folder: args.folder,
       trigger: args.trigger,
       requiresTrigger: args.requiresTrigger ?? false,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
     };
 
     writeIpcFile(TASKS_DIR, data);

--- a/apps/core/src/runtime/agent-spawn-host.ts
+++ b/apps/core/src/runtime/agent-spawn-host.ts
@@ -12,6 +12,11 @@ import {
   ONECLI_URL,
 } from '../core/config.js';
 import { resolveHostCredentialMode } from '../core/credential-mode.js';
+import {
+  isPathInside,
+  resolvePathWithRealParent,
+  safeRealpathSync,
+} from '../core/fs-paths.js';
 import { logger } from '../core/logger.js';
 import { RegisteredGroup } from '../core/types.js';
 import {
@@ -30,42 +35,6 @@ const onecli = new OneCLI({ url: ONECLI_URL });
 
 const ONECLI_ALLOWED_ENV_KEY_SET = new Set<string>(ONECLI_ALLOWED_ENV_KEYS);
 const ONECLI_CA_CERT_ROOT = path.resolve(DATA_DIR, 'onecli', 'certs');
-
-function isPathInside(root: string, candidate: string): boolean {
-  const relative = path.relative(path.resolve(root), path.resolve(candidate));
-  return (
-    relative === '' ||
-    (!relative.startsWith('..') && !path.isAbsolute(relative))
-  );
-}
-
-function safeRealpathSync(targetPath: string): string {
-  const maybeRealpath = (
-    fs as unknown as { realpathSync?: (p: string) => string }
-  ).realpathSync;
-  if (typeof maybeRealpath !== 'function') {
-    return path.resolve(targetPath);
-  }
-  try {
-    return maybeRealpath(targetPath);
-  } catch {
-    return path.resolve(targetPath);
-  }
-}
-
-function resolvePathWithRealParent(targetPath: string): string {
-  const resolved = path.resolve(targetPath);
-  const suffix: string[] = [path.basename(resolved)];
-  let anchor = path.dirname(resolved);
-  while (!fs.existsSync(anchor)) {
-    const parent = path.dirname(anchor);
-    if (parent === anchor) break;
-    suffix.unshift(path.basename(anchor));
-    anchor = parent;
-  }
-  const realAnchor = safeRealpathSync(anchor);
-  return path.join(realAnchor, ...suffix);
-}
 
 function sanitizeCertFileSegment(value?: string): string {
   const trimmed = value?.trim();

--- a/apps/core/src/runtime/ipc-task-admin-handlers.ts
+++ b/apps/core/src/runtime/ipc-task-admin-handlers.ts
@@ -1,4 +1,5 @@
 import { MYCLAW_HOME } from '../core/config.js';
+import { nowIso } from '../core/datetime.js';
 import { logger } from '../core/logger.js';
 import { isValidGroupFolder } from '../platform/group-folder.js';
 import { validateRuntimePreflight } from '../cli/runtime-preflight.js';
@@ -54,7 +55,7 @@ const registerAgentHandler: TaskHandler = (context) => {
       name: data.name,
       folder: data.folder,
       trigger: data.trigger,
-      added_at: new Date().toISOString(),
+      added_at: nowIso(),
       agentConfig: data.agentConfig,
       requiresTrigger: data.requiresTrigger,
       isMain: existingGroup?.isMain,

--- a/apps/core/src/runtime/ipc-task-scheduler-create-handlers.ts
+++ b/apps/core/src/runtime/ipc-task-scheduler-create-handlers.ts
@@ -1,6 +1,7 @@
 import { CronExpressionParser } from 'cron-parser';
 
 import { TIMEZONE } from '../core/config.js';
+import { nowMs, parseIso, toIso } from '../core/datetime.js';
 import { logger } from '../core/logger.js';
 import { getJobById, upsertJob } from '../storage/db.js';
 import { TaskHandler } from './ipc-task-types.js';
@@ -88,14 +89,14 @@ const schedulerUpsertJobHandler: TaskHandler = async (context) => {
       logger.warn({ scheduleValue }, 'Invalid interval for job');
       return;
     }
-    nextRun = new Date(Date.now() + ms).toISOString();
+    nextRun = toIso(nowMs() + ms);
   } else if (scheduleType === 'once') {
-    const date = new Date(scheduleValue);
-    if (isNaN(date.getTime())) {
+    const date = parseIso(scheduleValue);
+    if (!date) {
       logger.warn({ scheduleValue }, 'Invalid once timestamp for job');
       return;
     }
-    nextRun = date.toISOString();
+    nextRun = toIso(date);
   } else {
     return;
   }

--- a/apps/core/src/runtime/ipc-task-scheduler-mutate-handlers.ts
+++ b/apps/core/src/runtime/ipc-task-scheduler-mutate-handlers.ts
@@ -1,6 +1,7 @@
 import { CronExpressionParser } from 'cron-parser';
 
 import { TIMEZONE } from '../core/config.js';
+import { nowIso, nowMs, parseIso, toIso } from '../core/datetime.js';
 import { logger } from '../core/logger.js';
 import { deleteJob, getJobById, updateJob } from '../storage/db.js';
 import { TaskHandler } from './ipc-task-types.js';
@@ -18,14 +19,14 @@ function computeResumeNextRun(job: {
   if (job.next_run) return job.next_run;
 
   if (job.schedule_type === 'once') {
-    const date = new Date(job.schedule_value);
-    return Number.isFinite(date.getTime()) ? new Date().toISOString() : null;
+    const date = parseIso(job.schedule_value);
+    return date ? nowIso() : null;
   }
 
   if (job.schedule_type === 'cron') {
     try {
       CronExpressionParser.parse(job.schedule_value, { tz: TIMEZONE });
-      return new Date().toISOString();
+      return nowIso();
     } catch {
       return null;
     }
@@ -34,7 +35,7 @@ function computeResumeNextRun(job: {
   if (job.schedule_type === 'interval') {
     const ms = parseInt(job.schedule_value, 10);
     if (!Number.isFinite(ms) || ms <= 0) return null;
-    return new Date().toISOString();
+    return nowIso();
   }
 
   return null;
@@ -165,17 +166,17 @@ const schedulerUpdateJobHandler: TaskHandler = (context) => {
         );
         return;
       }
-      updates.next_run = new Date(Date.now() + ms).toISOString();
+      updates.next_run = toIso(nowMs() + ms);
     } else if (merged.schedule_type === 'once') {
-      const date = new Date(merged.schedule_value);
-      if (isNaN(date.getTime())) {
+      const date = parseIso(merged.schedule_value);
+      if (!date) {
         logger.warn(
           { jobId, value: merged.schedule_value },
           'Invalid once timestamp in scheduler_update_job',
         );
         return;
       }
-      updates.next_run = date.toISOString();
+      updates.next_run = toIso(date);
     } else {
       return;
     }

--- a/apps/core/src/runtime/ipc-task-shared.ts
+++ b/apps/core/src/runtime/ipc-task-shared.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { createHash } from 'crypto';
 
 import { DATA_DIR } from '../core/config.js';
+import { nowIso } from '../core/datetime.js';
+import { writeFileAtomic } from '../core/fs-paths.js';
 import { JobExecutionMode, RegisteredGroup } from '../core/types.js';
 import { isValidGroupFolder } from '../platform/group-folder.js';
 import {
@@ -12,17 +14,7 @@ import {
 } from '../cli/service-manager.js';
 
 const TASK_IPC_RESPONSE_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
-
-export function toTrimmedString(
-  value: unknown,
-  opts: { maxLen?: number; allowEmpty?: boolean } = {},
-): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  if (!opts.allowEmpty && trimmed.length === 0) return undefined;
-  if (opts.maxLen && trimmed.length > opts.maxLen) return undefined;
-  return trimmed;
-}
+export { toTrimmedString } from '../core/object.js';
 
 export function normalizeIpcExecutionMode(
   executionMode: unknown,
@@ -73,9 +65,7 @@ export function generateJobId(params: {
 }
 
 function writeJsonAtomic(filePath: string, value: unknown): void {
-  const tempPath = `${filePath}.tmp`;
-  fs.writeFileSync(tempPath, JSON.stringify(value, null, 2));
-  fs.renameSync(tempPath, filePath);
+  writeFileAtomic(filePath, JSON.stringify(value, null, 2));
 }
 
 export function writeTaskIpcResponse(
@@ -96,7 +86,7 @@ export function writeTaskIpcResponse(
   writeJsonAtomic(responsePath, {
     taskId,
     ...payload,
-    timestamp: new Date().toISOString(),
+    timestamp: nowIso(),
   });
 }
 

--- a/apps/core/src/runtime/ipc.ts
+++ b/apps/core/src/runtime/ipc.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { DATA_DIR, IPC_POLL_INTERVAL } from '../core/config.js';
+import { nowIso, nowMs } from '../core/datetime.js';
+import { isPlainObject, toTrimmedString } from '../core/object.js';
 import { isValidGroupFolder } from '../platform/group-folder.js';
 import { logger } from '../core/logger.js';
 import { IPC_GROUP_SUBDIRS } from './agent-spawn-layout.js';
@@ -52,21 +54,6 @@ const ipcRateLimitState = new Map<
   string,
   { windowStart: number; count: number }
 >();
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function toTrimmedString(
-  value: unknown,
-  opts: { maxLen?: number; allowEmpty?: boolean } = {},
-): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  if (!opts.allowEmpty && trimmed.length === 0) return undefined;
-  if (opts.maxLen && trimmed.length > opts.maxLen) return undefined;
-  return trimmed;
-}
 
 function toOptionalStringArray(
   value: unknown,
@@ -143,7 +130,7 @@ function sanitizeToolInput(
 }
 
 function canProcessIpcFile(sourceGroup: string, kind: string): boolean {
-  const now = Date.now();
+  const now = nowMs();
   const key = `${sourceGroup}:${kind}`;
   const state = ipcRateLimitState.get(key);
   if (!state || now - state.windowStart >= IPC_RATE_LIMIT_WINDOW_MS) {
@@ -192,7 +179,7 @@ function claimIpcFile(filePath: string): string {
   }
   const claimed = path.join(
     path.dirname(filePath),
-    `.processing-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${path.basename(filePath)}`,
+    `.processing-${process.pid}-${nowMs()}-${Math.random().toString(36).slice(2, 8)}-${path.basename(filePath)}`,
   );
   fs.renameSync(filePath, claimed);
   return claimed;
@@ -296,7 +283,7 @@ function acquireIpcRootLock(ipcBaseDir: string): string {
     lockPath,
     JSON.stringify({
       pid: process.pid,
-      startedAt: new Date().toISOString(),
+      startedAt: nowIso(),
     }),
     { flag: 'wx' },
   );

--- a/apps/core/src/runtime/scheduler-state-file.ts
+++ b/apps/core/src/runtime/scheduler-state-file.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { SCHEDULER_JOBS_JSON_PATH } from '../core/config.js';
+import { nowIso } from '../core/datetime.js';
+import { writeFileAtomic } from '../core/fs-paths.js';
 import { Job, JobEvent, JobRun } from '../core/types.js';
 import { logger } from '../core/logger.js';
 
@@ -15,15 +17,13 @@ export function writeSchedulerStateFile(
   fs.mkdirSync(dir, { recursive: true });
 
   const payload = {
-    updated_at: new Date().toISOString(),
+    updated_at: nowIso(),
     jobs,
     recent_runs: runs,
     recent_events: events,
   };
 
-  const tempPath = `${filePath}.tmp`;
-  fs.writeFileSync(tempPath, JSON.stringify(payload, null, 2));
-  fs.renameSync(tempPath, filePath);
+  writeFileAtomic(filePath, JSON.stringify(payload, null, 2));
 }
 
 export function writeSchedulerStateFileSafe(

--- a/apps/core/src/runtime/task-scheduler-schedule.ts
+++ b/apps/core/src/runtime/task-scheduler-schedule.ts
@@ -1,6 +1,7 @@
 import { CronExpressionParser } from 'cron-parser';
 
 import { TIMEZONE } from '../core/config.js';
+import { parseIso } from '../core/datetime.js';
 
 interface ScheduleValidationInput {
   schedule_type: string;
@@ -12,8 +13,7 @@ export function validateScheduleConfig(
 ): string | null {
   const scheduleType = String(job.schedule_type);
   if (scheduleType === 'once') {
-    const date = new Date(job.schedule_value);
-    if (!Number.isFinite(date.getTime())) {
+    if (!parseIso(job.schedule_value)) {
       return `Invalid once schedule_value: ${job.schedule_value}`;
     }
     return null;

--- a/apps/core/src/runtime/task-scheduler.ts
+++ b/apps/core/src/runtime/task-scheduler.ts
@@ -11,7 +11,17 @@ import {
   SCHEDULER_POLL_INTERVAL,
   TIMEZONE,
 } from '../core/config.js';
-import { Job, JobExecutionMode, RegisteredGroup } from '../core/types.js';
+import {
+  nowIso as currentIso,
+  nowMs as currentTimeMs,
+  toIso,
+} from '../core/datetime.js';
+import {
+  Job,
+  JobExecutionMode,
+  RegisteredGroup,
+  StreamingChunkOptions,
+} from '../core/types.js';
 import { logger } from '../core/logger.js';
 import { runMemoryCleanupInSubprocess } from '../memory/cleanup-job.js';
 import {
@@ -37,7 +47,6 @@ import {
   upsertJob,
   updateJob,
 } from '../storage/db.js';
-import { StreamingChunkOptions } from '../core/types.js';
 
 export interface SchedulerDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
@@ -61,8 +70,8 @@ export interface SchedulerDependencies {
   runAgent?: typeof spawnAgent;
 }
 
-const DEFAULT_JOB_CLEANUP_AFTER_MS = 86_400_000;
-const MAX_PARALLEL_JOBS_PER_GROUP_SCOPE = 2;
+const DEFAULT_JOB_CLEANUP_AFTER_MS = 86_400_000,
+  MAX_PARALLEL_JOBS_PER_GROUP_SCOPE = 2;
 let schedulerStreamingGenerationCounter = 0;
 const activeParallelRunsByGroupScope = new Map<string, number>();
 const activeSerializedRunsByGroupScope = new Map<string, number>();
@@ -78,13 +87,11 @@ let memoryMaintenanceQueue: MemoryMaintenanceQueueLike =
   getMemoryMaintenanceQueue();
 
 function nextSchedulerStreamingGeneration(): number {
-  schedulerStreamingGenerationCounter += 1;
-  return schedulerStreamingGenerationCounter;
+  return ++schedulerStreamingGenerationCounter;
 }
 
 function schedulerQueueJid(groupScope: string, jobId?: string): string {
-  if (jobId) return `__scheduler__:${groupScope}:${jobId}`;
-  return `__scheduler__:${groupScope}`;
+  return `__scheduler__:${groupScope}${jobId ? `:${jobId}` : ''}`;
 }
 
 function canScheduleParallelRunForGroup(
@@ -163,10 +170,6 @@ function acquireSerializedRunSlot(groupScope: string): () => void {
   };
 }
 
-function normalizeExecutionMode(mode: unknown): JobExecutionMode {
-  return mode === 'serialized' ? 'serialized' : 'parallel';
-}
-
 function normalizeCleanupAfterMs(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return DEFAULT_JOB_CLEANUP_AFTER_MS;
@@ -189,7 +192,7 @@ function shouldDeleteCompletedOneTimeJob(job: Job, nowMs: number): boolean {
 
 function sweepCompletedOneTimeJobs(): boolean {
   const jobs = getAllJobs();
-  const nowMs = Date.now();
+  const nowMs = currentTimeMs();
   let deleted = false;
   for (const job of jobs) {
     if (!shouldDeleteCompletedOneTimeJob(job, nowMs)) continue;
@@ -213,7 +216,7 @@ export function computeNextJobRun(
   if (job.schedule_type === 'cron') {
     const interval = CronExpressionParser.parse(job.schedule_value, {
       tz: TIMEZONE,
-      currentDate: scheduledFor || new Date().toISOString(),
+      currentDate: scheduledFor || currentIso(),
     });
     return interval.next().toISOString();
   }
@@ -225,14 +228,16 @@ export function computeNextJobRun(
   const ms = parseInt(job.schedule_value, 10);
   if (!ms || ms <= 0) return null;
 
-  const parsedAnchor = scheduledFor ? Date.parse(scheduledFor) : Date.now();
-  const anchor = Number.isFinite(parsedAnchor) ? parsedAnchor : Date.now();
-  const now = Date.now();
+  const parsedAnchor = scheduledFor
+    ? Date.parse(scheduledFor)
+    : currentTimeMs();
+  const anchor = Number.isFinite(parsedAnchor) ? parsedAnchor : currentTimeMs();
+  const now = currentTimeMs();
   const steps = anchor >= now ? 1 : Math.floor((now - anchor) / ms) + 1;
   const next = anchor + steps * ms;
 
   if (!Number.isFinite(next) || Math.abs(next) > 8.64e15) return null;
-  return new Date(next).toISOString();
+  return toIso(next);
 }
 
 function formatRunStatusMessage(args: {
@@ -335,7 +340,7 @@ function registerSystemJobs(deps: SchedulerDependencies): void {
     }
   }
 
-  const nowIso = new Date().toISOString();
+  const nowIso = currentIso();
   if (RUNTIME_MEMORY_DREAMING_ENABLED) {
     for (const [groupFolder, linkedSessions] of byFolder.entries()) {
       const jobId = `system:dreaming:${groupFolder}`;
@@ -489,15 +494,14 @@ async function runJob(
     return;
   }
 
-  const scheduledFor = currentJob.next_run || new Date().toISOString();
+  const scheduledFor = currentJob.next_run || currentIso();
   const runId = randomUUID();
   const timeoutMs = Math.max(30_000, currentJob.timeout_ms || 300_000);
-  const executionMode = normalizeExecutionMode(
-    executionModeHint ?? currentJob.execution_mode,
-  );
-  const leaseExpiresAt = new Date(
-    Date.now() + timeoutMs + 30_000,
-  ).toISOString();
+  const executionMode: JobExecutionMode =
+    (executionModeHint ?? currentJob.execution_mode) === 'serialized'
+      ? 'serialized'
+      : 'parallel';
+  const leaseExpiresAt = toIso(currentTimeMs() + timeoutMs + 30_000);
 
   if (!markJobRunning(currentJob.id, runId, leaseExpiresAt)) {
     return;
@@ -507,7 +511,7 @@ async function runJob(
     run_id: runId,
     job_id: currentJob.id,
     scheduled_for: scheduledFor,
-    started_at: new Date().toISOString(),
+    started_at: currentIso(),
     ended_at: null,
     status: 'running',
     result_summary: null,
@@ -524,11 +528,21 @@ async function runJob(
     deps.onSchedulerChanged?.();
     return;
   }
-
   let jobDeletedDuringRun = false;
   const isJobDeleted = (): boolean => {
     if (jobDeletedDuringRun) return true;
-    if (getJobById(currentJob.id)) return false;
+    let jobStillExists: boolean;
+    try {
+      jobStillExists = Boolean(getJobById(currentJob.id));
+    } catch (err) {
+      jobDeletedDuringRun = true;
+      logger.debug(
+        { jobId: currentJob.id, runId, err },
+        'Scheduler run observed closed storage while checking job state',
+      );
+      return true;
+    }
+    if (jobStillExists) return false;
     jobDeletedDuringRun = true;
     logger.info(
       { jobId: currentJob.id, runId },
@@ -536,7 +550,6 @@ async function runJob(
     );
     return true;
   };
-
   const emitJobEvent = (
     eventType: string,
     payload: Record<string, unknown> | null,
@@ -548,7 +561,7 @@ async function runJob(
         run_id: runId,
         event_type: eventType,
         payload: payload ? JSON.stringify(payload) : null,
-        created_at: new Date().toISOString(),
+        created_at: currentIso(),
       });
     } catch (err) {
       logger.warn(
@@ -563,12 +576,10 @@ async function runJob(
     scheduled_for: scheduledFor,
     timeout_ms: timeoutMs,
   });
-
   let result: string | null = null;
   let error: string | null = null;
   let collectedResult = '';
   let pendingSessionId: string | undefined;
-
   let groupDir: string;
   try {
     groupDir = resolveGroupFolderPath(execution.group.folder);
@@ -583,7 +594,6 @@ async function runJob(
   const linkedSessions = Array.from(new Set(currentJob.linked_sessions));
   const shouldDeliverToChat = !currentJob.silent && linkedSessions.length > 0;
   const streamGeneration = nextSchedulerStreamingGeneration();
-
   const buildStreamingOptions = (args: {
     done?: boolean;
   }): StreamingChunkOptions => {
@@ -594,7 +604,6 @@ async function runJob(
     if (args.done !== undefined) options.done = args.done;
     return options;
   };
-
   const resetDeliveryStreams = () => {
     if (!deps.resetStreaming || !shouldDeliverToChat) return;
     for (const jid of linkedSessions) {
@@ -608,7 +617,6 @@ async function runJob(
       }
     }
   };
-
   const deliverMessage = async (text: string): Promise<boolean> => {
     if (!shouldDeliverToChat || !text || isJobDeleted()) return false;
     let delivered = false;
@@ -625,7 +633,6 @@ async function runJob(
     }
     return delivered;
   };
-
   const deliverStreamingChunk = async (text: string): Promise<boolean> => {
     if (!shouldDeliverToChat || !text || isJobDeleted()) return false;
     if (!deps.sendStreamingChunk) {
@@ -650,7 +657,6 @@ async function runJob(
     }
     return delivered;
   };
-
   let streamFinalized = false;
   const finalizeStreaming = async (): Promise<boolean> => {
     if (
@@ -680,7 +686,6 @@ async function runJob(
     }
     return delivered;
   };
-
   if (shouldDeliverToChat) {
     resetDeliveryStreams();
     await deliverMessage(`🔔 Scheduled task: ${currentJob.name}`);
@@ -706,7 +711,7 @@ async function runJob(
       let lastStreamingEventMs = 0;
       const flushStreamingEvent = (force = false): void => {
         if (bufferedStreamingChars <= 0) return;
-        const nowMs = Date.now();
+        const nowMs = currentTimeMs();
         if (!force && nowMs - lastStreamingEventMs < 1000) return;
         emitJobEvent('job.streaming', {
           buffered_chars: bufferedStreamingChars,
@@ -787,7 +792,7 @@ async function runJob(
     }
   }
 
-  const now = new Date().toISOString();
+  const now = currentIso();
   isJobDeleted();
   if (jobDeletedDuringRun) {
     result = null;
@@ -832,7 +837,7 @@ async function runJob(
       const boundedDelay = Number.isFinite(rawDelay)
         ? Math.min(rawDelay, 30 * 24 * 60 * 60 * 1000)
         : 30 * 24 * 60 * 60 * 1000;
-      nextRun = new Date(Date.now() + boundedDelay).toISOString();
+      nextRun = toIso(currentTimeMs() + boundedDelay);
       updateJob(currentJob.id, {
         status: 'active',
         next_run: nextRun,
@@ -975,7 +980,8 @@ export async function runSchedulerTick(
         deps.onSchedulerChanged?.();
         continue;
       }
-      const executionMode = normalizeExecutionMode(current.execution_mode);
+      const executionMode: JobExecutionMode =
+        current.execution_mode === 'serialized' ? 'serialized' : 'parallel';
       if (
         executionMode === 'parallel' &&
         !canScheduleParallelRunForGroup(
@@ -1020,6 +1026,11 @@ export async function runSchedulerTick(
               : acquireSerializedRunSlot(current.group_scope);
           try {
             await runJob(current, deps, queueJid, executionMode);
+          } catch (err) {
+            logger.warn(
+              { err, jobId: current.id, queueJid },
+              'Scheduler run crashed before completion',
+            );
           } finally {
             releaseSlot?.();
           }

--- a/apps/core/src/storage/db.ts
+++ b/apps/core/src/storage/db.ts
@@ -3,12 +3,14 @@ import fs from 'fs';
 import path from 'path';
 
 import { STORE_DIR } from '../core/config.js';
+import { nowIso as currentIso } from '../core/datetime.js';
 import {
   decodeGlobalMessageCursor,
   decodeGroupMessageCursor,
   encodeGlobalMessageCursor,
   toGlobalMessageCursor,
 } from '../core/message-cursor.js';
+import { isPlainObject } from '../core/object.js';
 import { isValidGroupFolder } from '../platform/group-folder.js';
 import { logger } from '../core/logger.js';
 import {
@@ -21,10 +23,6 @@ import {
 } from '../core/types.js';
 
 let db: Database.Database;
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function parseRegisteredGroupAgentConfig(
   rawConfig: string | null,
@@ -620,7 +618,7 @@ export function upsertJob(job: JobUpsertInput): { created: boolean } {
   const existing = db
     .prepare('SELECT id FROM jobs WHERE id = ?')
     .get(job.id) as { id: string } | undefined;
-  const now = new Date().toISOString();
+  const now = currentIso();
 
   db.prepare(
     `
@@ -838,7 +836,7 @@ export function updateJob(
   if (fields.length === 0) return;
 
   fields.push('updated_at = ?');
-  values.push(new Date().toISOString());
+  values.push(currentIso());
   values.push(id);
   db.prepare(`UPDATE jobs SET ${fields.join(', ')} WHERE id = ?`).run(
     ...values,
@@ -851,7 +849,7 @@ export function deleteJob(id: string): void {
   db.prepare('DELETE FROM jobs WHERE id = ?').run(id);
 }
 
-export function listDueJobs(nowIso: string = new Date().toISOString()): Job[] {
+export function listDueJobs(nowIso: string = currentIso()): Job[] {
   return db
     .prepare(
       `
@@ -880,13 +878,11 @@ export function markJobRunning(
       WHERE id = ? AND status = 'active'
     `,
     )
-    .run(runId, leaseExpiresAt, new Date().toISOString(), id).changes;
+    .run(runId, leaseExpiresAt, currentIso(), id).changes;
   return changes > 0;
 }
 
-export function releaseStaleJobLeases(
-  nowIso: string = new Date().toISOString(),
-): number {
+export function releaseStaleJobLeases(nowIso: string = currentIso()): number {
   return db
     .prepare(
       `
@@ -938,12 +934,12 @@ export function completeJobRun(
       SET status = ?, ended_at = ?, result_summary = ?, error_summary = ?
       WHERE run_id = ?
     `,
-  ).run(status, new Date().toISOString(), resultSummary, errorSummary, runId);
+  ).run(status, currentIso(), resultSummary, errorSummary, runId);
 }
 
 export function markJobRunNotified(runId: string): void {
   db.prepare('UPDATE job_runs SET notified_at = ? WHERE run_id = ?').run(
-    new Date().toISOString(),
+    currentIso(),
     runId,
   );
 }

--- a/apps/core/src/text-styles.ts
+++ b/apps/core/src/text-styles.ts
@@ -1,5 +1,5 @@
 /**
- * parseTextStyles — convert Codex Markdown output to channel-native formatting.
+ * parseTextStyles — convert agent Markdown output to channel-native formatting.
  *
  * Code blocks (fenced and inline) are preserved exactly. Marker substitution is
  * applied only to non-code segments.

--- a/apps/core/test/unit/bootstrap/channel-providers.test.ts
+++ b/apps/core/test/unit/bootstrap/channel-providers.test.ts
@@ -12,6 +12,7 @@ import {
 function makeRuntimeSettings(enabled: {
   telegram: boolean;
   slack: boolean;
+  [key: string]: boolean;
 }): RuntimeSettings {
   const allowlist = {
     default: { allow: '*', mode: 'trigger' as const },
@@ -22,6 +23,14 @@ function makeRuntimeSettings(enabled: {
     channels: {
       telegram: { enabled: enabled.telegram, senderAllowlist: allowlist },
       slack: { enabled: enabled.slack, senderAllowlist: allowlist },
+      ...Object.fromEntries(
+        Object.entries(enabled)
+          .filter(([key]) => key !== 'telegram' && key !== 'slack')
+          .map(([key, value]) => [
+            key,
+            { enabled: value, senderAllowlist: allowlist },
+          ]),
+      ),
     },
     memory: {
       enabled: true,
@@ -127,5 +136,25 @@ describe('listChannelProviders', () => {
     expect(providerForJid('tg:-100123')?.id).toBe('telegram');
     expect(providerForJid('sl:C123456')?.id).toBe('slack');
     expect(providerForJid('unknown:123')).toBeUndefined();
+  });
+
+  it('supports a third provider in registry and settings checks', () => {
+    const id = `test-provider-${Date.now()}`;
+    registerChannelProvider({
+      ...listChannelProviders()[0]!,
+      id,
+      jidPrefix: `tp${Date.now()}:`,
+      folderPrefix: `tp_${Date.now()}_`,
+      isEnabled: (settings) => settings.channels[id]?.enabled === true,
+    });
+
+    const provider = getChannelProvider(id);
+    expect(provider).toBeDefined();
+    expect(
+      provider?.isEnabled(
+        makeRuntimeSettings({ telegram: false, slack: false, [id]: true }),
+      ),
+    ).toBe(true);
+    expect(providerForJid(provider!.jidPrefix + 'abc')?.id).toBe(id);
   });
 });

--- a/apps/core/test/unit/core/datetime.test.ts
+++ b/apps/core/test/unit/core/datetime.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  fixedClock,
+  formatDurationMs,
+  nowIso,
+  nowMs,
+  parseIso,
+  sleep,
+  toIso,
+} from '@core/core/datetime.js';
+
+describe('datetime helpers', () => {
+  it('returns deterministic values with fixedClock', () => {
+    const clock = fixedClock('2026-04-21T00:00:00.123Z');
+    expect(nowMs(clock)).toBe(1_776_729_600_123);
+    expect(nowIso(clock)).toBe('2026-04-21T00:00:00.123Z');
+  });
+
+  it('parses and formats ISO timestamps', () => {
+    const parsed = parseIso('2026-04-21T00:00:00.000Z');
+    expect(parsed?.toISOString()).toBe('2026-04-21T00:00:00.000Z');
+    expect(parseIso('')).toBeUndefined();
+    expect(parseIso('bad-date')).toBeUndefined();
+    expect(toIso('2026-04-21T00:00:00.000Z')).toBe('2026-04-21T00:00:00.000Z');
+  });
+
+  it('formats durations in a readable compact format', () => {
+    expect(formatDurationMs(0)).toBe('0ms');
+    expect(formatDurationMs(1_234)).toBe('1s 234ms');
+    expect(formatDurationMs(3_661_250)).toBe('1h 1m 1s 250ms');
+  });
+
+  it('supports async sleep', async () => {
+    const start = Date.now();
+    await sleep(10);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/apps/core/test/unit/core/fs-paths.test.ts
+++ b/apps/core/test/unit/core/fs-paths.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { writeFileAtomic } from '@core/core/fs-paths.js';
+
+describe('fs-path helpers', () => {
+  it('uses restrictive default permissions for atomic writes', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myclaw-fs-paths-'));
+    try {
+      const filePath = path.join(tmpDir, 'secret.json');
+      writeFileAtomic(filePath, '{"secret":true}');
+      const mode = fs.statSync(filePath).mode & 0o777;
+      expect(mode & 0o077).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/core/test/unit/core/logger.test.ts
+++ b/apps/core/test/unit/core/logger.test.ts
@@ -1,14 +1,19 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fixedClock } from '@core/core/datetime.js';
+import {
+  createLogger,
+  installGlobalErrorHandlers,
+  logger,
+  type LogRecord,
+  type LogSink,
+} from '@core/core/logger.js';
 
 describe('logger', () => {
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
   let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
-  let originalLogLevel: string | undefined;
 
   beforeEach(() => {
-    originalLogLevel = process.env.LOG_LEVEL;
-    process.env.LOG_LEVEL = 'info';
-    vi.resetModules();
     stdoutWriteSpy = vi
       .spyOn(process.stdout, 'write')
       .mockImplementation(() => true);
@@ -20,114 +25,157 @@ describe('logger', () => {
   afterEach(() => {
     stdoutWriteSpy.mockRestore();
     stderrWriteSpy.mockRestore();
-    if (originalLogLevel === undefined) {
-      delete process.env.LOG_LEVEL;
-    } else {
-      process.env.LOG_LEVEL = originalLogLevel;
-    }
   });
 
-  it('logger.fatal writes to stderr', async () => {
-    // Cover line 72: fatal log level
-    const { logger } = await import('@core/core/logger.js');
-    logger.fatal('test fatal message');
-
+  it('writes text logs to stderr for warn/error/fatal', () => {
+    const l = createLogger({
+      level: 'debug',
+      clock: fixedClock('2026-04-21T00:00:00.000Z'),
+      format: 'text',
+    });
+    l.warn('warning message');
     const output = stderrWriteSpy.mock.calls
       .map((call: unknown[]) => String(call[0]))
       .join('');
-    expect(output).toContain('FATAL');
-    expect(output).toContain('test fatal message');
+    expect(output).toContain('WARN');
+    expect(output).toContain('warning message');
+    expect(output).toContain('2026-04-21T00:00:00.000Z');
   });
 
-  it('logger.fatal with data object writes to stderr', async () => {
-    // Cover line 72: fatal with data object
-    const { logger } = await import('@core/core/logger.js');
-    logger.fatal({ key: 'val' }, 'fatal with data');
-
-    const output = stderrWriteSpy.mock.calls
+  it('writes json logs when json format is selected', () => {
+    const l = createLogger({
+      level: 'debug',
+      clock: fixedClock('2026-04-21T00:00:00.000Z'),
+      format: 'json',
+    });
+    l.info({ foo: 'bar' }, 'json log');
+    const output = stdoutWriteSpy.mock.calls
       .map((call: unknown[]) => String(call[0]))
-      .join('');
-    expect(output).toContain('FATAL');
-    expect(output).toContain('fatal with data');
+      .join('')
+      .trim();
+    const parsed = JSON.parse(output) as LogRecord;
+    expect(parsed.level).toBe('info');
+    expect(parsed.message).toBe('json log');
+    expect(parsed.context).toEqual({ foo: 'bar' });
+    expect(parsed.timestamp).toBe('2026-04-21T00:00:00.000Z');
   });
 
-  it('formatErr handles non-Error objects', async () => {
-    // Cover line 23: formatErr non-Error branch
-    const { logger } = await import('@core/core/logger.js');
-    logger.error({ err: 'string-error' }, 'non-error object');
-
-    const output = stderrWriteSpy.mock.calls
-      .map((call: unknown[]) => String(call[0]))
-      .join('');
-    expect(output).toContain('non-error object');
-    expect(output).toContain('string-error');
+  it('supports sink injection and child context', () => {
+    const records: LogRecord[] = [];
+    const sink: LogSink = {
+      write: (record) => {
+        records.push(record);
+      },
+    };
+    const l = createLogger({
+      level: 'debug',
+      sink,
+      clock: fixedClock('2026-04-21T00:00:00.000Z'),
+      context: { scope: 'root' },
+    });
+    l.child({ group: 'team-a' }).info({ event: 'start' }, 'child event');
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      level: 'info',
+      message: 'child event',
+      context: { scope: 'root', group: 'team-a', event: 'start' },
+    });
   });
 
-  it('formatErr handles Error instances', async () => {
-    // Cover line 20-21: formatErr Error branch
-    const { logger } = await import('@core/core/logger.js');
-    logger.error({ err: new Error('real-error') }, 'error instance');
-
-    const output = stderrWriteSpy.mock.calls
-      .map((call: unknown[]) => String(call[0]))
-      .join('');
-    expect(output).toContain('error instance');
-    expect(output).toContain('real-error');
+  it('keeps base and child context for string-only log calls', () => {
+    const records: LogRecord[] = [];
+    const l = createLogger({
+      level: 'debug',
+      sink: { write: (record) => records.push(record) },
+      context: { scope: 'root' },
+    });
+    l.child({ group: 'team-a' }).info('string only event');
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      level: 'info',
+      message: 'string only event',
+      context: { scope: 'root', group: 'team-a' },
+    });
   });
 
-  it('log below threshold is suppressed', async () => {
-    // Cover line 48: threshold check (debug messages suppressed at info level)
-    const { logger } = await import('@core/core/logger.js');
-    logger.debug('debug message suppressed');
-
-    // Depending on LOG_LEVEL env, debug may be suppressed
-    // At default (info level), debug output should not appear
-    const stdoutOutput = stdoutWriteSpy.mock.calls
-      .map((call: unknown[]) => String(call[0]))
-      .join('');
-    // If LOG_LEVEL is not set to debug, this will be suppressed
-    if (!process.env.LOG_LEVEL || process.env.LOG_LEVEL === 'info') {
-      expect(stdoutOutput).not.toContain('debug message suppressed');
-    }
+  it('redacts sensitive keys by default', () => {
+    const records: LogRecord[] = [];
+    const l = createLogger({
+      level: 'debug',
+      sink: { write: (record) => records.push(record) },
+    });
+    l.info(
+      {
+        apiToken: 'secret',
+        nested: { password: 'p@ss', keep: 'ok' },
+      },
+      'redaction test',
+    );
+    expect(records[0]?.context).toEqual({
+      apiToken: '[REDACTED]',
+      nested: { password: '[REDACTED]', keep: 'ok' },
+    });
   });
 
-  it('uncaughtException handler calls logger.fatal and process.exit', async () => {
+  it('filters entries below configured level', () => {
+    const records: LogRecord[] = [];
+    const l = createLogger({
+      level: 'warn',
+      sink: { write: (record) => records.push(record) },
+    });
+    l.debug('skip debug');
+    l.info('skip info');
+    l.warn('emit warn');
+    expect(records).toHaveLength(1);
+    expect(records[0]?.level).toBe('warn');
+  });
+
+  it('does not install process handlers on module import', async () => {
+    vi.resetModules();
+    const beforeUncaught = process.listeners('uncaughtException').length;
+    const beforeUnhandled = process.listeners('unhandledRejection').length;
+    await import('@core/core/logger.js');
+    const afterUncaught = process.listeners('uncaughtException').length;
+    const afterUnhandled = process.listeners('unhandledRejection').length;
+    expect(afterUncaught).toBe(beforeUncaught);
+    expect(afterUnhandled).toBe(beforeUnhandled);
+  });
+
+  it('installs global handlers only when asked', () => {
     const exitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation(() => undefined as never);
-    const { logger } = await import('@core/core/logger.js');
     const fatalSpy = vi.spyOn(logger, 'fatal');
+    const errorSpy = vi.spyOn(logger, 'error');
+    const cleanup = installGlobalErrorHandlers(logger);
 
-    // Find the uncaughtException listener registered by logger.ts
-    const listeners = process.listeners('uncaughtException');
-    const loggerListener = listeners[listeners.length - 1] as (
+    const uncaught = process.listeners('uncaughtException');
+    const unhandled = process.listeners('unhandledRejection');
+    expect(uncaught.length).toBeGreaterThan(0);
+    expect(unhandled.length).toBeGreaterThan(0);
+
+    const uncaughtHandler = uncaught[uncaught.length - 1] as (
       err: Error,
     ) => void;
-    loggerListener(new Error('test uncaught'));
+    const unhandledHandler = unhandled[unhandled.length - 1] as (
+      reason: unknown,
+    ) => void;
+    uncaughtHandler(new Error('boom'));
+    unhandledHandler(new Error('reject'));
 
     expect(fatalSpy).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
       'Uncaught exception',
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
-    fatalSpy.mockRestore();
-  });
-
-  it('unhandledRejection handler calls logger.error', async () => {
-    const { logger } = await import('@core/core/logger.js');
-    const errorSpy = vi.spyOn(logger, 'error');
-
-    const listeners = process.listeners('unhandledRejection');
-    const loggerListener = listeners[listeners.length - 1] as (
-      reason: unknown,
-    ) => void;
-    loggerListener(new Error('test rejection'));
-
     expect(errorSpy).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
       'Unhandled rejection',
     );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    cleanup();
+    fatalSpy.mockRestore();
     errorSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });

--- a/apps/core/test/unit/runner/agent-capabilities.test.ts
+++ b/apps/core/test/unit/runner/agent-capabilities.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BUILTIN_AGENT_CAPABILITY_PROVIDERS,
+  composeAgentCapabilities,
+  type AgentCapabilityProvider,
+} from '@agent-runner-src/agent-capabilities.js';
+
+describe('agent capability composition', () => {
+  it('keeps the default built-in tools and myclaw MCP server wiring', () => {
+    const profile = composeAgentCapabilities({
+      mcpServerPath: '/tmp/ipc-mcp-stdio.js',
+      chatJid: 'tg:team',
+      groupFolder: 'telegram_team',
+      isMain: false,
+      ipcDir: '/tmp/ipc/team',
+      ipcAuthToken: 'token',
+    });
+
+    expect(profile.allowedTools).toContain('Bash');
+    expect(profile.allowedTools).toContain('mcp__myclaw__*');
+    expect(profile.permissionMode).toBe('default');
+    expect(profile.alwaysAllowedTools).toEqual(
+      expect.arrayContaining(['Config', 'EnterWorktree', 'ExitWorktree']),
+    );
+    expect(profile.mcpServers.myclaw).toEqual({
+      command: 'node',
+      args: ['/tmp/ipc-mcp-stdio.js'],
+      env: {
+        MYCLAW_CHAT_JID: 'tg:team',
+        MYCLAW_GROUP_FOLDER: 'telegram_team',
+        MYCLAW_IS_MAIN: '0',
+        MYCLAW_IPC_DIR: '/tmp/ipc/team',
+        MYCLAW_IPC_AUTH_TOKEN: 'token',
+      },
+    });
+  });
+
+  it('supports provider extension without replacing built-ins', () => {
+    const extraProvider: AgentCapabilityProvider = {
+      id: 'extra',
+      provide: () => ({
+        allowedTools: ['CustomTool'],
+        alwaysAllowedTools: ['CustomTool'],
+      }),
+    };
+    const profile = composeAgentCapabilities(
+      {
+        mcpServerPath: '/tmp/ipc-mcp-stdio.js',
+        chatJid: 'tg:team',
+        groupFolder: 'telegram_team',
+        isMain: true,
+      },
+      [...BUILTIN_AGENT_CAPABILITY_PROVIDERS, extraProvider],
+    );
+    expect(profile.allowedTools).toContain('CustomTool');
+    expect(profile.allowedTools).toContain('mcp__myclaw__*');
+    expect(profile.alwaysAllowedTools).toContain('CustomTool');
+  });
+});

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -38,6 +38,20 @@ function writeJson(filePath: string, value: unknown): void {
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
 }
 
+function symlinkPackage(
+  root: string,
+  packageName: string,
+  target: string,
+): void {
+  const packagePath = path.join(
+    root,
+    'node_modules',
+    ...packageName.split('/'),
+  );
+  fs.mkdirSync(path.dirname(packagePath), { recursive: true });
+  fs.symlinkSync(path.resolve(target), packagePath, 'dir');
+}
+
 function createRunnerFixture(): {
   root: string;
   runnerPath: string;
@@ -47,7 +61,9 @@ function createRunnerFixture(): {
   memoryContextFile: string;
 } {
   const root = makeTempRoot();
-  const runnerPath = path.join(root, 'runner.ts');
+  const runnerDir = path.join(root, 'runner');
+  const coreDir = path.join(root, 'core');
+  const runnerPath = path.join(runnerDir, 'index.ts');
   const sdkDir = path.join(
     root,
     'node_modules',
@@ -60,7 +76,22 @@ function createRunnerFixture(): {
   const memoryContextFile = path.join(ipcDir, 'memory_context.json');
 
   fs.mkdirSync(sdkDir, { recursive: true });
+  fs.mkdirSync(runnerDir, { recursive: true });
+  fs.mkdirSync(coreDir, { recursive: true });
   fs.copyFileSync(path.resolve('apps/core/src/runner/index.ts'), runnerPath);
+  fs.copyFileSync(
+    path.resolve('apps/core/src/runner/agent-capabilities.ts'),
+    path.join(runnerDir, 'agent-capabilities.ts'),
+  );
+  fs.copyFileSync(
+    path.resolve('apps/core/src/core/datetime.ts'),
+    path.join(coreDir, 'datetime.ts'),
+  );
+  fs.copyFileSync(
+    path.resolve('apps/core/src/core/object.ts'),
+    path.join(coreDir, 'object.ts'),
+  );
+  symlinkPackage(root, 'dayjs', 'node_modules/dayjs');
   fs.writeFileSync(
     path.join(sdkDir, 'package.json'),
     JSON.stringify({ type: 'module', main: 'index.js' }),

--- a/apps/core/test/unit/runner/ipc-mcp-stdio.test.ts
+++ b/apps/core/test/unit/runner/ipc-mcp-stdio.test.ts
@@ -40,7 +40,9 @@ function createMcpFixture(): {
   resultPath: string;
 } {
   const root = makeTempRoot();
-  const serverPath = path.join(root, 'ipc-mcp-stdio.ts');
+  const runnerDir = path.join(root, 'runner');
+  const coreDir = path.join(root, 'core');
+  const serverPath = path.join(runnerDir, 'ipc-mcp-stdio.ts');
   const ipcDir = path.join(root, 'ipc', 'team');
   const resultPath = path.join(root, 'mcp-result.json');
   const sdkRoot = path.join(
@@ -51,6 +53,8 @@ function createMcpFixture(): {
   );
   const sdkServerDir = path.join(sdkRoot, 'server');
 
+  fs.mkdirSync(runnerDir, { recursive: true });
+  fs.mkdirSync(coreDir, { recursive: true });
   fs.mkdirSync(sdkServerDir, { recursive: true });
   fs.writeFileSync(
     path.join(root, 'package.json'),
@@ -62,8 +66,13 @@ function createMcpFixture(): {
   );
   fs.copyFileSync(
     path.resolve('apps/core/src/runner/memory-timeouts.ts'),
-    path.join(root, 'memory-timeouts.ts'),
+    path.join(runnerDir, 'memory-timeouts.ts'),
   );
+  fs.copyFileSync(
+    path.resolve('apps/core/src/core/datetime.ts'),
+    path.join(coreDir, 'datetime.ts'),
+  );
+  symlinkPackage(root, 'dayjs', 'node_modules/dayjs');
   symlinkPackage(root, 'zod', 'node_modules/zod');
   symlinkPackage(root, 'cron-parser', 'node_modules/cron-parser');
   symlinkPackage(root, '@myclaw/contracts', 'packages/contracts');

--- a/apps/core/test/unit/runtime/ipc.test.ts
+++ b/apps/core/test/unit/runtime/ipc.test.ts
@@ -4274,8 +4274,10 @@ describe('startIpcWatcher', () => {
       (call: unknown[]) =>
         typeof call[0] === 'string' &&
         String(call[0]).includes(
-          '/tmp/test-ipc/ipc/other-group/task-responses/task-svc-reject-1.json.tmp',
-        ),
+          '/tmp/test-ipc/ipc/other-group/task-responses',
+        ) &&
+        typeof call[1] === 'string' &&
+        String(call[1]).includes('"taskId": "svc-reject-1"'),
     );
     expect(writeCall).toBeTruthy();
     expect(String(writeCall?.[1])).toContain('"ok": false');
@@ -4306,8 +4308,10 @@ describe('startIpcWatcher', () => {
       (call: unknown[]) =>
         typeof call[0] === 'string' &&
         String(call[0]).includes(
-          '/tmp/test-ipc/ipc/whatsapp_main/task-responses/task-svc-validate-1.json.tmp',
-        ),
+          '/tmp/test-ipc/ipc/whatsapp_main/task-responses',
+        ) &&
+        typeof call[1] === 'string' &&
+        String(call[1]).includes('"taskId": "svc-validate-1"'),
     );
     expect(writeCall).toBeTruthy();
     const payload = String(writeCall?.[1]);
@@ -4335,8 +4339,10 @@ describe('startIpcWatcher', () => {
       (call: unknown[]) =>
         typeof call[0] === 'string' &&
         String(call[0]).includes(
-          '/tmp/test-ipc/ipc/whatsapp_main/task-responses/task-svc-ack-1.json.tmp',
-        ),
+          '/tmp/test-ipc/ipc/whatsapp_main/task-responses',
+        ) &&
+        typeof call[1] === 'string' &&
+        String(call[1]).includes('"taskId": "svc-ack-1"'),
     );
     expect(writeCall).toBeTruthy();
     const payload = String(writeCall?.[1]);
@@ -4366,8 +4372,10 @@ describe('startIpcWatcher', () => {
       (call: unknown[]) =>
         typeof call[0] === 'string' &&
         String(call[0]).includes(
-          '/tmp/test-ipc/ipc/whatsapp_main/task-responses/task-svc-throw-1.json.tmp',
-        ),
+          '/tmp/test-ipc/ipc/whatsapp_main/task-responses',
+        ) &&
+        typeof call[1] === 'string' &&
+        String(call[1]).includes('"taskId": "svc-throw-1"'),
     );
     expect(writeCall).toBeTruthy();
     const payload = String(writeCall?.[1]);

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -31,7 +31,7 @@ If a behavior matters, it should be easy to change in code. Avoid building large
 
 ### AI-Native Operations
 
-Setup, debugging, and maintenance should work well through Claude Code or Codex without requiring a heavyweight admin UI.
+Setup, debugging, and maintenance should work well through Claude Code without requiring a heavyweight admin UI.
 
 ### Skills Over Core Bloat
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -31,8 +31,8 @@ A personal Claude assistant with multi-channel support, persistent memory per co
 │                                                                       │
 │  ┌──────────────────┐                  ┌────────────────────┐        │
 │  │ Channels         │─────────────────▶│   SQLite Database  │        │
-│  │ (self-register   │◀────────────────│   (messages.db)    │        │
-│  │  at startup)     │  store/send      └─────────┬──────────┘        │
+│  │ (provider        │◀────────────────│   (messages.db)    │        │
+│  │  registry)       │  store/send      └─────────┬──────────┘        │
 │  └──────────────────┘                            │                   │
 │                                                   │                   │
 │         ┌─────────────────────────────────────────┘                   │
@@ -75,7 +75,7 @@ A personal Claude assistant with multi-channel support, persistent memory per co
 
 | Component | Technology | Purpose |
 |-----------|------------|---------|
-| Channel System | Channel registry (`apps/core/src/channels/registry.ts`) | Channels self-register at startup |
+| Channel System | Provider registry (`apps/core/src/channels/provider-registry.ts`) | Channels are looked up by provider id and JID prefix |
 | Message Storage | SQLite (better-sqlite3) | Store messages for polling |
 | Runtime Execution | Host process execution | Agent execution with runtime-home scoped paths |
 | Agent | @anthropic-ai/claude-agent-sdk (0.2.97) | Run Claude with tools and MCP servers |
@@ -86,7 +86,7 @@ A personal Claude assistant with multi-channel support, persistent memory per co
 
 ## Architecture: Channel System
 
-The runtime supports multi-channel operation via a channel registry. Telegram and Slack are available in this codebase, and additional channels (for example WhatsApp, Discord, Gmail) can be added through skills. Channels self-register at startup; channels with missing credentials emit a WARN log and are skipped.
+The runtime supports multi-channel operation via a provider registry. Telegram and Slack are available in this codebase, and additional channels (for example WhatsApp, Discord, Gmail) can be added through skills. Providers are registered at startup via `register-builtins.ts`; providers with missing credentials emit a WARN log and are skipped.
 
 ### System Diagram
 
@@ -134,27 +134,23 @@ graph LR
 
 ### Channel Registry
 
-The channel system is built on a factory registry in `apps/core/src/channels/registry.ts`:
+The channel system is built on a provider registry in `apps/core/src/channels/provider-registry.ts`:
 
 ```typescript
-export type ChannelFactory = (opts: ChannelOpts) => Channel | null;
-
-const registry = new Map<string, ChannelFactory>();
-
-export function registerChannel(name: string, factory: ChannelFactory): void {
-  registry.set(name, factory);
+export interface ChannelProvider {
+  id: string;
+  jidPrefix: string;
+  folderPrefix: string;
+  create: ChannelFactory;
 }
 
-export function getChannelFactory(name: string): ChannelFactory | undefined {
-  return registry.get(name);
-}
-
-export function getRegisteredChannelNames(): string[] {
-  return [...registry.keys()];
-}
+export function registerChannelProvider(provider: ChannelProvider): void;
+export function listChannelProviders(): readonly ChannelProvider[];
+export function getChannelProvider(id: string): ChannelProvider | undefined;
+export function providerForJid(jid: string): ChannelProvider | undefined;
 ```
 
-Each factory receives `ChannelOpts` (callbacks for `onMessage`, `onChatMetadata`, and `registeredGroups`) and returns either a `Channel` instance or `null` if that channel's credentials are not configured.
+Each provider receives `ChannelOpts` through its `create` function and returns either a `Channel` instance or `null` if the provider's credentials are not configured.
 
 ### Channel Interface
 
@@ -188,53 +184,20 @@ interface Channel {
 }
 ```
 
-### Self-Registration Pattern
+### Registration Pattern
 
-Channels self-register using a barrel-import pattern:
+Providers are registered via `apps/core/src/channels/register-builtins.ts`:
 
-1. Each channel skill adds a file to `apps/core/src/channels/` (e.g. `whatsapp.ts`, `telegram.ts`) that calls `registerChannel()` at module load time:
-
-   ```typescript
-   // apps/core/src/channels/whatsapp.ts
-   import { registerChannel, ChannelOpts } from './registry.js';
-
-   export class WhatsAppChannel implements Channel { /* ... */ }
-
-   registerChannel('whatsapp', (opts: ChannelOpts) => {
-     // Return null if credentials are missing
-     if (!existsSync(authPath)) return null;
-     return new WhatsAppChannel(opts);
-   });
-   ```
-
-2. The barrel file `apps/core/src/channels/index.ts` imports all channel modules, triggering registration:
-
-   ```typescript
-   import './whatsapp.js';
-   import './telegram.js';
-   import './slack.js';
-   // ... each skill adds its import here
-   ```
-
-3. At startup, the orchestrator (`apps/core/src/index.ts`) loops through registered channels and connects whichever ones return a valid instance:
-
-   ```typescript
-   for (const name of getRegisteredChannelNames()) {
-     const factory = getChannelFactory(name);
-     const channel = factory?.(channelOpts);
-     if (channel) {
-       await channel.connect();
-       channels.push(channel);
-     }
-   }
-   ```
+1. Built-in providers (Telegram/Slack) call `registerChannelProvider(provider)`.
+2. Startup wiring iterates `listChannelProviders()`, creates enabled providers, and connects returned channel instances.
+3. Routing uses `providerForJid(jid)` to determine ownership and formatting behavior.
 
 ### Key Files
 
 | File | Purpose |
 |------|---------|
-| `apps/core/src/channels/registry.ts` | Channel factory registry |
-| `apps/core/src/channels/index.ts` | Barrel imports that trigger channel self-registration |
+| `apps/core/src/channels/provider-registry.ts` | Channel provider registry |
+| `apps/core/src/channels/register-builtins.ts` | Built-in provider registration |
 | `apps/core/src/core/types.ts` | `Channel` interface, `ChannelOpts`, message types |
 | `apps/core/src/index.ts` | Orchestrator — instantiates channels, runs message loop |
 | `apps/core/src/messaging/router.ts` | Finds the owning channel for a JID, formats messages |
@@ -244,9 +207,9 @@ Channels self-register using a barrel-import pattern:
 To add a new channel, contribute a skill to `.claude/skills/add-<name>/` that:
 
 1. Adds a `apps/core/src/channels/<name>.ts` file implementing the `Channel` interface
-2. Calls `registerChannel(name, factory)` at module load
-3. Returns `null` from the factory if credentials are missing
-4. Adds an import line to `apps/core/src/channels/index.ts`
+2. Exposes a `ChannelProvider` entry with `id`, prefixes, setup metadata, and `create`
+3. Returns `null` from `create` if credentials are missing
+4. Registers the provider via `register-builtins.ts` (or equivalent provider registration module)
 
 Channel-extension skills can follow this pattern when they are added to the bundled or user-installed skill set. The default npm package only ships the core command-discovery and administration skills.
 
@@ -271,7 +234,7 @@ myclaw/
 │   └── core/
 │       ├── src/
 │       │   ├── index.ts           # Orchestrator: state, message loop, agent invocation
-│       │   ├── channels/          # Channel registry and channel implementations
+│       │   ├── channels/          # Channel provider registry and channel implementations
 │       │   ├── core/              # Config, logging, environment, shared types
 │       │   ├── memory/            # Memory ingestion, retrieval, and storage logic
 │       │   ├── messaging/         # Routing and formatting
@@ -280,14 +243,9 @@ myclaw/
 │       │   ├── session/           # Slash commands and transcript archive flow
 │       │   └── storage/           # SQLite persistence
 │       ├── config-examples/       # Example config payloads
-│
-├── packages/
-│   └── agent-runner/             # Code that runs inside the host-synced agent runtime
-│       ├── package.json
-│       ├── tsconfig.json
-│       └── src/
-│           ├── index.ts          # Entry point (query loop, IPC polling, session resume)
-│           └── ipc-mcp-stdio.ts  # Stdio-based MCP server for host communication
+│       │   └── runner/            # Agent runner + MCP stdio runtime code
+│       │       ├── index.ts       # Entry point (query loop, IPC polling, session resume)
+│       │       └── ipc-mcp-stdio.ts # Stdio-based MCP server for host communication
 │
 ├── ops/
 │   ├── bootstrap.sh              # Local bootstrap script
@@ -820,7 +778,7 @@ MyClaw runs as a single macOS launchd service.
 
 When MyClaw starts, it:
 1. Runs runtime preflight for host execution and emits actionable fix steps on failure
-2. Auto-builds `packages/agent-runner` artifacts and fails startup if build fails
+2. Auto-builds runner artifacts from `apps/core/src/runner` and fails startup if build fails
 3. Initializes the SQLite database (migrates from JSON files if they exist)
 4. Loads state from SQLite (registered groups, sessions, router state)
 5. **Connects channels** — loops through registered channels, instantiates those with credentials, calls `connect()` on each

--- a/docs/memory-redesign-plan.md
+++ b/docs/memory-redesign-plan.md
@@ -1,6 +1,8 @@
-# Memory, Continuation, Dreaming — Implementation Plan
+# Memory, Continuation, Dreaming — Historical Plan (Archived)
 
-**Status:** Ready for handoff, 2026-04-18
+> Historical document. This file describes an older redesign proposal and is not the active implementation contract for current MyClaw runtime behavior.
+
+**Status:** Historical reference (archived), 2026-04-18
 **Owner:** Ravi
 **Audience:** coding agent implementing this plan
 **Scope:** Redesign three pipelines — turn-time extraction, session continuation, nightly dreaming — and surrounding cleanup/observability. Self-only rollout. Clean cutover. Haiku 4.5 for hot-path extraction, Sonnet 4.6 for session summary + nightly dream + consolidation. Embeddings stay optional.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@slack/bolt": "^4.7.0",
         "better-sqlite3": "11.10.0",
         "cron-parser": "5.5.0",
+        "dayjs": "^1.11.20",
         "grammy": "^1.42.0",
         "sqlite-vec": "^0.1.9",
         "zod": "^4.0.0"
@@ -2827,6 +2828,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@slack/bolt": "^4.7.0",
     "better-sqlite3": "11.10.0",
     "cron-parser": "5.5.0",
+    "dayjs": "^1.11.20",
     "grammy": "^1.42.0",
     "sqlite-vec": "^0.1.9",
     "zod": "^4.0.0"


### PR DESCRIPTION
## Summary
- apply single-cut modernization for core runtime and agent capability surface
- add in-repo structured logger with explicit global handler install and deterministic clock integration
- introduce shared datetime and fs/object utility helpers to remove duplicated implementations
- add typed agent capability composition to preserve current host defaults while improving maintainability
- align active docs to current provider-registry/runtime truth and mark outdated memory redesign guidance as historical
- add provider-pattern and capability tests including non-Telegram/non-Slack provider coverage
- fix review regressions: secure default `0o600` in atomic writes and logger context propagation for string-only log calls

## Validation
- npm run build
- npm test
- python3 .codex/scripts/verify.py
- python3 .codex/scripts/validate_artifacts.py --allow-missing-run
- python3 .codex/scripts/validate_work.py