### PR TITLE
[codex] Harden runtime home and launchd status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Important constraints:
 
 - `/new` clears persisted session state but preserves the group model override
 - transcript archive during `/new` is best-effort and must not block reset success
-- durable memory lives in the configured SQLite/QMD memory provider; do not load `~/myclaw/agents/<folder>/memory/`
+- durable memory lives under the configured SQLite memory root; do not load `~/myclaw/agents/<folder>/memory/`
 
 ## Docs Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,17 +8,17 @@ Single Node.js process with skill-based channel provider system. Built-in provid
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `apps/core/src/index.ts` | Orchestrator: state, message loop, agent invocation |
-| `apps/core/src/channels/provider-registry.ts` | Channel provider registry |
-| `apps/core/src/runtime/ipc.ts` | IPC watcher and task processing |
-| `apps/core/src/messaging/router.ts` | Message formatting and outbound routing |
-| `apps/core/src/core/config.ts` | Trigger pattern, paths, intervals |
-| `apps/core/src/runtime/task-scheduler.ts` | Runs scheduled tasks |
-| `apps/core/src/storage/db.ts` | SQLite operations |
-| `~/myclaw/agents/{name}/CLAUDE.md` | Runtime per-agent memory files |
-| `$AGENT_ROOT/.claude/skills/` | Custom skills (single source of truth, managed externally) |
+| File                                          | Purpose                                                    |
+| --------------------------------------------- | ---------------------------------------------------------- |
+| `apps/core/src/index.ts`                      | Orchestrator: state, message loop, agent invocation        |
+| `apps/core/src/channels/provider-registry.ts` | Channel provider registry                                  |
+| `apps/core/src/runtime/ipc.ts`                | IPC watcher and task processing                            |
+| `apps/core/src/messaging/router.ts`           | Message formatting and outbound routing                    |
+| `apps/core/src/core/config.ts`                | Trigger pattern, paths, intervals                          |
+| `apps/core/src/runtime/task-scheduler.ts`     | Runs scheduled tasks                                       |
+| `apps/core/src/storage/db.ts`                 | SQLite operations                                          |
+| `~/myclaw/agents/{name}/CLAUDE.md`            | Runtime per-agent prompt guidance                          |
+| `~/myclaw/.claude/skills/`                    | Custom skills (single source of truth, managed externally) |
 
 ## Secrets / Credentials / Proxy (OneCLI)
 
@@ -31,16 +31,16 @@ Four types of skills exist in MyClaw. See [CONTRIBUTING.md](CONTRIBUTING.md) for
 - **Feature skills** — merge a `skill/*` branch to add capabilities (e.g. `/add-telegram`, `/add-slack`)
 - **Utility skills** — ship code files alongside SKILL.md (e.g. `/claw`)
 - **Operational skills** — instruction-only workflows, always on `main` (e.g. `/setup`, `/debug`)
-- **Custom skills** — managed under `$AGENT_ROOT/.claude/skills/` (single source of truth, defaults to `~/myclaw/.claude/skills/`)
+- **Custom skills** — managed under `~/myclaw/.claude/skills/` as the single source of truth
 
-| Skill | When to Use |
-|-------|-------------|
-| `/commands` | List all available slash commands with descriptions |
-| `/setup` | First-time installation, authentication, service configuration |
-| `/customize` | Adding channels, integrations, changing behavior |
-| `/debug` | Runtime issues, logs, troubleshooting |
-| `/update-myclaw` | Bring upstream MyClaw updates into a customized install |
-| `/init-onecli` | Install OneCLI Agent Vault and migrate `.env` credentials to it |
+| Skill            | When to Use                                                     |
+| ---------------- | --------------------------------------------------------------- |
+| `/commands`      | List all available slash commands with descriptions             |
+| `/setup`         | First-time installation, authentication, service configuration  |
+| `/customize`     | Adding channels, integrations, changing behavior                |
+| `/debug`         | Runtime issues, logs, troubleshooting                           |
+| `/update-myclaw` | Bring upstream MyClaw updates into a customized install         |
+| `/init-onecli`   | Install OneCLI Agent Vault and migrate `.env` credentials to it |
 
 ## Contributing
 
@@ -53,20 +53,16 @@ Run commands directly—don't tell the user to run them.
 ```bash
 npm run dev          # Run with hot reload
 npm run build        # Compile TypeScript
-npm run build        # Compile the app and agent runner
 ```
 
 Service management:
-```bash
-# macOS (launchd)
-launchctl load ~/Library/LaunchAgents/com.myclaw.plist
-launchctl unload ~/Library/LaunchAgents/com.myclaw.plist
-launchctl kickstart -k gui/$(id -u)/com.myclaw  # restart
 
-# Linux (systemd)
-systemctl --user start myclaw
-systemctl --user stop myclaw
-systemctl --user restart myclaw
+```bash
+myclaw service install
+myclaw service start
+myclaw service stop
+myclaw service restart
+myclaw status
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ myclaw setup
 myclaw doctor
 myclaw status
 myclaw memory status
-myclaw memory provider <sqlite|qmd|noop|none>
 myclaw memory embeddings <off|openai>
 myclaw memory dreaming <on|off>
 myclaw start
@@ -43,19 +42,19 @@ Defaults in v1:
 - runtime settings file: `~/myclaw/settings.yaml` (validated before `start`/`restart`)
 - setup flow: Telegram-first (Slack can be added with `myclaw slack connect`)
 - memory: on
-- memory provider: `sqlite` by default; `qmd` adds a markdown audit mirror
+- memory storage: SQLite under the configured `memory.root`
 - embeddings: off (unless OpenAI key is provided and enabled)
 - dreaming: off
 - sender allowlist: `channels.<provider>.sender_allowlist` in `settings.yaml`
+
+Runtime home is a single-cut contract. MyClaw reads `~/myclaw` by default and does not load or migrate state from `~/.myclaw`.
 
 Canonical memory settings live in `~/myclaw/settings.yaml`:
 
 ```yaml
 memory:
   enabled: true
-  provider: sqlite
-  sqlite_path: store/memory.db
-  qmd_root: agent-memory
+  root: memory
   embeddings:
     enabled: false
     provider: disabled
@@ -117,10 +116,7 @@ Continuity is the runtime context that helps the agent pick up where it left off
 
 Embeddings are off by default. Memory search and context injection still work without embeddings; embeddings only improve ranking when enabled.
 
-Provider model:
-
-- `sqlite`: simple local SQLite database, no markdown mirror
-- `qmd`: SQLite plus human-readable markdown mirror under `~/myclaw/agent-memory`
+Memory storage is SQLite-first. By default, the live database is `~/myclaw/memory/.cache/memory.db` and journal files are under `~/myclaw/memory/.journal`.
 
 ## Runtime
 
@@ -169,9 +165,9 @@ npm run test:e2e
 
 Skills are agent instructions bundled into the npm package and synced into `~/myclaw/.claude/skills/`.
 
-| Skill | Purpose |
-| ----- | ------- |
-| `/commands` | List available chat commands and installed skill packs |
+| Skill          | Purpose                                                               |
+| -------------- | --------------------------------------------------------------------- |
+| `/commands`    | List available chat commands and installed skill packs                |
 | `myclaw-admin` | Internal administration reference used by agents when managing MyClaw |
 
 Session commands are handled by the host runtime, not bundled skills:
@@ -214,8 +210,8 @@ Key paths:
 - `~/myclaw/agents/shared/CLAUDE.md` - static shared prompt guidance
 - `~/myclaw/agents/*/SOUL.md` - per-agent personality prompt
 - `~/myclaw/agents/*/CLAUDE.md` - static group-specific prompt guidance
-- `~/myclaw/store/memory.db` - default SQLite memory database
-- `~/myclaw/agent-memory/` - QMD markdown mirror when `settings.yaml memory.provider=qmd`
+- `~/myclaw/memory/.cache/memory.db` - default SQLite memory database
+- `~/myclaw/memory/.journal/` - memory journal files
 
 ## Factory Mode
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Defaults in v1:
 - dreaming: off
 - sender allowlist: `channels.<provider>.sender_allowlist` in `settings.yaml`
 
-Runtime home is a single-cut contract. MyClaw reads `~/myclaw` by default and does not load or migrate state from `~/.myclaw`.
+Runtime home is a single-cut contract. MyClaw reads `~/myclaw` by default unless `--runtime-home` or `MYCLAW_HOME` is set.
 
 Canonical memory settings live in `~/myclaw/settings.yaml`:
 

--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -8,7 +8,7 @@
 
 - Keep runtime imports aligned with the split domains under `apps/core/src/` rather than rebuilding root wrapper modules.
 - Service changes must keep `ops/bootstrap.sh`, `ops/launchd/com.myclaw.plist`, and runtime diagnostics consistent.
-- CLI onboarding code in `apps/core/src/cli/` must remain runtime-home based (`AGENT_ROOT`) and must not assume repo cwd.
+- CLI onboarding code in `apps/core/src/cli/` must remain runtime-home based (`MYCLAW_HOME`) and must not assume repo cwd.
 - Keep prompt rendering separate from side-effect modules so onboarding behavior stays testable.
 - `myclaw` CLI commands should return actionable plain-English recovery guidance instead of raw startup failures.
 - When path-sensitive code changes, update the matching tests in `apps/core/src/**/*.test.ts` in the same change.

--- a/apps/core/scripts/cleanup-sessions.sh
+++ b/apps/core/scripts/cleanup-sessions.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-RUNTIME_HOME="${MYCLAW_HOME:-${MYCLAW_RUNTIME_HOME:-$HOME/.myclaw}}"
+RUNTIME_HOME="${MYCLAW_HOME:-$HOME/myclaw}"
 
 STORE_DB="$RUNTIME_HOME/store/messages.db"
 SESSIONS_DIR="$RUNTIME_HOME/data/sessions"

--- a/apps/core/src/cli/launchd-service.ts
+++ b/apps/core/src/cli/launchd-service.ts
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { buildServicePath } from '../platform/service-path.js';
+import { runtimeErrorLogPath, runtimeLogPath } from './runtime-home.js';
+import { tryExec } from './platform.js';
+
+const SERVICE_LABEL = 'com.myclaw';
+
+export function launchdPlistPath(): string {
+  return path.join(
+    os.homedir(),
+    'Library',
+    'LaunchAgents',
+    `${SERVICE_LABEL}.plist`,
+  );
+}
+
+export function writeLaunchdPlist(
+  runtimeHome: string,
+  runtimeEntry: string,
+): void {
+  const target = launchdPlistPath();
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const uid = process.getuid?.() || 0;
+  const servicePath = buildServicePath(os.homedir());
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVICE_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${process.execPath}</string>
+    <string>${runtimeEntry}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${runtimeHome}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>MYCLAW_HOME</key>
+    <string>${runtimeHome}</string>
+    <key>HOME</key>
+    <string>${os.homedir()}</string>
+    <key>PATH</key>
+    <string>${servicePath}</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${runtimeLogPath(runtimeHome)}</string>
+  <key>StandardErrorPath</key>
+  <string>${runtimeErrorLogPath(runtimeHome)}</string>
+  <key>LimitLoadToSessionType</key>
+  <array>
+    <string>Aqua</string>
+  </array>
+</dict>
+</plist>
+`;
+  fs.writeFileSync(target, plist, 'utf-8');
+
+  tryExec('launchctl', ['bootout', `gui/${uid}`, target]);
+  const loaded = tryExec('launchctl', ['bootstrap', `gui/${uid}`, target]);
+  if (!loaded.ok && !loaded.stderr.includes('already bootstrapped')) {
+    throw new Error(
+      loaded.stderr || loaded.stdout || 'launchctl bootstrap failed',
+    );
+  }
+}
+
+export function startLaunchdService(): void {
+  const uid = process.getuid?.() || 0;
+  const result = tryExec('launchctl', [
+    'kickstart',
+    '-k',
+    `gui/${uid}/${SERVICE_LABEL}`,
+  ]);
+  if (!result.ok) {
+    throw new Error(
+      result.stderr || result.stdout || 'launchctl kickstart failed',
+    );
+  }
+}
+
+export function stopLaunchdService(): void {
+  const uid = process.getuid?.() || 0;
+  const result = tryExec('launchctl', [
+    'bootout',
+    `gui/${uid}/${SERVICE_LABEL}`,
+  ]);
+  if (!result.ok && !result.stderr.includes('Could not find service')) {
+    throw new Error(
+      result.stderr || result.stdout || 'launchctl bootout failed',
+    );
+  }
+}
+
+export function getLaunchdServiceStatus(): string {
+  const uid = process.getuid?.() || 0;
+  const printed = tryExec('launchctl', [
+    'print',
+    `gui/${uid}/${SERVICE_LABEL}`,
+  ]);
+  if (printed.ok) {
+    const state = /^\s*state = (.+)$/m.exec(printed.stdout)?.[1]?.trim();
+    const pid = /^\s*pid = (\d+)$/m.exec(printed.stdout)?.[1]?.trim();
+    if (state === 'running') return pid ? `running(pid:${pid})` : 'running';
+    return state || 'loaded';
+  }
+
+  const listing = tryExec('launchctl', ['list']);
+  if (!listing.ok) return 'unknown';
+  return listing.stdout.includes(SERVICE_LABEL) ? 'loaded' : 'not_loaded';
+}

--- a/apps/core/src/cli/onboarding-config.ts
+++ b/apps/core/src/cli/onboarding-config.ts
@@ -2,11 +2,7 @@ import { upsertEnvFile } from './env-file.js';
 import type { HostCredentialMode } from '../core/credential-mode.js';
 import '../channels/register-builtins.js';
 import { getChannelProvider } from '../channels/provider-registry.js';
-import {
-  envFilePath,
-  ensureRuntimeLayout,
-  savePreferredRuntimeHome,
-} from './runtime-home.js';
+import { envFilePath, ensureRuntimeLayout } from './runtime-home.js';
 import {
   loadRuntimeSettings,
   saveRuntimeSettings,
@@ -25,7 +21,6 @@ export interface OnboardingConfigInput {
 
 export function persistOnboardingConfig(input: OnboardingConfigInput): void {
   ensureRuntimeLayout(input.runtimeHome);
-  savePreferredRuntimeHome(input.runtimeHome);
 
   const onecliUrl = input.onecliUrl?.trim() || '';
 

--- a/apps/core/src/cli/runtime-home.ts
+++ b/apps/core/src/cli/runtime-home.ts
@@ -6,18 +6,10 @@ import { getMyclawHome } from '../core/myclaw-home.js';
 import { ensureRuntimeLayoutDirectories } from '../platform/runtime-layout.js';
 
 export const DEFAULT_RUNTIME_HOME = path.join(os.homedir(), 'myclaw');
-const GLOBAL_CONFIG_DIR = path.join(os.homedir(), '.config', 'myclaw');
-const RUNTIME_HOME_POINTER_PATH = path.join(
-  GLOBAL_CONFIG_DIR,
-  'runtime-home.txt',
-);
 
 export function resolveRuntimeHome(raw?: string): string {
   const source =
-    raw?.trim() ||
-    process.env.MYCLAW_HOME?.trim() ||
-    readPreferredRuntimeHome() ||
-    DEFAULT_RUNTIME_HOME;
+    raw?.trim() || process.env.MYCLAW_HOME?.trim() || DEFAULT_RUNTIME_HOME;
   return getMyclawHome(source);
 }
 
@@ -48,18 +40,4 @@ export function runtimeLogPath(runtimeHome: string): string {
 
 export function runtimeErrorLogPath(runtimeHome: string): string {
   return path.join(runtimeHome, 'logs', 'myclaw.error.log');
-}
-
-export function savePreferredRuntimeHome(runtimeHome: string): void {
-  fs.mkdirSync(GLOBAL_CONFIG_DIR, { recursive: true });
-  fs.writeFileSync(RUNTIME_HOME_POINTER_PATH, `${runtimeHome}\n`, 'utf-8');
-}
-
-export function readPreferredRuntimeHome(): string | null {
-  try {
-    const value = fs.readFileSync(RUNTIME_HOME_POINTER_PATH, 'utf-8').trim();
-    return value ? getMyclawHome(value) : null;
-  } catch {
-    return null;
-  }
 }

--- a/apps/core/src/cli/runtime-home.ts
+++ b/apps/core/src/cli/runtime-home.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { getMyclawHome } from '../core/myclaw-home.js';
 import { ensureRuntimeLayoutDirectories } from '../platform/runtime-layout.js';
 
-export const DEFAULT_RUNTIME_HOME = path.join(os.homedir(), '.myclaw');
+export const DEFAULT_RUNTIME_HOME = path.join(os.homedir(), 'myclaw');
 const GLOBAL_CONFIG_DIR = path.join(os.homedir(), '.config', 'myclaw');
 const RUNTIME_HOME_POINTER_PATH = path.join(
   GLOBAL_CONFIG_DIR,

--- a/apps/core/src/cli/service-manager.ts
+++ b/apps/core/src/cli/service-manager.ts
@@ -7,6 +7,13 @@ import { getRuntimeEntryPath } from './package-paths.js';
 import { detectPlatform, hasSystemdUser, tryExec } from './platform.js';
 import { buildServicePath } from '../platform/service-path.js';
 import {
+  getLaunchdServiceStatus,
+  launchdPlistPath,
+  startLaunchdService,
+  stopLaunchdService,
+  writeLaunchdPlist,
+} from './launchd-service.js';
+import {
   ensureRuntimeLayout,
   runtimeErrorLogPath,
   runtimeLogPath,
@@ -21,7 +28,6 @@ export interface ServiceOutcome {
   message: string;
 }
 
-const SERVICE_LABEL = 'com.myclaw';
 const FALLBACK_SERVICE_META = 'service-meta.json';
 const PID_FILE = 'myclaw.pid';
 
@@ -45,12 +51,12 @@ function writeFallbackServiceMetadata(
   runtimeHome: string,
   runtimeEntry: string,
 ): void {
-  const metadata: FallbackServiceMetadata = { runtimeEntry };
-  fs.writeFileSync(
-    serviceMetaPath(runtimeHome),
-    JSON.stringify(metadata, null, 2),
-    'utf-8',
+  const metadata = JSON.stringify(
+    { runtimeEntry } satisfies FallbackServiceMetadata,
+    null,
+    2,
   );
+  fs.writeFileSync(serviceMetaPath(runtimeHome), metadata, 'utf-8');
 }
 
 function readFallbackServiceMetadata(
@@ -86,9 +92,7 @@ function readFallbackPid(runtimeHome: string): number | null {
 function clearFallbackPid(runtimeHome: string): void {
   try {
     fs.unlinkSync(fallbackPidPath(runtimeHome));
-  } catch {
-    // Ignore pid cleanup errors.
-  }
+  } catch {}
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -167,68 +171,6 @@ function isManagedFallbackProcess(
   return normalizedCommand.includes(normalizedRuntimeEntry);
 }
 
-function plistPath(): string {
-  return path.join(
-    os.homedir(),
-    'Library',
-    'LaunchAgents',
-    `${SERVICE_LABEL}.plist`,
-  );
-}
-
-function writeLaunchdPlist(runtimeHome: string, runtimeEntry: string): void {
-  const target = plistPath();
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-  const uid = process.getuid?.() || 0;
-  const servicePath = buildServicePath(os.homedir());
-  const plist = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>${SERVICE_LABEL}</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>${process.execPath}</string>
-    <string>${runtimeEntry}</string>
-  </array>
-  <key>WorkingDirectory</key>
-  <string>${runtimeHome}</string>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>MYCLAW_HOME</key>
-    <string>${runtimeHome}</string>
-    <key>HOME</key>
-    <string>${os.homedir()}</string>
-    <key>PATH</key>
-    <string>${servicePath}</string>
-  </dict>
-  <key>StandardOutPath</key>
-  <string>${runtimeLogPath(runtimeHome)}</string>
-  <key>StandardErrorPath</key>
-  <string>${runtimeErrorLogPath(runtimeHome)}</string>
-  <key>LimitLoadToSessionType</key>
-  <array>
-    <string>Aqua</string>
-  </array>
-</dict>
-</plist>
-`;
-  fs.writeFileSync(target, plist, 'utf-8');
-
-  tryExec('launchctl', ['bootout', `gui/${uid}`, target]);
-  const loaded = tryExec('launchctl', ['bootstrap', `gui/${uid}`, target]);
-  if (!loaded.ok && !loaded.stderr.includes('already bootstrapped')) {
-    throw new Error(
-      loaded.stderr || loaded.stdout || 'launchctl bootstrap failed',
-    );
-  }
-}
-
 function writeSystemdUnit(runtimeHome: string, runtimeEntry: string): string {
   const unitDir = path.join(os.homedir(), '.config', 'systemd', 'user');
   const unitPath = path.join(unitDir, 'myclaw.service');
@@ -296,7 +238,7 @@ export function installService(
       return {
         ok: true,
         kind,
-        message: `Installed launchd service at ${plistPath()}.`,
+        message: `Installed launchd service at ${launchdPlistPath()}.`,
       };
     }
 
@@ -348,17 +290,7 @@ export function startService(runtimeHome: string): ServiceOutcome {
   const kind = resolveServiceKind();
   try {
     if (kind === 'launchd') {
-      const uid = process.getuid?.() || 0;
-      const result = tryExec('launchctl', [
-        'kickstart',
-        '-k',
-        `gui/${uid}/${SERVICE_LABEL}`,
-      ]);
-      if (!result.ok) {
-        throw new Error(
-          result.stderr || result.stdout || 'launchctl kickstart failed',
-        );
-      }
+      startLaunchdService();
       return { ok: true, kind, message: 'launchd service started.' };
     }
 
@@ -494,16 +426,7 @@ export function stopService(runtimeHome: string): ServiceOutcome {
   const kind = resolveServiceKind();
   try {
     if (kind === 'launchd') {
-      const uid = process.getuid?.() || 0;
-      const result = tryExec('launchctl', [
-        'bootout',
-        `gui/${uid}/${SERVICE_LABEL}`,
-      ]);
-      if (!result.ok && !result.stderr.includes('Could not find service')) {
-        throw new Error(
-          result.stderr || result.stdout || 'launchctl bootout failed',
-        );
-      }
+      stopLaunchdService();
       return { ok: true, kind, message: 'launchd service stopped.' };
     }
 
@@ -581,11 +504,7 @@ export function getServiceStatus(runtimeHome: string): {
   const kind = resolveServiceKind();
 
   if (kind === 'launchd') {
-    const listing = tryExec('launchctl', ['list']);
-    if (!listing.ok) return { kind, status: 'unknown' };
-    if (listing.stdout.includes(SERVICE_LABEL))
-      return { kind, status: 'loaded' };
-    return { kind, status: 'not_loaded' };
+    return { kind, status: getLaunchdServiceStatus() };
   }
 
   if (kind === 'systemd-user') {

--- a/apps/core/src/cli/setup-flow.ts
+++ b/apps/core/src/cli/setup-flow.ts
@@ -24,7 +24,6 @@ import {
   envFilePath,
   ensureRuntimeWritable,
   resolveRuntimeHome,
-  savePreferredRuntimeHome,
 } from './runtime-home.js';
 import {
   createDefaultRuntimeSettings,
@@ -870,7 +869,6 @@ export async function runSetupFlow(
         runtimeHome = result.changedHome;
         draft.runtimeHome = runtimeHome;
         state.data.runtimeHome = runtimeHome;
-        savePreferredRuntimeHome(runtimeHome);
         if (previous !== runtimeHome) {
           clearOnboardingState(previous);
         }

--- a/apps/core/src/cli/status.ts
+++ b/apps/core/src/cli/status.ts
@@ -128,6 +128,12 @@ function statusWord(value: boolean): string {
   return value ? 'on' : 'off';
 }
 
+function isServiceRunning(status: string): boolean {
+  return (
+    status === 'active' || status === 'running' || status.startsWith('running(')
+  );
+}
+
 export function formatRuntimeStatus(summary: RuntimeStatusSummary): string {
   const lines: string[] = [];
   lines.push('MyClaw Status');
@@ -186,7 +192,9 @@ export function formatRuntimeStatus(summary: RuntimeStatusSummary): string {
   if (!summary.doctor.ok) {
     nextActions.push('Run `myclaw doctor` and fix blocking items.');
   }
-  if (nextActions.length === 0) {
+  if (nextActions.length === 0 && isServiceRunning(summary.service.status)) {
+    nextActions.push('MyClaw is running.');
+  } else if (nextActions.length === 0) {
     nextActions.push('Run `myclaw start` to start the runtime.');
   }
 

--- a/apps/core/src/core/myclaw-home.ts
+++ b/apps/core/src/core/myclaw-home.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import path from 'path';
 
-const DEFAULT_MYCLAW_HOME = path.join(os.homedir(), '.myclaw');
+const DEFAULT_MYCLAW_HOME = path.join(os.homedir(), 'myclaw');
 
 function expandHomePath(input: string): string {
   if (input === '~') return os.homedir();

--- a/apps/core/test/unit/bootstrap/channel-wiring.test.ts
+++ b/apps/core/test/unit/bootstrap/channel-wiring.test.ts
@@ -22,8 +22,7 @@ function makeRuntimeSettings(enabled: {
     },
     memory: {
       enabled: true,
-      provider: 'sqlite',
-      sqlitePath: 'store/memory.db',
+      root: 'memory',
       embeddings: {
         enabled: false,
         provider: 'disabled',
@@ -37,7 +36,6 @@ function makeRuntimeSettings(enabled: {
           extractor: 'claude-haiku-4-5-20251001',
           dreaming: 'claude-sonnet-4-6',
           consolidation: 'claude-sonnet-4-6',
-          sessionSummary: 'claude-haiku-4-5-20251001',
         },
       },
     },

--- a/apps/core/test/unit/cli/runtime-home.test.ts
+++ b/apps/core/test/unit/cli/runtime-home.test.ts
@@ -2,7 +2,10 @@ import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveRuntimeHome } from '@core/cli/runtime-home.js';
+import {
+  DEFAULT_RUNTIME_HOME,
+  resolveRuntimeHome,
+} from '@core/cli/runtime-home.js';
 
 describe('resolveRuntimeHome', () => {
   afterEach(() => {
@@ -26,5 +29,9 @@ describe('resolveRuntimeHome', () => {
     expect(resolveRuntimeHome('~other-user/myclaw')).toBe(
       path.resolve('~other-user/myclaw'),
     );
+  });
+
+  it('uses ~/myclaw as the canonical default runtime home', () => {
+    expect(path.basename(DEFAULT_RUNTIME_HOME)).toBe('myclaw');
   });
 });

--- a/apps/core/test/unit/cli/runtime-home.test.ts
+++ b/apps/core/test/unit/cli/runtime-home.test.ts
@@ -9,6 +9,7 @@ import {
 
 describe('resolveRuntimeHome', () => {
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 

--- a/apps/core/test/unit/cli/service-manager.test.ts
+++ b/apps/core/test/unit/cli/service-manager.test.ts
@@ -28,6 +28,8 @@ async function loadServiceManagerWithMocks(
 ) {
   vi.resetModules();
   vi.stubEnv('MYCLAW_HOME', options.runtimeHome ?? createRuntimeHome());
+  const actualHomeDir = os.homedir();
+  vi.spyOn(os, 'homedir').mockReturnValue(options.homeDir ?? actualHomeDir);
   const platform = options.platform ?? 'unknown';
   const systemdUser = options.hasSystemdUser ?? false;
   vi.doMock('@core/cli/platform.js', () => ({
@@ -35,13 +37,6 @@ async function loadServiceManagerWithMocks(
     hasSystemdUser: () => systemdUser,
     tryExec: tryExecMock,
   }));
-  vi.doMock('os', async () => {
-    const actual = await vi.importActual<typeof import('os')>('os');
-    return {
-      ...actual,
-      homedir: () => options.homeDir ?? actual.homedir(),
-    };
-  });
   vi.doMock('child_process', async () => {
     const actual =
       await vi.importActual<typeof import('child_process')>('child_process');
@@ -125,6 +120,55 @@ describe('service manager background start', () => {
       'start',
       'myclaw',
     ]);
+  });
+
+  it('installs launchd service with MYCLAW_HOME in the plist', async () => {
+    const runtimeHome = createRuntimeHome();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myclaw-home-'));
+    const tryExecMock = vi
+      .fn()
+      .mockReturnValue({ ok: true, stdout: '', stderr: '' });
+    const mod = await loadServiceManagerWithMocks(vi.fn(), tryExecMock, {
+      platform: 'macos',
+      homeDir,
+      runtimeHome,
+    });
+
+    const outcome = mod.installService(import.meta.url, runtimeHome);
+
+    expect(outcome.ok).toBe(true);
+    const plistPath = path.join(
+      homeDir,
+      'Library',
+      'LaunchAgents',
+      'com.myclaw.plist',
+    );
+    const plist = fs.readFileSync(plistPath, 'utf-8');
+    expect(plist).toContain('<key>MYCLAW_HOME</key>');
+    expect(plist).toContain(`<string>${runtimeHome}</string>`);
+    expect(plist).not.toContain('<key>AGENT_ROOT</key>');
+  });
+
+  it('reports launchd running state with pid', async () => {
+    const runtimeHome = createRuntimeHome();
+    const tryExecMock = vi.fn((command: string, args: string[]) => {
+      if (command === 'launchctl' && args[0] === 'print') {
+        return {
+          ok: true,
+          stdout: '\tstate = running\n\tpid = 1234\n',
+          stderr: '',
+        };
+      }
+      return { ok: true, stdout: '', stderr: '' };
+    });
+    const mod = await loadServiceManagerWithMocks(vi.fn(), tryExecMock, {
+      platform: 'macos',
+      runtimeHome,
+    });
+
+    const status = mod.getServiceStatus(runtimeHome);
+
+    expect(status).toEqual({ kind: 'launchd', status: 'running(pid:1234)' });
   });
 
   it('creates settings.yaml on service install when missing', async () => {

--- a/apps/core/test/unit/cli/setup-flow.test.ts
+++ b/apps/core/test/unit/cli/setup-flow.test.ts
@@ -114,8 +114,7 @@ async function loadSetupFlowModule(options: SetupFlowTestOptions) {
       },
       memory: {
         enabled: true,
-        provider: 'sqlite',
-        sqlitePath: 'store/memory.db',
+        root: 'memory',
         embeddings: {
           enabled: false,
           provider: 'disabled',
@@ -129,7 +128,6 @@ async function loadSetupFlowModule(options: SetupFlowTestOptions) {
             extractor: 'claude-haiku-4-5-20251001',
             dreaming: 'claude-sonnet-4-6',
             consolidation: 'claude-sonnet-4-6',
-            sessionSummary: 'claude-haiku-4-5-20251001',
           },
         },
       },

--- a/apps/core/test/unit/cli/setup-flow.test.ts
+++ b/apps/core/test/unit/cli/setup-flow.test.ts
@@ -90,7 +90,6 @@ async function loadSetupFlowModule(options: SetupFlowTestOptions) {
     envFilePath: (runtimeHome: string) => `${runtimeHome}/.env`,
     ensureRuntimeWritable: vi.fn(),
     resolveRuntimeHome: (runtimeHome: string) => runtimeHome,
-    savePreferredRuntimeHome: vi.fn(),
   }));
   vi.doMock('@core/cli/runtime-settings.js', () => ({
     loadRuntimeSettings: vi.fn(() => ({

--- a/apps/core/test/unit/cli/status.test.ts
+++ b/apps/core/test/unit/cli/status.test.ts
@@ -4,7 +4,11 @@ import path from 'path';
 
 import { describe, expect, it } from 'vitest';
 
-import { collectRuntimeStatus } from '@core/cli/status.js';
+import {
+  collectRuntimeStatus,
+  formatRuntimeStatus,
+  type RuntimeStatusSummary,
+} from '@core/cli/status.js';
 import { settingsFilePath } from '@core/cli/runtime-home.js';
 
 function createRuntimeHome(): string {
@@ -14,6 +18,46 @@ function createRuntimeHome(): string {
   fs.mkdirSync(path.join(home, 'logs'), { recursive: true });
   fs.mkdirSync(path.join(home, 'data'), { recursive: true });
   return home;
+}
+
+function createReadySummary(
+  service: RuntimeStatusSummary['service'],
+): RuntimeStatusSummary {
+  return {
+    runtimeHome: '/tmp/myclaw',
+    runtimeMode: 'host',
+    doctor: {
+      ok: true,
+      warnings: 0,
+      blockingFailures: 0,
+      checks: [],
+    },
+    service,
+    channels: [
+      {
+        id: 'telegram',
+        label: 'Telegram',
+        enabled: true,
+        configuredEnvKeys: ['TELEGRAM_BOT_TOKEN'],
+        missingEnvKeys: [],
+        groups: 1,
+      },
+    ],
+    memoryEnabled: true,
+    memoryHealth: 'pass',
+    memoryRoot: '/tmp/myclaw/memory',
+    memoryRootSource: 'settings.yaml',
+    memorySqlitePath: '/tmp/myclaw/memory/.cache/memory.db',
+    memorySqlitePathSource: 'derived',
+    embeddingsEnabled: false,
+    embeddingProvider: 'disabled',
+    embeddingProviderSource: 'settings.yaml',
+    embeddingProviderHealth: 'pass',
+    embeddingModel: 'text-embedding-3-large',
+    embeddingModelSource: 'settings.yaml',
+    dreamingEnabled: false,
+    dreamingSource: 'settings.yaml',
+  };
 }
 
 describe('runtime status', () => {
@@ -30,5 +74,31 @@ describe('runtime status', () => {
     expect(
       status.channels.find((channel) => channel.id === 'slack')?.enabled,
     ).toBe(false);
+  });
+
+  it('does not tell users to start an already running service', () => {
+    const summary = createReadySummary({
+      kind: 'launchd',
+      status: 'running(pid:1234)',
+    });
+
+    const text = formatRuntimeStatus(summary);
+
+    expect(text).toContain('Service (launchd): running(pid:1234)');
+    expect(text).toContain('- MyClaw is running.');
+    expect(text).not.toContain('Run `myclaw start`');
+  });
+
+  it('does not tell systemd users to start an active service', () => {
+    const summary = createReadySummary({
+      kind: 'systemd-user',
+      status: 'active',
+    });
+
+    const text = formatRuntimeStatus(summary);
+
+    expect(text).toContain('Service (systemd-user): active');
+    expect(text).toContain('- MyClaw is running.');
+    expect(text).not.toContain('Run `myclaw start`');
   });
 });

--- a/apps/core/test/unit/runtime/agent-spawn-layout.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-layout.test.ts
@@ -51,7 +51,7 @@ describe('ensureSharedSessionSettings', () => {
       ),
     );
 
-    // Mock AGENT_ROOT to point to our temp root
+    // Mock runtime paths to point to our temp root.
     vi.doMock('@core/core/config.js', () => ({
       MYCLAW_HOME: root,
       DATA_DIR: root,

--- a/docs/CONTINUITY.md
+++ b/docs/CONTINUITY.md
@@ -74,7 +74,7 @@ Save durable, reusable statements:
 - "User prefers direct engineering answers without filler."
 - "Decision: embeddings are optional and provider-based."
 - "Correction: do not store raw logs as memory."
-- "Fact: default SQLite memory path is `~/myclaw/store/memory.db`."
+- "Fact: default SQLite memory path is `~/myclaw/memory/.cache/memory.db`."
 - "Procedure: before changing memory, run focused memory tests."
 
 Do not save:
@@ -109,30 +109,15 @@ Static prompt files are not memory dumps.
 
 Dynamic facts, task state, and open loops belong in structured memory and continuity context, not in static prompt files.
 
-## Provider Model
+## Storage Model
 
-MyClaw supports provider-based memory storage.
+MyClaw stores live memory in SQLite under `settings.yaml memory.root`.
 
-### `sqlite`
+- Default root: `memory`
+- Default database: `~/myclaw/memory/.cache/memory.db`
+- Default journal: `~/myclaw/memory/.journal`
 
-Default provider.
-
-- Stores memory in SQLite only.
-- Uses `settings.yaml memory.sqlite_path` (default: `store/memory.db`).
-- No markdown mirror.
-- Best for simple installs.
-
-### `qmd`
-
-SQLite plus markdown mirror.
-
-- Stores live search data in SQLite.
-- Mirrors memory items and procedures to markdown files.
-- Appends journal entries.
-- Archives sessions as markdown when supported.
-- Best when users want inspectable memory files.
-
-SQLite remains the source of truth for search in both modes. Markdown is an audit and recovery layer, not the live query engine.
+SQLite is the source of truth for memory search and continuity context.
 
 ## Embeddings Are Optional
 

--- a/docs/DEBUG_CHECKLIST.md
+++ b/docs/DEBUG_CHECKLIST.md
@@ -8,7 +8,7 @@ MyClaw runs as a local host process.
 
 ```bash
 # 1. Is the service running?
-launchctl list | grep myclaw
+myclaw status
 
 # 2. Recent runtime errors
 grep -E 'ERROR|WARN' logs/myclaw.log | tail -20
@@ -87,17 +87,20 @@ If auth state is missing or expired, rerun guided setup with `myclaw setup`.
 
 ```bash
 # Restart
-launchctl kickstart -k gui/$(id -u)/com.myclaw
+myclaw service restart
 
 # View live logs
 tail -f logs/myclaw.log
 
 # Stop service
-launchctl bootout gui/$(id -u)/com.myclaw
+myclaw service stop
 
-# Start service
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.myclaw.plist
+# Install or reinstall service
+myclaw service install
+
+# Start an already-installed service without rewriting it
+myclaw service start
 
 # Rebuild after code changes
-npm run build && launchctl kickstart -k gui/$(id -u)/com.myclaw
+npm run build && myclaw service restart
 ```

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -17,9 +17,7 @@ Memory behavior is configured only in `~/myclaw/settings.yaml`:
 ```yaml
 memory:
   enabled: true
-  provider: sqlite
-  sqlite_path: store/memory.db
-  qmd_root: agent-memory
+  root: memory
   embeddings:
     enabled: false
     provider: disabled
@@ -28,24 +26,12 @@ memory:
     enabled: false
 ```
 
-## Providers
+## Storage
 
-### `sqlite`
-
-- SQLite-only storage.
-- Uses `memory.sqlite_path`.
-- No markdown mirror.
-
-### `qmd`
-
-- SQLite + markdown mirror.
-- Uses `memory.qmd_root`.
-- SQLite remains the search source of truth.
-
-### `noop` / `none`
-
-- Non-persistent mode.
-- Useful for temporary testing only.
+- SQLite is the only supported memory store.
+- `memory.root` resolves under the runtime home unless it is absolute.
+- The default database path is `~/myclaw/memory/.cache/memory.db`.
+- The journal path is `~/myclaw/memory/.journal`.
 
 ## Embeddings
 
@@ -58,14 +44,13 @@ memory:
 
 - Optional background memory refinement.
 - Disabled by default.
-- Should be used only with persistent memory providers.
+- Should be used only with persistent memory enabled.
 
 ## User Controls
 
 - `myclaw status`
 - `myclaw doctor`
 - `myclaw memory status`
-- `myclaw memory provider <sqlite|qmd|noop|none>`
 - `myclaw memory embeddings <off|openai>`
 - `myclaw memory dreaming <on|off>`
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -73,14 +73,14 @@ A personal Claude assistant with multi-channel support, persistent memory per co
 
 ### Technology Stack
 
-| Component | Technology | Purpose |
-|-----------|------------|---------|
-| Channel System | Provider registry (`apps/core/src/channels/provider-registry.ts`) | Channels are looked up by provider id and JID prefix |
-| Message Storage | SQLite (better-sqlite3) | Store messages for polling |
-| Runtime Execution | Host process execution | Agent execution with runtime-home scoped paths |
-| Agent | @anthropic-ai/claude-agent-sdk (0.2.97) | Run Claude with tools and MCP servers |
-| Browser Automation | agent-browser + Chromium | Web interaction and screenshots |
-| Runtime | Node.js 20+ | Host process for routing and scheduling |
+| Component          | Technology                                                        | Purpose                                              |
+| ------------------ | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| Channel System     | Provider registry (`apps/core/src/channels/provider-registry.ts`) | Channels are looked up by provider id and JID prefix |
+| Message Storage    | SQLite (better-sqlite3)                                           | Store messages for polling                           |
+| Runtime Execution  | Host process execution                                            | Agent execution with runtime-home scoped paths       |
+| Agent              | @anthropic-ai/claude-agent-sdk (0.2.97)                           | Run Claude with tools and MCP servers                |
+| Browser Automation | agent-browser + Chromium                                          | Web interaction and screenshots                      |
+| Runtime            | Node.js 20+                                                       | Host process for routing and scheduling              |
 
 ---
 
@@ -194,13 +194,13 @@ Providers are registered via `apps/core/src/channels/register-builtins.ts`:
 
 ### Key Files
 
-| File | Purpose |
-|------|---------|
-| `apps/core/src/channels/provider-registry.ts` | Channel provider registry |
-| `apps/core/src/channels/register-builtins.ts` | Built-in provider registration |
-| `apps/core/src/core/types.ts` | `Channel` interface, `ChannelOpts`, message types |
-| `apps/core/src/index.ts` | Orchestrator — instantiates channels, runs message loop |
-| `apps/core/src/messaging/router.ts` | Finds the owning channel for a JID, formats messages |
+| File                                          | Purpose                                                 |
+| --------------------------------------------- | ------------------------------------------------------- |
+| `apps/core/src/channels/provider-registry.ts` | Channel provider registry                               |
+| `apps/core/src/channels/register-builtins.ts` | Built-in provider registration                          |
+| `apps/core/src/core/types.ts`                 | `Channel` interface, `ChannelOpts`, message types       |
+| `apps/core/src/index.ts`                      | Orchestrator — instantiates channels, runs message loop |
+| `apps/core/src/messaging/router.ts`           | Finds the owning channel for a JID, formats messages    |
 
 ### Adding a New Channel
 
@@ -268,8 +268,11 @@ myclaw/
 │       └── logs/                  # Task execution logs
 │
 ├── store/                         # Local data (gitignored)
-│   ├── memory.db                  # Default SQLite memory database
 │   └── messages.db                # SQLite database (messages, chats, jobs, job_runs, job_events, registered_groups, sessions, router_state)
+│
+├── memory/                        # Durable memory root (gitignored)
+│   ├── .cache/memory.db           # Default SQLite memory database
+│   └── .journal/                  # Memory journal events
 │
 ├── data/                          # Application state (gitignored)
 │   ├── sessions/                  # Per-group session data (.claude/ dirs with JSONL transcripts)
@@ -299,13 +302,16 @@ export const POLL_INTERVAL = 2000;
 export const SCHEDULER_POLL_INTERVAL = 60000;
 
 // Paths are absolute (required for runtime path enforcement)
-const AGENT_ROOT = path.resolve(process.env.AGENT_ROOT || '~/myclaw');
-export const STORE_DIR = path.resolve(AGENT_ROOT, 'store');
-export const AGENTS_DIR = path.resolve(AGENT_ROOT, 'agents');
-export const DATA_DIR = path.resolve(AGENT_ROOT, 'data');
+const MYCLAW_HOME = path.resolve(process.env.MYCLAW_HOME || '~/myclaw');
+export const STORE_DIR = path.resolve(MYCLAW_HOME, 'store');
+export const AGENTS_DIR = path.resolve(MYCLAW_HOME, 'agents');
+export const DATA_DIR = path.resolve(MYCLAW_HOME, 'data');
 
 // Runtime configuration
-export const AGENT_TIMEOUT = parseInt(process.env.AGENT_TIMEOUT || '1800000', 10); // 30min default
+export const AGENT_TIMEOUT = parseInt(
+  process.env.AGENT_TIMEOUT || '1800000',
+  10,
+); // 30min default
 export const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL;
 export const IPC_POLL_INTERVAL = 1000;
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min — keep runtime worker alive after last result
@@ -320,16 +326,16 @@ export const TRIGGER_PATTERN = new RegExp(`^@${ASSISTANT_NAME}\\b`, 'i');
 Groups can have additional directories exposed to the agent workspace through the registered group agent config. Example registration:
 
 ```typescript
-setRegisteredGroup("1234567890@g.us", {
-  name: "Dev Team",
-  folder: "whatsapp_dev-team",
-  trigger: "@Andy",
+setRegisteredGroup('1234567890@g.us', {
+  name: 'Dev Team',
+  folder: 'whatsapp_dev-team',
+  trigger: '@Andy',
   added_at: new Date().toISOString(),
   agentConfig: {
-    model: "opus",
+    model: 'opus',
     additionalMounts: [
       {
-        hostPath: "~/projects/webapp",
+        hostPath: '~/projects/webapp',
         readonly: false,
       },
     ],
@@ -354,12 +360,15 @@ Use `/model` in a group session to switch the live model (`/model`, `/model <ali
 Configure authentication in a `.env` file in the project root. Two options:
 
 **Option 1: Claude Subscription (OAuth token)**
+
 ```bash
 CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
 ```
+
 The token can be extracted from `~/.claude/.credentials.json` if you're logged in to Claude Code.
 
 **Option 2: Pay-per-use API Key**
+
 ```bash
 ANTHROPIC_API_KEY=sk-ant-api03-...
 ```
@@ -375,13 +384,16 @@ ASSISTANT_NAME=Bot npm start
 ```
 
 Or edit the default in `apps/core/src/core/config.ts`. This changes:
+
 - The trigger pattern (messages must start with `@YourName`)
 - The response prefix (`YourName:` added automatically)
 
 ### Placeholder Values in launchd
 
 Files with `{{PLACEHOLDER}}` values need to be configured:
-- `{{PROJECT_ROOT}}` - Absolute path to your myclaw installation
+
+- `{{RUNTIME_ENTRY}}` - Absolute path to the compiled MyClaw runtime entry
+- `{{RUNTIME_HOME}}` - Runtime home, normally `~/myclaw`
 - `{{NODE_PATH}}` - Path to node binary (detected via `which node`)
 - `{{HOME}}` - User's home directory
 
@@ -395,11 +407,11 @@ MyClaw separates static prompt profile files from structured memory and runtime 
 
 Prompt profile files are static guidance, not memory dumps:
 
-| Layer | Location | Purpose |
-|-------|----------|---------|
-| **Shared context** | `agents/shared/CLAUDE.md` | Stable operating rules, memory rules, communication conventions |
-| **Soul** | `agents/{group}/SOUL.md` | Agent personality, voice, and boundaries |
-| **Group context** | `agents/{group}/CLAUDE.md` | Stable group-specific guidance |
+| Layer              | Location                   | Purpose                                                         |
+| ------------------ | -------------------------- | --------------------------------------------------------------- |
+| **Shared context** | `agents/shared/CLAUDE.md`  | Stable operating rules, memory rules, communication conventions |
+| **Soul**           | `agents/{group}/SOUL.md`   | Agent personality, voice, and boundaries                        |
+| **Group context**  | `agents/{group}/CLAUDE.md` | Stable group-specific guidance                                  |
 
 Dynamic facts, current task state, open loops, and raw transcripts must not be written into these files. Durable facts go through structured memory. Current task state belongs to continuity context.
 
@@ -423,37 +435,37 @@ The structured memory store provides scoped recall for durable statements and le
 
 #### Storage Backend
 
-| Component | Technology | Purpose |
-|-----------|-----------|---------|
+| Component                          | Technology                                   | Purpose                                                            |
+| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------ |
 | **Memory statements & procedures** | SQLite (`memory_items`, `memory_procedures`) | Human-readable memory entries with scoping, confidence, versioning |
-| **Chunks** | SQLite (`memory_chunks`) | Chunked text from ingested source files |
-| **Lexical search** | FTS5 (`memory_chunks_fts`) | BM25 keyword search with unicode61 tokenization |
-| **Vector search** | sqlite-vec (`memory_chunks_vec`) | Optional semantic similarity search on embeddings |
-| **Audit log** | SQLite (`memory_events`) | All memory operations logged for debugging |
+| **Chunks**                         | SQLite (`memory_chunks`)                     | Chunked text from ingested source files                            |
+| **Lexical search**                 | FTS5 (`memory_chunks_fts`)                   | BM25 keyword search with unicode61 tokenization                    |
+| **Vector search**                  | sqlite-vec (`memory_chunks_vec`)             | Optional semantic similarity search on embeddings                  |
+| **Audit log**                      | SQLite (`memory_events`)                     | All memory operations logged for debugging                         |
 
-Default database path: `store/memory.db`
+Default database path: `~/myclaw/memory/.cache/memory.db`
 
 #### MCP Tools (Exposed to Agents)
 
 Agents interact with memory via MCP tools over IPC:
 
-| Tool | Purpose |
-|------|---------|
-| `memory_save` | Save a durable fact, decision, preference, correction, constraint, or context item |
-| `memory_search` | Search scoped memory statements and source snippets |
-| `memory_patch` | Update an existing item (optimistic concurrency via version) |
-| `procedure_save` | Save a reusable multi-step procedure |
-| `procedure_patch` | Update an existing procedure |
+| Tool              | Purpose                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `memory_save`     | Save a durable fact, decision, preference, correction, constraint, or context item |
+| `memory_search`   | Search scoped memory statements and source snippets                                |
+| `memory_patch`    | Update an existing item (optimistic concurrency via version)                       |
+| `procedure_save`  | Save a reusable multi-step procedure                                               |
+| `procedure_patch` | Update an existing procedure                                                       |
 
 #### Memory Scoping
 
 Three-tier scope model with strict isolation:
 
-| Scope | Write Access | Read Access | Use Case |
-|-------|-------------|-------------|----------|
-| `global` | Main only | All groups | Cross-group preferences, shared facts |
-| `group` | That group | That group | Group-specific knowledge |
-| `user` | That group | That group | Per-user facts within a group |
+| Scope    | Write Access | Read Access | Use Case                              |
+| -------- | ------------ | ----------- | ------------------------------------- |
+| `global` | Main only    | All groups  | Cross-group preferences, shared facts |
+| `group`  | That group   | That group  | Group-specific knowledge              |
+| `user`   | That group   | That group  | Per-user facts within a group         |
 
 Default scope is controlled by `MEMORY_SCOPE_POLICY` (default: `group`).
 
@@ -469,9 +481,9 @@ Search combines lexical recall with optional semantic recall using Reciprocal Ra
 
 On each message or scheduled task, MyClaw auto-ingests group source files into the chunk store:
 
-| Source | Path | Source Type |
-|--------|------|-------------|
-| CLAUDE.md | `agents/{name}/CLAUDE.md` | `claude_md` |
+| Source                    | Path                              | Source Type |
+| ------------------------- | --------------------------------- | ----------- |
+| CLAUDE.md                 | `agents/{name}/CLAUDE.md`         | `claude_md` |
 | Group knowledge directory | `agents/{name}/knowledge/**/*.md` | `local_doc` |
 
 **Chunking**: Sliding window (default 1400 chars, 240 overlap). Chunks < 30 chars are filtered. Deduplication via SHA256 hash of `scope:group:source_type:source_id:text`.
@@ -483,6 +495,7 @@ On each message or scheduled task, MyClaw auto-ingests group source files into t
 #### Reflection (Auto-Capture)
 
 After each successful agent turn, the system extracts durable memory statements from the conversation:
+
 - Uses a provider interface; the default extractor is rule-based and can be replaced without changing storage or recall.
 - Detects preferences, decisions, facts, corrections, and constraints.
 - Stores real human-readable statements with reflection-derived confidence scores.
@@ -490,95 +503,48 @@ After each successful agent turn, the system extracts durable memory statements 
 - Rejects prompt-injection style text before it becomes future context
 - Controlled by `MEMORY_REFLECTION_MIN_CONFIDENCE` (default 0.7) and `MEMORY_REFLECTION_MAX_FACTS_PER_TURN` (default 6)
 
-### Memory Providers
+### Memory Storage
 
-MyClaw supports two memory provider backends, set via `settings.yaml memory.provider`:
+MyClaw supports one active memory backend today: SQLite under `settings.yaml memory.root`.
 
-#### `sqlite` (Default)
-
-Standard SQLite backend. All data lives in `settings.yaml memory.sqlite_path` (default: `store/memory.db`).
-
-- Simple, single-file storage
-- No external dependencies beyond sqlite-vec
-- Good for most deployments
-
-#### `qmd` (Durable Markdown Mirror)
-
-QMD wraps the SQLite provider and mirrors every write to a filesystem tree at `settings.yaml memory.qmd_root`. The SQLite database still handles all reads and search. The markdown mirror provides:
-
-- **Human-readable audit trail** — every memory item and procedure is a markdown file
-- **Git-friendly durability** — the memory root can be committed to version control
-- **Journal logging** — all operations (saves, patches, lifecycle events) appended to daily journal files
-- **Session archiving** — compacted/stale sessions archived as dated markdown files
-
-**Default config**: `memory.qmd_root` defaults to `agent-memory` (resolved under runtime home).
+- Default root: `memory`
+- Default database: `~/myclaw/memory/.cache/memory.db`
+- Journal files: `~/myclaw/memory/.journal`
+- Vector search: optional sqlite-vec tables when embeddings are enabled
 
 **Filesystem layout**:
 
 ```
-{AGENT_MEMORY_ROOT}/
-├── profile/          # Memory items as markdown (one file per item)
-│   ├── mem-1712345678-a1b2.md
-│   └── mem-1712345679-c3d4.md
-├── procedures/       # Learned procedures as markdown
-│   └── proc-1712345680-e5f6.md
-├── journal/          # Daily audit log of all memory operations
+{MEMORY_ROOT}/
+├── .journal/         # Daily audit log of memory operations
 │   └── 2026/
 │       └── 04/
 │           └── 2026-04-11.md
-├── sessions/         # Archived session transcripts
-│   └── 2026/
-│       └── 04/
-│           └── 2026-04-11/
-│               └── 143022-stale-session-auth-fix.md
-├── knowledge/        # Reserved for future use
-├── .raw/             # Raw data storage
 └── .cache/
     └── memory.db     # SQLite database (search index)
 ```
 
-**How QMD writes work**:
-
-1. Agent calls `memory_save` → SQLite insert (same as `sqlite` provider)
-2. QMD wrapper also writes `profile/{sanitized-id}.md` with full metadata + value
-3. QMD appends a journal entry: timestamp, action, scope, key, file path
-4. All filesystem writes are atomic (write to `.tmp`, then rename)
-
-**How QMD reads work**: Identical to `sqlite` provider. All search hits the SQLite database, not the filesystem. The markdown files are for durability and human review only.
-
-**When to use QMD**:
-- You want a git-committable audit trail of what the agent remembers
-- You need to inspect memory contents without querying SQLite
-- You want session transcripts preserved as readable files
-- You're debugging memory behavior and need a journal
-
-**When `sqlite` is sufficient**:
-- Standard deployments where SQLite durability is enough
-- You don't need human-readable memory files
-- You want minimal disk I/O overhead
-
 ### Memory Configuration Reference
 
-| Setting | Default | Description |
-|----------|---------|-------------|
-| `memory.provider` | `sqlite` | Backend: `sqlite`, `qmd`, `noop`, or `none` |
-| `memory.sqlite_path` | `store/memory.db` | Path to SQLite database |
-| `memory.qmd_root` | `agent-memory` | Filesystem root for QMD mirror when provider is `qmd` |
-| `memory.embeddings.enabled` | `false` | Optional embedding toggle |
-| `memory.embeddings.provider` | `disabled` | Embedding provider (`disabled`, `none`, or `openai`) |
-| `memory.embeddings.model` | `text-embedding-3-large` | Embedding model |
-| `MEMORY_VECTOR_DIMENSIONS` | `3072` | Vector dimensions (must match model output) |
-| `MEMORY_EMBED_BATCH_SIZE` | `16` | Texts per embedding API call |
-| `MEMORY_CHUNK_SIZE` | `1400` | Characters per chunk |
-| `MEMORY_CHUNK_OVERLAP` | `240` | Overlap between chunks |
-| `MEMORY_RETRIEVAL_LIMIT` | `8` | Default results per search |
-| `MEMORY_SCOPE_POLICY` | `group` | Default scope for new items |
-| `MEMORY_REFLECTION_MIN_CONFIDENCE` | `0.7` | Min confidence for auto-captured facts |
-| `MEMORY_REFLECTION_MAX_FACTS_PER_TURN` | `6` | Max facts extracted per turn |
-| `MEMORY_MAX_CHUNKS_PER_GROUP` | `6000` | Chunk cap per group |
-| `MEMORY_CHUNK_RETENTION_DAYS` | `120` | Days before chunks are pruned |
-| `MEMORY_MAX_EVENTS` | `20000` | Max audit log entries |
-| `MEMORY_MAX_PROCEDURES_PER_GROUP` | `500` | Procedure cap per group |
+| Setting                                | Default                  | Description                                                   |
+| -------------------------------------- | ------------------------ | ------------------------------------------------------------- |
+| `memory.enabled`                       | `true`                   | Enables durable memory                                        |
+| `memory.root`                          | `memory`                 | Memory root path, resolved under runtime home unless absolute |
+| `memory.embeddings.enabled`            | `false`                  | Optional embedding toggle                                     |
+| `memory.embeddings.provider`           | `disabled`               | Embedding provider (`disabled`, `none`, or `openai`)          |
+| `memory.embeddings.model`              | `text-embedding-3-large` | Embedding model                                               |
+| `MEMORY_VECTOR_DIMENSIONS`             | `3072`                   | Vector dimensions (must match model output)                   |
+| `MEMORY_EMBED_BATCH_SIZE`              | `16`                     | Texts per embedding API call                                  |
+| `MEMORY_CHUNK_SIZE`                    | `1400`                   | Characters per chunk                                          |
+| `MEMORY_CHUNK_OVERLAP`                 | `240`                    | Overlap between chunks                                        |
+| `MEMORY_RETRIEVAL_LIMIT`               | `8`                      | Default results per search                                    |
+| `MEMORY_SCOPE_POLICY`                  | `group`                  | Default scope for new items                                   |
+| `MEMORY_REFLECTION_MIN_CONFIDENCE`     | `0.7`                    | Min confidence for auto-captured facts                        |
+| `MEMORY_REFLECTION_MAX_FACTS_PER_TURN` | `6`                      | Max facts extracted per turn                                  |
+| `MEMORY_MAX_CHUNKS_PER_GROUP`          | `6000`                   | Chunk cap per group                                           |
+| `MEMORY_CHUNK_RETENTION_DAYS`          | `120`                    | Days before chunks are pruned                                 |
+| `MEMORY_MAX_EVENTS`                    | `20000`                  | Max audit log entries                                         |
+| `MEMORY_MAX_PROCEDURES_PER_GROUP`      | `500`                    | Procedure cap per group                                       |
 
 ---
 
@@ -644,6 +610,7 @@ Sessions enable conversation continuity - Claude remembers what you talked about
 ### Trigger Word Matching
 
 Messages must start with the trigger pattern (default: `@Andy`):
+
 - `@Andy what's the weather?` → ✅ Triggers Claude
 - `@andy help me` → ✅ Triggers (case insensitive)
 - `Hey @Andy` → ❌ Ignored (trigger not at start)
@@ -667,18 +634,18 @@ This allows the agent to understand the conversation context even if it wasn't m
 
 ### Commands Available in Any Group
 
-| Command | Example | Effect |
-|---------|---------|--------|
+| Command                | Example                     | Effect         |
+| ---------------------- | --------------------------- | -------------- |
 | `@Assistant [message]` | `@Andy what's the weather?` | Talk to Claude |
 
 ### Commands Available in Main Channel Only
 
-| Command | Example | Effect |
-|---------|---------|--------|
-| `@Assistant add group "Name"` | `@Andy add group "Family Chat"` | Register a new group |
-| `@Assistant remove group "Name"` | `@Andy remove group "Work Team"` | Unregister a group |
-| `@Assistant list groups` | `@Andy list groups` | Show registered groups |
-| `@Assistant remember [fact]` | `@Andy remember I prefer dark mode` | Add to global memory |
+| Command                          | Example                             | Effect                 |
+| -------------------------------- | ----------------------------------- | ---------------------- |
+| `@Assistant add group "Name"`    | `@Andy add group "Family Chat"`     | Register a new group   |
+| `@Assistant remove group "Name"` | `@Andy remove group "Work Team"`    | Unregister a group     |
+| `@Assistant list groups`         | `@Andy list groups`                 | Show registered groups |
+| `@Assistant remember [fact]`     | `@Andy remember I prefer dark mode` | Add to global memory   |
 
 ---
 
@@ -695,11 +662,11 @@ MyClaw has a built-in scheduler that runs jobs as full agents in their group's c
 
 ### Schedule Types
 
-| Type | Value Format | Example |
-|------|--------------|---------|
-| `cron` | Cron expression | `0 9 * * 1` (Mondays at 9am) |
-| `interval` | Milliseconds | `3600000` (every hour) |
-| `once` | ISO timestamp | `2024-12-25T09:00:00Z` |
+| Type       | Value Format    | Example                      |
+| ---------- | --------------- | ---------------------------- |
+| `cron`     | Cron expression | `0 9 * * 1` (Mondays at 9am) |
+| `interval` | Milliseconds    | `3600000` (every hour)       |
+| `once`     | ISO timestamp   | `2024-12-25T09:00:00Z`       |
 
 ### Creating a Job
 
@@ -736,12 +703,14 @@ Claude: [calls mcp__myclaw__scheduler_upsert_job]
 ### Managing Jobs
 
 From any group:
+
 - `@Andy list my scheduled jobs` - View jobs for this group
 - `@Andy pause job [id]` - Pause a job
 - `@Andy resume job [id]` - Resume a paused job
 - `@Andy delete job [id]` - Delete a job
 
 From main channel:
+
 - `@Andy list all jobs` - View jobs from all groups
 - `@Andy schedule job for "Family Chat": [prompt]` - Schedule for another group
 
@@ -777,6 +746,7 @@ MyClaw runs as a single macOS launchd service.
 ### Startup Sequence
 
 When MyClaw starts, it:
+
 1. Runs runtime preflight for host execution and emits actionable fix steps on failure
 2. Auto-builds runner artifacts from `apps/core/src/runner` and fails startup if build fails
 3. Initializes the SQLite database (migrates from JSON files if they exist)
@@ -792,6 +762,7 @@ When MyClaw starts, it:
 ### Service: com.myclaw
 
 **ops/launchd/com.myclaw.plist:**
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "...">
@@ -802,27 +773,27 @@ When MyClaw starts, it:
     <key>ProgramArguments</key>
     <array>
         <string>{{NODE_PATH}}</string>
-        <string>{{PROJECT_ROOT}}/dist/index.js</string>
+        <string>{{RUNTIME_ENTRY}}</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>{{PROJECT_ROOT}}</string>
+    <string>{{RUNTIME_HOME}}</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>MYCLAW_HOME</key>
+        <string>{{RUNTIME_HOME}}</string>
         <key>PATH</key>
         <string>{{HOME}}/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>{{HOME}}</string>
-        <key>ASSISTANT_NAME</key>
-        <string>Andy</string>
     </dict>
     <key>StandardOutPath</key>
-    <string>{{PROJECT_ROOT}}/logs/myclaw.log</string>
+    <string>{{RUNTIME_HOME}}/logs/myclaw.log</string>
     <key>StandardErrorPath</key>
-    <string>{{PROJECT_ROOT}}/logs/myclaw.error.log</string>
+    <string>{{RUNTIME_HOME}}/logs/myclaw.error.log</string>
 </dict>
 </plist>
 ```
@@ -831,19 +802,19 @@ When MyClaw starts, it:
 
 ```bash
 # Install service
-cp ops/launchd/com.myclaw.plist ~/Library/LaunchAgents/
+myclaw service install
 
 # Start service
-launchctl load ~/Library/LaunchAgents/com.myclaw.plist
+myclaw service start
 
 # Stop service
-launchctl unload ~/Library/LaunchAgents/com.myclaw.plist
+myclaw service stop
 
 # Check status
-launchctl list | grep myclaw
+myclaw status
 
 # View logs
-tail -f logs/myclaw.log
+tail -f ~/myclaw/logs/myclaw.log
 ```
 
 ---
@@ -860,6 +831,7 @@ Security boundaries are enforced through per-group directory scope, runtime-home
 WhatsApp messages could contain malicious instructions attempting to manipulate Claude's behavior.
 
 **Mitigations:**
+
 - Only registered groups are processed
 - Trigger word required (reduces accidental processing)
 - Agents can only access their group's mounted directories
@@ -867,6 +839,7 @@ WhatsApp messages could contain malicious instructions attempting to manipulate 
 - Claude's built-in safety training
 
 **Recommendations:**
+
 - Only register trusted groups
 - Review additional directory mounts carefully
 - Review scheduled jobs periodically
@@ -874,14 +847,15 @@ WhatsApp messages could contain malicious instructions attempting to manipulate 
 
 ### Credential Storage
 
-| Credential | Storage Location | Notes |
-|------------|------------------|-------|
-| Claude CLI Auth | data/sessions/{group}/.claude/ | Per-group isolation, mounted to /home/node/.claude/ |
-| WhatsApp Session | store/auth/ | Auto-created, persists ~20 days |
+| Credential       | Storage Location               | Notes                                               |
+| ---------------- | ------------------------------ | --------------------------------------------------- |
+| Claude CLI Auth  | data/sessions/{group}/.claude/ | Per-group isolation, mounted to /home/node/.claude/ |
+| WhatsApp Session | store/auth/                    | Auto-created, persists ~20 days                     |
 
 ### File Permissions
 
 The runtime agents and store directories contain personal context and should be protected:
+
 ```bash
 chmod 700 ~/myclaw/agents ~/myclaw/store
 ```
@@ -892,15 +866,14 @@ chmod 700 ~/myclaw/agents ~/myclaw/store
 
 ### Common Issues
 
-| Issue | Cause | Solution |
-|-------|-------|----------|
-| No response to messages | Service not running | Check `launchctl list | grep myclaw` |
-| Startup fails at runtime preflight | Host runtime prerequisites failed | Run `npm run build` and re-check runtime diagnostics |
-| "Claude Code process exited with code 1" | Session mount path wrong | Ensure mount is to `/home/node/.claude/` not `/root/.claude/` |
-| Session not continuing | Session ID not saved | Check SQLite: `sqlite3 store/messages.db "SELECT * FROM sessions"` |
-| Session not continuing | Session path mismatch | Ensure per-group session paths exist under `data/sessions/{group}/.claude/` |
-| "QR code expired" | WhatsApp session expired | Delete store/auth/ and restart |
-| "No groups registered" | Haven't added groups | Use `@Andy add group "Name"` in main |
+| Issue                                    | Cause                             | Solution                                                                    |
+| ---------------------------------------- | --------------------------------- | --------------------------------------------------------------------------- |
+| No response to messages                  | Service not running               | Run `myclaw status` and check the service line                              |
+| Startup fails at runtime preflight       | Host runtime prerequisites failed | Run `npm run build` and re-check runtime diagnostics                        |
+| "Claude Code process exited with code 1" | Session mount path wrong          | Ensure mount is to `/home/node/.claude/` not `/root/.claude/`               |
+| Session not continuing                   | Session ID not saved              | Check SQLite: `sqlite3 store/messages.db "SELECT * FROM sessions"`          |
+| Session not continuing                   | Session path mismatch             | Ensure per-group session paths exist under `data/sessions/{group}/.claude/` |
+| "No groups registered"                   | Haven't added groups              | Register a channel group with the current channel setup flow                |
 
 ### Log Location
 
@@ -910,6 +883,7 @@ chmod 700 ~/myclaw/agents ~/myclaw/store
 ### Debug Mode
 
 Run manually for verbose output:
+
 ```bash
 npm run dev
 npm start

--- a/docs/decisions/2026-04-17-settings-runtime-truth.md
+++ b/docs/decisions/2026-04-17-settings-runtime-truth.md
@@ -11,9 +11,7 @@ MyClaw must present one runtime truth across runtime code, CLI, diagnostics, set
 3. `.env` is for secrets and channel credentials only.
 4. Memory runtime behavior is controlled only by `settings.yaml`:
    - `memory.enabled`
-   - `memory.provider` (`sqlite`, `qmd`, `noop`, `none`)
-   - `memory.sqlite_path`
-   - `memory.qmd_root`
+   - `memory.root`
    - `memory.embeddings.enabled`
    - `memory.embeddings.provider` (`disabled`, `none`, `openai`)
    - `memory.embeddings.model`
@@ -30,7 +28,6 @@ MyClaw must present one runtime truth across runtime code, CLI, diagnostics, set
 
 ## Notes
 
-- `sqlite` is SQLite-only.
-- `qmd` is SQLite plus markdown mirror.
+- SQLite under `memory.root` is the only supported memory store.
 - Embeddings are optional and disabled by default.
 - Dreaming is optional and disabled by default.

--- a/docs/npm-cli-onboarding.md
+++ b/docs/npm-cli-onboarding.md
@@ -39,7 +39,7 @@ Slack can be connected after first-run setup (or as an additional channel) with 
 
 ## Runtime Home
 
-MyClaw stores mutable state under `AGENT_ROOT`.
+MyClaw stores mutable state under `MYCLAW_HOME`.
 
 Default path:
 
@@ -96,15 +96,13 @@ myclaw slack connect
 
 - Memory: remember durable facts, preferences, decisions, corrections, constraints, and procedures.
 - Continuity: use remembered context so the agent can resume current work instead of starting cold.
-- SQLite provider: default local database storage.
-- QMD provider: optional SQLite-backed markdown mirror for users who want human-readable memory files.
+- SQLite storage: default local database storage under `memory.root`.
 - Embeddings: optional OpenAI-powered ranking improvement for memory search.
 - Dreaming: background memory cleanup and improvement.
 
 Default choices:
 
 - memory: on
-- provider: sqlite
 - embeddings: off
 - dreaming: off
 
@@ -113,9 +111,7 @@ Canonical memory block written by setup:
 ```yaml
 memory:
   enabled: true
-  provider: sqlite
-  sqlite_path: store/memory.db
-  qmd_root: agent-memory
+  root: memory
   embeddings:
     enabled: false
     provider: disabled

--- a/ops/launchd/com.myclaw.plist
+++ b/ops/launchd/com.myclaw.plist
@@ -7,26 +7,26 @@
     <key>ProgramArguments</key>
     <array>
         <string>{{NODE_PATH}}</string>
-        <string>{{PROJECT_ROOT}}/dist/index.js</string>
+        <string>{{RUNTIME_ENTRY}}</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>{{PROJECT_ROOT}}</string>
+    <string>{{RUNTIME_HOME}}</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>MYCLAW_HOME</key>
+        <string>{{RUNTIME_HOME}}</string>
         <key>PATH</key>
         <string>{{HOME}}/.local/bin:{{HOME}}/.npm-global/bin:{{HOME}}/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>HOME</key>
         <string>{{HOME}}</string>
-        <key>ASSISTANT_NAME</key>
-        <string>Andy</string>
     </dict>
     <key>StandardOutPath</key>
-    <string>{{PROJECT_ROOT}}/logs/myclaw.log</string>
+    <string>{{RUNTIME_HOME}}/logs/myclaw.log</string>
     <key>StandardErrorPath</key>
-    <string>{{PROJECT_ROOT}}/logs/myclaw.error.log</string>
+    <string>{{RUNTIME_HOME}}/logs/myclaw.error.log</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- make ~/myclaw the canonical runtime home and document the single-cut no-migration behavior for ~/.myclaw
- split launchd service handling into a dedicated helper and fix launchd running(pid) status detection
- update status next actions for running launchd and active systemd services
- clean active memory docs to SQLite-only memory.root guidance and update launchd/service docs

## Root cause
The live service was started from stale launchd/runtime-home assumptions: runner files were missing after a build boundary, status only reported launchd as loaded, and docs still mixed older QMD/provider/runtime-root language.

## Validation
- npm run build
- npm test
- python3 .codex/scripts/verify.py
- python3 .codex/scripts/validate_artifacts.py --allow-missing-run
- python3 .codex/scripts/validate_work.py
- python3 .codex/scripts/pr_ready.py
- live smoke: node dist/cli/index.js service install --runtime-home /Users/ravikiranvemula/myclaw
- live smoke: node dist/cli/index.js status --runtime-home /Users/ravikiranvemula/myclaw reported Doctor healthy and Service (launchd): running(pid:38883)

## Notes
Historical planning docs still contain old QMD terminology by design; active docs and source/test surfaces were cleaned.