### PR TITLE
docs: define canonical agent runtime architecture

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,12 +4,19 @@ Store architecture-level design inputs for planning and decomposition here.
 
 For MyClaw, canonical architecture references are:
 
+- `docs/architecture/canonical-domain-model.md`
+- `docs/architecture/target-folder-structure.md`
+- `docs/architecture/personal-and-enterprise-modes.md`
 - `docs/architecture/runtime-components.md`
 - `docs/architecture/agent-runtime.md`
 - `docs/architecture/credential-management.md`
 - `docs/MEMORY.md`
 - `docs/REQUIREMENTS.md`
 - `docs/SPEC.md`
+
+When these references conflict, decision records under `docs/decisions/` take
+precedence. The canonical product architecture starts with
+`docs/decisions/0001-agent-runtime-platform.md`.
 
 When adding architecture docs for a feature run:
 

--- a/docs/architecture/canonical-domain-model.md
+++ b/docs/architecture/canonical-domain-model.md
@@ -1,0 +1,302 @@
+# Canonical Domain Model
+
+This document defines the product vocabulary MyClaw code should converge on.
+It is intentionally provider-neutral and channel-neutral. Current
+implementation names such as registered group, group folder, main group, JID,
+and Claude session id are legacy implementation details unless they are
+explicitly mapped to one of the concepts below.
+
+## Model Summary
+
+```text
+App
+  Agent
+    AgentConfigVersion
+    LlmProfile
+    AgentChannelBinding
+      ChannelInstallation
+        ChannelProvider
+        Conversation
+          ConversationThread
+          Message
+            MessagePart
+            MessageAttachment
+    AgentSession
+      ProviderSession
+    AgentRun
+      AgentRunEvent
+    MemorySubject
+    Job
+    ToolCatalogItem
+    SkillCatalogItem
+    PermissionPolicy
+      PermissionRule
+      PermissionDecision
+    SandboxProfile
+      SandboxLease
+    WorkspaceSnapshot
+    BrowserProfile
+```
+
+Identity rules:
+
+- Domain identity uses MyClaw ids, not provider ids.
+- Provider ids are stored as external references on adapter-owned records.
+- Domain records are scoped by `appId` unless explicitly global.
+- Channel-specific payloads must be normalized before they reach application
+  use cases.
+- Model-provider session tokens are attached to `ProviderSession`, not used as
+  the only source of runtime continuity.
+
+## Core Ownership
+
+| Concept               | Owner                    | Meaning                                                                                                                                                                            |
+| --------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `App`                 | Domain                   | A runtime namespace for agents, users, memory, policies, channels, jobs, and SDK/API access.                                                                                       |
+| `Agent`               | Domain                   | A configured agent inside an app. It owns prompt profile lineage, model profile selection, tools, skills, memory visibility, and channel bindings.                                 |
+| `AgentConfigVersion`  | Domain                   | An immutable version of agent behavior: prompt profile, model selection, tool/skill catalog references, workspace defaults, permission policy references, and runtime limits.      |
+| `LlmProfile`          | Domain                   | Provider-neutral model intent such as purpose, model alias, budget, thinking mode, embedding usage, and credential-broker reference. Concrete SDK names live in provider adapters. |
+| `ChannelProvider`     | Adapter catalog          | A channel adapter type such as Telegram, WhatsApp, Slack, Teams, or Web UI. It describes capabilities and normalization rules.                                                     |
+| `ChannelInstallation` | Application plus adapter | An installed provider for an app, including workspace/team/bot/account identity, runtime-owned secrets, webhook/socket config, and enablement state.                               |
+| `Conversation`        | Domain                   | A provider-neutral communication container. It can be a DM, group, channel, chat, SDK conversation, or Web UI chat.                                                                |
+| `ConversationThread`  | Domain                   | A sub-conversation within a conversation, such as Slack `thread_ts`, Telegram forum topic, Teams reply chain, or a Web UI branch.                                                  |
+| `AgentChannelBinding` | Domain                   | The relationship that says an agent is present in a conversation or thread with trigger, routing, permissions, memory scope, and workspace projection.                             |
+| `User`                | Domain                   | A human or service actor known to an app. Provider-specific user ids are aliases.                                                                                                  |
+| `Message`             | Domain                   | A normalized inbound, outbound, system, or tool-visible communication event within a conversation or thread.                                                                       |
+| `MessagePart`         | Domain                   | A typed part of a message, such as text, markdown, image, file reference, tool result, form response, or structured data.                                                          |
+| `MessageAttachment`   | Domain plus adapter      | Binary or external media attached to a message. The domain owns metadata and trust classification; adapters own download and upload mechanics.                                     |
+| `AgentSession`        | Domain                   | Canonical continuity state for an agent in an app, conversation, thread, job, or run context. It survives provider swaps.                                                          |
+| `ProviderSession`     | Adapter                  | A provider-specific resume token or transcript pointer, such as a Claude session id. It is attached to an `AgentSession`.                                                          |
+| `AgentRun`            | Domain/application       | One execution attempt by an agent for a message, job, control request, or manual trigger.                                                                                          |
+| `AgentRunEvent`       | Domain/application       | A durable event emitted during a run: queued, started, model event, tool request, permission decision, output chunk, completed, failed, or canceled.                               |
+| `MemorySubject`       | Domain                   | A memory boundary for app, agent, user, group/team, conversation, thread, or common shared memory.                                                                                 |
+| `Job`                 | Domain/application       | Scheduled, recurring, or manual work that creates agent runs under explicit app, agent, session, and permission context.                                                           |
+| `ToolCatalogItem`     | Domain catalog           | A tool capability exposed to agents with name, input contract, risk classification, permission requirements, and adapter binding.                                                  |
+| `SkillCatalogItem`    | Domain catalog           | A reusable behavior package or prompt/tool bundle that can be attached to agent config versions.                                                                                   |
+| `PermissionPolicy`    | Domain                   | A named policy attached to an app, agent, binding, tool, job, or sandbox profile.                                                                                                  |
+| `PermissionRule`      | Domain                   | A deterministic rule inside a policy. It can allow, deny, require approval, or require a sandbox lease.                                                                            |
+| `PermissionDecision`  | Domain/application       | The audited result of evaluating a request against policy and runtime context.                                                                                                     |
+| `SandboxProfile`      | Domain/application       | A named execution environment policy: filesystem, network, process, browser, credential, timeout, and approval behavior.                                                           |
+| `SandboxLease`        | Runtime/application      | A time-bounded grant to execute work under a sandbox profile for a specific run or tool call.                                                                                      |
+| `WorkspaceSnapshot`   | Runtime/application      | A stable view of workspace files, mounts, prompt profile inputs, and generated runtime context used for an agent run.                                                              |
+| `BrowserProfile`      | Domain/application       | A named browser identity with storage state, auth markers, allowed usage, and ownership policy.                                                                                    |
+
+## Relationships And Lifecycle
+
+### App, Agent, And Config
+
+`App` is the top-level tenant or namespace. Personal mode seeds one local app,
+usually `personal`. Enterprise mode creates apps for teams, products, or
+customer-owned deployments.
+
+`Agent` belongs to exactly one app. An app may own multiple agents. Agents do
+not belong to a Telegram group, Slack channel, or folder.
+
+`AgentConfigVersion` is immutable. Changing prompt profile, tools, skills,
+model intent, workspace defaults, or permission policy creates a new version.
+`AgentRun` records the config version used so past runs remain explainable.
+
+`LlmProfile` describes model intent and policy in provider-neutral terms. It may
+resolve to Claude, OpenAI, Gemini, a local model, or a future provider through
+an adapter. The domain must not import provider SDKs or provider model
+registries.
+
+### Channels, Conversations, And Bindings
+
+`ChannelProvider` describes adapter capabilities. Examples include Telegram,
+WhatsApp, Slack, Teams, and Web UI. It is catalog metadata, not an installed
+runtime account.
+
+`ChannelInstallation` is an app's installed provider instance. For Slack it may
+represent a workspace app installation. For Telegram it may represent a bot
+token. For Teams it may represent a tenant/app installation. For Web UI it may
+represent the app-owned web channel. Secrets belong behind
+`RuntimeSecretProvider`.
+
+`Conversation` is the canonical message container. Provider ids such as
+Telegram chat id, WhatsApp chat id, Slack channel id, Teams chat id, or SDK
+conversation id are external aliases on a conversation.
+
+`ConversationThread` exists only when a provider or UI creates a nested reply,
+topic, branch, or thread boundary. Thread ids are external aliases under the
+conversation.
+
+`AgentChannelBinding` connects one agent to one conversation or thread. It owns
+trigger behavior, routing, allowlists, admin capabilities, memory subject
+selection, default workspace projection, and permission policy selection. A
+group folder is only one possible workspace projection of this binding.
+
+### Users And Messages
+
+`User` is a canonical actor in an app. Channel providers contribute aliases,
+display names, and membership facts. A message sender should map to a `User`
+when the provider exposes a stable user identity. Service actors and app
+backends can also be users.
+
+`Message` is the durable normalized event. It should store direction, app,
+conversation, optional thread, sender user, provider alias, timestamp, and
+trust classification. Provider raw payloads can be archived by adapters, but
+application logic should use normalized message fields.
+
+`MessagePart` supports mixed content without making text the only shape.
+Examples are text, markdown, code, image reference, file reference, form
+response, structured JSON, tool result, and redacted content.
+
+`MessageAttachment` stores attachment metadata, content type, size, external
+provider references, local cache references, scan state, and trust boundary.
+Adapters perform provider-specific download and upload.
+
+### Sessions And Runs
+
+`AgentSession` is canonical continuity. It links an agent to an app-level
+context such as a conversation, thread, job, user, or manual control request.
+`/new` clears the canonical session state for the relevant binding while
+preserving the binding's selected model override when policy says so.
+
+`ProviderSession` stores provider-specific resume state for an `AgentSession`.
+Claude session id is one provider session field. Other providers may use a
+thread id, response id, transcript pointer, or no provider resume token.
+
+`AgentRun` is one execution attempt. It has a cause, app, agent, config version,
+session, conversation/thread context, permission context, sandbox lease,
+workspace snapshot, provider profile, status, timestamps, and result summary.
+
+`AgentRunEvent` is the observable event stream for a run. SDK streams, Web UI,
+webhooks, channel progress, audit trails, and debugging should read run events
+instead of scraping provider stdout.
+
+### Memory And Jobs
+
+`MemorySubject` is the visibility boundary for durable memory. Valid subject
+shapes include app-wide common memory, agent memory, user memory, group/team
+memory, conversation memory, and thread memory. Channel provider names do not
+change the meaning of the boundary.
+
+`Job` belongs to an app and runs through the same agent/session/run path as a
+message-triggered run. Jobs can target an agent binding, a session, a
+conversation, a thread, or a service context. Job execution must not bypass
+permission policy or sandbox lease rules.
+
+### Tools, Skills, Permissions, And Sandboxes
+
+`ToolCatalogItem` describes a capability before it is invoked. It should include
+input schema, output schema, risk category, default policy, required sandbox
+profile, credential broker needs, and adapter binding.
+
+`SkillCatalogItem` describes a reusable behavior package. It may provide prompt
+sections, tools, workflows, docs, or setup hooks. Attaching a skill to an agent
+requires an `AgentConfigVersion` change.
+
+`PermissionPolicy` groups deterministic rules. It is attached explicitly to an
+app, agent, binding, tool catalog item, job, or sandbox profile.
+
+`PermissionRule` evaluates a request using known runtime facts: actor, agent,
+binding, message, tool, requested path, credential profile, channel, sandbox,
+and risk classification.
+
+`PermissionDecision` is durable and auditable. It records the request, matched
+rules, decision, approver when applicable, expiration, and run/tool context.
+
+`SandboxProfile` defines the environment available to a run or tool call. Host
+execution is one possible sandbox implementation, not the domain model.
+
+`SandboxLease` grants a run or tool call permission to use a sandbox profile for
+a bounded time and scope. Leases are created only after permission evaluation.
+
+### Workspace And Browser
+
+`WorkspaceSnapshot` captures the workspace view used by an agent run: root,
+additional mounts, read/write flags, prompt files, generated context, and
+content hashes when available. It makes runs reproducible and auditable.
+
+`BrowserProfile` is a named browser identity owned by an app or agent. It
+stores profile metadata, browser state references, auth markers, and usage
+policy. Browser profile use still requires permission and sandbox checks.
+
+## Channel Mapping
+
+| Provider concept                           | Canonical mapping                                                                                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Telegram DM                                | `Conversation`                                                                                                                                                                 |
+| Telegram group                             | `Conversation`                                                                                                                                                                 |
+| Telegram forum topic / `message_thread_id` | `ConversationThread`                                                                                                                                                           |
+| WhatsApp chat                              | `Conversation`                                                                                                                                                                 |
+| Slack DM                                   | `Conversation`                                                                                                                                                                 |
+| Slack channel                              | `Conversation`                                                                                                                                                                 |
+| Slack `thread_ts`                          | `ConversationThread`                                                                                                                                                           |
+| Teams personal chat                        | `Conversation`                                                                                                                                                                 |
+| Teams group/channel chat                   | `Conversation`                                                                                                                                                                 |
+| Teams thread/conversation reference        | `ConversationThread`                                                                                                                                                           |
+| Web UI chat                                | `Conversation` or `ConversationThread`, depending on whether the implementation treats each visible chat as a top-level conversation or a branch inside a larger conversation. |
+
+Mapping rules:
+
+- A provider conversation id is never the only MyClaw identity. Store it as an
+  alias under `ChannelInstallation`.
+- Threads are optional. A provider without threads maps all messages directly
+  to `Conversation`.
+- Web UI must choose one mapping during implementation and document it in the
+  Web UI adapter contract.
+- Channel adapters must preserve enough provider metadata to reply correctly,
+  but application behavior should use canonical ids.
+
+## Current Implementation Mapping
+
+These mappings describe current code so future refactors know what to replace:
+
+| Current implementation             | Canonical target                                                                            |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| Registered group                   | `AgentChannelBinding` plus `Conversation` and optional `ConversationThread`                 |
+| Group JID/chat JID                 | Provider alias for `Conversation`                                                           |
+| Group folder                       | Workspace projection for `AgentChannelBinding` and `WorkspaceSnapshot`                      |
+| Main group                         | Admin `AgentChannelBinding` governed by `PermissionPolicy`                                  |
+| Sender allowlist/control allowlist | `PermissionPolicy` and `PermissionRule` inputs                                              |
+| Claude session id                  | `ProviderSession` attached to `AgentSession`                                                |
+| Group queue key                    | Queue key derived from canonical app, agent, conversation, thread, session, and run context |
+| Host runner process                | Runtime execution adapter governed by `SandboxProfile` and `SandboxLease`                   |
+| Control events                     | `AgentRunEvent` plus API-visible event projections                                          |
+
+## Adapter Boundaries
+
+Channel adapters:
+
+- accept provider payloads
+- map provider users, conversations, threads, messages, and attachments to
+  canonical records
+- render canonical outbound messages, progress, permission prompts, and user
+  questions back into provider surfaces
+- keep provider SDK types out of domain and application services
+
+LLM provider adapters:
+
+- resolve `LlmProfile` to concrete model/provider calls
+- create and update `ProviderSession`
+- translate provider stream events into `AgentRunEvent`
+- keep provider SDK types out of domain and application services
+
+Storage adapters:
+
+- persist canonical entities through repository ports
+- may use Postgres, Drizzle, pg-boss, and indexes internally
+- must not expose database row shapes as domain identity
+
+CLI, control HTTP, Web UI, SDK, and ACP/ACPX adapters:
+
+- authenticate and parse external requests
+- invoke application use cases
+- render responses and events
+- must not mutate persistence directly or bypass application policy
+
+## Deletion And Replacement Targets
+
+Future implementation phases should remove or replace:
+
+- old personal group folder model as domain identity
+- main group specific behavior as a primary architecture concept
+- provider-specific session as the only resume mechanism
+- direct tool execution on host
+- CLI-owned business logic
+- control routes directly mutating persistence
+
+Do not add compatibility shims for old local state unless a later decision
+explicitly approves them.

--- a/docs/architecture/personal-and-enterprise-modes.md
+++ b/docs/architecture/personal-and-enterprise-modes.md
@@ -1,0 +1,189 @@
+# Personal And Enterprise Modes
+
+MyClaw has one canonical runtime model with multiple deployment modes. Personal
+usage and enterprise usage differ by seeding, installation, policy, user
+surfaces, and operations. They must not become separate product architectures.
+
+## Shared Runtime Model
+
+Both modes use:
+
+- `App` as the namespace
+- `Agent` and `AgentConfigVersion` for behavior
+- `LlmProfile` for provider-neutral model selection
+- `ChannelProvider`, `ChannelInstallation`, and `AgentChannelBinding` for
+  channel presence
+- `Conversation` and `ConversationThread` for communication
+- `User`, `Message`, `MessagePart`, and `MessageAttachment` for normalized
+  events
+- `AgentSession`, `ProviderSession`, `AgentRun`, and `AgentRunEvent` for
+  continuity and execution
+- `MemorySubject` for memory boundaries
+- `Job` for scheduled and manual work
+- `PermissionPolicy`, `PermissionRule`, and `PermissionDecision` for
+  deterministic authorization
+- `SandboxProfile`, `SandboxLease`, `WorkspaceSnapshot`, and `BrowserProfile`
+  for tool, workspace, browser, and host execution boundaries
+
+Channel and model providers adapt into this model. They do not define it.
+
+## Personal Mode
+
+Personal mode is a seeded local deployment. It is not the core domain model.
+
+Seeded defaults:
+
+- one local `App`, commonly named `personal`
+- one default `Agent`
+- local `settings.yaml`
+- local runtime secret source
+- local memory root and Postgres schema
+- one or more `ChannelInstallation` records for Telegram, WhatsApp, Slack, or
+  another personal channel
+- `AgentChannelBinding` records for the conversations where the user wants the
+  agent present
+- local default `LlmProfile`, typically backed by OneCLI or another credential
+  broker
+- conservative default `PermissionPolicy`
+- host runtime `SandboxProfile` until stronger isolation is implemented
+
+Personal setup may create folders for workspace projection, prompt profile
+files, logs, session artifacts, and browser profiles. Those folders are runtime
+storage, not domain identity.
+
+Personal administration should be represented as policy:
+
+- A private DM or trusted chat can be seeded as an admin binding.
+- Admin ability comes from `PermissionPolicy` and `PermissionRule`, not from a
+  hard-coded main group concept.
+- `/new` and related session commands operate on canonical `AgentSession`
+  records for the binding while preserving configured model overrides when the
+  policy requires it.
+
+Personal mode can stay lightweight and understandable while still using the
+same app, agent, conversation, session, run, memory, policy, sandbox, and
+workspace model as enterprise mode.
+
+## Enterprise Mode
+
+Enterprise mode uses the same runtime model with different integration
+surfaces:
+
+- Web UI for users, administrators, and operators
+- control API for backend integrations and administration
+- server-side SDK for application developers
+- channel installations for Slack, Teams, Web UI, and other providers
+- explicit users, roles, app scopes, and policy-managed admin actions
+- enterprise credential brokers or secret managers behind the same ports
+- deployment-specific sandbox providers
+- audit, event, and webhook integrations based on `AgentRunEvent`
+
+Enterprise applications should integrate through the SDK, control API, Web UI,
+and channel installations. They must not import runtime internals from
+`apps/core/src/**`.
+
+Enterprise channel examples:
+
+- Slack workspace installation creates a `ChannelInstallation`.
+- A Slack channel creates or maps to a `Conversation`.
+- A Slack thread maps to `ConversationThread`.
+- A Teams tenant/app installation creates a `ChannelInstallation`.
+- A Teams personal chat or channel chat maps to `Conversation`.
+- A Teams reply chain maps to `ConversationThread`.
+- A Web UI can model each chat as a `Conversation`, or model a visible chat as
+  a `ConversationThread` inside a larger workspace conversation. The Web UI
+  adapter must choose and document one mapping.
+
+## Web UI, Control API, And SDK
+
+Web UI, control API, and SDK are adapters over application use cases.
+
+They may:
+
+- create apps, agents, configs, and channel installations
+- bind agents to conversations and threads
+- send messages
+- stream run events
+- manage jobs
+- manage memory through scoped APIs
+- manage browser profiles and workspace projections
+- request or approve permissions when policy allows
+
+They must not:
+
+- directly mutate persistence
+- bypass permission evaluation
+- treat provider session ids as canonical continuity
+- import provider SDK payloads into domain behavior
+- assume ACP/ACPX is present
+
+## ACP/ACPX Integration
+
+The repo must work with plain Codex and with ACP/ACPX integrations. ACP/ACPX
+are orchestration adapters around the same runtime contracts.
+
+ACP/ACPX may provide:
+
+- persistent issue sessions
+- orchestration state
+- long-running coordination
+- external task graph synchronization
+
+ACP/ACPX must not define:
+
+- canonical app identity
+- agent identity
+- conversation or thread identity
+- permission policy semantics
+- provider session behavior
+- runtime storage layout
+
+Plain Codex and ACP/ACPX modes must produce the same factory artifacts and use
+the same in-repo architecture source of truth.
+
+## Provider Positioning
+
+Claude/Anthropic is one provider adapter. It can be the default local provider
+path, but it is not the architecture.
+
+The platform must be able to support:
+
+- Claude/Anthropic through an Anthropic adapter
+- OpenAI through an OpenAI adapter
+- Gemini through a Gemini adapter
+- local or enterprise-hosted models through future adapters
+
+Provider adapters resolve `LlmProfile`, manage `ProviderSession`, and emit
+canonical `AgentRunEvent` records. The domain and application layers should not
+know provider SDK types.
+
+## Mode Comparison
+
+| Concern       | Personal mode                                         | Enterprise mode                                                |
+| ------------- | ----------------------------------------------------- | -------------------------------------------------------------- |
+| App           | Seeded local app                                      | Explicit app per deployment, team, product, or tenant boundary |
+| Agent         | Default local agent plus optional custom agents       | Managed agents with versioned configs                          |
+| Channel setup | CLI-guided local channel installations                | Web UI/control API/SDK-managed installations                   |
+| Admin surface | Seeded trusted binding and local CLI                  | Web UI, control API, SDK, channel admin bindings               |
+| Credentials   | Local runtime secrets plus brokered agent credentials | Runtime secret provider and enterprise credential broker       |
+| Permissions   | Conservative defaults with local approvals            | Explicit policies, roles, audit, and approval flows            |
+| Workspace     | Local folders and snapshots                           | Managed workspace projections and snapshots                    |
+| Sessions      | Canonical sessions with provider session attachments  | Same model, often with more audit and retention policy         |
+| Runs          | Local run events and logs                             | API-visible event stream, webhooks, audits, and monitoring     |
+
+## Implementation Guidance
+
+Future code movement should keep personal setup as a convenience layer:
+
+- Seed default records through application services.
+- Store local folders as workspace projections.
+- Convert group registration flows into channel installation plus binding
+  flows.
+- Convert main group behavior into explicit admin policy.
+- Convert Claude session storage into provider sessions attached to agent
+  sessions.
+- Route CLI and control HTTP through application use cases.
+
+Do not create a separate personal-only runtime path. Do not create an
+enterprise-only runtime path. Both modes should exercise the same application
+and domain contracts.

--- a/docs/architecture/target-folder-structure.md
+++ b/docs/architecture/target-folder-structure.md
@@ -1,0 +1,214 @@
+# Target Folder Structure
+
+This document defines the source layout MyClaw should converge on while moving
+from the current implementation to the canonical platform architecture. It is a
+target for future code movement, not a statement that the repository already
+fully matches the layout.
+
+## Target Top-Level Source Layout
+
+```text
+apps/core/src/
+  domain/
+  application/
+  runtime/
+  adapters/
+  config/
+  shared/
+
+packages/
+  contracts/
+  sdk/
+```
+
+The target layout is intentionally small. Do not create broad `common`, `misc`,
+or `utils` buckets. Shared code must have a clear owner and narrow purpose.
+
+## Dependency Direction
+
+Allowed direction:
+
+```text
+adapters -> application -> domain
+runtime -> application -> domain
+control-http -> application -> domain
+cli -> application -> domain
+```
+
+Layer rules:
+
+- `domain` imports no adapters, runtime, CLI, HTTP, Postgres, Slack, Telegram,
+  Teams, WhatsApp, Claude, Anthropic SDK, OpenAI, Gemini, ACP/ACPX, or
+  provider-specific packages.
+- `application` may import domain entities, domain services, ports, and shared
+  contracts. It must not instantiate concrete adapters.
+- `runtime` may compose application services into queues, runs, leases, IPC,
+  process supervision, and lifecycle management. Provider-specific branching
+  belongs in adapters.
+- `adapters` implement ports for external systems and may depend on SDKs,
+  frameworks, databases, credential brokers, channel APIs, and model providers.
+- `control-http` and `cli` are adapter families. They should parse requests and
+  call application use cases.
+- `config` parses runtime settings and secret source selection. It must fail
+  loudly for wrong-lane credentials.
+- `shared` is for small dependency-light helpers with stable ownership, such as
+  time, object handling, and path-safe utilities. It is not a dumping ground.
+
+## Directory Responsibilities
+
+### `domain/`
+
+Owns provider-free and channel-free product concepts:
+
+- app, agent, config version, model profile
+- channel installation and binding abstractions without provider SDK types
+- conversation, thread, user, message, message part, attachment metadata
+- session, provider session reference, run, run event
+- memory subject, job
+- tool and skill catalog items
+- permission policy, rule, and decision
+- sandbox profile and lease
+- workspace snapshot and browser profile identity
+- repository and service ports
+
+Domain code should be testable without Node process globals, network access,
+provider credentials, or a database.
+
+### `application/`
+
+Owns use cases and policy orchestration:
+
+- create and configure apps and agents
+- install channels and bind agents to conversations
+- ingest normalized messages
+- create sessions and runs
+- evaluate permissions
+- request sandbox leases
+- manage memory subjects and job lifecycles
+- route control API, CLI, SDK, Web UI, and channel actions into domain behavior
+
+Application services depend on ports for storage, channel delivery, LLM
+providers, credential brokers, sandboxes, browser profiles, and event sinks.
+
+### `runtime/`
+
+Owns long-running process behavior:
+
+- bootstrap and lifecycle coordination
+- message and job queues
+- agent run supervision
+- continuation input and cancellation
+- IPC and MCP hosting where needed
+- sandbox lease activation
+- workspace snapshot materialization
+- browser profile process management
+- graceful shutdown and recovery
+
+Runtime should coordinate use cases. It should not define business rules that
+only CLI, control HTTP, or channel adapters can reach.
+
+### `adapters/`
+
+Owns concrete integrations:
+
+- channel adapters: Telegram, WhatsApp, Slack, Teams, Web UI, SDK app channel
+- LLM adapters: Claude/Anthropic, OpenAI, Gemini, local providers
+- credential adapters: OneCLI, external broker, runtime secret providers
+- storage adapters: Postgres, pg-boss, migrations, search indexes
+- control HTTP adapter
+- CLI adapter
+- browser and sandbox providers
+- ACP/ACPX orchestration adapters
+- logging, service-manager, and platform adapters
+
+Adapters translate external payloads into canonical application inputs and
+translate canonical outputs back to external surfaces.
+
+### `config/`
+
+Owns runtime configuration parsing and validation:
+
+- `settings.yaml` parsing and rendering
+- runtime-owned secret source classification
+- non-secret defaults
+- wrong-lane credential rejection
+- preflight checks that do not require concrete application behavior
+
+New config values must be classified before implementation:
+
+- non-secret runtime configuration belongs in `settings.yaml`
+- runtime-owned secrets belong behind `RuntimeSecretProvider`
+- agent-accessed credentials belong behind `AgentCredentialBroker`
+
+### `shared/`
+
+Owns narrow helpers that are safe for multiple layers to depend on. Shared
+helpers must not import provider SDKs, runtime lifecycle code, CLI, control
+HTTP, or Postgres.
+
+Acceptable examples:
+
+- pure object helpers
+- time formatting primitives
+- identifier normalization
+- path validation primitives
+
+Unacceptable examples:
+
+- provider-specific helpers
+- business workflows
+- persistence shortcuts
+- broad utility modules
+
+## Packages
+
+### `packages/contracts/`
+
+Owns published and internal shared contracts:
+
+- request and response schemas
+- event shapes
+- SDK-safe value types
+- versioned public API contracts
+
+Contracts must not expose internal database rows, provider SDK payloads, or
+runtime-only implementation details.
+
+### `packages/sdk/`
+
+Owns the server-side SDK over the control API:
+
+- typed client methods
+- streaming helpers
+- wait and webhook helper behavior
+- SDK documentation examples
+
+The SDK must not import runtime internals. It talks to the control API using
+contracts.
+
+## Current-To-Target Movement
+
+Future refactors should move by capability, not by arbitrary file count.
+
+| Current area               | Target direction                                                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `channels/`                | Provider-specific channel adapters under `adapters/channels/`; channel-neutral ports and types under `domain` or `application`. |
+| `control/server/`          | Control HTTP adapter under `adapters/control-http/`; route behavior becomes application use cases.                              |
+| `cli/`                     | CLI adapter under `adapters/cli/`; setup and admin operations become application use cases.                                     |
+| `infrastructure/postgres/` | Postgres storage adapter under `adapters/storage/postgres/`.                                                                    |
+| `runner/claude/`           | Claude/Anthropic LLM adapter under `adapters/llm/anthropic/` or equivalent.                                                     |
+| `runtime/group-*`          | Runtime queues and processors keyed by canonical app, agent, conversation, thread, session, and run context.                    |
+| `platform/group-folder*`   | Workspace projection and snapshot behavior under runtime/application boundaries.                                                |
+| `memory/`                  | Application memory services plus storage and LLM extractor adapters.                                                            |
+| `jobs/`                    | Application job lifecycle plus runtime scheduler adapter.                                                                       |
+
+## Explicit Non-Goals For This Docs Phase
+
+- Do not refactor implementation files.
+- Do not move source folders.
+- Do not add compatibility layers for old local state.
+- Do not introduce new public contract schemas.
+- Do not change package exports.
+
+The next implementation phase should use these docs as the decision source
+before moving code.

--- a/docs/decisions/0001-agent-runtime-platform.md
+++ b/docs/decisions/0001-agent-runtime-platform.md
@@ -1,0 +1,167 @@
+# Agent Runtime Platform
+
+## Context
+
+MyClaw is moving from a personal Claude assistant implementation toward a
+provider-neutral and channel-neutral agent runtime platform. The existing code
+and older docs still expose several implementation concepts as if they were the
+product architecture:
+
+- personal group folders
+- a main group as the primary administration model
+- Claude session ids as the only resume mechanism
+- host tool execution as a direct runner capability
+- CLI and control routes that own business behavior
+- channel-specific identifiers used as runtime identity
+
+Those concepts helped bootstrap the local personal runtime, but they should not
+define the platform. Personal Telegram and WhatsApp usage is one seeded local
+deployment mode. Enterprise Slack, Teams, Web UI, SDK, and control API usage is
+another deployment mode. Both must use the same canonical app, agent,
+conversation, message, session, run, memory, permission, sandbox, workspace, and
+browser concepts.
+
+The runtime must continue to support plain Codex and ACP/ACPX integrations.
+ACP/ACPX are orchestration integrations, not required runtime assumptions.
+
+## Decision
+
+MyClaw's canonical product architecture is an agent runtime platform built
+around this model:
+
+```text
+App
+  Agent
+    AgentConfigVersion
+    LlmProfile
+    AgentChannelBinding
+      ChannelInstallation
+        ChannelProvider
+        Conversation
+          ConversationThread
+          Message
+            MessagePart
+            MessageAttachment
+    AgentSession
+      ProviderSession
+    AgentRun
+      AgentRunEvent
+    MemorySubject
+    Job
+    PermissionPolicy
+      PermissionRule
+      PermissionDecision
+    SandboxProfile
+      SandboxLease
+    WorkspaceSnapshot
+    BrowserProfile
+```
+
+Core rules:
+
+- `App`, `Agent`, `Conversation`, `ConversationThread`, `Message`,
+  `AgentSession`, and `AgentRun` are product concepts.
+- `ChannelProvider`, `ChannelInstallation`, and `AgentChannelBinding` adapt
+  external networks into those product concepts.
+- `LlmProfile` and `ProviderSession` adapt model providers into the product
+  session and run model.
+- Claude and Anthropic SDKs are one LLM provider adapter. They are not the
+  runtime architecture.
+- Personal usage seeds a local `App`, default `Agent`, local settings, memory
+  roots, and one or more channel installations.
+- Enterprise usage integrates through Web UI, control API, SDK, and channel
+  installations. Enterprise applications must not import runtime internals.
+- Permissions are deterministic runtime decisions, not provider callback
+  behavior. Tool execution must go through `PermissionPolicy`,
+  `PermissionRule`, `PermissionDecision`, `SandboxProfile`, and `SandboxLease`.
+- CLI and control HTTP are adapters. They call application use cases and must
+  not directly own business logic or mutate persistence.
+
+## Boundary Direction
+
+Future code movement must follow these dependencies:
+
+```text
+adapters -> application -> domain
+runtime -> application -> domain
+control-http -> application -> domain
+cli -> application -> domain
+```
+
+`domain` must remain provider-free and channel-free. It may define entities,
+value objects, policy decisions, ports, and repository contracts.
+
+`application` coordinates use cases and depends on domain and ports, not on
+concrete providers.
+
+`runtime` composes application use cases into long-running queues, sessions,
+runs, sandboxes, IPC, and lifecycle supervision. It should not accumulate
+channel-specific or provider-specific branching.
+
+`adapters` implement ports for channels, model providers, credential brokers,
+Postgres, control HTTP, CLI, Web UI, sandbox providers, browser providers, and
+external orchestration integrations.
+
+## Replacements For Later Code Movement
+
+This decision does not refactor implementation. It sets the target for later
+changes.
+
+Replace or delete:
+
+- old personal group folder model as domain identity
+- main group specific behavior as a primary architecture concept
+- provider-specific session as the only resume mechanism
+- direct tool execution on host
+- CLI-owned business logic
+- control routes directly mutating persistence
+
+Replacement direction:
+
+- Group folders become workspace and storage projections of
+  `AgentChannelBinding`, not the identity of an agent, app, or conversation.
+- Main group privileges become `PermissionPolicy` and admin binding behavior.
+- Claude session ids and other provider resume tokens become `ProviderSession`
+  records attached to canonical `AgentSession` records.
+- Host execution becomes one sandbox implementation governed by
+  `SandboxProfile`, `SandboxLease`, and deterministic permission decisions.
+- CLI and control HTTP route commands into application services, which validate
+  intent and call repositories through ports.
+
+## Alternatives Considered
+
+- Keep the personal group model as the core model: rejected because Telegram
+  groups, Slack channels, Teams conversations, Web UI chats, and SDK sessions do
+  not share the same semantics.
+- Make Claude sessions the canonical session model: rejected because model
+  providers use different resume semantics and some deployments may not expose a
+  provider session at all.
+- Treat enterprise as a separate product architecture: rejected because personal
+  and enterprise modes should differ by seeding, installation, policy, and UI,
+  not by runtime domain.
+- Keep privileged main-group behavior as the administrative model: rejected
+  because enterprise administration needs explicit user, role, channel binding,
+  and policy decisions.
+
+## Consequences
+
+- Future architecture docs and implementation work should use canonical product
+  terms first and mention group folders or provider sessions only as current
+  implementation details.
+- Existing personal setup docs can remain user-facing, but they must not imply
+  that personal channels are the only runtime model.
+- Provider adapters can be added or replaced without changing domain entities.
+- Channel adapters normalize provider payloads into canonical messages,
+  conversations, threads, and users before application behavior runs.
+- Security and permission work can be reasoned about outside provider-specific
+  SDK callbacks.
+
+## Rollback Or Migration Notes
+
+There is no runtime migration in this docs-only decision. Later implementation
+phases should perform clean-cut migrations, not compatibility shims, because
+MyClaw is still early-stage.
+
+If this decision is replaced, update this ADR and the canonical architecture
+docs before moving source files. Do not introduce new provider- or
+channel-specific branches in core runtime while the decision is active.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,5 +16,7 @@ Current decisions:
 
 - [0000 — Runtime Stack Decision](./0000-runtime-stack.md)
 - [0000 — Credential Broker Boundary](./0000-credential-broker-boundary.md)
+- [0001 — Agent Runtime Platform](./0001-agent-runtime-platform.md)
+- [0001 — Config Secret Source Boundary](./0001-config-secret-source-boundary.md)
 - [2026-04-17 — Settings And Runtime Truth](./2026-04-17-settings-runtime-truth.md)
 - [2026-04-21 — App-Wide Storage Backend Cutover](./2026-04-21-storage-backend-cutover.md)


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
