### PR TITLE
[codex] Add shared contracts DTO schemas

### DIFF
--- a/.codex/architecture-map.json
+++ b/.codex/architecture-map.json
@@ -95,7 +95,7 @@
     "packages/contracts": {
       "paths": ["packages/contracts/src"],
       "allowedImportLayers": ["packages/contracts"],
-      "allowedExternalImports": []
+      "allowedExternalImports": ["zod"]
     },
     "packages/sdk": {
       "paths": ["packages/sdk/src"],

--- a/docs/architecture/target-folder-structure.md
+++ b/docs/architecture/target-folder-structure.md
@@ -174,6 +174,11 @@ Owns published and internal shared contracts:
 Contracts must not expose internal database rows, provider SDK payloads, or
 runtime-only implementation details.
 
+This package is the integration boundary for control API clients, the
+server-side SDK, Web UI applications, and external NestJS/NextJS integrations.
+Those consumers should import DTOs and schemas from `@myclaw/contracts`, not
+from runtime, adapters, Postgres, channel, or provider-specific source paths.
+
 ### `packages/sdk/`
 
 Owns the server-side SDK over the control API:

--- a/docs/architecture/target-folder-structure.md
+++ b/docs/architecture/target-folder-structure.md
@@ -212,8 +212,6 @@ Future refactors should move by capability, not by arbitrary file count.
 - Do not refactor implementation files.
 - Do not move source folders.
 - Do not add compatibility layers for old local state.
-- Do not introduce new public contract schemas.
-- Do not change package exports.
 
 The next implementation phase should use these docs as the decision source
 before moving code.

--- a/docs/sdk/overview.md
+++ b/docs/sdk/overview.md
@@ -18,6 +18,11 @@ The runtime exposes a small internal control API over:
 - Unix domain socket by default
 - loopback TCP only when explicitly enabled
 
+`@myclaw/contracts` is the shared DTO and schema boundary for the control API,
+the server-side SDK, future Web UI integrations, and framework integrations
+such as NestJS providers or Next.js route handlers. Application code should
+depend on those contracts instead of importing MyClaw runtime internals.
+
 Authentication is bearer-token based and scoped. The runtime reads keys from:
 
 - `MYCLAW_CONTROL_API_KEYS_JSON` for production scoped keys

--- a/package-lock.json
+++ b/package-lock.json
@@ -7611,6 +7611,9 @@
     "packages/contracts": {
       "name": "@myclaw/contracts",
       "version": "1.0.0",
+      "dependencies": {
+        "zod": "^4.0.0"
+      },
       "devDependencies": {
         "@types/node": "^24.12.2",
         "typescript": "^5.7.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7610,7 +7610,7 @@
     },
     "packages/contracts": {
       "name": "@myclaw/contracts",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "zod": "^4.0.0"
       },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -2,18 +2,102 @@
   "name": "@myclaw/contracts",
   "version": "1.0.0",
   "type": "module",
-  "description": "Canonical IPC contracts for MyClaw host and runner.",
+  "description": "Canonical DTO and schema contracts for MyClaw integrations.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./agents": {
+      "types": "./dist/agents/index.d.ts",
+      "import": "./dist/agents/index.js",
+      "default": "./dist/agents/index.js"
+    },
+    "./browser": {
+      "types": "./dist/browser/index.d.ts",
+      "import": "./dist/browser/index.js",
+      "default": "./dist/browser/index.js"
+    },
+    "./channels": {
+      "types": "./dist/channels/index.d.ts",
+      "import": "./dist/channels/index.js",
+      "default": "./dist/channels/index.js"
+    },
+    "./conversations": {
+      "types": "./dist/conversations/index.d.ts",
+      "import": "./dist/conversations/index.js",
+      "default": "./dist/conversations/index.js"
+    },
+    "./errors": {
+      "types": "./dist/errors/index.d.ts",
+      "import": "./dist/errors/index.js",
+      "default": "./dist/errors/index.js"
+    },
+    "./jobs": {
+      "types": "./dist/jobs/index.d.ts",
+      "import": "./dist/jobs/index.js",
+      "default": "./dist/jobs/index.js"
+    },
+    "./memory": {
+      "types": "./dist/memory/index.d.ts",
+      "import": "./dist/memory/index.js",
+      "default": "./dist/memory/index.js"
+    },
+    "./messages": {
+      "types": "./dist/messages/index.d.ts",
+      "import": "./dist/messages/index.js",
+      "default": "./dist/messages/index.js"
+    },
+    "./pagination": {
+      "types": "./dist/pagination/index.d.ts",
+      "import": "./dist/pagination/index.js",
+      "default": "./dist/pagination/index.js"
+    },
+    "./permissions": {
+      "types": "./dist/permissions/index.d.ts",
+      "import": "./dist/permissions/index.js",
+      "default": "./dist/permissions/index.js"
+    },
+    "./runs": {
+      "types": "./dist/runs/index.d.ts",
+      "import": "./dist/runs/index.js",
+      "default": "./dist/runs/index.js"
+    },
+    "./sandbox": {
+      "types": "./dist/sandbox/index.d.ts",
+      "import": "./dist/sandbox/index.js",
+      "default": "./dist/sandbox/index.js"
+    },
+    "./sessions": {
+      "types": "./dist/sessions/index.d.ts",
+      "import": "./dist/sessions/index.js",
+      "default": "./dist/sessions/index.js"
+    },
+    "./skills": {
+      "types": "./dist/skills/index.d.ts",
+      "import": "./dist/skills/index.js",
+      "default": "./dist/skills/index.js"
+    },
+    "./streaming": {
+      "types": "./dist/streaming/index.d.ts",
+      "import": "./dist/streaming/index.js",
+      "default": "./dist/streaming/index.js"
+    },
+    "./tools": {
+      "types": "./dist/tools/index.d.ts",
+      "import": "./dist/tools/index.js",
+      "default": "./dist/tools/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@myclaw/contracts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "Canonical DTO and schema contracts for MyClaw integrations.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -31,6 +34,11 @@
       "import": "./dist/conversations/index.js",
       "default": "./dist/conversations/index.js"
     },
+    "./contract-primitives": {
+      "types": "./dist/contract-primitives.d.ts",
+      "import": "./dist/contract-primitives.js",
+      "default": "./dist/contract-primitives.js"
+    },
     "./errors": {
       "types": "./dist/errors/index.d.ts",
       "import": "./dist/errors/index.js",
@@ -55,6 +63,11 @@
       "types": "./dist/pagination/index.d.ts",
       "import": "./dist/pagination/index.js",
       "default": "./dist/pagination/index.js"
+    },
+    "./primitives": {
+      "types": "./dist/contract-primitives.d.ts",
+      "import": "./dist/contract-primitives.js",
+      "default": "./dist/contract-primitives.js"
     },
     "./permissions": {
       "types": "./dist/permissions/index.d.ts",

--- a/packages/contracts/src/agents/index.ts
+++ b/packages/contracts/src/agents/index.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+  LlmProfileRefSchema,
+  RuntimeLimitSchema,
+} from '../contract-primitives.js';
+
+export const AgentStatusSchema = z.enum([
+  'active',
+  'inactive',
+  'archived',
+  'disabled',
+]);
+export type AgentStatus = z.infer<typeof AgentStatusSchema>;
+
+export const CreateAgentRequestSchema = z.object({
+  appId: z.string(),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  promptProfileRef: z.string().optional(),
+  llmProfileId: z.string().optional(),
+  toolIds: z.array(z.string()).optional(),
+  skillIds: z.array(z.string()).optional(),
+  permissionPolicyIds: z.array(z.string()).optional(),
+  sandboxProfileId: z.string().optional(),
+  workspaceSnapshotId: z.string().optional(),
+  runtimeLimits: RuntimeLimitSchema.optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type CreateAgentRequest = z.infer<typeof CreateAgentRequestSchema>;
+
+export const UpdateAgentRequestSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+  status: AgentStatusSchema.optional(),
+  promptProfileRef: z.string().optional(),
+  llmProfileId: z.string().optional(),
+  toolIds: z.array(z.string()).optional(),
+  skillIds: z.array(z.string()).optional(),
+  permissionPolicyIds: z.array(z.string()).optional(),
+  sandboxProfileId: z.string().nullable().optional(),
+  workspaceSnapshotId: z.string().nullable().optional(),
+  runtimeLimits: RuntimeLimitSchema.optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type UpdateAgentRequest = z.infer<typeof UpdateAgentRequestSchema>;
+
+export const AgentResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  status: AgentStatusSchema,
+  currentConfigVersionId: z.string().nullable().optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type AgentResponse = z.infer<typeof AgentResponseSchema>;
+
+export const AgentConfigVersionResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  agentId: z.string(),
+  version: z.number().int().positive(),
+  promptProfileRef: z.string(),
+  llmProfile: LlmProfileRefSchema.optional(),
+  llmProfileId: z.string().optional(),
+  toolIds: z.array(z.string()),
+  skillIds: z.array(z.string()),
+  permissionPolicyIds: z.array(z.string()),
+  sandboxProfileId: z.string().nullable().optional(),
+  workspaceSnapshotId: z.string().nullable().optional(),
+  runtimeLimits: RuntimeLimitSchema.optional(),
+  createdAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type AgentConfigVersionResponse = z.infer<
+  typeof AgentConfigVersionResponseSchema
+>;

--- a/packages/contracts/src/browser/index.ts
+++ b/packages/contracts/src/browser/index.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  ExternalReferenceSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const BrowserProfileStatusSchema = z.enum([
+  'active',
+  'inactive',
+  'disabled',
+  'archived',
+]);
+export type BrowserProfileStatus = z.infer<typeof BrowserProfileStatusSchema>;
+
+export const BrowserProfileResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  agentId: z.string().nullable().optional(),
+  name: z.string(),
+  status: BrowserProfileStatusSchema,
+  stateRef: z.string().nullable().optional(),
+  authMarkers: z.array(z.string()).optional(),
+  usagePolicyRef: z.string().nullable().optional(),
+  externalRef: ExternalReferenceSchema.optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type BrowserProfileResponse = z.infer<
+  typeof BrowserProfileResponseSchema
+>;
+
+export const BROWSER_IPC_ACTIONS = [
+  'browser_profile_list',
+  'browser_launch',
+  'browser_close',
+  'browser_status',
+] as const;
+
+export const BrowserIpcActionSchema = z.enum(BROWSER_IPC_ACTIONS);
+export type BrowserIpcAction = (typeof BROWSER_IPC_ACTIONS)[number];
+
+export const BrowserIpcRequestSchema = z.object({
+  requestId: z.string(),
+  action: BrowserIpcActionSchema,
+  payload: ContractMetadataSchema.optional(),
+  context: ContractMetadataSchema.optional(),
+});
+export type BrowserIpcRequest = z.infer<typeof BrowserIpcRequestSchema>;
+
+export const BrowserIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  requestId: z.string(),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
+});
+export type BrowserIpcResponse = z.infer<typeof BrowserIpcResponseSchema>;

--- a/packages/contracts/src/browser/index.ts
+++ b/packages/contracts/src/browser/index.ts
@@ -53,6 +53,7 @@ export type BrowserIpcRequest = z.infer<typeof BrowserIpcRequestSchema>;
 export const BrowserIpcResponseSchema = z.object({
   ok: z.boolean(),
   requestId: z.string(),
+  provider: z.string().optional(),
   data: z.unknown().optional(),
   error: z.string().optional(),
 });

--- a/packages/contracts/src/channels/index.ts
+++ b/packages/contracts/src/channels/index.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  ExternalReferenceSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+import { MemorySubjectRefSchema } from '../memory/index.js';
+
+export const ChannelInstallationStatusSchema = z.enum([
+  'active',
+  'inactive',
+  'disabled',
+  'archived',
+]);
+export type ChannelInstallationStatus = z.infer<
+  typeof ChannelInstallationStatusSchema
+>;
+
+export const ChannelProviderResponseSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  capabilities: z.array(z.string()),
+  status: z.enum(['available', 'unavailable', 'disabled']).optional(),
+  createdAt: IsoDateTimeSchema.optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type ChannelProviderResponse = z.infer<
+  typeof ChannelProviderResponseSchema
+>;
+
+export const CreateChannelInstallationRequestSchema = z.object({
+  appId: z.string(),
+  providerId: z.string(),
+  label: z.string().min(1),
+  externalRef: ExternalReferenceSchema.optional(),
+  runtimeSecretRefs: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type CreateChannelInstallationRequest = z.infer<
+  typeof CreateChannelInstallationRequestSchema
+>;
+
+export const ChannelInstallationResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  providerId: z.string(),
+  label: z.string(),
+  status: ChannelInstallationStatusSchema,
+  externalRef: ExternalReferenceSchema.optional(),
+  runtimeSecretRefs: z.array(z.string()).optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type ChannelInstallationResponse = z.infer<
+  typeof ChannelInstallationResponseSchema
+>;
+
+export const AgentChannelBindingRequestSchema = z.object({
+  appId: z.string(),
+  agentId: z.string(),
+  channelInstallationId: z.string(),
+  conversationId: z.string(),
+  threadId: z.string().optional(),
+  displayName: z.string().optional(),
+  triggerPattern: z.string().nullable().optional(),
+  requiresTrigger: z.boolean().optional(),
+  isAdminBinding: z.boolean().optional(),
+  memorySubject: MemorySubjectRefSchema.optional(),
+  workspaceSnapshotId: z.string().nullable().optional(),
+  permissionPolicyIds: z.array(z.string()).optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type AgentChannelBindingRequest = z.infer<
+  typeof AgentChannelBindingRequestSchema
+>;
+
+export const AgentChannelBindingResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  agentId: z.string(),
+  channelInstallationId: z.string(),
+  conversationId: z.string(),
+  threadId: z.string().nullable().optional(),
+  displayName: z.string(),
+  triggerPattern: z.string().nullable().optional(),
+  requiresTrigger: z.boolean(),
+  isAdminBinding: z.boolean(),
+  memorySubject: MemorySubjectRefSchema.optional(),
+  workspaceSnapshotId: z.string().nullable().optional(),
+  permissionPolicyIds: z.array(z.string()),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type AgentChannelBindingResponse = z.infer<
+  typeof AgentChannelBindingResponseSchema
+>;

--- a/packages/contracts/src/channels/index.ts
+++ b/packages/contracts/src/channels/index.ts
@@ -21,8 +21,8 @@ export const ChannelProviderResponseSchema = z.object({
   id: z.string(),
   displayName: z.string(),
   capabilities: z.array(z.string()),
-  status: z.enum(['available', 'unavailable', 'disabled']).optional(),
-  createdAt: IsoDateTimeSchema.optional(),
+  status: z.enum(['available', 'unavailable', 'disabled']),
+  createdAt: IsoDateTimeSchema,
   metadata: ContractMetadataSchema.optional(),
 });
 export type ChannelProviderResponse = z.infer<

--- a/packages/contracts/src/contract-primitives.ts
+++ b/packages/contracts/src/contract-primitives.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+export const IsoDateTimeSchema = z.string().datetime({ offset: true });
+
+export const ContractMetadataSchema = z.record(z.string(), z.unknown());
+export type ContractMetadata = z.infer<typeof ContractMetadataSchema>;
+
+export const ExternalReferenceSchema = z.object({
+  kind: z.string().optional(),
+  id: z.string(),
+  displayName: z.string().optional(),
+  providerId: z.string().optional(),
+  installationId: z.string().optional(),
+  metadata: ContractMetadataSchema.optional(),
+  raw: ContractMetadataSchema.optional(),
+});
+export type ExternalReference = z.infer<typeof ExternalReferenceSchema>;
+
+export const RuntimeLimitSchema = z.object({
+  timeoutMs: z.number().int().positive().optional(),
+  maxTurns: z.number().int().positive().optional(),
+  maxToolCalls: z.number().int().positive().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type RuntimeLimit = z.infer<typeof RuntimeLimitSchema>;
+
+export const SchemaDescriptorSchema = z.object({
+  format: z
+    .enum(['json-schema', 'zod', 'openapi', 'unknown'])
+    .default('unknown'),
+  schema: ContractMetadataSchema,
+});
+export type SchemaDescriptor = z.infer<typeof SchemaDescriptorSchema>;
+
+export const LlmProfileRefSchema = z.object({
+  id: z.string().optional(),
+  purpose: z.string().optional(),
+  modelAlias: z.string().optional(),
+  credentialProfileRef: z.string().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type LlmProfileRef = z.infer<typeof LlmProfileRefSchema>;

--- a/packages/contracts/src/conversations/index.ts
+++ b/packages/contracts/src/conversations/index.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  ExternalReferenceSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+import { CursorPageRequestSchema } from '../pagination/index.js';
+
+export const ConversationKindSchema = z.enum([
+  'dm',
+  'group',
+  'channel',
+  'chat',
+  'web',
+  'sdk',
+]);
+export type ConversationKind = z.infer<typeof ConversationKindSchema>;
+
+export const ConversationStatusSchema = z.enum([
+  'active',
+  'inactive',
+  'archived',
+]);
+export type ConversationStatus = z.infer<typeof ConversationStatusSchema>;
+
+export const DiscoverConversationsRequestSchema =
+  CursorPageRequestSchema.extend({
+    appId: z.string(),
+    channelInstallationId: z.string(),
+    query: z.string().optional(),
+    includeArchived: z.boolean().optional(),
+    providerMetadata: ContractMetadataSchema.optional(),
+  });
+export type DiscoverConversationsRequest = z.infer<
+  typeof DiscoverConversationsRequestSchema
+>;
+
+export const ConversationResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  channelInstallationId: z.string(),
+  externalRef: ExternalReferenceSchema.optional(),
+  kind: ConversationKindSchema,
+  title: z.string().nullable().optional(),
+  status: ConversationStatusSchema,
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type ConversationResponse = z.infer<typeof ConversationResponseSchema>;
+
+export const ConversationThreadResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  conversationId: z.string(),
+  externalRef: ExternalReferenceSchema.optional(),
+  title: z.string().nullable().optional(),
+  status: ConversationStatusSchema,
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type ConversationThreadResponse = z.infer<
+  typeof ConversationThreadResponseSchema
+>;

--- a/packages/contracts/src/errors/index.ts
+++ b/packages/contracts/src/errors/index.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+import { ContractMetadataSchema } from '../contract-primitives.js';
+
+export const ContractErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  details: ContractMetadataSchema.nullable().optional(),
+  retryable: z.boolean().optional(),
+  requestId: z.string().optional(),
+  restartRequired: z.boolean().optional(),
+  nextAction: z.string().optional(),
+});
+export type ContractError = z.infer<typeof ContractErrorSchema>;
+
+export const ErrorResponseSchema = z.object({
+  error: ContractErrorSchema,
+});
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,37 +1,16 @@
-export const MEMORY_IPC_ACTIONS = [
-  'memory_search',
-  'memory_save',
-  'memory_patch',
-  'memory_consolidate',
-  'memory_dream',
-  'procedure_save',
-  'procedure_patch',
-] as const;
-
-export type MemoryIpcAction = (typeof MEMORY_IPC_ACTIONS)[number];
-
-export interface MemoryIpcRequest {
-  requestId: string;
-  action: MemoryIpcAction;
-  payload: Record<string, unknown>;
-  context?: {
-    threadId?: string;
-  };
-}
-
-export interface MemoryIpcResponse {
-  ok: boolean;
-  requestId: string;
-  provider?: string;
-  data?: unknown;
-  error?: string;
-}
-
-export const BROWSER_IPC_ACTIONS = [
-  'browser_profile_list',
-  'browser_launch',
-  'browser_close',
-  'browser_status',
-] as const;
-
-export type BrowserIpcAction = (typeof BROWSER_IPC_ACTIONS)[number];
+export * from './agents/index.js';
+export * from './browser/index.js';
+export * from './channels/index.js';
+export * from './conversations/index.js';
+export * from './errors/index.js';
+export * from './jobs/index.js';
+export * from './memory/index.js';
+export * from './messages/index.js';
+export * from './pagination/index.js';
+export * from './permissions/index.js';
+export * from './runs/index.js';
+export * from './sandbox/index.js';
+export * from './sessions/index.js';
+export * from './skills/index.js';
+export * from './streaming/index.js';
+export * from './tools/index.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * from './contract-primitives.js';
 export * from './agents/index.js';
 export * from './browser/index.js';
 export * from './channels/index.js';

--- a/packages/contracts/src/jobs/index.ts
+++ b/packages/contracts/src/jobs/index.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const JobScheduleSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('manual') }),
+  z.object({ type: z.literal('once'), runAt: IsoDateTimeSchema }),
+  z.object({ type: z.literal('cron'), value: z.string().min(1) }),
+  z.object({ type: z.literal('interval'), value: z.string().min(1) }),
+]);
+export type JobSchedule = z.infer<typeof JobScheduleSchema>;
+
+export const JobStatusSchema = z.enum([
+  'active',
+  'paused',
+  'running',
+  'completed',
+  'failed',
+  'dead_lettered',
+  'archived',
+]);
+export type JobStatus = z.infer<typeof JobStatusSchema>;
+
+export const JobExecutionModeSchema = z.enum(['parallel', 'serialized']);
+export type JobExecutionMode = z.infer<typeof JobExecutionModeSchema>;
+
+export const JobTargetSchema = z.object({
+  sessionId: z.string().optional(),
+  bindingId: z.string().optional(),
+  conversationId: z.string().optional(),
+  threadId: z.string().optional(),
+  userId: z.string().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type JobTarget = z.infer<typeof JobTargetSchema>;
+
+export const CreateJobRequestSchema = z.object({
+  appId: z.string(),
+  agentId: z.string().optional(),
+  name: z.string().min(1),
+  prompt: z.string().min(1),
+  schedule: JobScheduleSchema.optional(),
+  target: JobTargetSchema.optional(),
+  executionMode: JobExecutionModeSchema.optional(),
+  modelOverride: z.string().optional(),
+  silent: z.boolean().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  maxRetries: z.number().int().nonnegative().optional(),
+  retryBackoffMs: z.number().int().nonnegative().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type CreateJobRequest = z.infer<typeof CreateJobRequestSchema>;
+
+export const JobResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  agentId: z.string(),
+  name: z.string(),
+  prompt: z.string(),
+  schedule: JobScheduleSchema,
+  status: JobStatusSchema,
+  executionMode: JobExecutionModeSchema,
+  target: JobTargetSchema,
+  modelOverride: z.string().nullable().optional(),
+  silent: z.boolean(),
+  timeoutMs: z.number().int().positive(),
+  maxRetries: z.number().int().nonnegative(),
+  retryBackoffMs: z.number().int().nonnegative(),
+  nextRunAt: IsoDateTimeSchema.nullable().optional(),
+  lastRunAt: IsoDateTimeSchema.nullable().optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type JobResponse = z.infer<typeof JobResponseSchema>;

--- a/packages/contracts/src/memory/index.ts
+++ b/packages/contracts/src/memory/index.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  ExternalReferenceSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const MemorySubjectTypeSchema = z.enum([
+  'app',
+  'agent',
+  'user',
+  'group',
+  'channel',
+  'conversation',
+  'thread',
+  'common',
+]);
+export type MemorySubjectType = z.infer<typeof MemorySubjectTypeSchema>;
+
+export const MemoryKindSchema = z.enum([
+  'preference',
+  'decision',
+  'fact',
+  'correction',
+  'constraint',
+  'project_fact',
+  'reference',
+  'procedure',
+]);
+export type MemoryKind = z.infer<typeof MemoryKindSchema>;
+
+export const MemorySubjectRefSchema = z.object({
+  type: MemorySubjectTypeSchema,
+  id: z.string(),
+  displayName: z.string().optional(),
+  externalRef: ExternalReferenceSchema.optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type MemorySubjectRef = z.infer<typeof MemorySubjectRefSchema>;
+
+export const MemorySearchRequestSchema = z.object({
+  appId: z.string().optional(),
+  agentId: z.string().optional(),
+  userId: z.string().optional(),
+  groupId: z.string().optional(),
+  channelId: z.string().optional(),
+  conversationId: z.string().optional(),
+  threadId: z.string().optional(),
+  query: z.string().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  includeCommon: z.boolean().optional(),
+  subjectTypes: z.array(MemorySubjectTypeSchema).optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type MemorySearchRequest = z.infer<typeof MemorySearchRequestSchema>;
+
+export const MemoryItemResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  subject: MemorySubjectRefSchema,
+  kind: MemoryKindSchema,
+  key: z.string(),
+  value: z.unknown(),
+  confidence: z.number().min(0).max(1),
+  source: ExternalReferenceSchema.optional(),
+  status: z.enum(['active', 'archived', 'superseded']),
+  lastObservedAt: IsoDateTimeSchema.nullable().optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type MemoryItemResponse = z.infer<typeof MemoryItemResponseSchema>;
+
+export const MEMORY_IPC_ACTIONS = [
+  'memory_search',
+  'memory_save',
+  'memory_patch',
+  'memory_consolidate',
+  'memory_dream',
+  'procedure_save',
+  'procedure_patch',
+] as const;
+
+export const MemoryIpcActionSchema = z.enum(MEMORY_IPC_ACTIONS);
+export type MemoryIpcAction = (typeof MEMORY_IPC_ACTIONS)[number];
+
+export const MemoryIpcRequestSchema = z.object({
+  requestId: z.string(),
+  action: MemoryIpcActionSchema,
+  payload: ContractMetadataSchema,
+  context: z
+    .object({
+      threadId: z.string().optional(),
+    })
+    .optional(),
+});
+export type MemoryIpcRequest = z.infer<typeof MemoryIpcRequestSchema>;
+
+export const MemoryIpcResponseSchema = z.object({
+  ok: z.boolean(),
+  requestId: z.string(),
+  provider: z.string().optional(),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
+});
+export type MemoryIpcResponse = z.infer<typeof MemoryIpcResponseSchema>;

--- a/packages/contracts/src/messages/index.ts
+++ b/packages/contracts/src/messages/index.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  ExternalReferenceSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+import { CursorPageRequestSchema } from '../pagination/index.js';
+
+export const MessageDirectionSchema = z.enum([
+  'inbound',
+  'outbound',
+  'system',
+  'tool',
+]);
+export type MessageDirection = z.infer<typeof MessageDirectionSchema>;
+
+export const MessageTrustSchema = z.enum([
+  'trusted',
+  'untrusted',
+  'system',
+  'redacted',
+]);
+export type MessageTrust = z.infer<typeof MessageTrustSchema>;
+
+export const MessagePartSchema = z.object({
+  id: z.string().optional(),
+  ordinal: z.number().int().min(0),
+  kind: z.enum([
+    'text',
+    'markdown',
+    'code',
+    'image',
+    'file',
+    'tool_result',
+    'form_response',
+    'structured',
+    'redacted',
+  ]),
+  payload: z.unknown(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type MessagePart = z.infer<typeof MessagePartSchema>;
+
+export const MessageAttachmentSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  contentType: z.string().nullable().optional(),
+  sizeBytes: z.number().int().nonnegative().nullable().optional(),
+  externalRef: ExternalReferenceSchema.optional(),
+  storageRef: z.string().nullable().optional(),
+  trust: MessageTrustSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type MessageAttachment = z.infer<typeof MessageAttachmentSchema>;
+
+export const ListMessagesRequestSchema = CursorPageRequestSchema.extend({
+  appId: z.string(),
+  conversationId: z.string(),
+  threadId: z.string().optional(),
+  direction: MessageDirectionSchema.optional(),
+  since: IsoDateTimeSchema.optional(),
+  until: IsoDateTimeSchema.optional(),
+});
+export type ListMessagesRequest = z.infer<typeof ListMessagesRequestSchema>;
+
+export const MessageResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  conversationId: z.string(),
+  threadId: z.string().nullable().optional(),
+  externalRef: ExternalReferenceSchema.optional(),
+  direction: MessageDirectionSchema,
+  senderUserId: z.string().nullable().optional(),
+  senderDisplayName: z.string().nullable().optional(),
+  trust: MessageTrustSchema,
+  parts: z.array(MessagePartSchema),
+  attachments: z.array(MessageAttachmentSchema).optional(),
+  createdAt: IsoDateTimeSchema,
+  receivedAt: IsoDateTimeSchema.nullable().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type MessageResponse = z.infer<typeof MessageResponseSchema>;

--- a/packages/contracts/src/pagination/index.ts
+++ b/packages/contracts/src/pagination/index.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+export const PageRequestSchema = z.object({
+  page: z.number().int().min(1).optional(),
+  pageSize: z.number().int().min(1).max(500).optional(),
+});
+export type PageRequest = z.infer<typeof PageRequestSchema>;
+
+export interface PageResponse<T> {
+  data: T[];
+  page: number;
+  pageSize: number;
+  total?: number;
+  hasNext: boolean;
+}
+
+export function createPageResponseSchema<T extends z.ZodType>(
+  itemSchema: T,
+): z.ZodType<PageResponse<z.infer<T>>> {
+  return z.object({
+    data: z.array(itemSchema),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1),
+    total: z.number().int().min(0).optional(),
+    hasNext: z.boolean(),
+  });
+}
+
+export const CursorPageRequestSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(500).optional(),
+});
+export type CursorPageRequest = z.infer<typeof CursorPageRequestSchema>;
+
+export interface CursorPageResponse<T> {
+  data: T[];
+  nextCursor?: string;
+  hasNext: boolean;
+}
+
+export function createCursorPageResponseSchema<T extends z.ZodType>(
+  itemSchema: T,
+): z.ZodType<CursorPageResponse<z.infer<T>>> {
+  return z.object({
+    data: z.array(itemSchema),
+    nextCursor: z.string().optional(),
+    hasNext: z.boolean(),
+  });
+}

--- a/packages/contracts/src/permissions/index.ts
+++ b/packages/contracts/src/permissions/index.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const PermissionEffectSchema = z.enum([
+  'allow',
+  'deny',
+  'require_approval',
+  'require_sandbox',
+]);
+export type PermissionEffect = z.infer<typeof PermissionEffectSchema>;
+
+export const PermissionRuleResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  policyId: z.string(),
+  priority: z.number().int(),
+  effect: PermissionEffectSchema,
+  match: ContractMetadataSchema,
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type PermissionRuleResponse = z.infer<
+  typeof PermissionRuleResponseSchema
+>;
+
+export const PermissionPolicyResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  status: z.enum(['active', 'inactive', 'archived']),
+  rules: z.array(PermissionRuleResponseSchema).optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type PermissionPolicyResponse = z.infer<
+  typeof PermissionPolicyResponseSchema
+>;
+
+export const PermissionDecisionResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  policyId: z.string().nullable().optional(),
+  ruleIds: z.array(z.string()),
+  runId: z.string().nullable().optional(),
+  toolId: z.string().nullable().optional(),
+  effect: PermissionEffectSchema,
+  reason: z.string(),
+  approverRef: z.string().nullable().optional(),
+  expiresAt: IsoDateTimeSchema.nullable().optional(),
+  createdAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type PermissionDecisionResponse = z.infer<
+  typeof PermissionDecisionResponseSchema
+>;

--- a/packages/contracts/src/runs/index.ts
+++ b/packages/contracts/src/runs/index.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const AgentRunCauseSchema = z.enum([
+  'message',
+  'job',
+  'control',
+  'manual',
+  'system',
+]);
+export type AgentRunCause = z.infer<typeof AgentRunCauseSchema>;
+
+export const AgentRunStatusSchema = z.enum([
+  'queued',
+  'running',
+  'completed',
+  'failed',
+  'canceled',
+  'timeout',
+]);
+export type AgentRunStatus = z.infer<typeof AgentRunStatusSchema>;
+
+export const AgentRunResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  agentId: z.string(),
+  configVersionId: z.string(),
+  sessionId: z.string().nullable().optional(),
+  conversationId: z.string().nullable().optional(),
+  threadId: z.string().nullable().optional(),
+  messageId: z.string().nullable().optional(),
+  jobId: z.string().nullable().optional(),
+  llmProfileId: z.string(),
+  permissionDecisionIds: z.array(z.string()),
+  sandboxLeaseId: z.string().nullable().optional(),
+  workspaceSnapshotId: z.string().nullable().optional(),
+  cause: AgentRunCauseSchema,
+  status: AgentRunStatusSchema,
+  createdAt: IsoDateTimeSchema,
+  startedAt: IsoDateTimeSchema.nullable().optional(),
+  endedAt: IsoDateTimeSchema.nullable().optional(),
+  resultSummary: z.string().nullable().optional(),
+  errorSummary: z.string().nullable().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type AgentRunResponse = z.infer<typeof AgentRunResponseSchema>;
+
+export const AgentRunEventResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  runId: z.string(),
+  type: z.string(),
+  payload: z.unknown(),
+  createdAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type AgentRunEventResponse = z.infer<typeof AgentRunEventResponseSchema>;

--- a/packages/contracts/src/sandbox/index.ts
+++ b/packages/contracts/src/sandbox/index.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const SandboxAccessSchema = z.enum([
+  'disabled',
+  'deny',
+  'read_only',
+  'scoped',
+  'unrestricted',
+  'approval_required',
+]);
+export type SandboxAccess = z.infer<typeof SandboxAccessSchema>;
+
+export const SandboxProfileResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  name: z.string(),
+  filesystem: SandboxAccessSchema,
+  network: SandboxAccessSchema,
+  process: SandboxAccessSchema,
+  browser: SandboxAccessSchema,
+  credentialAccess: SandboxAccessSchema,
+  timeoutMs: z.number().int().positive(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type SandboxProfileResponse = z.infer<
+  typeof SandboxProfileResponseSchema
+>;

--- a/packages/contracts/src/sessions/index.ts
+++ b/packages/contracts/src/sessions/index.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const AgentSessionStatusSchema = z.enum([
+  'active',
+  'paused',
+  'completed',
+  'archived',
+]);
+export type AgentSessionStatus = z.infer<typeof AgentSessionStatusSchema>;
+
+export const ResponseModeSchema = z.enum(['sse', 'webhook', 'both', 'none']);
+export type ResponseMode = z.infer<typeof ResponseModeSchema>;
+
+export const CreateSessionRequestSchema = z.object({
+  appId: z.string(),
+  agentId: z.string().optional(),
+  conversationId: z.string().optional(),
+  threadId: z.string().optional(),
+  jobId: z.string().optional(),
+  userId: z.string().optional(),
+  title: z.string().optional(),
+  responseMode: ResponseModeSchema.optional(),
+  webhookId: z.string().optional(),
+  modelOverride: z.string().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>;
+
+export const ResumeSessionRequestSchema = z.object({
+  appId: z.string().optional(),
+  sessionId: z.string(),
+  responseMode: ResponseModeSchema.optional(),
+  webhookId: z.string().optional(),
+  modelOverride: z.string().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type ResumeSessionRequest = z.infer<typeof ResumeSessionRequestSchema>;
+
+export const ProviderSessionResponseSchema = z.object({
+  id: z.string(),
+  providerRef: ContractMetadataSchema,
+  status: z.enum(['active', 'inactive', 'expired', 'revoked']),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type ProviderSessionResponse = z.infer<
+  typeof ProviderSessionResponseSchema
+>;
+
+export const AgentSessionResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  agentId: z.string(),
+  conversationId: z.string().nullable().optional(),
+  threadId: z.string().nullable().optional(),
+  jobId: z.string().nullable().optional(),
+  userId: z.string().nullable().optional(),
+  status: AgentSessionStatusSchema,
+  modelOverride: z.string().nullable().optional(),
+  providerSessions: z.array(ProviderSessionResponseSchema).optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  resetAt: IsoDateTimeSchema.nullable().optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+export type AgentSessionResponse = z.infer<typeof AgentSessionResponseSchema>;

--- a/packages/contracts/src/sessions/index.ts
+++ b/packages/contracts/src/sessions/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import {
   ContractMetadataSchema,
+  ExternalReferenceSchema,
   IsoDateTimeSchema,
 } from '../contract-primitives.js';
 
@@ -43,7 +44,7 @@ export type ResumeSessionRequest = z.infer<typeof ResumeSessionRequestSchema>;
 
 export const ProviderSessionResponseSchema = z.object({
   id: z.string(),
-  providerRef: ContractMetadataSchema,
+  providerRef: ExternalReferenceSchema,
   status: z.enum(['active', 'inactive', 'expired', 'revoked']),
   createdAt: IsoDateTimeSchema,
   updatedAt: IsoDateTimeSchema,

--- a/packages/contracts/src/skills/index.ts
+++ b/packages/contracts/src/skills/index.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+
+export const SkillCatalogItemResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  version: z.string(),
+  promptRefs: z.array(z.string()),
+  toolIds: z.array(z.string()),
+  workflowRefs: z.array(z.string()),
+  setupRefs: z.array(z.string()).optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type SkillCatalogItemResponse = z.infer<
+  typeof SkillCatalogItemResponseSchema
+>;

--- a/packages/contracts/src/streaming/index.ts
+++ b/packages/contracts/src/streaming/index.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+} from '../contract-primitives.js';
+import { ContractErrorSchema } from '../errors/index.js';
+import { MessageResponseSchema } from '../messages/index.js';
+import { PermissionDecisionResponseSchema } from '../permissions/index.js';
+import { AgentRunEventResponseSchema } from '../runs/index.js';
+
+const StreamEventBaseSchema = z.object({
+  id: z.string().optional(),
+  appId: z.string().optional(),
+  runId: z.string().optional(),
+  sessionId: z.string().optional(),
+  sequence: z.number().int().nonnegative().optional(),
+  createdAt: IsoDateTimeSchema.optional(),
+  metadata: ContractMetadataSchema.optional(),
+});
+
+export const StreamEventSchema = z.discriminatedUnion('type', [
+  StreamEventBaseSchema.extend({
+    type: z.literal('heartbeat'),
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('run.event'),
+    event: AgentRunEventResponseSchema,
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('message.delta'),
+    messageId: z.string().optional(),
+    delta: z.string(),
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('message.completed'),
+    message: MessageResponseSchema,
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('progress'),
+    label: z.string(),
+    detail: z.string().optional(),
+    done: z.boolean().optional(),
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('tool.requested'),
+    toolCallId: z.string(),
+    toolId: z.string().optional(),
+    name: z.string(),
+    input: z.unknown().optional(),
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('tool.completed'),
+    toolCallId: z.string(),
+    toolId: z.string().optional(),
+    output: z.unknown().optional(),
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('permission.decision'),
+    decision: PermissionDecisionResponseSchema,
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('error'),
+    error: ContractErrorSchema,
+  }),
+  StreamEventBaseSchema.extend({
+    type: z.literal('completed'),
+    status: z.enum(['completed', 'failed', 'canceled', 'timeout']),
+    resultSummary: z.string().nullable().optional(),
+    errorSummary: z.string().nullable().optional(),
+  }),
+]);
+export type StreamEvent = z.infer<typeof StreamEventSchema>;

--- a/packages/contracts/src/tools/index.ts
+++ b/packages/contracts/src/tools/index.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+import {
+  ContractMetadataSchema,
+  IsoDateTimeSchema,
+  SchemaDescriptorSchema,
+} from '../contract-primitives.js';
+
+export const ToolRiskSchema = z.enum(['low', 'medium', 'high', 'critical']);
+export type ToolRisk = z.infer<typeof ToolRiskSchema>;
+
+export const ToolCatalogItemResponseSchema = z.object({
+  id: z.string(),
+  appId: z.string(),
+  name: z.string(),
+  displayName: z.string().optional(),
+  description: z.string().nullable().optional(),
+  inputSchema: SchemaDescriptorSchema,
+  outputSchema: SchemaDescriptorSchema.optional(),
+  risk: ToolRiskSchema,
+  permissionPolicyId: z.string().nullable().optional(),
+  sandboxProfileId: z.string().nullable().optional(),
+  adapterRef: z.string().optional(),
+  credentialRefs: z.array(z.string()).optional(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  metadata: ContractMetadataSchema.optional(),
+});
+export type ToolCatalogItemResponse = z.infer<
+  typeof ToolCatalogItemResponseSchema
+>;

--- a/packages/contracts/test/unit/index.test.ts
+++ b/packages/contracts/test/unit/index.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { BROWSER_IPC_ACTIONS, MEMORY_IPC_ACTIONS } from '@contracts-src/index.js';
+import {
+  AgentResponseSchema,
+  BROWSER_IPC_ACTIONS,
+  BrowserProfileResponseSchema,
+  CreateJobRequestSchema,
+  MEMORY_IPC_ACTIONS,
+  MemoryItemResponseSchema,
+  PageRequestSchema,
+  StreamEventSchema,
+} from '@contracts-src/index.js';
 
 describe('contracts package', () => {
-  it('exports memory IPC actions', () => {
+  it('exports memory IPC actions from the canonical memory module', () => {
     expect(MEMORY_IPC_ACTIONS).toEqual([
       'memory_search',
       'memory_save',
@@ -15,12 +24,75 @@ describe('contracts package', () => {
     ]);
   });
 
-  it('exports browser IPC actions', () => {
+  it('exports browser IPC actions from the canonical browser module', () => {
     expect(BROWSER_IPC_ACTIONS).toEqual([
       'browser_profile_list',
       'browser_launch',
       'browser_close',
       'browser_status',
     ]);
+  });
+
+  it('validates representative canonical DTOs', () => {
+    expect(
+      AgentResponseSchema.parse({
+        id: 'agent-1',
+        appId: 'app-1',
+        name: 'Operator',
+        status: 'active',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      }),
+    ).toMatchObject({ id: 'agent-1', appId: 'app-1' });
+
+    expect(
+      CreateJobRequestSchema.parse({
+        appId: 'app-1',
+        name: 'Daily summary',
+        prompt: 'Summarize open work',
+        schedule: { type: 'manual' },
+      }),
+    ).toMatchObject({ name: 'Daily summary' });
+
+    expect(
+      MemoryItemResponseSchema.parse({
+        id: 'memory-1',
+        appId: 'app-1',
+        subject: { type: 'common', id: 'common' },
+        kind: 'fact',
+        key: 'timezone',
+        value: 'Asia/Kolkata',
+        confidence: 1,
+        status: 'active',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      }),
+    ).toMatchObject({ key: 'timezone' });
+
+    expect(
+      BrowserProfileResponseSchema.parse({
+        id: 'browser-1',
+        appId: 'app-1',
+        name: 'default',
+        status: 'active',
+        createdAt: '2026-04-27T00:00:00.000Z',
+        updatedAt: '2026-04-27T00:00:00.000Z',
+      }),
+    ).toMatchObject({ name: 'default' });
+  });
+
+  it('validates pagination and stream event contracts', () => {
+    expect(PageRequestSchema.parse({ page: 1, pageSize: 25 })).toEqual({
+      page: 1,
+      pageSize: 25,
+    });
+
+    expect(
+      StreamEventSchema.parse({
+        type: 'heartbeat',
+        id: 'event-1',
+        createdAt: '2026-04-27T00:00:00.000Z',
+      }),
+    ).toMatchObject({ type: 'heartbeat' });
   });
 });

--- a/packages/contracts/test/unit/index.test.ts
+++ b/packages/contracts/test/unit/index.test.ts
@@ -4,12 +4,59 @@ import {
   AgentResponseSchema,
   BROWSER_IPC_ACTIONS,
   BrowserProfileResponseSchema,
+  ChannelProviderResponseSchema,
+  ContractMetadataSchema,
+  CreateAgentRequestSchema,
   CreateJobRequestSchema,
+  ExternalReferenceSchema,
+  IsoDateTimeSchema,
+  JobScheduleSchema,
+  LlmProfileRefSchema,
   MEMORY_IPC_ACTIONS,
   MemoryItemResponseSchema,
+  MemorySearchRequestSchema,
+  MessageResponseSchema,
   PageRequestSchema,
+  RuntimeLimitSchema,
+  SchemaDescriptorSchema,
   StreamEventSchema,
+  createCursorPageResponseSchema,
+  createPageResponseSchema,
 } from '@contracts-src/index.js';
+
+function expectInvalid(schema: { safeParse: (input: unknown) => { success: boolean } }, input: unknown) {
+  expect(schema.safeParse(input).success).toBe(false);
+}
+
+const iso = '2026-04-27T00:00:00.000Z';
+
+const message = {
+  id: 'message-1',
+  appId: 'app-1',
+  conversationId: 'conversation-1',
+  direction: 'outbound',
+  trust: 'trusted',
+  parts: [{ ordinal: 0, kind: 'text', payload: { text: 'hello' } }],
+  createdAt: iso,
+};
+
+const runEvent = {
+  id: 'run-event-1',
+  appId: 'app-1',
+  runId: 'run-1',
+  type: 'model.output',
+  payload: { text: 'hello' },
+  createdAt: iso,
+};
+
+const permissionDecision = {
+  id: 'decision-1',
+  appId: 'app-1',
+  ruleIds: ['rule-1'],
+  effect: 'allow',
+  reason: 'Matched allow rule',
+  createdAt: iso,
+};
 
 describe('contracts package', () => {
   it('exports memory IPC actions from the canonical memory module', () => {
@@ -33,17 +80,54 @@ describe('contracts package', () => {
     ]);
   });
 
-  it('validates representative canonical DTOs', () => {
+  it('exports and validates contract primitives', () => {
+    expect(IsoDateTimeSchema.parse(iso)).toBe(iso);
+    expectInvalid(IsoDateTimeSchema, '2026-04-27T00:00:00');
+
+    expect(ContractMetadataSchema.parse({ provider: 'sdk' })).toEqual({
+      provider: 'sdk',
+    });
+    expect(ExternalReferenceSchema.parse({ id: 'external-1' })).toMatchObject({
+      id: 'external-1',
+    });
+
+    expect(RuntimeLimitSchema.parse({ timeoutMs: 1000 })).toEqual({
+      timeoutMs: 1000,
+    });
+    expectInvalid(RuntimeLimitSchema, { timeoutMs: 0 });
+    expectInvalid(RuntimeLimitSchema, { maxTurns: 1.5 });
+
+    expect(SchemaDescriptorSchema.parse({ schema: {} })).toEqual({
+      format: 'unknown',
+      schema: {},
+    });
+    expectInvalid(SchemaDescriptorSchema, { format: 'protobuf', schema: {} });
+
+    expect(LlmProfileRefSchema.parse({ modelAlias: 'opus' })).toEqual({
+      modelAlias: 'opus',
+    });
+  });
+
+  it('validates representative canonical DTOs and rejects constrained invalid input', () => {
     expect(
       AgentResponseSchema.parse({
         id: 'agent-1',
         appId: 'app-1',
         name: 'Operator',
         status: 'active',
-        createdAt: '2026-04-27T00:00:00.000Z',
-        updatedAt: '2026-04-27T00:00:00.000Z',
+        createdAt: iso,
+        updatedAt: iso,
       }),
     ).toMatchObject({ id: 'agent-1', appId: 'app-1' });
+    expectInvalid(AgentResponseSchema, {
+      id: 'agent-1',
+      appId: 'app-1',
+      name: 'Operator',
+      status: 'bad',
+      createdAt: iso,
+      updatedAt: iso,
+    });
+    expectInvalid(CreateAgentRequestSchema, { appId: 'app-1', name: '' });
 
     expect(
       CreateJobRequestSchema.parse({
@@ -53,6 +137,16 @@ describe('contracts package', () => {
         schedule: { type: 'manual' },
       }),
     ).toMatchObject({ name: 'Daily summary' });
+    expectInvalid(CreateJobRequestSchema, {
+      appId: 'app-1',
+      name: '',
+      prompt: 'Summarize open work',
+    });
+    expectInvalid(CreateJobRequestSchema, {
+      appId: 'app-1',
+      name: 'Daily summary',
+      prompt: '',
+    });
 
     expect(
       MemoryItemResponseSchema.parse({
@@ -64,10 +158,23 @@ describe('contracts package', () => {
         value: 'Asia/Kolkata',
         confidence: 1,
         status: 'active',
-        createdAt: '2026-04-27T00:00:00.000Z',
-        updatedAt: '2026-04-27T00:00:00.000Z',
+        createdAt: iso,
+        updatedAt: iso,
       }),
     ).toMatchObject({ key: 'timezone' });
+    expectInvalid(MemoryItemResponseSchema, {
+      id: 'memory-1',
+      appId: 'app-1',
+      subject: { type: 'common', id: 'common' },
+      kind: 'fact',
+      key: 'timezone',
+      value: 'Asia/Kolkata',
+      confidence: 1.0001,
+      status: 'active',
+      createdAt: iso,
+      updatedAt: iso,
+    });
+    expectInvalid(MemorySearchRequestSchema, { limit: 101 });
 
     expect(
       BrowserProfileResponseSchema.parse({
@@ -75,24 +182,165 @@ describe('contracts package', () => {
         appId: 'app-1',
         name: 'default',
         status: 'active',
-        createdAt: '2026-04-27T00:00:00.000Z',
-        updatedAt: '2026-04-27T00:00:00.000Z',
+        createdAt: iso,
+        updatedAt: iso,
       }),
     ).toMatchObject({ name: 'default' });
+    expectInvalid(BrowserProfileResponseSchema, {
+      id: 'browser-1',
+      appId: 'app-1',
+      name: 'default',
+      status: 'bad',
+      createdAt: iso,
+      updatedAt: iso,
+    });
+
+    expect(
+      ChannelProviderResponseSchema.parse({
+        id: 'slack',
+        displayName: 'Slack',
+        capabilities: ['threads'],
+        status: 'available',
+        createdAt: iso,
+      }),
+    ).toMatchObject({ id: 'slack' });
+    expectInvalid(ChannelProviderResponseSchema, {
+      id: 'slack',
+      displayName: 'Slack',
+      capabilities: ['threads'],
+    });
+
+    expectInvalid(MessageResponseSchema, {
+      ...message,
+      parts: [{ ordinal: -1, kind: 'text', payload: { text: 'hello' } }],
+    });
   });
 
-  it('validates pagination and stream event contracts', () => {
+  it('validates pagination request and response schema constraints', () => {
     expect(PageRequestSchema.parse({ page: 1, pageSize: 25 })).toEqual({
       page: 1,
       pageSize: 25,
     });
+    expectInvalid(PageRequestSchema, { page: 0 });
+    expectInvalid(PageRequestSchema, { page: 1, pageSize: 501 });
 
+    const pageResponse = createPageResponseSchema(AgentResponseSchema);
     expect(
-      StreamEventSchema.parse({
-        type: 'heartbeat',
-        id: 'event-1',
-        createdAt: '2026-04-27T00:00:00.000Z',
+      pageResponse.parse({
+        data: [
+          {
+            id: 'agent-1',
+            appId: 'app-1',
+            name: 'Operator',
+            status: 'active',
+            createdAt: iso,
+            updatedAt: iso,
+          },
+        ],
+        page: 1,
+        pageSize: 25,
+        total: 1,
+        hasNext: false,
       }),
-    ).toMatchObject({ type: 'heartbeat' });
+    ).toMatchObject({ page: 1, hasNext: false });
+    expectInvalid(pageResponse, {
+      data: [],
+      page: 0,
+      pageSize: 25,
+      hasNext: false,
+    });
+    expectInvalid(pageResponse, { data: [], page: 1, pageSize: 25 });
+    expectInvalid(pageResponse, {
+      data: [{ id: 'agent-1' }],
+      page: 1,
+      pageSize: 25,
+      hasNext: false,
+    });
+
+    const cursorResponse = createCursorPageResponseSchema(AgentResponseSchema);
+    expect(
+      cursorResponse.parse({
+        data: [],
+        nextCursor: 'next',
+        hasNext: true,
+      }),
+    ).toMatchObject({ hasNext: true });
+    expectInvalid(cursorResponse, { data: [] });
+    expectInvalid(cursorResponse, {
+      data: [{ id: 'agent-1' }],
+      hasNext: false,
+    });
+  });
+
+  it.each([
+    ['manual', { type: 'manual' }],
+    ['once', { type: 'once', runAt: iso }],
+    ['cron', { type: 'cron', value: '0 9 * * *' }],
+    ['interval', { type: 'interval', value: '60000' }],
+  ])('validates %s job schedules', (_name, schedule) => {
+    expect(JobScheduleSchema.parse(schedule)).toEqual(schedule);
+  });
+
+  it.each([
+    ['once without runAt', { type: 'once' }],
+    ['once with naive runAt', { type: 'once', runAt: '2026-04-27T00:00:00' }],
+    ['cron with empty value', { type: 'cron', value: '' }],
+    ['interval with empty value', { type: 'interval', value: '' }],
+  ])('rejects invalid job schedule: %s', (_name, schedule) => {
+    expectInvalid(JobScheduleSchema, schedule);
+  });
+
+  it.each([
+    ['heartbeat', { type: 'heartbeat', id: 'event-1', createdAt: iso }, {}],
+    [
+      'run.event',
+      { type: 'run.event', event: runEvent },
+      { type: 'run.event' },
+    ],
+    [
+      'message.delta',
+      { type: 'message.delta', messageId: 'message-1', delta: 'hello' },
+      { type: 'message.delta', messageId: 'message-1' },
+    ],
+    [
+      'message.completed',
+      { type: 'message.completed', message },
+      { type: 'message.completed' },
+    ],
+    [
+      'progress',
+      { type: 'progress', label: 'Running', detail: 'Step 1', done: false },
+      { type: 'progress', detail: 'Step 1' },
+    ],
+    [
+      'tool.requested',
+      { type: 'tool.requested', toolCallId: 'call-1', name: 'search' },
+      { type: 'tool.requested', name: 'search' },
+    ],
+    [
+      'tool.completed',
+      { type: 'tool.completed', toolCallId: 'call-1', output: { ok: true } },
+      { type: 'tool.completed', output: { ok: true } },
+    ],
+    [
+      'permission.decision',
+      { type: 'permission.decision', decision: permissionDecision },
+      { type: 'permission.decision' },
+    ],
+    [
+      'error',
+      { type: 'error', error: { code: 'INVALID_REQUEST', message: 'Nope' } },
+      { type: 'error' },
+    ],
+    [
+      'completed',
+      { type: 'completed', status: 'completed', resultSummary: 'Done' },
+      { type: 'completed' },
+    ],
+  ])('validates stream event variant %s', (_name, valid, invalid) => {
+    expect(StreamEventSchema.parse(valid)).toMatchObject(valid);
+    if (Object.keys(invalid).length > 0) {
+      expectInvalid(StreamEventSchema, invalid);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Restructure @myclaw/contracts into capability-owned DTO/schema modules for agents, channels, conversations, messages, sessions, runs, jobs, memory, permissions, tools, skills, sandbox, browser, streaming, errors, and pagination.
- Move memory/browser IPC contracts into their owned modules while keeping root barrel exports as the canonical entrypoint.
- Add Zod as the contracts schema dependency, package subpath exports, and docs describing @myclaw/contracts as the SDK/Web UI/control API integration boundary.

## Validation

- npm run build:contracts
- npm run test:unit
- npm run typecheck
- npm run format:check
- python3 .codex/scripts/check_architecture.py (fails on existing architecture debt; contracts/Zod violation resolved by scoped architecture-map allowance)
- python3 .codex/scripts/check_task_completion.py (fails because architecture check still has existing repo debt; no completion warnings)

## Notes

- No control API routes or SDK runtime behavior were changed.
- Generated packages/contracts/dist output remains ignored and untracked.
- AGENTS.md has an unrelated local modification and was intentionally excluded from this PR.