### PR TITLE
[codex] Add application service skeleton layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,9 @@ Important constraints:
 - MyClaw is early-stage: prefer deleting legacy code over compatibility shims because no users are live yet.
 - Do not add migration compatibility commands, auto-migration flows, cleanup shims, or runtime branches that exist only to support old local state.
 - Remove obsolete code paths in the same change when introducing a breaking replacement.
+- Treat cleanup as part of the implementation, not a follow-up. A replacement is not done until obsolete active repositories, schemas, runtime paths, tests, docs, exports, and factory wiring are deleted or deliberately retained with an owner, reason, and removal condition.
+- Before resolving PR review threads or marking cutover work complete, search for old type names, table names, imports, and runtime entrypoints affected by the change. Document any remaining matches and prove they are inactive, historical docs, or intentionally retained exceptions.
+- Do not leave stale code because the new path compiles. If an old path can still be imported, constructed, migrated, or called by supported runtime flows, either remove it in the same PR or explicitly block completion.
 - Do not add test-only or local-checkout branches to production code.
 - Classify every new config value before implementation: non-secret configuration belongs in `settings.yaml`, runtime-owned secrets belong behind `RuntimeSecretProvider`, and agent-accessed credentials belong behind `AgentCredentialBroker`.
 - Wrong-lane credential/config values must fail loudly. Raw model/provider credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `CLAUDE_CODE_OAUTH_TOKEN` must never be accepted from MyClaw `.env` or process env.
@@ -75,6 +78,7 @@ Important constraints:
 - Discover and document exact verification commands before changing implementation behavior.
 - Run the smallest relevant checks after each change.
 - Run full checks at the end of a phase.
+- For replacement or cutover work, include a cleanup verification step that searches for stale active references and records the result before final response or PR handoff.
 - Use [docs/architecture/current-verification-commands.md](docs/architecture/current-verification-commands.md) as the command reference.
 
 ## Codex Harness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,8 @@ Important constraints:
 - MyClaw is early-stage: prefer deleting legacy code over compatibility shims because no users are live yet.
 - Do not add migration compatibility commands, auto-migration flows, cleanup shims, or runtime branches that exist only to support old local state.
 - Remove obsolete code paths in the same change when introducing a breaking replacement.
-- Treat cleanup as part of the implementation, not a follow-up. A replacement is not done until obsolete active repositories, schemas, runtime paths, tests, docs, exports, and factory wiring are deleted or deliberately retained with an owner, reason, and removal condition.
+- Treat cleanup as part of replacement work: remove obsolete active repositories, schemas, runtime paths, tests, docs, exports, and factory wiring in the same PR, or deliberately retain them with an owner, reason, and removal condition.
 - Before resolving PR review threads or marking cutover work complete, search for old type names, table names, imports, and runtime entrypoints affected by the change. Document any remaining matches and prove they are inactive, historical docs, or intentionally retained exceptions.
-- Do not leave stale code because the new path compiles. If an old path can still be imported, constructed, migrated, or called by supported runtime flows, either remove it in the same PR or explicitly block completion.
 - Do not add test-only or local-checkout branches to production code.
 - Classify every new config value before implementation: non-secret configuration belongs in `settings.yaml`, runtime-owned secrets belong behind `RuntimeSecretProvider`, and agent-accessed credentials belong behind `AgentCredentialBroker`.
 - Wrong-lane credential/config values must fail loudly. Raw model/provider credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `CLAUDE_CODE_OAUTH_TOKEN` must never be accepted from MyClaw `.env` or process env.

--- a/apps/core/src/adapters/credentials/agent-credential-broker-factory.ts
+++ b/apps/core/src/adapters/credentials/agent-credential-broker-factory.ts
@@ -1,0 +1,49 @@
+import { ensureAgentCredentialBinding as ensureApplicationAgentCredentialBinding } from '../../application/credentials/agent-credential-service.js';
+import type { AgentCredentialBroker } from '../../domain/ports/agent-credential-broker.js';
+import type { CredentialBrokerProfile } from '../../domain/models/credentials.js';
+import { OnecliAgentCredentialBroker } from './onecli/broker.js';
+
+export interface AgentCredentialBrokerFactoryOptions {
+  mode: CredentialBrokerProfile;
+  broker?: AgentCredentialBroker;
+  onecliUrl?: string;
+  dataDir?: string;
+}
+
+export async function createAgentCredentialBroker(
+  options: AgentCredentialBrokerFactoryOptions,
+): Promise<AgentCredentialBroker | undefined> {
+  if (options.broker) return options.broker;
+  if (options.mode !== 'onecli') return undefined;
+  if (!options.dataDir) {
+    throw new Error(
+      'OneCLI credential broker creation requires an adapter-owned data directory.',
+    );
+  }
+  return new OnecliAgentCredentialBroker({
+    onecliUrl: options.onecliUrl,
+    dataDir: options.dataDir,
+  });
+}
+
+export async function ensureAgentCredentialBinding(input: {
+  mode: CredentialBrokerProfile;
+  agentIdentifier: string;
+  agentName: string;
+  onecliUrl?: string;
+  dataDir?: string;
+  broker?: AgentCredentialBroker;
+}): Promise<{ created?: boolean } | undefined> {
+  const broker = await createAgentCredentialBroker({
+    mode: input.mode,
+    broker: input.broker,
+    onecliUrl: input.onecliUrl,
+    dataDir: input.dataDir,
+  });
+  return ensureApplicationAgentCredentialBinding({
+    mode: input.mode,
+    agentIdentifier: input.agentIdentifier,
+    agentName: input.agentName,
+    broker,
+  });
+}

--- a/apps/core/src/adapters/llm/external-credential-injection.ts
+++ b/apps/core/src/adapters/llm/external-credential-injection.ts
@@ -1,0 +1,15 @@
+import type { AgentCredentialInjection } from '../../domain/models/credentials.js';
+
+export function createExternalAgentCredentialInjection(input: {
+  normalizedBaseUrl: string;
+  hostCredentialEnv?: Record<string, string>;
+}): AgentCredentialInjection {
+  return {
+    env: {
+      ...(input.hostCredentialEnv ?? {}),
+      ANTHROPIC_BASE_URL: input.normalizedBaseUrl,
+    },
+    applied: true,
+    brokerProfile: 'external',
+  };
+}

--- a/apps/core/src/adapters/llm/external-credential-injection.ts
+++ b/apps/core/src/adapters/llm/external-credential-injection.ts
@@ -1,14 +1,25 @@
 import type { AgentCredentialInjection } from '../../domain/models/credentials.js';
 
+const RAW_AGENT_CREDENTIAL_ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'OPENAI_ORG_ID',
+  'OPENAI_PROJECT',
+];
+
 export function createExternalAgentCredentialInjection(input: {
   normalizedBaseUrl: string;
   hostCredentialEnv?: Record<string, string>;
 }): AgentCredentialInjection {
+  const env = { ...(input.hostCredentialEnv ?? {}) };
+  for (const key of RAW_AGENT_CREDENTIAL_ENV_KEYS) {
+    delete env[key];
+  }
+  env.ANTHROPIC_BASE_URL = input.normalizedBaseUrl;
   return {
-    env: {
-      ...(input.hostCredentialEnv ?? {}),
-      ANTHROPIC_BASE_URL: input.normalizedBaseUrl,
-    },
+    env,
     applied: true,
     brokerProfile: 'external',
   };

--- a/apps/core/src/app/bootstrap/runtime-app.ts
+++ b/apps/core/src/app/bootstrap/runtime-app.ts
@@ -3,11 +3,10 @@ import {
   DATA_DIR,
   getCredentialBrokerRuntimeConfig,
 } from '../../config/index.js';
-import { envConfig } from '../../config/env/index.js';
 import {
   createAgentCredentialBroker,
   ensureAgentCredentialBinding,
-} from '../../application/credentials/agent-credential-service.js';
+} from '../../adapters/credentials/agent-credential-broker-factory.js';
 import type { AgentCredentialBroker } from '../../domain/ports/agent-credential-broker.js';
 import { encodeGroupMessageCursor } from '../../shared/message-cursor.js';
 import { logger } from '../../infrastructure/logging/logger.js';
@@ -108,8 +107,6 @@ export function createRuntimeApp(options: RuntimeAppOptions = {}): RuntimeApp {
     credentialBrokerPromise ??= createAgentCredentialBroker({
       mode: brokerConfig.mode,
       onecliUrl: brokerConfig.onecliUrl,
-      externalBrokerUrl: brokerConfig.externalBrokerBaseUrl,
-      env: envConfig,
       dataDir: DATA_DIR,
     });
     return credentialBrokerPromise;
@@ -132,7 +129,6 @@ export function createRuntimeApp(options: RuntimeAppOptions = {}): RuntimeApp {
         : await ensureAgentCredentialBinding({
             mode: brokerConfig.mode,
             onecliUrl: brokerConfig.onecliUrl,
-            env: envConfig,
             dataDir: DATA_DIR,
             broker: await getCredentialBroker(),
             agentIdentifier: identifier,

--- a/apps/core/src/app/bootstrap/runtime-app.ts
+++ b/apps/core/src/app/bootstrap/runtime-app.ts
@@ -108,6 +108,9 @@ export function createRuntimeApp(options: RuntimeAppOptions = {}): RuntimeApp {
       mode: brokerConfig.mode,
       onecliUrl: brokerConfig.onecliUrl,
       dataDir: DATA_DIR,
+    }).catch((error) => {
+      credentialBrokerPromise = undefined;
+      throw error;
     });
     return credentialBrokerPromise;
   }

--- a/apps/core/src/application/agents/create-agent-use-case.ts
+++ b/apps/core/src/application/agents/create-agent-use-case.ts
@@ -1,0 +1,38 @@
+import type { Agent, AgentId } from '../../domain/agent/agent.js';
+import type { AppId } from '../../domain/app/app.js';
+import type { AgentRepository } from '../../domain/ports/repositories.js';
+import type { Clock } from '../common/clock.js';
+import type { IdGenerator } from '../common/id-generator.js';
+
+export interface CreateAgentInput {
+  appId: AppId;
+  name: string;
+}
+
+export interface CreateAgentOutput {
+  agent: Agent;
+}
+
+export class CreateAgentUseCase {
+  constructor(
+    private readonly deps: {
+      agents: AgentRepository;
+      ids: IdGenerator;
+      clock: Clock;
+    },
+  ) {}
+
+  async execute(input: CreateAgentInput): Promise<CreateAgentOutput> {
+    const now = this.deps.clock.now();
+    const agent: Agent = {
+      id: this.deps.ids.generate() as AgentId,
+      appId: input.appId,
+      name: input.name.trim(),
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.deps.agents.saveAgent(agent);
+    return { agent };
+  }
+}

--- a/apps/core/src/application/agents/publish-agent-config-version-use-case.ts
+++ b/apps/core/src/application/agents/publish-agent-config-version-use-case.ts
@@ -1,0 +1,31 @@
+import type {
+  AgentConfigVersion,
+  AgentConfigVersionId,
+} from '../../domain/agent/agent.js';
+import type { AgentConfigRepository } from '../../domain/ports/repositories.js';
+import type { IdGenerator } from '../common/id-generator.js';
+
+export interface PublishAgentConfigVersionInput extends Omit<
+  AgentConfigVersion,
+  'id' | 'createdAt'
+> {
+  createdAt: AgentConfigVersion['createdAt'];
+}
+
+export class PublishAgentConfigVersionUseCase {
+  constructor(
+    private readonly deps: {
+      configs: AgentConfigRepository;
+      ids: IdGenerator;
+    },
+  ) {}
+
+  async execute(input: PublishAgentConfigVersionInput) {
+    const version: AgentConfigVersion = {
+      ...input,
+      id: this.deps.ids.generate() as AgentConfigVersionId,
+    };
+    await this.deps.configs.saveConfigVersion(version);
+    return { version };
+  }
+}

--- a/apps/core/src/application/agents/publish-agent-config-version-use-case.ts
+++ b/apps/core/src/application/agents/publish-agent-config-version-use-case.ts
@@ -5,12 +5,7 @@ import type {
 import type { AgentConfigRepository } from '../../domain/ports/repositories.js';
 import type { IdGenerator } from '../common/id-generator.js';
 
-export interface PublishAgentConfigVersionInput extends Omit<
-  AgentConfigVersion,
-  'id' | 'createdAt'
-> {
-  createdAt: AgentConfigVersion['createdAt'];
-}
+export type PublishAgentConfigVersionInput = Omit<AgentConfigVersion, 'id'>;
 
 export class PublishAgentConfigVersionUseCase {
   constructor(

--- a/apps/core/src/application/agents/resolve-effective-agent-config-service.ts
+++ b/apps/core/src/application/agents/resolve-effective-agent-config-service.ts
@@ -1,0 +1,35 @@
+import type { AgentConfigVersion, AgentId } from '../../domain/agent/agent.js';
+import type {
+  AgentConfigRepository,
+  AgentRepository,
+} from '../../domain/ports/repositories.js';
+import { ApplicationError } from '../common/application-error.js';
+
+export class ResolveEffectiveAgentConfigService {
+  constructor(
+    private readonly deps: {
+      agents: AgentRepository;
+      configs: AgentConfigRepository;
+    },
+  ) {}
+
+  async resolve(input: {
+    agentId: AgentId;
+  }): Promise<{ config: AgentConfigVersion }> {
+    const agent = await this.deps.agents.getAgent(input.agentId);
+    if (!agent) throw new ApplicationError('NOT_FOUND', 'Agent not found');
+    if (!agent.currentConfigVersionId) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Agent has no published config version',
+      );
+    }
+    const config = await this.deps.configs.getConfigVersion(
+      agent.currentConfigVersionId,
+    );
+    if (!config) {
+      throw new ApplicationError('NOT_FOUND', 'Agent config version not found');
+    }
+    return { config };
+  }
+}

--- a/apps/core/src/application/agents/update-agent-config-use-case.ts
+++ b/apps/core/src/application/agents/update-agent-config-use-case.ts
@@ -1,0 +1,36 @@
+import type {
+  AgentConfigVersionId,
+  AgentId,
+} from '../../domain/agent/agent.js';
+import type { AgentRepository } from '../../domain/ports/repositories.js';
+import { ApplicationError } from '../common/application-error.js';
+import type { Clock } from '../common/clock.js';
+
+export interface UpdateAgentConfigInput {
+  agentId: AgentId;
+  currentConfigVersionId?: AgentConfigVersionId;
+  status?: 'active' | 'disabled';
+}
+
+export class UpdateAgentConfigUseCase {
+  constructor(
+    private readonly deps: {
+      agents: AgentRepository;
+      clock: Clock;
+    },
+  ) {}
+
+  async execute(input: UpdateAgentConfigInput) {
+    const agent = await this.deps.agents.getAgent(input.agentId);
+    if (!agent) throw new ApplicationError('NOT_FOUND', 'Agent not found');
+    const updated = {
+      ...agent,
+      currentConfigVersionId:
+        input.currentConfigVersionId ?? agent.currentConfigVersionId,
+      status: input.status ?? agent.status,
+      updatedAt: this.deps.clock.now(),
+    };
+    await this.deps.agents.saveAgent(updated);
+    return { agent: updated };
+  }
+}

--- a/apps/core/src/application/browser/acquire-browser-profile-use-case.ts
+++ b/apps/core/src/application/browser/acquire-browser-profile-use-case.ts
@@ -1,0 +1,21 @@
+import type { BrowserProfileId } from '../../domain/browser/browser.js';
+import type { BrowserRuntimeProvider } from '../../domain/ports/providers.js';
+import type { BrowserProfileRepository } from '../../domain/ports/repositories.js';
+import { ApplicationError } from '../common/application-error.js';
+
+export class AcquireBrowserProfileUseCase {
+  constructor(
+    private readonly deps: {
+      profiles: BrowserProfileRepository;
+      runtime: BrowserRuntimeProvider;
+    },
+  ) {}
+
+  async execute(input: { profileId: BrowserProfileId }) {
+    const profile = await this.deps.profiles.getBrowserProfile(input.profileId);
+    if (!profile)
+      throw new ApplicationError('NOT_FOUND', 'Browser profile not found');
+    await this.deps.runtime.ensureProfile(profile);
+    return { profile };
+  }
+}

--- a/apps/core/src/application/browser/create-browser-profile-use-case.ts
+++ b/apps/core/src/application/browser/create-browser-profile-use-case.ts
@@ -1,0 +1,11 @@
+import type { BrowserProfile } from '../../domain/browser/browser.js';
+import type { BrowserProfileRepository } from '../../domain/ports/repositories.js';
+
+export class CreateBrowserProfileUseCase {
+  constructor(private readonly profiles: BrowserProfileRepository) {}
+
+  async execute(input: { profile: BrowserProfile }) {
+    await this.profiles.saveBrowserProfile(input.profile);
+    return { profile: input.profile };
+  }
+}

--- a/apps/core/src/application/browser/release-browser-profile-use-case.ts
+++ b/apps/core/src/application/browser/release-browser-profile-use-case.ts
@@ -1,0 +1,21 @@
+import type { BrowserProfileId } from '../../domain/browser/browser.js';
+import type { BrowserRuntimeProvider } from '../../domain/ports/providers.js';
+import type { BrowserProfileRepository } from '../../domain/ports/repositories.js';
+import { ApplicationError } from '../common/application-error.js';
+
+export class ReleaseBrowserProfileUseCase {
+  constructor(
+    private readonly deps: {
+      profiles: BrowserProfileRepository;
+      runtime: BrowserRuntimeProvider;
+    },
+  ) {}
+
+  async execute(input: { profileId: BrowserProfileId }) {
+    const profile = await this.deps.profiles.getBrowserProfile(input.profileId);
+    if (!profile)
+      throw new ApplicationError('NOT_FOUND', 'Browser profile not found');
+    await this.deps.runtime.closeProfile(profile);
+    return { released: true };
+  }
+}

--- a/apps/core/src/application/channels/channel-provider-ports.ts
+++ b/apps/core/src/application/channels/channel-provider-ports.ts
@@ -1,0 +1,5 @@
+import type { ChannelProvider } from '../../domain/channel/channel.js';
+
+export interface ChannelProviderCatalogPort {
+  listProviders(): Promise<ChannelProvider[]> | ChannelProvider[];
+}

--- a/apps/core/src/application/channels/create-channel-installation-use-case.ts
+++ b/apps/core/src/application/channels/create-channel-installation-use-case.ts
@@ -1,0 +1,42 @@
+import type { AppId } from '../../domain/app/app.js';
+import type {
+  ChannelInstallation,
+  ChannelInstallationId,
+  ChannelProviderId,
+} from '../../domain/channel/channel.js';
+import type { ChannelInstallationRepository } from '../../domain/ports/repositories.js';
+import type { Clock } from '../common/clock.js';
+import type { IdGenerator } from '../common/id-generator.js';
+
+export interface CreateChannelInstallationInput {
+  appId: AppId;
+  providerId: ChannelProviderId;
+  label: string;
+  runtimeSecretRefs?: string[];
+}
+
+export class CreateChannelInstallationUseCase {
+  constructor(
+    private readonly deps: {
+      installations: ChannelInstallationRepository;
+      ids: IdGenerator;
+      clock: Clock;
+    },
+  ) {}
+
+  async execute(input: CreateChannelInstallationInput) {
+    const now = this.deps.clock.now();
+    const installation: ChannelInstallation = {
+      id: this.deps.ids.generate() as ChannelInstallationId,
+      appId: input.appId,
+      providerId: input.providerId,
+      label: input.label.trim(),
+      status: 'active',
+      runtimeSecretRefs: input.runtimeSecretRefs ?? [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.deps.installations.saveChannelInstallation(installation);
+    return { installation };
+  }
+}

--- a/apps/core/src/application/channels/list-channel-providers-use-case.ts
+++ b/apps/core/src/application/channels/list-channel-providers-use-case.ts
@@ -1,0 +1,10 @@
+import type { ChannelProvider } from '../../domain/channel/channel.js';
+import type { ChannelProviderCatalogPort } from './channel-provider-ports.js';
+
+export class ListChannelProvidersUseCase {
+  constructor(private readonly providers: ChannelProviderCatalogPort) {}
+
+  async execute(): Promise<{ providers: ChannelProvider[] }> {
+    return { providers: await this.providers.listProviders() };
+  }
+}

--- a/apps/core/src/application/common/application-error.ts
+++ b/apps/core/src/application/common/application-error.ts
@@ -1,0 +1,25 @@
+export type ApplicationErrorCode =
+  | 'FORBIDDEN'
+  | 'INVALID_REQUEST'
+  | 'NOT_FOUND'
+  | 'NOT_IMPLEMENTED'
+  | 'CONFLICT'
+  | 'UNAVAILABLE';
+
+export class ApplicationError extends Error {
+  constructor(
+    readonly code: ApplicationErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'ApplicationError';
+  }
+}
+
+export function notImplemented(feature: string): ApplicationError {
+  return new ApplicationError(
+    'NOT_IMPLEMENTED',
+    `${feature} is reserved for the next application-layer migration phase.`,
+  );
+}

--- a/apps/core/src/application/common/clock.ts
+++ b/apps/core/src/application/common/clock.ts
@@ -1,0 +1,11 @@
+import type { IsoTimestamp } from '../../shared/time/primitives.js';
+
+export interface Clock {
+  now(): IsoTimestamp;
+}
+
+export class SystemClock implements Clock {
+  now(): IsoTimestamp {
+    return new Date().toISOString() as IsoTimestamp;
+  }
+}

--- a/apps/core/src/application/common/id-generator.ts
+++ b/apps/core/src/application/common/id-generator.ts
@@ -1,0 +1,3 @@
+export interface IdGenerator {
+  generate(): string;
+}

--- a/apps/core/src/application/conversations/disable-agent-in-conversation-use-case.ts
+++ b/apps/core/src/application/conversations/disable-agent-in-conversation-use-case.ts
@@ -1,0 +1,10 @@
+import type { AgentChannelBinding } from '../../domain/channel/channel.js';
+import { notImplemented } from '../common/application-error.js';
+
+export class DisableAgentInConversationUseCase {
+  async execute(input: { binding: AgentChannelBinding }) {
+    void input;
+    // TODO(next-phase): add binding status to the domain model or a repository delete contract.
+    throw notImplemented('DisableAgentInConversationUseCase');
+  }
+}

--- a/apps/core/src/application/conversations/discover-conversations-use-case.ts
+++ b/apps/core/src/application/conversations/discover-conversations-use-case.ts
@@ -1,0 +1,16 @@
+import type { ChannelInstallationId } from '../../domain/channel/channel.js';
+import type { Conversation } from '../../domain/conversation/conversation.js';
+
+export interface ConversationDiscoveryPort {
+  discover(input: {
+    channelInstallationId: ChannelInstallationId;
+  }): Promise<Conversation[]>;
+}
+
+export class DiscoverConversationsUseCase {
+  constructor(private readonly discovery: ConversationDiscoveryPort) {}
+
+  async execute(input: { channelInstallationId: ChannelInstallationId }) {
+    return { conversations: await this.discovery.discover(input) };
+  }
+}

--- a/apps/core/src/application/conversations/enable-agent-in-conversation-use-case.ts
+++ b/apps/core/src/application/conversations/enable-agent-in-conversation-use-case.ts
@@ -1,0 +1,15 @@
+import type { AgentChannelBinding } from '../../domain/channel/channel.js';
+import type { ChannelInstallationRepository } from '../../domain/ports/repositories.js';
+
+export class EnableAgentInConversationUseCase {
+  constructor(
+    private readonly deps: {
+      installations: ChannelInstallationRepository;
+    },
+  ) {}
+
+  async execute(input: { binding: AgentChannelBinding }) {
+    await this.deps.installations.saveAgentChannelBinding(input.binding);
+    return { binding: input.binding };
+  }
+}

--- a/apps/core/src/application/credentials/agent-credential-service.ts
+++ b/apps/core/src/application/credentials/agent-credential-service.ts
@@ -1,82 +1,42 @@
-import { DATA_DIR, getHostCredentialEnv } from '../../config/index.js';
-import type { HostCredentialMode } from '../../config/credentials/mode.js';
 import type {
   AgentCredentialInjection,
   CredentialBrokerProfile,
 } from '../../domain/models/credentials.js';
 import type { AgentCredentialBroker } from '../../domain/ports/agent-credential-broker.js';
-import { logger } from '../../infrastructure/logging/logger.js';
-import { validateExternalBrokerUrl } from '../../config/credentials/broker-url-policy.js';
 import { isCredentialBrokerBoundaryError } from '../../domain/models/credential-errors.js';
 
-export interface AgentCredentialServiceOptions {
-  mode: HostCredentialMode;
-  broker?: AgentCredentialBroker;
-  onecliUrl?: string;
-  externalBrokerUrl?: string;
-  dataDir?: string;
-  env?: Partial<Record<string, string | undefined>>;
-}
-
-export async function createAgentCredentialBroker(
-  options: AgentCredentialServiceOptions,
-): Promise<AgentCredentialBroker | undefined> {
-  if (options.broker) return options.broker;
-  if (options.mode !== 'onecli') return undefined;
-  const { OnecliAgentCredentialBroker } =
-    await import('../../adapters/credentials/onecli/broker.js');
-  return new OnecliAgentCredentialBroker({
-    onecliUrl: options.onecliUrl,
-    dataDir: options.dataDir ?? DATA_DIR,
-  });
-}
-
-export async function getAgentCredentialInjection(input: {
-  mode: HostCredentialMode;
+export interface AgentCredentialInjectionInput {
+  mode: CredentialBrokerProfile;
   agentIdentifier?: string;
-  onecliUrl?: string;
-  externalBrokerUrl?: string;
   broker?: AgentCredentialBroker;
-  env?: Partial<Record<string, string | undefined>>;
-}): Promise<AgentCredentialInjection> {
-  if (!input.broker && input.mode === 'external') {
-    const rawBrokerUrl = input.externalBrokerUrl?.trim() || '';
-    if (!rawBrokerUrl) {
+  externalInjection?: AgentCredentialInjection;
+}
+
+export async function getAgentCredentialInjection(
+  input: AgentCredentialInjectionInput,
+): Promise<AgentCredentialInjection> {
+  if (input.mode === 'external') {
+    if (!input.externalInjection) {
       throw new Error(
-        'External credential mode is enabled but credential_broker.external.base_url is not configured.',
+        'External credential mode is enabled but no external credential injection was provided.',
       );
     }
-    const validation = validateExternalBrokerUrl(
-      rawBrokerUrl,
-      'credential_broker.external.base_url',
-    );
-    if (!validation.ok || !validation.normalizedUrl) {
-      throw new Error(
-        validation.error || 'credential_broker.external.base_url is invalid.',
-      );
-    }
-    const env = getHostCredentialEnv({
-      ANTHROPIC_BASE_URL: validation.normalizedUrl,
-    });
-    return {
-      env,
-      applied: true,
-      brokerProfile: 'external',
-    };
+    return input.externalInjection;
   }
 
-  const broker = await createAgentCredentialBroker({
-    mode: input.mode,
-    broker: input.broker,
-    onecliUrl: input.onecliUrl,
-    env: input.env,
-  });
-  if (!broker) {
+  if (input.mode === 'none') {
     return {
       env: {},
       applied: false,
-      brokerProfile: input.mode as CredentialBrokerProfile,
+      brokerProfile: 'none',
     };
+  }
+
+  const broker = input.broker;
+  if (!broker) {
+    throw new Error(
+      'Credential broker mode is enabled but no agent credential broker was provided.',
+    );
   }
 
   try {
@@ -87,44 +47,29 @@ export async function getAgentCredentialInjection(input: {
       },
     });
   } catch (err) {
-    logger.warn(
-      { err, agentIdentifier: input.agentIdentifier || 'default' },
-      'Agent credential broker not reachable',
-    );
     if (isCredentialBrokerBoundaryError(err)) {
       throw err;
     }
-    if (input.mode === 'onecli') {
-      throw new Error(
-        'OneCLI credential mode is enabled but the OneCLI gateway is not reachable.',
-        { cause: err },
-      );
-    }
-    return {
-      env: {},
-      applied: false,
-      brokerProfile: input.mode as CredentialBrokerProfile,
-    };
+    throw new Error(
+      'Credential broker mode is enabled but the credential broker is not reachable.',
+      { cause: err },
+    );
   }
 }
 
 export async function ensureAgentCredentialBinding(input: {
-  mode: HostCredentialMode;
+  mode: CredentialBrokerProfile;
   agentIdentifier: string;
   agentName: string;
-  onecliUrl?: string;
-  dataDir?: string;
-  env?: Partial<Record<string, string | undefined>>;
   broker?: AgentCredentialBroker;
 }): Promise<{ created?: boolean } | undefined> {
   if (input.mode !== 'onecli') return undefined;
-  const broker = await createAgentCredentialBroker({
-    mode: input.mode,
-    broker: input.broker,
-    onecliUrl: input.onecliUrl,
-    dataDir: input.dataDir,
-    env: input.env,
-  });
+  const broker = input.broker;
+  if (!broker) {
+    throw new Error(
+      'Credential broker mode is enabled but no agent credential broker was provided.',
+    );
+  }
   const bindable = broker as
     | (AgentCredentialBroker & {
         ensureAgent?: (agent: {

--- a/apps/core/src/application/credentials/agent-credential-service.ts
+++ b/apps/core/src/application/credentials/agent-credential-service.ts
@@ -5,12 +5,21 @@ import type {
 import type { AgentCredentialBroker } from '../../domain/ports/agent-credential-broker.js';
 import { isCredentialBrokerBoundaryError } from '../../domain/models/credential-errors.js';
 
-export interface AgentCredentialInjectionInput {
-  mode: CredentialBrokerProfile;
-  agentIdentifier?: string;
-  broker?: AgentCredentialBroker;
-  externalInjection?: AgentCredentialInjection;
-}
+export type AgentCredentialInjectionInput =
+  | {
+      mode: 'external';
+      agentIdentifier?: string;
+      externalInjection: AgentCredentialInjection;
+    }
+  | {
+      mode: 'onecli';
+      agentIdentifier?: string;
+      broker: AgentCredentialBroker;
+    }
+  | {
+      mode: 'none';
+      agentIdentifier?: string;
+    };
 
 export async function getAgentCredentialInjection(
   input: AgentCredentialInjectionInput,
@@ -50,8 +59,11 @@ export async function getAgentCredentialInjection(
     if (isCredentialBrokerBoundaryError(err)) {
       throw err;
     }
+    const suffix = input.agentIdentifier
+      ? ` for agent ${input.agentIdentifier}`
+      : '';
     throw new Error(
-      'Credential broker mode is enabled but the credential broker is not reachable.',
+      `Credential broker mode is enabled but the credential broker is not reachable${suffix}.`,
       { cause: err },
     );
   }

--- a/apps/core/src/application/jobs/create-job-use-case.ts
+++ b/apps/core/src/application/jobs/create-job-use-case.ts
@@ -1,0 +1,20 @@
+import type {
+  JobUpsertInput,
+  OpsRepository,
+} from '../../domain/repositories/ops-repo.js';
+import type { SchedulerCoordinationPort } from './scheduler-coordination-port.js';
+
+export class CreateJobUseCase {
+  constructor(
+    private readonly deps: {
+      ops: OpsRepository;
+      scheduler: SchedulerCoordinationPort;
+    },
+  ) {}
+
+  async execute(input: { job: JobUpsertInput }) {
+    const result = await this.deps.ops.upsertJob(input.job);
+    this.deps.scheduler.requestSchedulerSync(input.job.id);
+    return { jobId: input.job.id, created: result.created };
+  }
+}

--- a/apps/core/src/application/jobs/job-access.ts
+++ b/apps/core/src/application/jobs/job-access.ts
@@ -1,0 +1,22 @@
+import type { Job } from '../../domain/types.js';
+import { ApplicationError } from '../common/application-error.js';
+
+export function jobBelongsToApp(job: Job, appId: string): boolean {
+  return (Array.isArray(job.linked_sessions) ? job.linked_sessions : []).some(
+    (chatJid) => {
+      if (!chatJid.startsWith('app:')) return false;
+      const rest = chatJid.slice('app:'.length);
+      const delimiterIndex = rest.indexOf(':');
+      if (delimiterIndex <= 0 || rest.indexOf(':', delimiterIndex + 1) !== -1) {
+        return false;
+      }
+      return rest.slice(0, delimiterIndex) === appId;
+    },
+  );
+}
+
+export function assertJobBelongsToApp(job: Job, appId: string): void {
+  if (!jobBelongsToApp(job, appId)) {
+    throw new ApplicationError('FORBIDDEN', 'API key cannot access this job');
+  }
+}

--- a/apps/core/src/application/jobs/pause-job-use-case.ts
+++ b/apps/core/src/application/jobs/pause-job-use-case.ts
@@ -1,0 +1,26 @@
+import type { OpsRepository } from '../../domain/repositories/ops-repo.js';
+import { ApplicationError } from '../common/application-error.js';
+import { assertJobBelongsToApp } from './job-access.js';
+import type { SchedulerCoordinationPort } from './scheduler-coordination-port.js';
+
+export class PauseJobUseCase {
+  constructor(
+    private readonly deps: {
+      ops: OpsRepository;
+      scheduler: SchedulerCoordinationPort;
+    },
+  ) {}
+
+  async execute(input: { appId: string; jobId: string; reason?: string }) {
+    const job = await this.deps.ops.getJobById(input.jobId);
+    if (!job) throw new ApplicationError('NOT_FOUND', 'Job not found');
+    assertJobBelongsToApp(job, input.appId);
+    await this.deps.ops.updateJob(job.id, {
+      status: 'paused',
+      pause_reason: input.reason ?? 'Paused by SDK',
+      next_run: null,
+    });
+    this.deps.scheduler.requestSchedulerSync(job.id);
+    return { paused: true };
+  }
+}

--- a/apps/core/src/application/jobs/pause-job-use-case.ts
+++ b/apps/core/src/application/jobs/pause-job-use-case.ts
@@ -15,9 +15,10 @@ export class PauseJobUseCase {
     const job = await this.deps.ops.getJobById(input.jobId);
     if (!job) throw new ApplicationError('NOT_FOUND', 'Job not found');
     assertJobBelongsToApp(job, input.appId);
+    const reason = input.reason?.trim() || 'Paused by SDK';
     await this.deps.ops.updateJob(job.id, {
       status: 'paused',
-      pause_reason: input.reason ?? 'Paused by SDK',
+      pause_reason: reason,
       next_run: null,
     });
     this.deps.scheduler.requestSchedulerSync(job.id);

--- a/apps/core/src/application/jobs/scheduler-coordination-port.ts
+++ b/apps/core/src/application/jobs/scheduler-coordination-port.ts
@@ -1,0 +1,3 @@
+export interface SchedulerCoordinationPort {
+  requestSchedulerSync(jobId?: string): void;
+}

--- a/apps/core/src/application/jobs/trigger-job-use-case.ts
+++ b/apps/core/src/application/jobs/trigger-job-use-case.ts
@@ -1,0 +1,9 @@
+import { notImplemented } from '../common/application-error.js';
+
+export class TriggerJobUseCase {
+  async execute(input: { appId: string; jobId: string }) {
+    void input;
+    // TODO(next-phase): move trigger persistence, rate limits, and event emission here together.
+    throw notImplemented('TriggerJobUseCase');
+  }
+}

--- a/apps/core/src/application/jobs/update-job-use-case.ts
+++ b/apps/core/src/application/jobs/update-job-use-case.ts
@@ -1,0 +1,67 @@
+import type { Job, JobExecutionMode, JobStatus } from '../../domain/types.js';
+import type { OpsRepository } from '../../domain/repositories/ops-repo.js';
+import { ApplicationError } from '../common/application-error.js';
+import type { Clock } from '../common/clock.js';
+import { assertJobBelongsToApp } from './job-access.js';
+import type { SchedulerCoordinationPort } from './scheduler-coordination-port.js';
+
+export interface UpdateJobInput {
+  appId: string;
+  jobId: string;
+  patch?: {
+    name?: string;
+    prompt?: string;
+    executionMode?: JobExecutionMode;
+    threadId?: string;
+    status?: Extract<JobStatus, 'active' | 'paused'>;
+  };
+  resume?: boolean;
+}
+
+export class UpdateJobUseCase {
+  constructor(
+    private readonly deps: {
+      ops: OpsRepository;
+      scheduler: SchedulerCoordinationPort;
+      clock: Clock;
+    },
+  ) {}
+
+  async execute(input: UpdateJobInput): Promise<{ job: Job }> {
+    const existing = await this.deps.ops.getJobById(input.jobId);
+    if (!existing) throw new ApplicationError('NOT_FOUND', 'Job not found');
+    assertJobBelongsToApp(existing, input.appId);
+
+    const updates: Partial<Job> = {};
+    if (input.patch) {
+      if (typeof input.patch.name === 'string') updates.name = input.patch.name;
+      if (typeof input.patch.prompt === 'string') {
+        updates.prompt = input.patch.prompt;
+      }
+      if (input.patch.executionMode) {
+        updates.execution_mode = input.patch.executionMode;
+      }
+      if (typeof input.patch.threadId === 'string') {
+        updates.thread_id = input.patch.threadId;
+      }
+      if (input.patch.status) updates.status = input.patch.status;
+    }
+
+    if (input.resume) {
+      updates.status = 'active';
+      updates.pause_reason = null;
+      updates.next_run =
+        existing.schedule_type === 'manual'
+          ? null
+          : existing.schedule_type === 'once' && existing.schedule_value
+            ? existing.schedule_value
+            : this.deps.clock.now();
+    }
+
+    await this.deps.ops.updateJob(existing.id, updates);
+    this.deps.scheduler.requestSchedulerSync(existing.id);
+    const updated = await this.deps.ops.getJobById(existing.id);
+    if (!updated) throw new ApplicationError('NOT_FOUND', 'Job not found');
+    return { job: updated };
+  }
+}

--- a/apps/core/src/application/jobs/update-job-use-case.ts
+++ b/apps/core/src/application/jobs/update-job-use-case.ts
@@ -31,37 +31,69 @@ export class UpdateJobUseCase {
     const existing = await this.deps.ops.getJobById(input.jobId);
     if (!existing) throw new ApplicationError('NOT_FOUND', 'Job not found');
     assertJobBelongsToApp(existing, input.appId);
+    if (input.resume && input.patch && Object.keys(input.patch).length > 0) {
+      throw new ApplicationError(
+        'INVALID_REQUEST',
+        'resume cannot be combined with patch updates',
+      );
+    }
 
     const updates: Partial<Job> = {};
     if (input.patch) {
-      if (typeof input.patch.name === 'string') updates.name = input.patch.name;
+      if (typeof input.patch.name === 'string') {
+        updates.name = requireNonEmpty(input.patch.name, 'name');
+      }
       if (typeof input.patch.prompt === 'string') {
-        updates.prompt = input.patch.prompt;
+        updates.prompt = requireNonEmpty(input.patch.prompt, 'prompt');
       }
       if (input.patch.executionMode) {
         updates.execution_mode = input.patch.executionMode;
       }
       if (typeof input.patch.threadId === 'string') {
-        updates.thread_id = input.patch.threadId;
+        updates.thread_id = requireNonEmpty(input.patch.threadId, 'threadId');
       }
-      if (input.patch.status) updates.status = input.patch.status;
+      if (input.patch.status === 'active') {
+        applyResumeUpdates(existing, updates, this.deps.clock);
+      } else if (input.patch.status === 'paused') {
+        updates.status = 'paused';
+        updates.pause_reason = 'Paused by SDK';
+        updates.next_run = null;
+      }
     }
 
     if (input.resume) {
-      updates.status = 'active';
-      updates.pause_reason = null;
-      updates.next_run =
-        existing.schedule_type === 'manual'
-          ? null
-          : existing.schedule_type === 'once' && existing.schedule_value
-            ? existing.schedule_value
-            : this.deps.clock.now();
+      applyResumeUpdates(existing, updates, this.deps.clock);
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return { job: existing };
     }
 
     await this.deps.ops.updateJob(existing.id, updates);
     this.deps.scheduler.requestSchedulerSync(existing.id);
-    const updated = await this.deps.ops.getJobById(existing.id);
-    if (!updated) throw new ApplicationError('NOT_FOUND', 'Job not found');
-    return { job: updated };
+    return { job: { ...existing, ...updates } };
   }
+}
+
+function requireNonEmpty(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new ApplicationError('INVALID_REQUEST', `${field} cannot be empty`);
+  }
+  return trimmed;
+}
+
+function applyResumeUpdates(
+  existing: Job,
+  updates: Partial<Job>,
+  clock: Clock,
+): void {
+  updates.status = 'active';
+  updates.pause_reason = null;
+  updates.next_run =
+    existing.schedule_type === 'manual'
+      ? null
+      : existing.schedule_type === 'once' && existing.schedule_value
+        ? existing.schedule_value
+        : clock.now();
 }

--- a/apps/core/src/application/memory/save-memory-use-case.ts
+++ b/apps/core/src/application/memory/save-memory-use-case.ts
@@ -1,0 +1,11 @@
+import type { MemoryItem } from '../../domain/memory/memory.js';
+import type { MemoryRepository } from '../../domain/ports/repositories.js';
+
+export class SaveMemoryUseCase {
+  constructor(private readonly memory: MemoryRepository) {}
+
+  async execute(input: { item: MemoryItem }) {
+    await this.memory.saveMemoryItem(input.item);
+    return { item: input.item };
+  }
+}

--- a/apps/core/src/application/memory/search-memory-use-case.ts
+++ b/apps/core/src/application/memory/search-memory-use-case.ts
@@ -1,0 +1,12 @@
+import type { MemoryRepository } from '../../domain/ports/repositories.js';
+import type { MemorySubject } from '../../domain/memory/memory.js';
+
+export class SearchMemoryUseCase {
+  constructor(private readonly memory: MemoryRepository) {}
+
+  async execute(input: { subject: MemorySubject; limit?: number }) {
+    return {
+      memories: await this.memory.listMemoryItems(input.subject, input.limit),
+    };
+  }
+}

--- a/apps/core/src/application/messages/inbound-message-ports.ts
+++ b/apps/core/src/application/messages/inbound-message-ports.ts
@@ -1,0 +1,5 @@
+import type { Message } from '../../domain/messages/messages.js';
+
+export interface InboundMessageQueuePort {
+  enqueue(message: Message): Promise<void>;
+}

--- a/apps/core/src/application/messages/ingest-inbound-message-use-case.ts
+++ b/apps/core/src/application/messages/ingest-inbound-message-use-case.ts
@@ -1,0 +1,18 @@
+import type { MessageRepository } from '../../domain/ports/repositories.js';
+import type { InboundMessage } from '../../domain/messages/messages.js';
+import type { InboundMessageQueuePort } from './inbound-message-ports.js';
+
+export class IngestInboundMessageUseCase {
+  constructor(
+    private readonly deps: {
+      messages: MessageRepository;
+      queue?: InboundMessageQueuePort;
+    },
+  ) {}
+
+  async execute(input: { message: InboundMessage }) {
+    await this.deps.messages.saveMessage(input.message);
+    await this.deps.queue?.enqueue(input.message);
+    return { message: input.message };
+  }
+}

--- a/apps/core/src/application/messages/record-outbound-message-use-case.ts
+++ b/apps/core/src/application/messages/record-outbound-message-use-case.ts
@@ -1,0 +1,11 @@
+import type { OutboundMessage } from '../../domain/messages/messages.js';
+import type { MessageRepository } from '../../domain/ports/repositories.js';
+
+export class RecordOutboundMessageUseCase {
+  constructor(private readonly messages: MessageRepository) {}
+
+  async execute(input: { message: OutboundMessage }) {
+    await this.messages.saveMessage(input.message);
+    return { message: input.message };
+  }
+}

--- a/apps/core/src/application/messages/send-outbound-message-use-case.ts
+++ b/apps/core/src/application/messages/send-outbound-message-use-case.ts
@@ -1,0 +1,21 @@
+import type { OutboundMessage } from '../../domain/messages/messages.js';
+import type { MessageRepository } from '../../domain/ports/repositories.js';
+
+export interface OutboundMessageDeliveryPort {
+  send(message: OutboundMessage): Promise<void>;
+}
+
+export class SendOutboundMessageUseCase {
+  constructor(
+    private readonly deps: {
+      messages: MessageRepository;
+      delivery: OutboundMessageDeliveryPort;
+    },
+  ) {}
+
+  async execute(input: { message: OutboundMessage }) {
+    await this.deps.delivery.send(input.message);
+    await this.deps.messages.saveMessage(input.message);
+    return { message: input.message };
+  }
+}

--- a/apps/core/src/application/permissions/record-permission-decision-use-case.ts
+++ b/apps/core/src/application/permissions/record-permission-decision-use-case.ts
@@ -1,0 +1,11 @@
+import type { PermissionDecision } from '../../domain/permissions/permissions.js';
+import type { PermissionRepository } from '../../domain/ports/repositories.js';
+
+export class RecordPermissionDecisionUseCase {
+  constructor(private readonly permissions: PermissionRepository) {}
+
+  async execute(input: { decision: PermissionDecision }) {
+    await this.permissions.saveDecision(input.decision);
+    return { decision: input.decision };
+  }
+}

--- a/apps/core/src/application/permissions/request-human-approval-use-case.ts
+++ b/apps/core/src/application/permissions/request-human-approval-use-case.ts
@@ -1,0 +1,13 @@
+import type { PermissionDecision } from '../../domain/permissions/permissions.js';
+
+export interface HumanApprovalPort {
+  request(input: Record<string, unknown>): Promise<PermissionDecision>;
+}
+
+export class RequestHumanApprovalUseCase {
+  constructor(private readonly approvals: HumanApprovalPort) {}
+
+  async execute(input: { request: Record<string, unknown> }) {
+    return { decision: await this.approvals.request(input.request) };
+  }
+}

--- a/apps/core/src/application/runs/append-agent-run-event-use-case.ts
+++ b/apps/core/src/application/runs/append-agent-run-event-use-case.ts
@@ -1,0 +1,11 @@
+import type { AgentRunEvent } from '../../domain/events/events.js';
+import type { AgentRunRepository } from '../../domain/ports/repositories.js';
+
+export class AppendAgentRunEventUseCase {
+  constructor(private readonly runs: AgentRunRepository) {}
+
+  async execute(input: { event: AgentRunEvent }) {
+    await this.runs.appendAgentRunEvent(input.event);
+    return { event: input.event };
+  }
+}

--- a/apps/core/src/application/runs/run-event-stream-port.ts
+++ b/apps/core/src/application/runs/run-event-stream-port.ts
@@ -1,0 +1,5 @@
+import type { AgentRunEvent, AgentRunId } from '../../domain/events/events.js';
+
+export interface RunEventStreamPort {
+  subscribe(input: { runId?: AgentRunId }): AsyncIterable<AgentRunEvent>;
+}

--- a/apps/core/src/application/runs/start-agent-run-use-case.ts
+++ b/apps/core/src/application/runs/start-agent-run-use-case.ts
@@ -1,0 +1,11 @@
+import type { AgentRun } from '../../domain/events/events.js';
+import type { AgentRunRepository } from '../../domain/ports/repositories.js';
+
+export class StartAgentRunUseCase {
+  constructor(private readonly runs: AgentRunRepository) {}
+
+  async execute(input: { run: AgentRun }) {
+    await this.runs.saveAgentRun(input.run);
+    return { run: input.run };
+  }
+}

--- a/apps/core/src/application/sandbox/create-sandbox-lease-use-case.ts
+++ b/apps/core/src/application/sandbox/create-sandbox-lease-use-case.ts
@@ -1,0 +1,19 @@
+import type { AgentRun } from '../../domain/events/events.js';
+import type { SandboxProfile } from '../../domain/sandbox/sandbox.js';
+import type { SandboxProvider } from '../../domain/ports/providers.js';
+import type { SandboxRepository } from '../../domain/ports/repositories.js';
+
+export class CreateSandboxLeaseUseCase {
+  constructor(
+    private readonly deps: {
+      provider: SandboxProvider;
+      sandboxes: SandboxRepository;
+    },
+  ) {}
+
+  async execute(input: { profile: SandboxProfile; run: AgentRun }) {
+    const lease = await this.deps.provider.acquireLease(input);
+    await this.deps.sandboxes.saveSandboxLease(lease);
+    return { lease };
+  }
+}

--- a/apps/core/src/application/sandbox/release-sandbox-lease-use-case.ts
+++ b/apps/core/src/application/sandbox/release-sandbox-lease-use-case.ts
@@ -1,0 +1,25 @@
+import type { SandboxProvider } from '../../domain/ports/providers.js';
+import type { SandboxRepository } from '../../domain/ports/repositories.js';
+import type { SandboxLeaseId } from '../../domain/sandbox/sandbox.js';
+import { ApplicationError } from '../common/application-error.js';
+
+export class ReleaseSandboxLeaseUseCase {
+  constructor(
+    private readonly deps: {
+      provider: SandboxProvider;
+      sandboxes: SandboxRepository;
+    },
+  ) {}
+
+  async execute(input: { leaseId: SandboxLeaseId }) {
+    const lease = await this.deps.sandboxes.getSandboxLease(input.leaseId);
+    if (!lease)
+      throw new ApplicationError('NOT_FOUND', 'Sandbox lease not found');
+    await this.deps.provider.releaseLease(lease);
+    await this.deps.sandboxes.saveSandboxLease({
+      ...lease,
+      status: 'released',
+    });
+    return { released: true };
+  }
+}

--- a/apps/core/src/application/sandbox/release-sandbox-lease-use-case.ts
+++ b/apps/core/src/application/sandbox/release-sandbox-lease-use-case.ts
@@ -15,6 +15,7 @@ export class ReleaseSandboxLeaseUseCase {
     const lease = await this.deps.sandboxes.getSandboxLease(input.leaseId);
     if (!lease)
       throw new ApplicationError('NOT_FOUND', 'Sandbox lease not found');
+    if (lease.status === 'released') return { released: true };
     await this.deps.provider.releaseLease(lease);
     await this.deps.sandboxes.saveSandboxLease({
       ...lease,

--- a/apps/core/src/application/sandbox/snapshot-workspace-use-case.ts
+++ b/apps/core/src/application/sandbox/snapshot-workspace-use-case.ts
@@ -1,0 +1,11 @@
+import type { WorkspaceSnapshot } from '../../domain/sandbox/sandbox.js';
+import type { SandboxRepository } from '../../domain/ports/repositories.js';
+
+export class SnapshotWorkspaceUseCase {
+  constructor(private readonly sandboxes: SandboxRepository) {}
+
+  async execute(input: { snapshot: WorkspaceSnapshot }) {
+    await this.sandboxes.saveWorkspaceSnapshot(input.snapshot);
+    return { snapshot: input.snapshot };
+  }
+}

--- a/apps/core/src/application/sessions/create-or-resume-session-use-case.ts
+++ b/apps/core/src/application/sessions/create-or-resume-session-use-case.ts
@@ -1,0 +1,13 @@
+import type { AgentSession } from '../../domain/sessions/sessions.js';
+import type { AgentSessionRepository } from '../../domain/ports/repositories.js';
+
+export class CreateOrResumeSessionUseCase {
+  constructor(private readonly sessions: AgentSessionRepository) {}
+
+  async execute(input: { session: AgentSession }) {
+    const existing = await this.sessions.getAgentSession(input.session.id);
+    if (existing) return { session: existing, created: false };
+    await this.sessions.saveAgentSession(input.session);
+    return { session: input.session, created: true };
+  }
+}

--- a/apps/core/src/application/sessions/hydrate-agent-context-service.ts
+++ b/apps/core/src/application/sessions/hydrate-agent-context-service.ts
@@ -1,0 +1,10 @@
+import type { AgentSessionId } from '../../domain/sessions/sessions.js';
+import { notImplemented } from '../common/application-error.js';
+
+export class HydrateAgentContextService {
+  async hydrate(input: { sessionId: AgentSessionId }) {
+    void input;
+    // TODO(next-phase): compose memory, recent messages, config, and workspace context here.
+    throw notImplemented('HydrateAgentContextService');
+  }
+}

--- a/apps/core/src/application/sessions/resume-session-use-case.ts
+++ b/apps/core/src/application/sessions/resume-session-use-case.ts
@@ -1,0 +1,13 @@
+import type { AgentSessionId } from '../../domain/sessions/sessions.js';
+import type { AgentSessionRepository } from '../../domain/ports/repositories.js';
+import { ApplicationError } from '../common/application-error.js';
+
+export class ResumeSessionUseCase {
+  constructor(private readonly sessions: AgentSessionRepository) {}
+
+  async execute(input: { sessionId: AgentSessionId }) {
+    const session = await this.sessions.getAgentSession(input.sessionId);
+    if (!session) throw new ApplicationError('NOT_FOUND', 'Session not found');
+    return { session };
+  }
+}

--- a/apps/core/src/application/skills/resolve-skill-catalog-service.ts
+++ b/apps/core/src/application/skills/resolve-skill-catalog-service.ts
@@ -1,0 +1,13 @@
+import type { SkillCatalogRepository } from '../../domain/ports/repositories.js';
+import type { SkillId } from '../../domain/skills/skills.js';
+import { ApplicationError } from '../common/application-error.js';
+
+export class ResolveSkillCatalogService {
+  constructor(private readonly skills: SkillCatalogRepository) {}
+
+  async resolve(input: { skillId: SkillId }) {
+    const skill = await this.skills.getSkill(input.skillId);
+    if (!skill) throw new ApplicationError('NOT_FOUND', 'Skill not found');
+    return { skill };
+  }
+}

--- a/apps/core/src/application/streaming/stream-run-events-use-case.ts
+++ b/apps/core/src/application/streaming/stream-run-events-use-case.ts
@@ -1,0 +1,10 @@
+import type { AgentRunId } from '../../domain/events/events.js';
+import type { RunEventStreamPort } from '../runs/run-event-stream-port.js';
+
+export class StreamRunEventsUseCase {
+  constructor(private readonly stream: RunEventStreamPort) {}
+
+  execute(input: { runId?: AgentRunId }) {
+    return this.stream.subscribe(input);
+  }
+}

--- a/apps/core/src/application/tools/evaluate-tool-action-use-case.ts
+++ b/apps/core/src/application/tools/evaluate-tool-action-use-case.ts
@@ -1,0 +1,12 @@
+import type { PermissionDecision } from '../../domain/permissions/permissions.js';
+import { notImplemented } from '../common/application-error.js';
+
+export class EvaluateToolActionUseCase {
+  async execute(input: { action: Record<string, unknown> }): Promise<{
+    decision: PermissionDecision;
+  }> {
+    void input;
+    // TODO(next-phase): evaluate tool requests against permission policies before sandbox leasing.
+    throw notImplemented('EvaluateToolActionUseCase');
+  }
+}

--- a/apps/core/src/config/credentials/broker-url-policy.ts
+++ b/apps/core/src/config/credentials/broker-url-policy.ts
@@ -68,3 +68,16 @@ export function validateExternalBrokerUrl(
 ): BrokerUrlValidationResult {
   return validateBrokerUrl(rawUrl, label);
 }
+
+export function resolveExternalCredentialBaseUrl(rawBrokerUrl: string): string {
+  const validation = validateExternalBrokerUrl(
+    rawBrokerUrl,
+    'credential_broker.external.base_url',
+  );
+  if (!validation.ok || !validation.normalizedUrl) {
+    throw new Error(
+      validation.error || 'credential_broker.external.base_url is invalid.',
+    );
+  }
+  return validation.normalizedUrl;
+}

--- a/apps/core/src/config/preflight.ts
+++ b/apps/core/src/config/preflight.ts
@@ -10,6 +10,7 @@ import {
 } from '../adapters/credentials/onecli/local/persistence.js';
 import { EnvRuntimeSecretProvider } from '../adapters/credentials/env-runtime-secret-provider.js';
 import { inspectRuntimeStorageReadiness } from '../infrastructure/postgres/storage-readiness.js';
+import { validateExternalBrokerUrl } from './credentials/broker-url-policy.js';
 
 export interface RuntimePreflightFailure {
   summary: string;
@@ -70,16 +71,13 @@ export async function validateRuntimePreflightWithStorage(
   const credentialMode = settings.credentialBroker.mode;
   if (credentialMode === 'external') {
     try {
-      const { getAgentCredentialInjection } =
-        await import('../application/credentials/agent-credential-service.js');
-      const injection = await getAgentCredentialInjection({
-        mode: credentialMode,
-        externalBrokerUrl: settings.credentialBroker.external.baseUrl,
-        env: runtimeSecretsSource,
-      });
-      if (!injection.env.ANTHROPIC_BASE_URL) {
+      const validation = validateExternalBrokerUrl(
+        settings.credentialBroker.external.baseUrl,
+        'credential_broker.external.base_url',
+      );
+      if (!validation.ok || !validation.normalizedUrl) {
         throw new Error(
-          'External credential mode is enabled but credential_broker.external.base_url is not configured.',
+          validation.error || 'credential_broker.external.base_url is invalid.',
         );
       }
       return { ok: true };

--- a/apps/core/src/control/server/app-identity.ts
+++ b/apps/core/src/control/server/app-identity.ts
@@ -3,10 +3,12 @@ import { createHash } from 'node:crypto';
 import type { Job, RegisteredGroup } from '../../domain/types.js';
 import type { getRuntimeControlRepository } from '../../infrastructure/postgres/runtime-store.js';
 import { nowIso as runtimeNowIso } from '../../infrastructure/time/datetime.js';
+import { jobBelongsToApp as applicationJobBelongsToApp } from '../../application/jobs/job-access.js';
+import type { IsoTimestamp } from '../../shared/time/primitives.js';
 import type { ApiKeyRecord } from './auth.js';
 
-export function nowIso(): string {
-  return runtimeNowIso();
+export function nowIso(): IsoTimestamp {
+  return runtimeNowIso() as IsoTimestamp;
 }
 
 function sanitizeSegment(value: string): string {
@@ -55,19 +57,7 @@ export function canAccessApp(
 }
 
 export function jobBelongsToApp(job: Job, appId: string): boolean {
-  return (Array.isArray(job.linked_sessions) ? job.linked_sessions : []).some(
-    (chatJid) => {
-      if (!chatJid.startsWith('app:')) return false;
-      const rest = chatJid.slice('app:'.length);
-      const delimiterIndex = rest.indexOf(':');
-      if (delimiterIndex <= 0 || rest.indexOf(':', delimiterIndex + 1) !== -1) {
-        return false;
-      }
-      const jidAppId =
-        delimiterIndex === -1 ? rest : rest.slice(0, delimiterIndex);
-      return jidAppId === appId;
-    },
-  );
+  return applicationJobBelongsToApp(job, appId);
 }
 
 export async function resolveJobAppSession(

--- a/apps/core/src/control/server/routes/jobs.ts
+++ b/apps/core/src/control/server/routes/jobs.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
+import { ApplicationError } from '../../../application/common/application-error.js';
+import { PauseJobUseCase } from '../../../application/jobs/pause-job-use-case.js';
+import { UpdateJobUseCase } from '../../../application/jobs/update-job-use-case.js';
 import {
   enqueueJobTrigger,
   isSchedulerReady,
@@ -29,6 +32,38 @@ import {
   TRIGGER_RATE_LIMIT_PER_JOB,
 } from '../rate-limit.js';
 import { parseJobRoute, parseTriggerWaitRoute } from '../route-parser.js';
+
+function sendApplicationError(res: ServerResponse, error: unknown): boolean {
+  if (!(error instanceof ApplicationError)) return false;
+  if (error.code === 'NOT_FOUND') {
+    sendError(res, 404, 'JOB_NOT_FOUND', error.message);
+    return true;
+  }
+  if (error.code === 'FORBIDDEN') {
+    sendError(res, 403, 'FORBIDDEN', error.message);
+    return true;
+  }
+  if (error.code === 'INVALID_REQUEST') {
+    sendError(res, 400, 'INVALID_REQUEST', error.message);
+    return true;
+  }
+  throw error;
+}
+
+function createUpdateJobUseCase() {
+  return new UpdateJobUseCase({
+    ops: getRuntimeOpsRepository(),
+    scheduler: { requestSchedulerSync },
+    clock: { now: nowIso },
+  });
+}
+
+function createPauseJobUseCase() {
+  return new PauseJobUseCase({
+    ops: getRuntimeOpsRepository(),
+    scheduler: { requestSchedulerSync },
+  });
+}
 
 export async function handleJobRoutes(
   req: IncomingMessage,
@@ -188,84 +223,59 @@ export async function handleJobRoutes(
   if (jobRoute && req.method === 'PATCH' && jobRoute.action === 'get') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['jobs:write']);
     if (!auth) return true;
-    const existing = await getRuntimeOpsRepository().getJobById(jobRoute.jobId);
-    if (!existing) {
-      sendError(res, 404, 'JOB_NOT_FOUND', 'Job not found');
-      return true;
-    }
-    if (!jobBelongsToApp(existing, auth.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this job');
-      return true;
-    }
     const body = (await readJson(req)) as Record<string, unknown>;
-    const updates: Partial<Job> = {};
-    if (typeof body.name === 'string') updates.name = body.name;
-    if (typeof body.prompt === 'string') updates.prompt = body.prompt;
-    if (
-      body.executionMode === 'serialized' ||
-      body.executionMode === 'parallel'
-    ) {
-      updates.execution_mode = body.executionMode;
+    try {
+      const { job: updated } = await createUpdateJobUseCase().execute({
+        appId: auth.appId,
+        jobId: jobRoute.jobId,
+        patch: {
+          ...(typeof body.name === 'string' ? { name: body.name } : {}),
+          ...(typeof body.prompt === 'string' ? { prompt: body.prompt } : {}),
+          ...(body.executionMode === 'serialized' ||
+          body.executionMode === 'parallel'
+            ? { executionMode: body.executionMode }
+            : {}),
+          ...(typeof body.threadId === 'string'
+            ? { threadId: body.threadId }
+            : {}),
+          ...(body.status === 'active' || body.status === 'paused'
+            ? { status: body.status }
+            : {}),
+        },
+      });
+      sendJson(res, 200, mapManualJobToStored(updated));
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
     }
-    if (typeof body.threadId === 'string') updates.thread_id = body.threadId;
-    if (body.status === 'active' || body.status === 'paused') {
-      updates.status = body.status;
-    }
-    await getRuntimeOpsRepository().updateJob(jobRoute.jobId, updates);
-    requestSchedulerSync(jobRoute.jobId);
-    const updated = await getRuntimeOpsRepository().getJobById(jobRoute.jobId);
-    if (!updated) {
-      sendError(res, 404, 'JOB_NOT_FOUND', 'Job not found');
-      return true;
-    }
-    sendJson(res, 200, mapManualJobToStored(updated));
     return true;
   }
   if (jobRoute?.action === 'pause' && req.method === 'POST') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['jobs:write']);
     if (!auth) return true;
-    const job = await getRuntimeOpsRepository().getJobById(jobRoute.jobId);
-    if (!job) {
-      sendError(res, 404, 'JOB_NOT_FOUND', 'Job not found');
-      return true;
+    try {
+      const result = await createPauseJobUseCase().execute({
+        appId: auth.appId,
+        jobId: jobRoute.jobId,
+      });
+      sendJson(res, 200, result);
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
     }
-    if (!jobBelongsToApp(job, auth.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this job');
-      return true;
-    }
-    await getRuntimeOpsRepository().updateJob(jobRoute.jobId, {
-      status: 'paused',
-      pause_reason: 'Paused by SDK',
-      next_run: null,
-    });
-    requestSchedulerSync(jobRoute.jobId);
-    sendJson(res, 200, { paused: true });
     return true;
   }
   if (jobRoute?.action === 'resume' && req.method === 'POST') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['jobs:write']);
     if (!auth) return true;
-    const job = await getRuntimeOpsRepository().getJobById(jobRoute.jobId);
-    if (!job) {
-      sendError(res, 404, 'JOB_NOT_FOUND', 'Job not found');
-      return true;
+    try {
+      await createUpdateJobUseCase().execute({
+        appId: auth.appId,
+        jobId: jobRoute.jobId,
+        resume: true,
+      });
+      sendJson(res, 200, { resumed: true });
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
     }
-    if (!jobBelongsToApp(job, auth.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this job');
-      return true;
-    }
-    await getRuntimeOpsRepository().updateJob(jobRoute.jobId, {
-      status: 'active',
-      pause_reason: null,
-      next_run:
-        job.schedule_type === 'manual'
-          ? null
-          : job.schedule_type === 'once' && job.schedule_value
-            ? job.schedule_value
-            : nowIso(),
-    });
-    requestSchedulerSync(jobRoute.jobId);
-    sendJson(res, 200, { resumed: true });
     return true;
   }
   if (jobRoute?.action === 'trigger' && req.method === 'POST') {

--- a/apps/core/src/control/server/routes/jobs.ts
+++ b/apps/core/src/control/server/routes/jobs.ts
@@ -35,17 +35,25 @@ import { parseJobRoute, parseTriggerWaitRoute } from '../route-parser.js';
 
 function sendApplicationError(res: ServerResponse, error: unknown): boolean {
   if (!(error instanceof ApplicationError)) return false;
-  if (error.code === 'NOT_FOUND') {
-    sendError(res, 404, 'JOB_NOT_FOUND', error.message);
-    return true;
-  }
-  if (error.code === 'FORBIDDEN') {
-    sendError(res, 403, 'FORBIDDEN', error.message);
-    return true;
-  }
-  if (error.code === 'INVALID_REQUEST') {
-    sendError(res, 400, 'INVALID_REQUEST', error.message);
-    return true;
+  switch (error.code) {
+    case 'NOT_FOUND':
+      sendError(res, 404, 'JOB_NOT_FOUND', error.message);
+      return true;
+    case 'FORBIDDEN':
+      sendError(res, 403, 'FORBIDDEN', error.message);
+      return true;
+    case 'INVALID_REQUEST':
+      sendError(res, 400, 'INVALID_REQUEST', error.message);
+      return true;
+    case 'CONFLICT':
+      sendError(res, 409, 'CONFLICT', error.message);
+      return true;
+    case 'UNAVAILABLE':
+      sendError(res, 503, 'UNAVAILABLE', error.message);
+      return true;
+    case 'NOT_IMPLEMENTED':
+      sendError(res, 501, 'NOT_IMPLEMENTED', error.message);
+      return true;
   }
   throw error;
 }
@@ -332,9 +340,10 @@ export async function handleJobRoutes(
       }),
     });
     if (job.status === 'paused' || job.status === 'dead_lettered') {
-      await ops.updateJob(job.id, {
-        status: 'active',
-        pause_reason: null,
+      await createUpdateJobUseCase().execute({
+        appId: auth.appId,
+        jobId: job.id,
+        resume: true,
       });
     }
     try {

--- a/apps/core/src/memory/claude-query.ts
+++ b/apps/core/src/memory/claude-query.ts
@@ -1,14 +1,15 @@
 import { query } from '@anthropic-ai/claude-agent-sdk';
 
 import {
+  DATA_DIR,
   getCredentialBrokerRuntimeConfig,
+  getHostCredentialEnv,
   type ClaudeAuthMode,
 } from '../config/index.js';
-import { envConfig } from '../config/env/index.js';
-import {
-  createAgentCredentialBroker,
-  getAgentCredentialInjection,
-} from '../application/credentials/agent-credential-service.js';
+import { validateExternalBrokerUrl } from '../config/credentials/broker-url-policy.js';
+import { getAgentCredentialInjection } from '../application/credentials/agent-credential-service.js';
+import { createAgentCredentialBroker } from '../adapters/credentials/agent-credential-broker-factory.js';
+import { createExternalAgentCredentialInjection } from '../adapters/llm/external-credential-injection.js';
 import type { AgentCredentialBroker } from '../domain/ports/agent-credential-broker.js';
 import { AGENT_CREDENTIAL_ENV_KEYS } from '../config/source-classification.js';
 
@@ -105,8 +106,12 @@ async function resolveOnecliMemoryEnv(): Promise<Record<string, string>> {
     const injection = await getAgentCredentialInjection({
       mode: brokerConfig.mode,
       agentIdentifier: 'memory',
-      externalBrokerUrl: brokerConfig.externalBrokerBaseUrl,
-      env: envConfig,
+      externalInjection: createExternalAgentCredentialInjection({
+        normalizedBaseUrl: resolveExternalCredentialBaseUrl(
+          brokerConfig.externalBrokerBaseUrl,
+        ),
+        hostCredentialEnv: getHostCredentialEnv(),
+      }),
     });
     return injection.env;
   }
@@ -121,16 +126,27 @@ async function resolveOnecliMemoryEnv(): Promise<Record<string, string>> {
   memoryCredentialBrokerPromise ??= createAgentCredentialBroker({
     mode: brokerConfig.mode,
     onecliUrl: brokerConfig.onecliUrl,
-    env: envConfig,
+    dataDir: DATA_DIR,
   });
   const injection = await getAgentCredentialInjection({
     mode: brokerConfig.mode,
     agentIdentifier: 'memory',
-    onecliUrl: brokerConfig.onecliUrl,
     broker: await memoryCredentialBrokerPromise,
-    env: envConfig,
   });
   return injection.env;
+}
+
+function resolveExternalCredentialBaseUrl(rawBrokerUrl: string): string {
+  const validation = validateExternalBrokerUrl(
+    rawBrokerUrl,
+    'credential_broker.external.base_url',
+  );
+  if (!validation.ok || !validation.normalizedUrl) {
+    throw new Error(
+      validation.error || 'credential_broker.external.base_url is invalid.',
+    );
+  }
+  return validation.normalizedUrl;
 }
 
 async function runWithOnecli(opts: ClaudeQueryOpts): Promise<string> {

--- a/apps/core/src/memory/claude-query.ts
+++ b/apps/core/src/memory/claude-query.ts
@@ -6,7 +6,7 @@ import {
   getHostCredentialEnv,
   type ClaudeAuthMode,
 } from '../config/index.js';
-import { validateExternalBrokerUrl } from '../config/credentials/broker-url-policy.js';
+import { resolveExternalCredentialBaseUrl } from '../config/credentials/broker-url-policy.js';
 import { getAgentCredentialInjection } from '../application/credentials/agent-credential-service.js';
 import { createAgentCredentialBroker } from '../adapters/credentials/agent-credential-broker-factory.js';
 import { createExternalAgentCredentialInjection } from '../adapters/llm/external-credential-injection.js';
@@ -102,9 +102,14 @@ function flattenPrompt(opts: ClaudeQueryOpts): string {
 
 async function resolveOnecliMemoryEnv(): Promise<Record<string, string>> {
   const brokerConfig = getCredentialBrokerRuntimeConfig();
+  const cacheKey = `${brokerConfig.mode}:${brokerConfig.onecliUrl}:${brokerConfig.externalBrokerBaseUrl}`;
+  if (memoryCredentialBrokerCacheKey !== cacheKey) {
+    memoryCredentialBrokerPromise = undefined;
+    memoryCredentialBrokerCacheKey = cacheKey;
+  }
   if (brokerConfig.mode === 'external') {
     const injection = await getAgentCredentialInjection({
-      mode: brokerConfig.mode,
+      mode: 'external',
       agentIdentifier: 'memory',
       externalInjection: createExternalAgentCredentialInjection({
         normalizedBaseUrl: resolveExternalCredentialBaseUrl(
@@ -115,38 +120,37 @@ async function resolveOnecliMemoryEnv(): Promise<Record<string, string>> {
     });
     return injection.env;
   }
+  if (brokerConfig.mode !== 'onecli') {
+    throw new Error('Credential broker is not configured for Claude access');
+  }
   if (!brokerConfig.onecliUrl.trim()) {
     throw new Error('OneCLI is not configured for Claude access');
-  }
-  const cacheKey = `${brokerConfig.mode}:${brokerConfig.onecliUrl}:${brokerConfig.externalBrokerBaseUrl}`;
-  if (memoryCredentialBrokerCacheKey !== cacheKey) {
-    memoryCredentialBrokerPromise = undefined;
-    memoryCredentialBrokerCacheKey = cacheKey;
   }
   memoryCredentialBrokerPromise ??= createAgentCredentialBroker({
     mode: brokerConfig.mode,
     onecliUrl: brokerConfig.onecliUrl,
     dataDir: DATA_DIR,
+  }).catch((error) => {
+    memoryCredentialBrokerPromise = undefined;
+    throw error;
   });
   const injection = await getAgentCredentialInjection({
-    mode: brokerConfig.mode,
+    mode: 'onecli',
     agentIdentifier: 'memory',
-    broker: await memoryCredentialBrokerPromise,
+    broker: requireOnecliBroker(await memoryCredentialBrokerPromise),
   });
   return injection.env;
 }
 
-function resolveExternalCredentialBaseUrl(rawBrokerUrl: string): string {
-  const validation = validateExternalBrokerUrl(
-    rawBrokerUrl,
-    'credential_broker.external.base_url',
-  );
-  if (!validation.ok || !validation.normalizedUrl) {
+function requireOnecliBroker(
+  broker: AgentCredentialBroker | undefined,
+): AgentCredentialBroker {
+  if (!broker) {
     throw new Error(
-      validation.error || 'credential_broker.external.base_url is invalid.',
+      'Credential broker mode is enabled but no agent credential broker was provided.',
     );
   }
-  return validation.normalizedUrl;
+  return broker;
 }
 
 async function runWithOnecli(opts: ClaudeQueryOpts): Promise<string> {

--- a/apps/core/src/runtime/agent-spawn-host.ts
+++ b/apps/core/src/runtime/agent-spawn-host.ts
@@ -3,10 +3,14 @@ import path from 'path';
 
 import {
   AGENTS_DIR,
+  DATA_DIR,
   getCredentialBrokerRuntimeConfig,
+  getHostCredentialEnv,
 } from '../config/index.js';
-import { envConfig } from '../config/env/index.js';
+import { validateExternalBrokerUrl } from '../config/credentials/broker-url-policy.js';
 import { getAgentCredentialInjection } from '../application/credentials/agent-credential-service.js';
+import { createAgentCredentialBroker } from '../adapters/credentials/agent-credential-broker-factory.js';
+import { createExternalAgentCredentialInjection } from '../adapters/llm/external-credential-injection.js';
 import { RegisteredGroup } from '../domain/types.js';
 import type { AgentCredentialBroker } from '../domain/ports/agent-credential-broker.js';
 import type { CredentialBrokerProfile } from '../domain/models/credentials.js';
@@ -31,13 +35,27 @@ export async function getHostRuntimeCredentialEnv(
   brokerProfile: CredentialBrokerProfile;
 }> {
   const brokerConfig = getCredentialBrokerRuntimeConfig();
+  const resolvedBroker =
+    broker ??
+    (await createAgentCredentialBroker({
+      mode: brokerConfig.mode,
+      onecliUrl: brokerConfig.onecliUrl,
+      dataDir: DATA_DIR,
+    }));
+  const externalInjection =
+    brokerConfig.mode === 'external'
+      ? createExternalAgentCredentialInjection({
+          normalizedBaseUrl: resolveExternalCredentialBaseUrl(
+            brokerConfig.externalBrokerBaseUrl,
+          ),
+          hostCredentialEnv: getHostCredentialEnv(),
+        })
+      : undefined;
   const injection = await getAgentCredentialInjection({
     mode: brokerConfig.mode,
     agentIdentifier,
-    onecliUrl: brokerConfig.onecliUrl,
-    externalBrokerUrl: brokerConfig.externalBrokerBaseUrl,
-    broker,
-    env: envConfig,
+    broker: resolvedBroker,
+    externalInjection,
   });
 
   return {
@@ -45,6 +63,19 @@ export async function getHostRuntimeCredentialEnv(
     brokerApplied: injection.applied,
     brokerProfile: injection.brokerProfile,
   };
+}
+
+function resolveExternalCredentialBaseUrl(rawBrokerUrl: string): string {
+  const validation = validateExternalBrokerUrl(
+    rawBrokerUrl,
+    'credential_broker.external.base_url',
+  );
+  if (!validation.ok || !validation.normalizedUrl) {
+    throw new Error(
+      validation.error || 'credential_broker.external.base_url is invalid.',
+    );
+  }
+  return validation.normalizedUrl;
 }
 
 export function prepareHostRuntimeContext(

--- a/apps/core/src/runtime/agent-spawn-host.ts
+++ b/apps/core/src/runtime/agent-spawn-host.ts
@@ -7,7 +7,7 @@ import {
   getCredentialBrokerRuntimeConfig,
   getHostCredentialEnv,
 } from '../config/index.js';
-import { validateExternalBrokerUrl } from '../config/credentials/broker-url-policy.js';
+import { resolveExternalCredentialBaseUrl } from '../config/credentials/broker-url-policy.js';
 import { getAgentCredentialInjection } from '../application/credentials/agent-credential-service.js';
 import { createAgentCredentialBroker } from '../adapters/credentials/agent-credential-broker-factory.js';
 import { createExternalAgentCredentialInjection } from '../adapters/llm/external-credential-injection.js';
@@ -35,28 +35,28 @@ export async function getHostRuntimeCredentialEnv(
   brokerProfile: CredentialBrokerProfile;
 }> {
   const brokerConfig = getCredentialBrokerRuntimeConfig();
-  const resolvedBroker =
-    broker ??
-    (await createAgentCredentialBroker({
-      mode: brokerConfig.mode,
-      onecliUrl: brokerConfig.onecliUrl,
-      dataDir: DATA_DIR,
-    }));
-  const externalInjection =
+  const injection =
     brokerConfig.mode === 'external'
-      ? createExternalAgentCredentialInjection({
-          normalizedBaseUrl: resolveExternalCredentialBaseUrl(
-            brokerConfig.externalBrokerBaseUrl,
-          ),
-          hostCredentialEnv: getHostCredentialEnv(),
+      ? await getAgentCredentialInjection({
+          mode: 'external',
+          agentIdentifier,
+          externalInjection: createExternalAgentCredentialInjection({
+            normalizedBaseUrl: resolveExternalCredentialBaseUrl(
+              brokerConfig.externalBrokerBaseUrl,
+            ),
+            hostCredentialEnv: getHostCredentialEnv(),
+          }),
         })
-      : undefined;
-  const injection = await getAgentCredentialInjection({
-    mode: brokerConfig.mode,
-    agentIdentifier,
-    broker: resolvedBroker,
-    externalInjection,
-  });
+      : brokerConfig.mode === 'onecli'
+        ? await getAgentCredentialInjection({
+            mode: 'onecli',
+            agentIdentifier,
+            broker: await resolveOnecliBroker(broker, brokerConfig.onecliUrl),
+          })
+        : await getAgentCredentialInjection({
+            mode: 'none',
+            agentIdentifier,
+          });
 
   return {
     env: injection.env,
@@ -65,17 +65,23 @@ export async function getHostRuntimeCredentialEnv(
   };
 }
 
-function resolveExternalCredentialBaseUrl(rawBrokerUrl: string): string {
-  const validation = validateExternalBrokerUrl(
-    rawBrokerUrl,
-    'credential_broker.external.base_url',
-  );
-  if (!validation.ok || !validation.normalizedUrl) {
+async function resolveOnecliBroker(
+  broker: AgentCredentialBroker | undefined,
+  onecliUrl: string,
+): Promise<AgentCredentialBroker> {
+  const resolved =
+    broker ??
+    (await createAgentCredentialBroker({
+      mode: 'onecli',
+      onecliUrl,
+      dataDir: DATA_DIR,
+    }));
+  if (!resolved) {
     throw new Error(
-      validation.error || 'credential_broker.external.base_url is invalid.',
+      'Credential broker mode is enabled but no agent credential broker was provided.',
     );
   }
-  return validation.normalizedUrl;
+  return resolved;
 }
 
 export function prepareHostRuntimeContext(

--- a/apps/core/test/unit/application/jobs-use-cases.test.ts
+++ b/apps/core/test/unit/application/jobs-use-cases.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PauseJobUseCase } from '@core/application/jobs/pause-job-use-case.js';
+import { UpdateJobUseCase } from '@core/application/jobs/update-job-use-case.js';
+import type { OpsRepository } from '@core/domain/repositories/ops-repo.js';
+import type { Job } from '@core/domain/types.js';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: 'job-1',
+    name: 'Job',
+    prompt: 'Run',
+    model: null,
+    script: null,
+    schedule_type: 'manual',
+    schedule_value: 'manual',
+    status: 'active',
+    linked_sessions: ['app:app-one:conv-1'],
+    session_id: null,
+    thread_id: null,
+    group_scope: 'app-folder',
+    created_by: 'human',
+    created_at: '2026-04-24T00:00:00.000Z',
+    updated_at: '2026-04-24T00:00:00.000Z',
+    next_run: null,
+    last_run: null,
+    silent: false,
+    cleanup_after_ms: 0,
+    timeout_ms: 300000,
+    max_retries: 0,
+    retry_backoff_ms: 0,
+    max_consecutive_failures: 3,
+    consecutive_failures: 0,
+    execution_mode: 'parallel',
+    lease_run_id: null,
+    lease_expires_at: null,
+    pause_reason: null,
+    ...overrides,
+  };
+}
+
+function makeOps(
+  job: Job | undefined,
+): Pick<OpsRepository, 'getJobById' | 'updateJob'> {
+  let current = job;
+  return {
+    getJobById: vi.fn(async () => current),
+    updateJob: vi.fn(async (_id, updates) => {
+      if (current) current = { ...current, ...updates };
+    }),
+  };
+}
+
+describe('job application use cases', () => {
+  it('updates mutable job fields and requests scheduler sync', async () => {
+    const ops = makeOps(makeJob());
+    const scheduler = { requestSchedulerSync: vi.fn() };
+    const useCase = new UpdateJobUseCase({
+      ops: ops as OpsRepository,
+      scheduler,
+      clock: { now: () => '2026-04-24T01:00:00.000Z' },
+    });
+
+    const result = await useCase.execute({
+      appId: 'app-one',
+      jobId: 'job-1',
+      patch: {
+        name: 'Updated',
+        prompt: 'New prompt',
+        executionMode: 'serialized',
+        threadId: 'thread-1',
+        status: 'paused',
+      },
+    });
+
+    expect(result.job).toMatchObject({
+      name: 'Updated',
+      prompt: 'New prompt',
+      execution_mode: 'serialized',
+      thread_id: 'thread-1',
+      status: 'paused',
+    });
+    expect(ops.updateJob).toHaveBeenCalledWith('job-1', {
+      name: 'Updated',
+      prompt: 'New prompt',
+      execution_mode: 'serialized',
+      thread_id: 'thread-1',
+      status: 'paused',
+    });
+    expect(scheduler.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+  });
+
+  it('computes resume next_run in the application layer', async () => {
+    const ops = makeOps(
+      makeJob({
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        status: 'paused',
+        next_run: null,
+      }),
+    );
+    const scheduler = { requestSchedulerSync: vi.fn() };
+    const useCase = new UpdateJobUseCase({
+      ops: ops as OpsRepository,
+      scheduler,
+      clock: { now: () => '2026-04-24T01:00:00.000Z' },
+    });
+
+    await useCase.execute({
+      appId: 'app-one',
+      jobId: 'job-1',
+      resume: true,
+    });
+
+    expect(ops.updateJob).toHaveBeenCalledWith('job-1', {
+      status: 'active',
+      pause_reason: null,
+      next_run: '2026-04-24T01:00:00.000Z',
+    });
+  });
+
+  it('pauses jobs without route-owned mutation logic', async () => {
+    const ops = makeOps(makeJob());
+    const scheduler = { requestSchedulerSync: vi.fn() };
+    const useCase = new PauseJobUseCase({
+      ops: ops as OpsRepository,
+      scheduler,
+    });
+
+    await expect(
+      useCase.execute({ appId: 'app-one', jobId: 'job-1' }),
+    ).resolves.toEqual({ paused: true });
+    expect(ops.updateJob).toHaveBeenCalledWith('job-1', {
+      status: 'paused',
+      pause_reason: 'Paused by SDK',
+      next_run: null,
+    });
+    expect(scheduler.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+  });
+
+  it('rejects cross-app job access', async () => {
+    const ops = makeOps(makeJob());
+    const useCase = new PauseJobUseCase({
+      ops: ops as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+    });
+
+    await expect(
+      useCase.execute({ appId: 'other-app', jobId: 'job-1' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(ops.updateJob).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/test/unit/application/jobs-use-cases.test.ts
+++ b/apps/core/test/unit/application/jobs-use-cases.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { PauseJobUseCase } from '@core/application/jobs/pause-job-use-case.js';
 import { UpdateJobUseCase } from '@core/application/jobs/update-job-use-case.js';
+import { jobBelongsToApp } from '@core/application/jobs/job-access.js';
 import type { OpsRepository } from '@core/domain/repositories/ops-repo.js';
 import type { Job } from '@core/domain/types.js';
 
@@ -52,6 +53,22 @@ function makeOps(
 }
 
 describe('job application use cases', () => {
+  it('parses app-owned job session bindings without accepting malformed IDs', () => {
+    expect(jobBelongsToApp(makeJob(), 'app-one')).toBe(true);
+    expect(
+      jobBelongsToApp(
+        makeJob({ linked_sessions: ['app:app-one:conv:extra'] }),
+        'app-one',
+      ),
+    ).toBe(false);
+    expect(
+      jobBelongsToApp(
+        makeJob({ linked_sessions: ['telegram:chat'] }),
+        'app-one',
+      ),
+    ).toBe(false);
+  });
+
   it('updates mutable job fields and requests scheduler sync', async () => {
     const ops = makeOps(makeJob());
     const scheduler = { requestSchedulerSync: vi.fn() };
@@ -79,6 +96,8 @@ describe('job application use cases', () => {
       execution_mode: 'serialized',
       thread_id: 'thread-1',
       status: 'paused',
+      pause_reason: 'Paused by SDK',
+      next_run: null,
     });
     expect(ops.updateJob).toHaveBeenCalledWith('job-1', {
       name: 'Updated',
@@ -86,8 +105,88 @@ describe('job application use cases', () => {
       execution_mode: 'serialized',
       thread_id: 'thread-1',
       status: 'paused',
+      pause_reason: 'Paused by SDK',
+      next_run: null,
     });
     expect(scheduler.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+  });
+
+  it('applies resume semantics when patching status active', async () => {
+    const ops = makeOps(
+      makeJob({
+        schedule_type: 'interval',
+        schedule_value: '900',
+        status: 'paused',
+        pause_reason: 'maintenance',
+        next_run: null,
+      }),
+    );
+    const scheduler = { requestSchedulerSync: vi.fn() };
+    const useCase = new UpdateJobUseCase({
+      ops: ops as OpsRepository,
+      scheduler,
+      clock: { now: () => '2026-04-24T01:00:00.000Z' },
+    });
+
+    await useCase.execute({
+      appId: 'app-one',
+      jobId: 'job-1',
+      patch: { status: 'active' },
+    });
+
+    expect(ops.updateJob).toHaveBeenCalledWith('job-1', {
+      status: 'active',
+      pause_reason: null,
+      next_run: '2026-04-24T01:00:00.000Z',
+    });
+    expect(scheduler.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+  });
+
+  it('rejects empty mutable strings and no-ops empty patches', async () => {
+    const ops = makeOps(makeJob());
+    const scheduler = { requestSchedulerSync: vi.fn() };
+    const useCase = new UpdateJobUseCase({
+      ops: ops as OpsRepository,
+      scheduler,
+      clock: { now: () => '2026-04-24T01:00:00.000Z' },
+    });
+
+    await expect(
+      useCase.execute({
+        appId: 'app-one',
+        jobId: 'job-1',
+        patch: { name: '   ' },
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+
+    await expect(
+      useCase.execute({
+        appId: 'app-one',
+        jobId: 'job-1',
+        patch: {},
+      }),
+    ).resolves.toMatchObject({ job: { id: 'job-1' } });
+    expect(ops.updateJob).not.toHaveBeenCalled();
+    expect(scheduler.requestSchedulerSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects ambiguous resume plus patch updates', async () => {
+    const ops = makeOps(makeJob({ status: 'paused' }));
+    const useCase = new UpdateJobUseCase({
+      ops: ops as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      clock: { now: () => '2026-04-24T01:00:00.000Z' },
+    });
+
+    await expect(
+      useCase.execute({
+        appId: 'app-one',
+        jobId: 'job-1',
+        resume: true,
+        patch: { status: 'paused' },
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+    expect(ops.updateJob).not.toHaveBeenCalled();
   });
 
   it('computes resume next_run in the application layer', async () => {
@@ -128,7 +227,7 @@ describe('job application use cases', () => {
     });
 
     await expect(
-      useCase.execute({ appId: 'app-one', jobId: 'job-1' }),
+      useCase.execute({ appId: 'app-one', jobId: 'job-1', reason: '' }),
     ).resolves.toEqual({ paused: true });
     expect(ops.updateJob).toHaveBeenCalledWith('job-1', {
       status: 'paused',

--- a/apps/core/test/unit/control/job-trigger.test.ts
+++ b/apps/core/test/unit/control/job-trigger.test.ts
@@ -111,6 +111,182 @@ afterEach(() => {
 });
 
 describe('control job trigger', () => {
+  function makeJob(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'job-1',
+      name: 'Job',
+      prompt: 'Run',
+      model: null,
+      script: null,
+      schedule_type: 'manual',
+      schedule_value: 'manual',
+      status: 'active',
+      linked_sessions: ['app:app-one:conv-1'],
+      session_id: null,
+      thread_id: null,
+      group_scope: 'app-folder',
+      created_by: 'human',
+      created_at: '2026-04-24T00:00:00.000Z',
+      updated_at: '2026-04-24T00:00:00.000Z',
+      next_run: null,
+      last_run: null,
+      silent: false,
+      cleanup_after_ms: 0,
+      timeout_ms: 300000,
+      max_retries: 0,
+      retry_backoff_ms: 0,
+      max_consecutive_failures: 3,
+      consecutive_failures: 0,
+      execution_mode: 'parallel',
+      lease_run_id: null,
+      lease_expires_at: null,
+      pause_reason: null,
+      ...overrides,
+    };
+  }
+
+  function mockMutableJob(job: ReturnType<typeof makeJob>) {
+    let current = job;
+    opsRepo.getJobById.mockImplementation(async () => current);
+    opsRepo.updateJob.mockImplementation(async (_id, updates) => {
+      current = { ...current, ...updates };
+    });
+  }
+
+  it('updates jobs through the application use case', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    process.env.MYCLAW_CONTROL_API_KEYS_JSON = JSON.stringify([
+      {
+        kid: 'k',
+        token: 'token-jobs',
+        scopes: ['jobs:write'],
+        appId: 'app-one',
+      },
+    ]);
+    mockMutableJob(makeJob());
+    const handle = startControlServer({
+      app: { queue: { enqueueMessageCheck: vi.fn() } } as never,
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/jobs/job-1`,
+        'token-jobs',
+        {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            name: 'Updated',
+            prompt: 'New prompt',
+            executionMode: 'serialized',
+            threadId: 'thread-1',
+            status: 'paused',
+          }),
+        },
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        jobId: 'job-1',
+        name: 'Updated',
+        prompt: 'New prompt',
+        executionMode: 'serialized',
+        threadId: 'thread-1',
+        status: 'paused',
+      });
+      expect(opsRepo.updateJob).toHaveBeenCalledWith('job-1', {
+        name: 'Updated',
+        prompt: 'New prompt',
+        execution_mode: 'serialized',
+        thread_id: 'thread-1',
+        status: 'paused',
+      });
+      expect(schedulerMocks.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('pauses jobs through the application use case', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    process.env.MYCLAW_CONTROL_API_KEYS_JSON = JSON.stringify([
+      {
+        kid: 'k',
+        token: 'token-jobs',
+        scopes: ['jobs:write'],
+        appId: 'app-one',
+      },
+    ]);
+    mockMutableJob(makeJob());
+    const handle = startControlServer({
+      app: { queue: { enqueueMessageCheck: vi.fn() } } as never,
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/jobs/job-1/pause`,
+        'token-jobs',
+        { method: 'POST' },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ paused: true });
+      expect(opsRepo.updateJob).toHaveBeenCalledWith('job-1', {
+        status: 'paused',
+        pause_reason: 'Paused by SDK',
+        next_run: null,
+      });
+      expect(schedulerMocks.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('resumes jobs through the application use case', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    process.env.MYCLAW_CONTROL_API_KEYS_JSON = JSON.stringify([
+      {
+        kid: 'k',
+        token: 'token-jobs',
+        scopes: ['jobs:write'],
+        appId: 'app-one',
+      },
+    ]);
+    mockMutableJob(
+      makeJob({
+        schedule_type: 'once',
+        schedule_value: '2026-05-01T00:00:00.000Z',
+        status: 'paused',
+      }),
+    );
+    const handle = startControlServer({
+      app: { queue: { enqueueMessageCheck: vi.fn() } } as never,
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/jobs/job-1/resume`,
+        'token-jobs',
+        { method: 'POST' },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ resumed: true });
+      expect(opsRepo.updateJob).toHaveBeenCalledWith('job-1', {
+        status: 'active',
+        pause_reason: null,
+        next_run: '2026-05-01T00:00:00.000Z',
+      });
+      expect(schedulerMocks.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+    } finally {
+      await handle.close();
+    }
+  });
+
   it('rejects triggers before scheduler readiness without persisting trigger rows', async () => {
     const port = await reservePort();
     process.env.MYCLAW_CONTROL_PORT = String(port);

--- a/apps/core/test/unit/control/job-trigger.test.ts
+++ b/apps/core/test/unit/control/job-trigger.test.ts
@@ -202,6 +202,8 @@ describe('control job trigger', () => {
         execution_mode: 'serialized',
         thread_id: 'thread-1',
         status: 'paused',
+        pause_reason: 'Paused by SDK',
+        next_run: null,
       });
       expect(schedulerMocks.requestSchedulerSync).toHaveBeenCalledWith('job-1');
     } finally {
@@ -282,6 +284,53 @@ describe('control job trigger', () => {
         next_run: '2026-05-01T00:00:00.000Z',
       });
       expect(schedulerMocks.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('resumes paused recurring jobs before manual trigger enqueue', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    process.env.MYCLAW_CONTROL_API_KEYS_JSON = JSON.stringify([
+      {
+        kid: 'k',
+        token: 'token-jobs',
+        scopes: ['jobs:write'],
+        appId: 'app-one',
+      },
+    ]);
+    mockMutableJob(
+      makeJob({
+        schedule_type: 'interval',
+        schedule_value: '900',
+        status: 'paused',
+        pause_reason: 'maintenance',
+        next_run: null,
+      }),
+    );
+    const handle = startControlServer({
+      app: { queue: { enqueueMessageCheck: vi.fn() } } as never,
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/jobs/job-1/trigger`,
+        'token-jobs',
+        { method: 'POST' },
+      );
+
+      expect(response.status).toBe(202);
+      expect(opsRepo.updateJob).toHaveBeenCalledWith('job-1', {
+        status: 'active',
+        pause_reason: null,
+        next_run: expect.any(String),
+      });
+      expect(schedulerMocks.requestSchedulerSync).toHaveBeenCalledWith('job-1');
+      expect(schedulerMocks.enqueueJobTrigger).toHaveBeenCalledWith(
+        'job-1',
+        'trigger-1',
+      );
     } finally {
       await handle.close();
     }

--- a/apps/core/test/unit/core/agent-credential-service.test.ts
+++ b/apps/core/test/unit/core/agent-credential-service.test.ts
@@ -47,20 +47,18 @@ afterEach(() => {
 });
 
 describe('agent credential service', () => {
-  it('throws missing ONECLI_URL only when onecli mode is required', async () => {
+  it('requires a broker only when broker mode is enabled', async () => {
     const { getAgentCredentialInjection } = await loadCredentialService();
 
     await expect(
       getAgentCredentialInjection({
         mode: 'onecli',
-        onecliUrl: '',
       }),
-    ).rejects.toThrow('ONECLI_URL');
+    ).rejects.toThrow('no agent credential broker was provided');
 
     await expect(
       getAgentCredentialInjection({
         mode: 'none',
-        onecliUrl: '',
       }),
     ).resolves.toEqual({
       env: {},
@@ -71,23 +69,21 @@ describe('agent credential service', () => {
     await expect(
       getAgentCredentialInjection({
         mode: 'external',
-        onecliUrl: '',
       }),
-    ).rejects.toThrow('credential_broker.external.base_url');
+    ).rejects.toThrow('no external credential injection was provided');
   });
 
   it('passes safe external broker env to spawned agents', async () => {
-    vi.stubEnv('MYCLAW_CREDENTIAL_MODE', 'external');
-    vi.stubEnv('ANTHROPIC_BASE_URL', 'https://broker.example.com');
-    vi.stubEnv('ANTHROPIC_MODEL', 'claude-test');
-    vi.stubEnv('ANTHROPIC_API_KEY', 'raw-secret');
+    const { createExternalAgentCredentialInjection } =
+      await import('@core/adapters/llm/external-credential-injection.js');
     const { getAgentCredentialInjection } = await loadCredentialService();
 
     await expect(
       getAgentCredentialInjection({
         mode: 'external',
-        onecliUrl: '',
-        externalBrokerUrl: 'https://broker.example.com',
+        externalInjection: createExternalAgentCredentialInjection({
+          normalizedBaseUrl: 'https://broker.example.com',
+        }),
       }),
     ).resolves.toEqual({
       env: {
@@ -98,20 +94,44 @@ describe('agent credential service', () => {
     });
   });
 
-  it('rejects unsafe external broker URLs before injecting agent env', async () => {
-    vi.stubEnv('MYCLAW_CREDENTIAL_MODE', 'external');
-    vi.stubEnv('ANTHROPIC_BASE_URL', 'https://user:pass@broker.example.com');
+  it('preserves host credential env when preparing external broker env', async () => {
+    const { createExternalAgentCredentialInjection } =
+      await import('@core/adapters/llm/external-credential-injection.js');
+
+    expect(
+      createExternalAgentCredentialInjection({
+        normalizedBaseUrl: 'https://broker.example.com',
+        hostCredentialEnv: {
+          HTTPS_PROXY: 'http://proxy.example.com',
+        },
+      }),
+    ).toEqual({
+      env: {
+        ANTHROPIC_BASE_URL: 'https://broker.example.com',
+        HTTPS_PROXY: 'http://proxy.example.com',
+      },
+      applied: true,
+      brokerProfile: 'external',
+    });
+  });
+
+  it('uses externally prepared credential injection without reading adapter config', async () => {
     const { getAgentCredentialInjection } = await loadCredentialService();
 
     await expect(
       getAgentCredentialInjection({
         mode: 'external',
-        onecliUrl: '',
-        externalBrokerUrl: 'https://user:pass@broker.example.com',
+        externalInjection: {
+          env: { PROVIDER_BASE_URL: 'https://broker.example.com' },
+          applied: true,
+          brokerProfile: 'external',
+        },
       }),
-    ).rejects.toThrow(
-      'credential_broker.external.base_url must not contain embedded credentials',
-    );
+    ).resolves.toEqual({
+      env: { PROVIDER_BASE_URL: 'https://broker.example.com' },
+      applied: true,
+      brokerProfile: 'external',
+    });
   });
 
   it('keeps broker requests agent-scoped and does not request runtime-owned secrets', async () => {
@@ -188,7 +208,7 @@ describe('agent credential service', () => {
         broker: unreachableBroker,
       }),
     ).rejects.toThrow(
-      'OneCLI credential mode is enabled but the OneCLI gateway is not reachable.',
+      'Credential broker mode is enabled but the credential broker is not reachable.',
     );
   });
 
@@ -206,7 +226,7 @@ describe('agent credential service', () => {
         broker,
       }),
     ).rejects.toThrow(
-      'OneCLI credential mode is enabled but the OneCLI gateway is not reachable.',
+      'Credential broker mode is enabled but the credential broker is not reachable.',
     );
   });
 });

--- a/apps/core/test/unit/core/agent-credential-service.test.ts
+++ b/apps/core/test/unit/core/agent-credential-service.test.ts
@@ -53,7 +53,7 @@ describe('agent credential service', () => {
     await expect(
       getAgentCredentialInjection({
         mode: 'onecli',
-      }),
+      } as never),
     ).rejects.toThrow('no agent credential broker was provided');
 
     await expect(
@@ -69,7 +69,7 @@ describe('agent credential service', () => {
     await expect(
       getAgentCredentialInjection({
         mode: 'external',
-      }),
+      } as never),
     ).rejects.toThrow('no external credential injection was provided');
   });
 
@@ -94,7 +94,7 @@ describe('agent credential service', () => {
     });
   });
 
-  it('preserves host credential env when preparing external broker env', async () => {
+  it('preserves safe host env and drops raw agent credentials for external broker env', async () => {
     const { createExternalAgentCredentialInjection } =
       await import('@core/adapters/llm/external-credential-injection.js');
 
@@ -103,6 +103,8 @@ describe('agent credential service', () => {
         normalizedBaseUrl: 'https://broker.example.com',
         hostCredentialEnv: {
           HTTPS_PROXY: 'http://proxy.example.com',
+          ANTHROPIC_API_KEY: 'raw-secret',
+          OPENAI_API_KEY: 'raw-secret',
         },
       }),
     ).toEqual({
@@ -205,10 +207,11 @@ describe('agent credential service', () => {
     await expect(
       getAgentCredentialInjection({
         mode: 'onecli',
+        agentIdentifier: 'agent-one',
         broker: unreachableBroker,
       }),
     ).rejects.toThrow(
-      'Credential broker mode is enabled but the credential broker is not reachable.',
+      'Credential broker mode is enabled but the credential broker is not reachable for agent agent-one.',
     );
   });
 


### PR DESCRIPTION
## Summary
- Add the application service/use-case skeleton layer under apps/core/src/application across agents, channels, conversations, messages, sessions, runs, jobs, memory, permissions, tools, skills, sandbox, browser, streaming, and common primitives.
- Migrate the safe control jobs mutation path to UpdateJobUseCase and PauseJobUseCase while keeping HTTP parsing and response mapping in the route layer.
- Clean the application credential boundary so application credentials depend on domain ports and DTOs, with concrete OneCLI/external credential wiring moved into adapter/runtime ownership.
- Address review findings for job status scheduling semantics, ambiguous update precedence, empty update validation, trigger resume scheduling, credential injection typing/scrubbing, duplicate app job ownership parsing, and broker cache rejection handling.
- Include AGENTS.md cleanup/cutover guidance updates.

## Validation
- npm run typecheck: passed
- npm run test:unit -- apps/core/test/unit/application/jobs-use-cases.test.ts apps/core/test/unit/control/job-trigger.test.ts apps/core/test/unit/core/agent-credential-service.test.ts apps/core/test/unit/runtime/agent-spawn-host.test.ts apps/core/test/unit/memory/claude-query.test.ts: passed, 5 files and 39 tests
- npm run test:unit: passed, 95 files and 1150 tests
- Targeted apps/core/src/application import scan: no provider/concrete/config/infra matches
- python3 .codex/scripts/check_architecture.py: fails against the known pre-existing architecture baseline; the prior application/credentials boundary violation is removed, while broader runtime/config/adapter and provider-specific debt remains
- python3 .codex/scripts/check_task_completion.py: fails because it wraps the same architecture baseline and emits broad warnings for skeleton folders without domain-specific tests
