### PR TITLE
[codex] add canonical postgres repositories

### DIFF
--- a/.codex/architecture-map.json
+++ b/.codex/architecture-map.json
@@ -2,6 +2,7 @@
   "version": 1,
   "defaultLineBudget": 700,
   "lineBudgets": {
+    "apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts": 2100,
     "apps/core/src/adapters/storage/postgres/schema/canonical-ops-repo.postgres.ts": 950,
     "apps/core/src/adapters/storage/postgres/schema/schema.ts": 900
   },

--- a/apps/core/src/adapters/storage/postgres/factory.ts
+++ b/apps/core/src/adapters/storage/postgres/factory.ts
@@ -3,6 +3,10 @@ import {
   type ResolvedStorageConfig,
 } from './storage-service.js';
 import {
+  createPostgresDomainRepositories,
+  type PostgresDomainRepositoryBundle,
+} from './repositories/domain-repositories.postgres.js';
+import {
   STORAGE_POSTGRES_SCHEMA,
   STORAGE_POSTGRES_URL,
   STORAGE_POSTGRES_URL_ENV,
@@ -16,6 +20,7 @@ export interface StorageRuntime {
   service: PostgresStorageService;
   ops: OpsRepository;
   control: PostgresControlPlaneRepository;
+  repositories: PostgresDomainRepositoryBundle;
 }
 
 export function resolveStorageConfigFromRuntime(): ResolvedStorageConfig {
@@ -35,9 +40,11 @@ export function createStorageRuntime(
     service.db,
   );
   const control = new PostgresControlPlaneRepository(service.pool);
+  const repositories = createPostgresDomainRepositories(service.db);
   return {
     service,
     ops,
     control,
+    repositories,
   };
 }

--- a/apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts
@@ -1,0 +1,1917 @@
+import { and, asc, desc, eq, gt, isNull, or, sql, type SQL } from 'drizzle-orm';
+
+import type {
+  Agent,
+  AgentConfigVersion,
+  LlmProfileId,
+} from '../../../../domain/agent/agent.js';
+import type { App } from '../../../../domain/app/app.js';
+import type { BrowserProfile } from '../../../../domain/browser/browser.js';
+import type {
+  AgentChannelBinding,
+  ChannelInstallation,
+  ChannelProviderId,
+} from '../../../../domain/channel/channel.js';
+import type {
+  Conversation,
+  ConversationThread,
+} from '../../../../domain/conversation/conversation.js';
+import type {
+  AgentRun,
+  AgentRunEvent,
+} from '../../../../domain/events/events.js';
+import type { Job, JobTrigger } from '../../../../domain/jobs/jobs.js';
+import type {
+  MemoryItem,
+  MemorySubject,
+} from '../../../../domain/memory/memory.js';
+import type {
+  Message,
+  MessageAttachment,
+  MessagePart,
+} from '../../../../domain/messages/messages.js';
+import type {
+  PermissionDecision,
+  PermissionPolicy,
+  PermissionRule,
+} from '../../../../domain/permissions/permissions.js';
+import type {
+  AgentConfigRepository,
+  AgentRepository,
+  AgentRunRepository,
+  AgentSessionRepository,
+  AppRepository,
+  BrowserProfileRepository,
+  ChannelInstallationRepository,
+  ConversationRepository,
+  JobRepository,
+  MemoryRepository,
+  MessageRepository,
+  PermissionRepository,
+  ProviderSessionRepository,
+  SandboxRepository,
+  SkillCatalogRepository,
+  ToolCatalogRepository,
+} from '../../../../domain/ports/repositories.js';
+import type {
+  SandboxLease,
+  SandboxProfile,
+  WorkspaceSnapshot,
+} from '../../../../domain/sandbox/sandbox.js';
+import type {
+  AgentSession,
+  ProviderSession,
+} from '../../../../domain/sessions/sessions.js';
+import type { SkillCatalogItem } from '../../../../domain/skills/skills.js';
+import type { ToolCatalogItem } from '../../../../domain/tools/tools.js';
+import type { ExternalRef } from '../../../../shared/ids/branded-id.js';
+import * as pgSchema from '../schema/schema.js';
+import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
+
+export interface PostgresDomainRepositoryBundle {
+  apps: AppRepository;
+  agents: AgentRepository;
+  agentConfigs: AgentConfigRepository;
+  channelInstallations: ChannelInstallationRepository;
+  conversations: ConversationRepository;
+  messages: MessageRepository;
+  agentSessions: AgentSessionRepository;
+  providerSessions: ProviderSessionRepository;
+  agentRuns: AgentRunRepository;
+  memory: MemoryRepository;
+  jobs: JobRepository;
+  tools: ToolCatalogRepository;
+  skills: SkillCatalogRepository;
+  permissions: PermissionRepository;
+  sandboxes: SandboxRepository;
+  browserProfiles: BrowserProfileRepository;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function encodeJson(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+function encodeJsonOrNull(value: unknown | undefined): string | null {
+  return value === undefined ? null : encodeJson(value);
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== 'string' || value.length === 0) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch (err) {
+    if (!(err instanceof SyntaxError)) {
+      throw err;
+    }
+    return fallback;
+  }
+}
+
+function parseJsonArray<T extends string>(value: unknown): T[] {
+  const parsed = parseJson<unknown>(value, []);
+  return Array.isArray(parsed)
+    ? (parsed.filter((v) => typeof v === 'string') as T[])
+    : [];
+}
+
+function externalRef<Kind extends string>(
+  value: unknown,
+  fallbackKind: Kind,
+  fallbackValue?: string | null,
+): ExternalRef<Kind> | undefined {
+  const parsed = parseJson<Partial<ExternalRef<Kind>> & JsonRecord>(value, {});
+  if (typeof parsed.kind === 'string' && typeof parsed.value === 'string') {
+    return { kind: parsed.kind as Kind, value: parsed.value };
+  }
+  const legacyValue =
+    typeof parsed.jid === 'string'
+      ? parsed.jid
+      : typeof parsed.threadId === 'string'
+        ? parsed.threadId
+        : typeof parsed.externalId === 'string'
+          ? parsed.externalId
+          : fallbackValue;
+  return legacyValue ? { kind: fallbackKind, value: legacyValue } : undefined;
+}
+
+function jsonTextEquals(column: unknown, keys: string[], value: string): SQL {
+  return sql`(${column} IS NOT NULL AND (${sql.join(
+    keys.map((key) => sql`${column}::jsonb->>${key} = ${value}`),
+    sql` OR `,
+  )}))`;
+}
+
+function providerFromProviderRef(ref: ExternalRef<'provider_session'>): string {
+  const idx = ref.value.indexOf(':');
+  return idx > 0 ? ref.value.slice(0, idx) : 'unknown';
+}
+
+function toMemorySubjectFields(subject: MemorySubject): {
+  subjectType: string;
+  subjectId: string;
+  userId: string | null;
+  conversationId: string | null;
+  threadId: string | null;
+} {
+  switch (subject.kind) {
+    case 'app':
+      return {
+        subjectType: 'app',
+        subjectId: subject.appId,
+        userId: null,
+        conversationId: null,
+        threadId: null,
+      };
+    case 'agent':
+      return {
+        subjectType: 'agent',
+        subjectId: subject.agentId,
+        userId: null,
+        conversationId: null,
+        threadId: null,
+      };
+    case 'user':
+      return {
+        subjectType: 'user',
+        subjectId: subject.userId,
+        userId: subject.userId,
+        conversationId: null,
+        threadId: null,
+      };
+    case 'conversation':
+      return {
+        subjectType: 'conversation',
+        subjectId: subject.conversationId,
+        userId: null,
+        conversationId: subject.conversationId,
+        threadId: null,
+      };
+    case 'thread':
+      return {
+        subjectType: 'thread',
+        subjectId: subject.threadId,
+        userId: null,
+        conversationId: subject.conversationId,
+        threadId: subject.threadId,
+      };
+  }
+}
+
+function memorySubjectFromRow(row: {
+  appId: string;
+  agentId: string | null;
+  subjectType: string;
+  subjectId: string;
+  userId: string | null;
+  conversationId: string | null;
+  threadId: string | null;
+}): MemorySubject {
+  if (row.subjectType === 'agent') {
+    return {
+      kind: 'agent',
+      appId: row.appId,
+      agentId: row.subjectId,
+    } as MemorySubject;
+  }
+  if (row.subjectType === 'user') {
+    return {
+      kind: 'user',
+      appId: row.appId,
+      userId: row.userId ?? row.subjectId,
+    } as MemorySubject;
+  }
+  if (row.subjectType === 'conversation') {
+    return {
+      kind: 'conversation',
+      appId: row.appId,
+      conversationId: row.conversationId ?? row.subjectId,
+    } as MemorySubject;
+  }
+  if (row.subjectType === 'thread') {
+    return {
+      kind: 'thread',
+      appId: row.appId,
+      conversationId: row.conversationId ?? '',
+      threadId: row.threadId ?? row.subjectId,
+    } as MemorySubject;
+  }
+  return { kind: 'app', appId: row.appId } as MemorySubject;
+}
+
+function messagePartToPayload(part: MessagePart): string {
+  switch (part.kind) {
+    case 'text':
+      return encodeJson({ text: part.text });
+    case 'markdown':
+      return encodeJson({ markdown: part.markdown });
+    case 'code':
+      return encodeJson({ language: part.language, code: part.code });
+    case 'structured':
+      return encodeJson({ value: part.value });
+    case 'tool_result':
+      return encodeJson({ toolId: part.toolId, value: part.value });
+    case 'redacted':
+      return encodeJson({ reason: part.reason });
+  }
+}
+
+function payloadToMessagePart(kind: string, payloadJson: string): MessagePart {
+  const payload = parseJson<JsonRecord>(payloadJson, {});
+  switch (kind) {
+    case 'markdown':
+      return { kind: 'markdown', markdown: String(payload.markdown ?? '') };
+    case 'code':
+      return {
+        kind: 'code',
+        language:
+          typeof payload.language === 'string' ? payload.language : undefined,
+        code: String(payload.code ?? ''),
+      };
+    case 'structured':
+      return { kind: 'structured', value: payload.value };
+    case 'tool_result':
+      return {
+        kind: 'tool_result',
+        toolId: String(payload.toolId ?? ''),
+        value: payload.value,
+      };
+    case 'redacted':
+      return { kind: 'redacted', reason: String(payload.reason ?? '') };
+    default:
+      return { kind: 'text', text: String(payload.text ?? '') };
+  }
+}
+
+export class PostgresAppRepository implements AppRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getApp(id: App['id']): Promise<App | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.appsPostgres)
+      .where(eq(pgSchema.appsPostgres.id, id))
+      .limit(1);
+    return (rows[0] as App | undefined) ?? null;
+  }
+
+  async saveApp(app: App): Promise<void> {
+    await this.db
+      .insert(pgSchema.appsPostgres)
+      .values(app)
+      .onConflictDoUpdate({
+        target: pgSchema.appsPostgres.id,
+        set: {
+          slug: app.slug,
+          name: app.name,
+          status: app.status,
+          updatedAt: app.updatedAt,
+        },
+      });
+  }
+}
+
+export class PostgresAgentRepository implements AgentRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getAgent(id: Agent['id']): Promise<Agent | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.agentsPostgres)
+      .where(eq(pgSchema.agentsPostgres.id, id))
+      .limit(1);
+    return (rows[0] as Agent | undefined) ?? null;
+  }
+
+  async listAgents(appId: App['id']): Promise<Agent[]> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.agentsPostgres)
+      .where(eq(pgSchema.agentsPostgres.appId, appId))
+      .orderBy(
+        asc(pgSchema.agentsPostgres.name),
+        asc(pgSchema.agentsPostgres.id),
+      );
+    return rows as Agent[];
+  }
+
+  async saveAgent(agent: Agent): Promise<void> {
+    await this.db
+      .insert(pgSchema.agentsPostgres)
+      .values({
+        ...agent,
+        currentConfigVersionId: agent.currentConfigVersionId ?? null,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.agentsPostgres.id,
+        set: {
+          name: agent.name,
+          status: agent.status,
+          currentConfigVersionId: agent.currentConfigVersionId ?? null,
+          updatedAt: agent.updatedAt,
+        },
+      });
+  }
+}
+
+export class PostgresAgentConfigRepository implements AgentConfigRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getConfigVersion(
+    id: AgentConfigVersion['id'],
+  ): Promise<AgentConfigVersion | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.agentConfigVersionsPostgres)
+      .where(eq(pgSchema.agentConfigVersionsPostgres.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentId: row.agentId,
+      version: row.version,
+      promptProfileRef: row.promptProfileRef,
+      llmProfileId: row.llmProfileId as LlmProfileId,
+      toolIds: parseJsonArray(row.toolIdsJson),
+      skillIds: parseJsonArray(row.skillIdsJson),
+      permissionPolicyIds: parseJsonArray(row.permissionPolicyIdsJson),
+      sandboxProfileId: row.sandboxProfileId ?? undefined,
+      workspaceSnapshotId: row.workspaceSnapshotId ?? undefined,
+      runtimeLimits: parseJson<AgentConfigVersion['runtimeLimits']>(
+        row.runtimeLimitsJson,
+        undefined,
+      ),
+      createdAt: row.createdAt,
+    } as AgentConfigVersion;
+  }
+
+  async saveConfigVersion(version: AgentConfigVersion): Promise<void> {
+    await this.db
+      .insert(pgSchema.agentConfigVersionsPostgres)
+      .values({
+        id: version.id,
+        appId: version.appId,
+        agentId: version.agentId,
+        version: version.version,
+        promptProfileRef: version.promptProfileRef,
+        llmProfileId: version.llmProfileId,
+        toolIdsJson: encodeJson(version.toolIds),
+        skillIdsJson: encodeJson(version.skillIds),
+        permissionPolicyIdsJson: encodeJson(version.permissionPolicyIds),
+        sandboxProfileId: version.sandboxProfileId ?? null,
+        workspaceSnapshotId: version.workspaceSnapshotId ?? null,
+        runtimeLimitsJson: encodeJson(version.runtimeLimits ?? {}),
+        createdAt: version.createdAt,
+      })
+      .onConflictDoNothing();
+  }
+}
+
+export class PostgresChannelInstallationRepository implements ChannelInstallationRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getChannelInstallation(
+    id: ChannelInstallation['id'],
+  ): Promise<ChannelInstallation | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.channelInstallationsPostgres)
+      .where(eq(pgSchema.channelInstallationsPostgres.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      appId: row.appId,
+      providerId: row.providerId as ChannelProviderId,
+      externalInstallationRef: externalRef(
+        row.externalRefJson,
+        'channel_installation',
+      ),
+      label: row.label,
+      status: row.status as ChannelInstallation['status'],
+      runtimeSecretRefs: parseJsonArray(row.runtimeSecretRefsJson),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as unknown as ChannelInstallation;
+  }
+
+  async saveChannelInstallation(
+    installation: ChannelInstallation,
+  ): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx
+        .insert(pgSchema.channelProvidersPostgres)
+        .values({
+          id: installation.providerId,
+          displayName: installation.providerId,
+        })
+        .onConflictDoNothing();
+      await tx
+        .insert(pgSchema.channelInstallationsPostgres)
+        .values({
+          id: installation.id,
+          appId: installation.appId,
+          providerId: installation.providerId,
+          externalRefJson: encodeJsonOrNull(
+            installation.externalInstallationRef,
+          ),
+          label: installation.label,
+          status: installation.status,
+          runtimeSecretRefsJson: encodeJson(installation.runtimeSecretRefs),
+          createdAt: installation.createdAt,
+          updatedAt: installation.updatedAt,
+        })
+        .onConflictDoUpdate({
+          target: pgSchema.channelInstallationsPostgres.id,
+          set: {
+            externalRefJson: encodeJsonOrNull(
+              installation.externalInstallationRef,
+            ),
+            label: installation.label,
+            status: installation.status,
+            runtimeSecretRefsJson: encodeJson(installation.runtimeSecretRefs),
+            updatedAt: installation.updatedAt,
+          },
+        });
+    });
+  }
+
+  async saveAgentChannelBinding(binding: AgentChannelBinding): Promise<void> {
+    await this.db
+      .insert(pgSchema.agentChannelBindingsPostgres)
+      .values({
+        id: binding.id,
+        appId: binding.appId,
+        agentId: binding.agentId,
+        channelInstallationId: binding.channelInstallationId,
+        conversationId: binding.conversationId,
+        threadId: binding.threadId ?? null,
+        displayName: binding.displayName,
+        triggerPattern: binding.triggerPattern ?? null,
+        requiresTrigger: binding.requiresTrigger,
+        isAdminBinding: binding.isAdminBinding,
+        memorySubjectJson: encodeJson(binding.memorySubject),
+        workspaceSnapshotId: binding.workspaceSnapshotId ?? null,
+        permissionPolicyIdsJson: encodeJson(binding.permissionPolicyIds),
+        createdAt: binding.createdAt,
+        updatedAt: binding.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.agentChannelBindingsPostgres.id,
+        set: {
+          displayName: binding.displayName,
+          triggerPattern: binding.triggerPattern ?? null,
+          requiresTrigger: binding.requiresTrigger,
+          isAdminBinding: binding.isAdminBinding,
+          memorySubjectJson: encodeJson(binding.memorySubject),
+          workspaceSnapshotId: binding.workspaceSnapshotId ?? null,
+          permissionPolicyIdsJson: encodeJson(binding.permissionPolicyIds),
+          updatedAt: binding.updatedAt,
+        },
+      });
+  }
+
+  async getAgentChannelBinding(input: {
+    appId: App['id'];
+    agentId: Agent['id'];
+    conversationId: Conversation['id'];
+    threadId?: ConversationThread['id'];
+  }): Promise<AgentChannelBinding | null> {
+    const b = pgSchema.agentChannelBindingsPostgres;
+    const threadPredicate = input.threadId
+      ? or(eq(b.threadId, input.threadId), isNull(b.threadId))
+      : isNull(b.threadId);
+    const rows = await this.db
+      .select()
+      .from(b)
+      .where(
+        and(
+          eq(b.appId, input.appId),
+          eq(b.agentId, input.agentId),
+          eq(b.conversationId, input.conversationId),
+          threadPredicate,
+        ),
+      )
+      .orderBy(
+        sql`CASE WHEN ${b.threadId} IS NULL THEN 1 ELSE 0 END`,
+        asc(b.id),
+      )
+      .limit(1);
+    return rows[0] ? this.bindingFromRow(rows[0]) : null;
+  }
+
+  async isAgentEnabledInConversation(input: {
+    appId: App['id'];
+    agentId: Agent['id'];
+    conversationId: Conversation['id'];
+    threadId?: ConversationThread['id'];
+  }): Promise<boolean> {
+    const b = await this.getAgentChannelBinding(input);
+    if (!b) return false;
+    const rows = await this.db
+      .select({ id: pgSchema.agentsPostgres.id })
+      .from(pgSchema.agentsPostgres)
+      .innerJoin(
+        pgSchema.channelInstallationsPostgres,
+        eq(pgSchema.channelInstallationsPostgres.id, b.channelInstallationId),
+      )
+      .innerJoin(
+        pgSchema.conversationsPostgres,
+        eq(pgSchema.conversationsPostgres.id, b.conversationId),
+      )
+      .where(
+        and(
+          eq(pgSchema.agentsPostgres.id, b.agentId),
+          eq(pgSchema.agentsPostgres.status, 'active'),
+          eq(pgSchema.channelInstallationsPostgres.status, 'active'),
+          eq(pgSchema.conversationsPostgres.status, 'active'),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  async listAgentChannelBindings(
+    appId: App['id'],
+  ): Promise<AgentChannelBinding[]> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.agentChannelBindingsPostgres)
+      .where(eq(pgSchema.agentChannelBindingsPostgres.appId, appId))
+      .orderBy(asc(pgSchema.agentChannelBindingsPostgres.createdAt));
+    return rows.map((row) => this.bindingFromRow(row));
+  }
+
+  private bindingFromRow(
+    row: typeof pgSchema.agentChannelBindingsPostgres.$inferSelect,
+  ): AgentChannelBinding {
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentId: row.agentId,
+      channelInstallationId: row.channelInstallationId,
+      conversationId: row.conversationId,
+      threadId: row.threadId ?? undefined,
+      displayName: row.displayName,
+      triggerPattern: row.triggerPattern ?? undefined,
+      requiresTrigger: row.requiresTrigger,
+      isAdminBinding: row.isAdminBinding,
+      memorySubject: parseJson<MemorySubject>(row.memorySubjectJson, {
+        kind: 'conversation',
+        appId: row.appId,
+        conversationId: row.conversationId,
+      } as MemorySubject),
+      workspaceSnapshotId: row.workspaceSnapshotId ?? undefined,
+      permissionPolicyIds: parseJsonArray(row.permissionPolicyIdsJson),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as AgentChannelBinding;
+  }
+}
+
+export class PostgresConversationRepository implements ConversationRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getConversation(id: Conversation['id']): Promise<Conversation | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.conversationsPostgres)
+      .where(eq(pgSchema.conversationsPostgres.id, id))
+      .limit(1);
+    return rows[0] ? this.conversationFromRow(rows[0]) : null;
+  }
+
+  async getConversationByExternalRef(input: {
+    appId: App['id'];
+    providerId: ChannelProviderId;
+    channelInstallationId: ChannelInstallation['id'];
+    externalConversationId: string;
+  }): Promise<Conversation | null> {
+    const c = pgSchema.conversationsPostgres;
+    const ci = pgSchema.channelInstallationsPostgres;
+    const rows = await this.db
+      .select({ conversation: c })
+      .from(c)
+      .innerJoin(ci, eq(ci.id, c.channelInstallationId))
+      .where(
+        and(
+          eq(c.appId, input.appId),
+          eq(ci.providerId, input.providerId),
+          eq(c.channelInstallationId, input.channelInstallationId),
+          jsonTextEquals(
+            c.externalRefJson,
+            ['value', 'jid', 'externalConversationId'],
+            input.externalConversationId,
+          ),
+        ),
+      )
+      .limit(1);
+    return rows[0] ? this.conversationFromRow(rows[0].conversation) : null;
+  }
+
+  async getThread(
+    id: ConversationThread['id'],
+  ): Promise<ConversationThread | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.conversationThreadsPostgres)
+      .where(eq(pgSchema.conversationThreadsPostgres.id, id))
+      .limit(1);
+    return rows[0] ? this.threadFromRow(rows[0]) : null;
+  }
+
+  async getThreadByExternalRef(input: {
+    appId: App['id'];
+    providerId: ChannelProviderId;
+    conversationId: Conversation['id'];
+    externalThreadId: string;
+  }): Promise<ConversationThread | null> {
+    const t = pgSchema.conversationThreadsPostgres;
+    const c = pgSchema.conversationsPostgres;
+    const ci = pgSchema.channelInstallationsPostgres;
+    const rows = await this.db
+      .select({ thread: t })
+      .from(t)
+      .innerJoin(c, eq(c.id, t.conversationId))
+      .innerJoin(ci, eq(ci.id, c.channelInstallationId))
+      .where(
+        and(
+          eq(t.appId, input.appId),
+          eq(t.conversationId, input.conversationId),
+          eq(ci.providerId, input.providerId),
+          jsonTextEquals(
+            t.externalRefJson,
+            ['value', 'threadId', 'externalThreadId'],
+            input.externalThreadId,
+          ),
+        ),
+      )
+      .limit(1);
+    return rows[0] ? this.threadFromRow(rows[0].thread) : null;
+  }
+
+  async saveConversation(conversation: Conversation): Promise<void> {
+    await this.db
+      .insert(pgSchema.conversationsPostgres)
+      .values({
+        id: conversation.id,
+        appId: conversation.appId,
+        channelInstallationId: conversation.channelInstallationId,
+        externalRefJson: encodeJsonOrNull(conversation.externalRef),
+        kind: conversation.kind,
+        title: conversation.title ?? null,
+        status: conversation.status,
+        createdAt: conversation.createdAt,
+        updatedAt: conversation.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.conversationsPostgres.id,
+        set: {
+          externalRefJson: encodeJsonOrNull(conversation.externalRef),
+          kind: conversation.kind,
+          title: conversation.title ?? null,
+          status: conversation.status,
+          updatedAt: conversation.updatedAt,
+        },
+      });
+  }
+
+  async saveThread(thread: ConversationThread): Promise<void> {
+    await this.db
+      .insert(pgSchema.conversationThreadsPostgres)
+      .values({
+        id: thread.id,
+        appId: thread.appId,
+        conversationId: thread.conversationId,
+        externalRefJson: encodeJsonOrNull(thread.externalRef),
+        title: thread.title ?? null,
+        status: thread.status,
+        createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.conversationThreadsPostgres.id,
+        set: {
+          externalRefJson: encodeJsonOrNull(thread.externalRef),
+          title: thread.title ?? null,
+          status: thread.status,
+          updatedAt: thread.updatedAt,
+        },
+      });
+  }
+
+  private conversationFromRow(
+    row: typeof pgSchema.conversationsPostgres.$inferSelect,
+  ): Conversation {
+    return {
+      id: row.id,
+      appId: row.appId,
+      channelInstallationId: row.channelInstallationId,
+      externalRef: externalRef(row.externalRefJson, 'conversation'),
+      kind: row.kind as Conversation['kind'],
+      title: row.title ?? undefined,
+      status: row.status as Conversation['status'],
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as unknown as Conversation;
+  }
+
+  private threadFromRow(
+    row: typeof pgSchema.conversationThreadsPostgres.$inferSelect,
+  ): ConversationThread {
+    return {
+      id: row.id,
+      appId: row.appId,
+      conversationId: row.conversationId,
+      externalRef: externalRef(row.externalRefJson, 'conversation_thread'),
+      title: row.title ?? undefined,
+      status: row.status as ConversationThread['status'],
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as unknown as ConversationThread;
+  }
+}
+
+export class PostgresMessageRepository implements MessageRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getMessage(id: Message['id']): Promise<Message | null> {
+    const m = pgSchema.messagesPostgres;
+    const rows = await this.db.select().from(m).where(eq(m.id, id)).limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    const parts = await this.db
+      .select()
+      .from(pgSchema.messagePartsPostgres)
+      .where(eq(pgSchema.messagePartsPostgres.messageId, row.id))
+      .orderBy(asc(pgSchema.messagePartsPostgres.ordinal));
+    const attachments = await this.db
+      .select()
+      .from(pgSchema.messageAttachmentsPostgres)
+      .where(eq(pgSchema.messageAttachmentsPostgres.messageId, row.id))
+      .orderBy(asc(pgSchema.messageAttachmentsPostgres.id));
+    return this.messageFromRows(row, parts, attachments);
+  }
+
+  async saveMessage(message: Message): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      const c = pgSchema.conversationsPostgres;
+      const ci = pgSchema.channelInstallationsPostgres;
+      const channelRows = await tx
+        .select({
+          channelInstallationId: c.channelInstallationId,
+          providerId: ci.providerId,
+        })
+        .from(c)
+        .innerJoin(ci, eq(ci.id, c.channelInstallationId))
+        .where(eq(c.id, message.conversationId))
+        .limit(1);
+      const channel = channelRows[0];
+      if (!channel) {
+        throw new Error(
+          `Cannot save message ${message.id}: conversation ${message.conversationId} was not found`,
+        );
+      }
+
+      const externalMessageId = message.externalRef?.value ?? null;
+      let targetMessageId: Message['id'] = message.id;
+      if (externalMessageId) {
+        const duplicateRows = await tx
+          .select({ id: pgSchema.messagesPostgres.id })
+          .from(pgSchema.messagesPostgres)
+          .where(
+            and(
+              eq(pgSchema.messagesPostgres.channelProvider, channel.providerId),
+              eq(
+                pgSchema.messagesPostgres.channelInstallationId,
+                channel.channelInstallationId,
+              ),
+              eq(
+                pgSchema.messagesPostgres.conversationId,
+                message.conversationId,
+              ),
+              message.threadId
+                ? eq(pgSchema.messagesPostgres.threadId, message.threadId)
+                : isNull(pgSchema.messagesPostgres.threadId),
+              eq(
+                pgSchema.messagesPostgres.externalMessageId,
+                externalMessageId,
+              ),
+            ),
+          )
+          .limit(1);
+        targetMessageId = (duplicateRows[0]?.id ?? message.id) as Message['id'];
+      }
+
+      await tx
+        .insert(pgSchema.messagesPostgres)
+        .values({
+          id: targetMessageId,
+          appId: message.appId,
+          channelProvider: channel.providerId,
+          channelInstallationId: channel.channelInstallationId,
+          conversationId: message.conversationId,
+          threadId: message.threadId ?? null,
+          externalMessageId,
+          externalRefJson: encodeJsonOrNull(message.externalRef),
+          direction: message.direction,
+          senderUserId: message.senderUserId ?? null,
+          senderDisplayName: message.senderDisplayName ?? null,
+          trust: message.trust,
+          createdAt: message.createdAt,
+          receivedAt: message.receivedAt ?? null,
+        })
+        .onConflictDoUpdate({
+          target: pgSchema.messagesPostgres.id,
+          set: {
+            externalRefJson: encodeJsonOrNull(message.externalRef),
+            direction: message.direction,
+            senderUserId: message.senderUserId ?? null,
+            senderDisplayName: message.senderDisplayName ?? null,
+            trust: message.trust,
+            receivedAt: message.receivedAt ?? null,
+          },
+        });
+
+      await tx
+        .delete(pgSchema.messagePartsPostgres)
+        .where(eq(pgSchema.messagePartsPostgres.messageId, targetMessageId));
+      await tx
+        .delete(pgSchema.messageAttachmentsPostgres)
+        .where(
+          eq(pgSchema.messageAttachmentsPostgres.messageId, targetMessageId),
+        );
+      if (message.parts.length > 0) {
+        await tx.insert(pgSchema.messagePartsPostgres).values(
+          message.parts.map((part, ordinal) => ({
+            messageId: targetMessageId,
+            ordinal,
+            kind: part.kind,
+            payloadJson: messagePartToPayload(part),
+          })),
+        );
+      }
+      if (message.attachments.length > 0) {
+        await tx.insert(pgSchema.messageAttachmentsPostgres).values(
+          message.attachments.map((attachment) => ({
+            id: attachment.id,
+            messageId: targetMessageId,
+            kind: attachment.kind,
+            contentType: attachment.contentType ?? null,
+            sizeBytes: attachment.sizeBytes ?? null,
+            externalRefJson: encodeJsonOrNull(attachment.externalRef),
+            storageRef: attachment.storageRef ?? null,
+            trust: attachment.trust,
+          })),
+        );
+      }
+    });
+  }
+
+  async listMessages(input: {
+    conversationId: Conversation['id'];
+    threadId?: ConversationThread['id'];
+    after?: string;
+    limit?: number;
+  }): Promise<Message[]> {
+    const m = pgSchema.messagesPostgres;
+    let afterFilter: SQL | undefined;
+    if (input.after) {
+      const afterRows = await this.db
+        .select({ createdAt: m.createdAt, id: m.id })
+        .from(m)
+        .where(eq(m.id, input.after))
+        .limit(1);
+      const after = afterRows[0];
+      if (after) {
+        afterFilter = or(
+          gt(m.createdAt, after.createdAt),
+          and(eq(m.createdAt, after.createdAt), gt(m.id, after.id)),
+        );
+      }
+    }
+    const rows = await this.db
+      .select({ id: m.id })
+      .from(m)
+      .where(
+        and(
+          eq(m.conversationId, input.conversationId),
+          input.threadId ? eq(m.threadId, input.threadId) : undefined,
+          afterFilter,
+        ),
+      )
+      .orderBy(asc(m.createdAt), asc(m.id))
+      .limit(input.limit ?? 100);
+    const messages = await Promise.all(
+      rows.map((row) => this.getMessage(row.id as Message['id'])),
+    );
+    return messages.filter((message): message is Message => Boolean(message));
+  }
+
+  private messageFromRows(
+    row: typeof pgSchema.messagesPostgres.$inferSelect,
+    parts: Array<typeof pgSchema.messagePartsPostgres.$inferSelect>,
+    attachments: Array<typeof pgSchema.messageAttachmentsPostgres.$inferSelect>,
+  ): Message {
+    return {
+      id: row.id,
+      appId: row.appId,
+      conversationId: row.conversationId,
+      threadId: row.threadId ?? undefined,
+      externalRef: externalRef(
+        row.externalRefJson,
+        'message',
+        row.externalMessageId,
+      ),
+      direction: row.direction as Message['direction'],
+      senderUserId: row.senderUserId ?? undefined,
+      senderDisplayName: row.senderDisplayName ?? undefined,
+      trust: row.trust as Message['trust'],
+      createdAt: row.createdAt,
+      receivedAt: row.receivedAt ?? undefined,
+      parts: parts.map((part) =>
+        payloadToMessagePart(part.kind, part.payloadJson),
+      ),
+      attachments: attachments.map(
+        (attachment): MessageAttachment =>
+          ({
+            id: attachment.id,
+            messageId: attachment.messageId,
+            kind: attachment.kind as MessageAttachment['kind'],
+            contentType: attachment.contentType ?? undefined,
+            sizeBytes: attachment.sizeBytes ?? undefined,
+            externalRef: externalRef(
+              attachment.externalRefJson,
+              'message_attachment',
+            ),
+            storageRef: attachment.storageRef ?? undefined,
+            trust: attachment.trust as MessageAttachment['trust'],
+          }) as unknown as MessageAttachment,
+      ),
+    } as unknown as Message;
+  }
+}
+
+export class PostgresAgentSessionRepository implements AgentSessionRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getAgentSession(id: AgentSession['id']): Promise<AgentSession | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.agentSessionsPostgres)
+      .where(eq(pgSchema.agentSessionsPostgres.id, id))
+      .limit(1);
+    return rows[0] ? this.sessionFromRow(rows[0]) : null;
+  }
+
+  async getAgentSessionByKey(input: {
+    appId: App['id'];
+    agentId: Agent['id'];
+    conversationId: Conversation['id'];
+    threadId?: ConversationThread['id'];
+    userId?: string;
+  }): Promise<AgentSession | null> {
+    const s = pgSchema.agentSessionsPostgres;
+    const rows = await this.db
+      .select()
+      .from(s)
+      .where(
+        and(
+          eq(s.appId, input.appId),
+          eq(s.agentId, input.agentId),
+          eq(s.conversationId, input.conversationId),
+          input.threadId ? eq(s.threadId, input.threadId) : isNull(s.threadId),
+          input.userId ? eq(s.userId, input.userId) : isNull(s.userId),
+          isNull(s.jobId),
+        ),
+      )
+      .orderBy(desc(s.updatedAt), desc(s.id))
+      .limit(1);
+    return rows[0] ? this.sessionFromRow(rows[0]) : null;
+  }
+
+  async saveAgentSession(session: AgentSession): Promise<void> {
+    await this.db
+      .insert(pgSchema.agentSessionsPostgres)
+      .values({
+        id: session.id,
+        appId: session.appId,
+        agentId: session.agentId,
+        conversationId: session.conversationId ?? null,
+        threadId: session.threadId ?? null,
+        jobId: session.jobId ?? null,
+        userId: session.userId ?? null,
+        status: session.status,
+        modelOverride: session.modelOverride ?? null,
+        createdAt: session.createdAt,
+        updatedAt: session.updatedAt,
+        resetAt: session.resetAt ?? null,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.agentSessionsPostgres.id,
+        set: {
+          status: session.status,
+          modelOverride: session.modelOverride ?? null,
+          updatedAt: session.updatedAt,
+          resetAt: session.resetAt ?? null,
+        },
+      });
+  }
+
+  private sessionFromRow(
+    row: typeof pgSchema.agentSessionsPostgres.$inferSelect,
+  ): AgentSession {
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentId: row.agentId,
+      conversationId: row.conversationId ?? undefined,
+      threadId: row.threadId ?? undefined,
+      jobId: row.jobId ?? undefined,
+      userId: row.userId ?? undefined,
+      status: row.status as AgentSession['status'],
+      modelOverride: row.modelOverride ?? undefined,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      resetAt: row.resetAt ?? undefined,
+    } as AgentSession;
+  }
+}
+
+export class PostgresProviderSessionRepository implements ProviderSessionRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getProviderSession(
+    id: ProviderSession['id'],
+  ): Promise<ProviderSession | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.providerSessionsPostgres)
+      .where(eq(pgSchema.providerSessionsPostgres.id, id))
+      .limit(1);
+    return rows[0] ? this.providerSessionFromRow(rows[0]) : null;
+  }
+
+  async getLatestProviderSession(input: {
+    agentSessionId: AgentSession['id'];
+    provider?: string;
+  }): Promise<ProviderSession | null> {
+    const ps = pgSchema.providerSessionsPostgres;
+    const rows = await this.db
+      .select()
+      .from(ps)
+      .where(
+        and(
+          eq(ps.agentSessionId, input.agentSessionId),
+          eq(ps.status, 'active'),
+          input.provider ? eq(ps.provider, input.provider) : undefined,
+        ),
+      )
+      .orderBy(desc(ps.updatedAt), desc(ps.createdAt), desc(ps.id))
+      .limit(1);
+    return rows[0] ? this.providerSessionFromRow(rows[0]) : null;
+  }
+
+  async saveProviderSession(session: ProviderSession): Promise<void> {
+    const provider = providerFromProviderRef(session.providerRef);
+    await this.db.transaction(async (tx) => {
+      await tx
+        .insert(pgSchema.providerSessionsPostgres)
+        .values({
+          id: session.id,
+          appId: session.appId,
+          agentSessionId: session.agentSessionId,
+          provider,
+          externalSessionId: session.providerRef.value,
+          artifactRef: session.providerRef.value,
+          providerRefJson: encodeJson(session.providerRef),
+          status: session.status,
+          createdAt: session.createdAt,
+          updatedAt: session.updatedAt,
+        })
+        .onConflictDoUpdate({
+          target: pgSchema.providerSessionsPostgres.id,
+          set: {
+            provider,
+            externalSessionId: session.providerRef.value,
+            artifactRef: session.providerRef.value,
+            providerRefJson: encodeJson(session.providerRef),
+            status: session.status,
+            updatedAt: session.updatedAt,
+          },
+        });
+      await tx
+        .update(pgSchema.agentSessionsPostgres)
+        .set({
+          latestProviderSessionId: session.id,
+          updatedAt: session.updatedAt,
+        })
+        .where(eq(pgSchema.agentSessionsPostgres.id, session.agentSessionId));
+    });
+  }
+
+  private providerSessionFromRow(
+    row: typeof pgSchema.providerSessionsPostgres.$inferSelect,
+  ): ProviderSession {
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentSessionId: row.agentSessionId,
+      providerRef:
+        externalRef(
+          row.providerRefJson,
+          'provider_session',
+          row.externalSessionId,
+        ) ??
+        ({ kind: 'provider_session', value: row.externalSessionId } as const),
+      status: row.status as ProviderSession['status'],
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as ProviderSession;
+  }
+}
+
+export class PostgresAgentRunRepository implements AgentRunRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getAgentRun(id: AgentRun['id']): Promise<AgentRun | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.agentRunsPostgres)
+      .where(eq(pgSchema.agentRunsPostgres.id, id))
+      .limit(1);
+    return rows[0] ? this.runFromRow(rows[0]) : null;
+  }
+
+  async saveAgentRun(run: AgentRun): Promise<void> {
+    await this.db
+      .insert(pgSchema.agentRunsPostgres)
+      .values({
+        id: run.id,
+        appId: run.appId,
+        agentId: run.agentId,
+        configVersionId: run.configVersionId,
+        sessionId: run.sessionId ?? null,
+        conversationId: run.conversationId ?? null,
+        threadId: run.threadId ?? null,
+        messageId: run.messageId ?? null,
+        jobId: run.jobId ?? null,
+        llmProfileId: run.llmProfileId,
+        permissionDecisionIdsJson: encodeJson(run.permissionDecisionIds),
+        sandboxLeaseId: run.sandboxLeaseId ?? null,
+        workspaceSnapshotId: run.workspaceSnapshotId ?? null,
+        cause: run.cause,
+        status: run.status,
+        createdAt: run.createdAt,
+        startedAt: run.startedAt ?? null,
+        endedAt: run.endedAt ?? null,
+        resultSummary: run.resultSummary ?? null,
+        errorSummary: run.errorSummary ?? null,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.agentRunsPostgres.id,
+        set: {
+          permissionDecisionIdsJson: encodeJson(run.permissionDecisionIds),
+          sandboxLeaseId: run.sandboxLeaseId ?? null,
+          workspaceSnapshotId: run.workspaceSnapshotId ?? null,
+          status: run.status,
+          startedAt: run.startedAt ?? null,
+          endedAt: run.endedAt ?? null,
+          resultSummary: run.resultSummary ?? null,
+          errorSummary: run.errorSummary ?? null,
+        },
+      });
+  }
+
+  async appendAgentRunEvent(event: AgentRunEvent): Promise<void> {
+    await this.db.insert(pgSchema.agentRunEventsPostgres).values({
+      id: event.id,
+      appId: event.appId,
+      runId: event.runId,
+      type: event.type,
+      payloadJson: encodeJson(event.payload),
+      createdAt: event.createdAt,
+    });
+  }
+
+  async listAgentRunEvents(runId: AgentRun['id']): Promise<AgentRunEvent[]> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.agentRunEventsPostgres)
+      .where(eq(pgSchema.agentRunEventsPostgres.runId, runId))
+      .orderBy(
+        asc(pgSchema.agentRunEventsPostgres.createdAt),
+        asc(pgSchema.agentRunEventsPostgres.id),
+      );
+    return rows.map((row) => ({
+      id: row.id,
+      appId: row.appId,
+      runId: row.runId,
+      type: row.type as AgentRunEvent['type'],
+      payload: parseJson(row.payloadJson, null),
+      createdAt: row.createdAt,
+    })) as AgentRunEvent[];
+  }
+
+  private runFromRow(
+    row: typeof pgSchema.agentRunsPostgres.$inferSelect,
+  ): AgentRun {
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentId: row.agentId,
+      configVersionId: row.configVersionId,
+      sessionId: row.sessionId ?? undefined,
+      conversationId: row.conversationId ?? undefined,
+      threadId: row.threadId ?? undefined,
+      messageId: row.messageId ?? undefined,
+      jobId: row.jobId ?? undefined,
+      llmProfileId: row.llmProfileId as LlmProfileId,
+      permissionDecisionIds: parseJsonArray(row.permissionDecisionIdsJson),
+      sandboxLeaseId: row.sandboxLeaseId ?? undefined,
+      workspaceSnapshotId: row.workspaceSnapshotId ?? undefined,
+      cause: row.cause as AgentRun['cause'],
+      status: row.status as AgentRun['status'],
+      createdAt: row.createdAt,
+      startedAt: row.startedAt ?? undefined,
+      endedAt: row.endedAt ?? undefined,
+      resultSummary: row.resultSummary ?? undefined,
+      errorSummary: row.errorSummary ?? undefined,
+    } as AgentRun;
+  }
+}
+
+export class PostgresMemoryRepository implements MemoryRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getMemoryItem(id: MemoryItem['id']): Promise<MemoryItem | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.memoryItemsPostgres)
+      .where(eq(pgSchema.memoryItemsPostgres.id, id))
+      .limit(1);
+    return rows[0] ? this.memoryFromRow(rows[0]) : null;
+  }
+
+  async saveMemoryItem(item: MemoryItem): Promise<void> {
+    const fields = toMemorySubjectFields(item.subject);
+    await this.db
+      .insert(pgSchema.memoryItemsPostgres)
+      .values({
+        id: item.id,
+        appId: item.appId,
+        agentId:
+          item.agentId ??
+          (item.subject.kind === 'agent' ? item.subject.agentId : null),
+        subjectType: fields.subjectType,
+        subjectId: fields.subjectId,
+        userId: fields.userId,
+        conversationId: fields.conversationId,
+        threadId: fields.threadId,
+        kind: item.kind,
+        key: item.key,
+        valueJson: encodeJson({ value: item.value }),
+        confidence: item.confidence,
+        sourceRefJson: encodeJson({
+          source: item.source,
+          isPinned: item.isPinned,
+        }),
+        status: item.isDeleted ? 'deleted' : 'active',
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.memoryItemsPostgres.id,
+        set: {
+          valueJson: encodeJson({ value: item.value }),
+          confidence: item.confidence,
+          sourceRefJson: encodeJson({
+            source: item.source,
+            isPinned: item.isPinned,
+          }),
+          status: item.isDeleted ? 'deleted' : 'active',
+          updatedAt: item.updatedAt,
+        },
+      });
+  }
+
+  async listMemoryItems(
+    subject: MemorySubject,
+    limit = 100,
+  ): Promise<MemoryItem[]> {
+    const fields = toMemorySubjectFields(subject);
+    const rows = await this.db
+      .select()
+      .from(pgSchema.memoryItemsPostgres)
+      .where(
+        and(
+          eq(pgSchema.memoryItemsPostgres.appId, subject.appId),
+          eq(pgSchema.memoryItemsPostgres.subjectType, fields.subjectType),
+          eq(pgSchema.memoryItemsPostgres.subjectId, fields.subjectId),
+        ),
+      )
+      .orderBy(desc(pgSchema.memoryItemsPostgres.updatedAt))
+      .limit(limit);
+    return rows.map((row) => this.memoryFromRow(row));
+  }
+
+  private memoryFromRow(
+    row: typeof pgSchema.memoryItemsPostgres.$inferSelect,
+  ): MemoryItem {
+    const source = parseJson<{ source?: string; isPinned?: boolean }>(
+      row.sourceRefJson,
+      {},
+    );
+    const value = parseJson<{ value?: string }>(row.valueJson, {});
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentId: row.agentId ?? undefined,
+      subject: memorySubjectFromRow(row),
+      kind: row.kind as MemoryItem['kind'],
+      key: row.key,
+      value: String(value.value ?? ''),
+      source: source.source ?? '',
+      confidence: row.confidence,
+      isPinned: Boolean(source.isPinned),
+      isDeleted: row.status === 'deleted',
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as MemoryItem;
+  }
+}
+
+export class PostgresJobRepository implements JobRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getJob(id: Job['id']): Promise<Job | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.canonicalJobsPostgres)
+      .where(eq(pgSchema.canonicalJobsPostgres.id, id))
+      .limit(1);
+    return rows[0] ? this.jobFromRow(rows[0]) : null;
+  }
+
+  async saveJob(job: Job): Promise<void> {
+    await this.db
+      .insert(pgSchema.canonicalJobsPostgres)
+      .values({
+        id: job.id,
+        appId: job.appId,
+        agentId: job.agentId,
+        conversationId: job.target?.conversationId ?? null,
+        threadId: job.target?.threadId ?? null,
+        createdByActorId: job.target?.userId ?? 'runtime',
+        createdBySource: 'repository',
+        name: job.name,
+        prompt: job.prompt,
+        modelOverride: job.modelOverride ?? null,
+        scheduleJson: encodeJson(job.schedule),
+        status: job.status,
+        executionMode: job.executionMode,
+        targetJson: encodeJson(job.target ?? {}),
+        silent: job.silent,
+        timeoutMs: job.timeoutMs,
+        maxRetries: job.maxRetries,
+        retryBackoffMs: job.retryBackoffMs,
+        nextRunAt: job.nextRunAt ?? null,
+        lastRunAt: job.lastRunAt ?? null,
+        leaseRunId: job.leaseRunId ?? null,
+        leaseExpiresAt: job.leaseExpiresAt ?? null,
+        createdAt: job.createdAt,
+        updatedAt: job.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.canonicalJobsPostgres.id,
+        set: {
+          name: job.name,
+          prompt: job.prompt,
+          modelOverride: job.modelOverride ?? null,
+          scheduleJson: encodeJson(job.schedule),
+          status: job.status,
+          executionMode: job.executionMode,
+          targetJson: encodeJson(job.target ?? {}),
+          silent: job.silent,
+          timeoutMs: job.timeoutMs,
+          maxRetries: job.maxRetries,
+          retryBackoffMs: job.retryBackoffMs,
+          nextRunAt: job.nextRunAt ?? null,
+          lastRunAt: job.lastRunAt ?? null,
+          leaseRunId: job.leaseRunId ?? null,
+          leaseExpiresAt: job.leaseExpiresAt ?? null,
+          updatedAt: job.updatedAt,
+        },
+      });
+  }
+
+  async listJobs(appId: App['id']): Promise<Job[]> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.canonicalJobsPostgres)
+      .where(eq(pgSchema.canonicalJobsPostgres.appId, appId))
+      .orderBy(desc(pgSchema.canonicalJobsPostgres.updatedAt));
+    return rows.map((row) => this.jobFromRow(row));
+  }
+
+  async saveJobTrigger(trigger: JobTrigger): Promise<void> {
+    await this.db
+      .insert(pgSchema.canonicalJobTriggersPostgres)
+      .values({
+        id: trigger.id,
+        appId: trigger.appId,
+        jobId: trigger.jobId,
+        runId: trigger.runId ?? null,
+        requestedBy: trigger.requestedBy,
+        requestedAt: trigger.requestedAt,
+        status: trigger.status,
+        createdAt: trigger.createdAt,
+        updatedAt: trigger.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.canonicalJobTriggersPostgres.id,
+        set: {
+          runId: trigger.runId ?? null,
+          status: trigger.status,
+          updatedAt: trigger.updatedAt,
+        },
+      });
+  }
+
+  private jobFromRow(
+    row: typeof pgSchema.canonicalJobsPostgres.$inferSelect,
+  ): Job {
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentId: row.agentId ?? '',
+      name: row.name,
+      prompt: row.prompt,
+      modelOverride: row.modelOverride ?? undefined,
+      schedule: parseJson<Job['schedule']>(row.scheduleJson, {
+        kind: 'manual',
+      }),
+      status: row.status as Job['status'],
+      executionMode: row.executionMode as Job['executionMode'],
+      target: parseJson<Job['target']>(row.targetJson, undefined),
+      silent: row.silent,
+      timeoutMs: row.timeoutMs,
+      maxRetries: row.maxRetries,
+      retryBackoffMs: row.retryBackoffMs,
+      nextRunAt: row.nextRunAt ?? undefined,
+      lastRunAt: row.lastRunAt ?? undefined,
+      leaseRunId: row.leaseRunId ?? undefined,
+      leaseExpiresAt: row.leaseExpiresAt ?? undefined,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as Job;
+  }
+}
+
+export class PostgresToolCatalogRepository implements ToolCatalogRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getTool(id: ToolCatalogItem['id']): Promise<ToolCatalogItem | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.toolCatalogPostgres)
+      .where(eq(pgSchema.toolCatalogPostgres.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      appId: row.appId,
+      name: row.name,
+      description: row.description ?? undefined,
+      inputSchema: parseJson(row.inputSchemaJson, undefined),
+      outputSchema: parseJson(row.outputSchemaJson, undefined),
+      risk: row.risk as ToolCatalogItem['risk'],
+      permissionPolicyId: row.permissionPolicyId ?? undefined,
+      sandboxProfileId: row.sandboxProfileId ?? undefined,
+      adapterRef: row.adapterRef,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as ToolCatalogItem;
+  }
+
+  async saveTool(item: ToolCatalogItem): Promise<void> {
+    await this.db
+      .insert(pgSchema.toolCatalogPostgres)
+      .values({
+        id: item.id,
+        appId: item.appId,
+        name: item.name,
+        description: item.description ?? null,
+        inputSchemaJson: encodeJson(item.inputSchema ?? {}),
+        outputSchemaJson: encodeJson(item.outputSchema ?? {}),
+        risk: item.risk,
+        permissionPolicyId: item.permissionPolicyId ?? null,
+        sandboxProfileId: item.sandboxProfileId ?? null,
+        adapterRef: item.adapterRef,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.toolCatalogPostgres.id,
+        set: {
+          name: item.name,
+          description: item.description ?? null,
+          inputSchemaJson: encodeJson(item.inputSchema ?? {}),
+          outputSchemaJson: encodeJson(item.outputSchema ?? {}),
+          risk: item.risk,
+          permissionPolicyId: item.permissionPolicyId ?? null,
+          sandboxProfileId: item.sandboxProfileId ?? null,
+          adapterRef: item.adapterRef,
+          updatedAt: item.updatedAt,
+        },
+      });
+  }
+}
+
+export class PostgresSkillCatalogRepository implements SkillCatalogRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getSkill(id: SkillCatalogItem['id']): Promise<SkillCatalogItem | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.skillCatalogPostgres)
+      .where(eq(pgSchema.skillCatalogPostgres.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      appId: row.appId,
+      name: row.name,
+      description: row.description ?? undefined,
+      version: row.version,
+      promptRefs: parseJsonArray(row.promptRefsJson),
+      toolIds: parseJsonArray(row.toolIdsJson),
+      workflowRefs: parseJsonArray(row.workflowRefsJson),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as SkillCatalogItem;
+  }
+
+  async saveSkill(item: SkillCatalogItem): Promise<void> {
+    await this.db
+      .insert(pgSchema.skillCatalogPostgres)
+      .values({
+        id: item.id,
+        appId: item.appId,
+        name: item.name,
+        description: item.description ?? null,
+        version: item.version,
+        promptRefsJson: encodeJson(item.promptRefs),
+        toolIdsJson: encodeJson(item.toolIds),
+        workflowRefsJson: encodeJson(item.workflowRefs),
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.skillCatalogPostgres.id,
+        set: {
+          name: item.name,
+          description: item.description ?? null,
+          version: item.version,
+          promptRefsJson: encodeJson(item.promptRefs),
+          toolIdsJson: encodeJson(item.toolIds),
+          workflowRefsJson: encodeJson(item.workflowRefs),
+          updatedAt: item.updatedAt,
+        },
+      });
+  }
+}
+
+export class PostgresPermissionRepository implements PermissionRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async savePolicy(policy: PermissionPolicy): Promise<void> {
+    await this.db
+      .insert(pgSchema.permissionPoliciesPostgres)
+      .values(policy)
+      .onConflictDoUpdate({
+        target: pgSchema.permissionPoliciesPostgres.id,
+        set: {
+          name: policy.name,
+          description: policy.description ?? null,
+          status: policy.status,
+          updatedAt: policy.updatedAt,
+        },
+      });
+  }
+
+  async saveRule(rule: PermissionRule): Promise<void> {
+    await this.db
+      .insert(pgSchema.permissionRulesPostgres)
+      .values({
+        id: rule.id,
+        appId: rule.appId,
+        policyId: rule.policyId,
+        priority: rule.priority,
+        effect: rule.effect,
+        matchJson: encodeJson(rule.match),
+        createdAt: rule.createdAt,
+        updatedAt: rule.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.permissionRulesPostgres.id,
+        set: {
+          priority: rule.priority,
+          effect: rule.effect,
+          matchJson: encodeJson(rule.match),
+          updatedAt: rule.updatedAt,
+        },
+      });
+  }
+
+  async saveDecision(decision: PermissionDecision): Promise<void> {
+    await this.db
+      .insert(pgSchema.permissionDecisionsPostgres)
+      .values({
+        id: decision.id,
+        appId: decision.appId,
+        policyId: decision.policyId ?? null,
+        ruleIdsJson: encodeJson(decision.ruleIds),
+        runId: decision.runId ?? null,
+        toolId: decision.toolId ?? null,
+        effect: decision.effect,
+        reason: decision.reason,
+        actorContextJson: encodeJsonOrNull(decision.actorContext),
+        actionPreview: decision.actionPreview ?? null,
+        approverRef: decision.approverRef ?? null,
+        expiresAt: decision.expiresAt ?? null,
+        createdAt: decision.createdAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.permissionDecisionsPostgres.id,
+        set: {
+          policyId: decision.policyId ?? null,
+          ruleIdsJson: encodeJson(decision.ruleIds),
+          runId: decision.runId ?? null,
+          toolId: decision.toolId ?? null,
+          effect: decision.effect,
+          reason: decision.reason,
+          actorContextJson: encodeJsonOrNull(decision.actorContext),
+          actionPreview: decision.actionPreview ?? null,
+          approverRef: decision.approverRef ?? null,
+          expiresAt: decision.expiresAt ?? null,
+        },
+      });
+  }
+
+  async getDecision(
+    id: PermissionDecision['id'],
+  ): Promise<PermissionDecision | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.permissionDecisionsPostgres)
+      .where(eq(pgSchema.permissionDecisionsPostgres.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      appId: row.appId,
+      policyId: row.policyId ?? undefined,
+      ruleIds: parseJsonArray(row.ruleIdsJson),
+      runId: row.runId ?? undefined,
+      toolId: row.toolId ?? undefined,
+      effect: row.effect as PermissionDecision['effect'],
+      reason: row.reason,
+      actorContext: row.actorContextJson
+        ? parseJson<JsonRecord>(row.actorContextJson, {})
+        : undefined,
+      actionPreview: row.actionPreview ?? undefined,
+      approverRef: row.approverRef ?? undefined,
+      expiresAt: row.expiresAt ?? undefined,
+      createdAt: row.createdAt,
+    } as PermissionDecision;
+  }
+}
+
+export class PostgresSandboxRepository implements SandboxRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getSandboxProfile(
+    id: SandboxProfile['id'],
+  ): Promise<SandboxProfile | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.sandboxProfilesPostgres)
+      .where(eq(pgSchema.sandboxProfilesPostgres.id, id))
+      .limit(1);
+    return (rows[0] as SandboxProfile | undefined) ?? null;
+  }
+
+  async saveSandboxProfile(profile: SandboxProfile): Promise<void> {
+    await this.db
+      .insert(pgSchema.sandboxProfilesPostgres)
+      .values(profile)
+      .onConflictDoUpdate({
+        target: pgSchema.sandboxProfilesPostgres.id,
+        set: {
+          name: profile.name,
+          filesystem: profile.filesystem,
+          network: profile.network,
+          process: profile.process,
+          browser: profile.browser,
+          credentialAccess: profile.credentialAccess,
+          timeoutMs: profile.timeoutMs,
+          updatedAt: profile.updatedAt,
+        },
+      });
+  }
+
+  async getSandboxLease(id: SandboxLease['id']): Promise<SandboxLease | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.sandboxLeasesPostgres)
+      .where(eq(pgSchema.sandboxLeasesPostgres.id, id))
+      .limit(1);
+    return (rows[0] as SandboxLease | undefined) ?? null;
+  }
+
+  async saveSandboxLease(lease: SandboxLease): Promise<void> {
+    await this.db
+      .insert(pgSchema.sandboxLeasesPostgres)
+      .values({
+        id: lease.id,
+        appId: lease.appId,
+        profileId: lease.profileId,
+        runId: lease.runId,
+        permissionDecisionId: lease.permissionDecisionId,
+        status: lease.status,
+        grantedAt: lease.grantedAt,
+        expiresAt: lease.expiresAt,
+        releasedAt: lease.releasedAt ?? null,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.sandboxLeasesPostgres.id,
+        set: {
+          status: lease.status,
+          releasedAt: lease.releasedAt ?? null,
+        },
+      });
+  }
+
+  async saveWorkspaceSnapshot(snapshot: WorkspaceSnapshot): Promise<void> {
+    await this.db
+      .insert(pgSchema.workspaceSnapshotsPostgres)
+      .values({
+        id: snapshot.id,
+        appId: snapshot.appId,
+        rootRef: snapshot.rootRef,
+        mountsJson: encodeJson(snapshot.mounts),
+        promptRefsJson: encodeJson(snapshot.promptRefs),
+        contextRefsJson: encodeJson(snapshot.contextRefs),
+        createdAt: snapshot.createdAt,
+      })
+      .onConflictDoNothing();
+  }
+
+  async getWorkspaceSnapshot(
+    id: WorkspaceSnapshot['id'],
+  ): Promise<WorkspaceSnapshot | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.workspaceSnapshotsPostgres)
+      .where(eq(pgSchema.workspaceSnapshotsPostgres.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      appId: row.appId,
+      rootRef: row.rootRef,
+      mounts: parseJson(row.mountsJson, []),
+      promptRefs: parseJsonArray(row.promptRefsJson),
+      contextRefs: parseJsonArray(row.contextRefsJson),
+      createdAt: row.createdAt,
+    } as unknown as WorkspaceSnapshot;
+  }
+}
+
+export class PostgresBrowserProfileRepository implements BrowserProfileRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async getBrowserProfile(
+    id: BrowserProfile['id'],
+  ): Promise<BrowserProfile | null> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.browserProfilesPostgres)
+      .where(eq(pgSchema.browserProfilesPostgres.id, id))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      appId: row.appId,
+      agentId: row.agentId ?? undefined,
+      label: row.label,
+      storageStateRef: row.storageStateRef ?? undefined,
+      authMarkers: parseJsonArray(row.authMarkersJson),
+      permissionPolicyId: row.permissionPolicyId ?? undefined,
+      status: row.status as BrowserProfile['status'],
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } as BrowserProfile;
+  }
+
+  async saveBrowserProfile(profile: BrowserProfile): Promise<void> {
+    await this.db
+      .insert(pgSchema.browserProfilesPostgres)
+      .values({
+        id: profile.id,
+        appId: profile.appId,
+        agentId: profile.agentId ?? null,
+        label: profile.label,
+        storageStateRef: profile.storageStateRef ?? null,
+        authMarkersJson: encodeJson(profile.authMarkers),
+        permissionPolicyId: profile.permissionPolicyId ?? null,
+        status: profile.status,
+        createdAt: profile.createdAt,
+        updatedAt: profile.updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.browserProfilesPostgres.id,
+        set: {
+          label: profile.label,
+          storageStateRef: profile.storageStateRef ?? null,
+          authMarkersJson: encodeJson(profile.authMarkers),
+          permissionPolicyId: profile.permissionPolicyId ?? null,
+          status: profile.status,
+          updatedAt: profile.updatedAt,
+        },
+      });
+  }
+}
+
+export function createPostgresDomainRepositories(
+  db: CanonicalDb,
+): PostgresDomainRepositoryBundle {
+  return {
+    apps: new PostgresAppRepository(db),
+    agents: new PostgresAgentRepository(db),
+    agentConfigs: new PostgresAgentConfigRepository(db),
+    channelInstallations: new PostgresChannelInstallationRepository(db),
+    conversations: new PostgresConversationRepository(db),
+    messages: new PostgresMessageRepository(db),
+    agentSessions: new PostgresAgentSessionRepository(db),
+    providerSessions: new PostgresProviderSessionRepository(db),
+    agentRuns: new PostgresAgentRunRepository(db),
+    memory: new PostgresMemoryRepository(db),
+    jobs: new PostgresJobRepository(db),
+    tools: new PostgresToolCatalogRepository(db),
+    skills: new PostgresSkillCatalogRepository(db),
+    permissions: new PostgresPermissionRepository(db),
+    sandboxes: new PostgresSandboxRepository(db),
+    browserProfiles: new PostgresBrowserProfileRepository(db),
+  };
+}

--- a/apps/core/src/adapters/storage/postgres/runtime-store.ts
+++ b/apps/core/src/adapters/storage/postgres/runtime-store.ts
@@ -58,5 +58,6 @@ export function _setRuntimeOpsRepositoryForTest(ops: OpsRepository): void {
     } as StorageRuntime['service'],
     ops,
     control: {} as StorageRuntime['control'],
+    repositories: {} as StorageRuntime['repositories'],
   };
 }

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0010_repository_contract_indexes.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0010_repository_contract_indexes.sql
@@ -1,0 +1,26 @@
+-- Repository contract support for canonical Postgres adapters.
+
+ALTER TABLE permission_decisions
+  ADD COLUMN IF NOT EXISTS actor_context_json text,
+  ADD COLUMN IF NOT EXISTS action_preview text;
+
+DROP INDEX IF EXISTS idx_messages_external_redelivery_unique;
+CREATE UNIQUE INDEX idx_messages_external_redelivery_unique
+  ON messages(
+    channel_provider,
+    channel_installation_id,
+    conversation_id,
+    COALESCE(thread_id, ''),
+    external_message_id
+  )
+  WHERE external_message_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_sessions_deterministic_key
+  ON agent_sessions(
+    app_id,
+    agent_id,
+    COALESCE(conversation_id, ''),
+    COALESCE(thread_id, ''),
+    COALESCE(user_id, '')
+  )
+  WHERE job_id IS NULL;

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777018200000,
       "tag": "0009_canonical_persistence_adapter_cut",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777021800000,
+      "tag": "0010_repository_contract_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/adapters/storage/postgres/schema/permissions.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/permissions.ts
@@ -50,6 +50,8 @@ export const permissionDecisionsPostgres = pgTable('permission_decisions', {
   toolId: text('tool_id').references(() => toolCatalogPostgres.id),
   effect: text('effect').notNull(),
   reason: text('reason').notNull(),
+  actorContextJson: text('actor_context_json'),
+  actionPreview: text('action_preview'),
   approverRef: text('approver_ref'),
   expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'string' }),
   createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })

--- a/apps/core/src/domain/permissions/permissions.ts
+++ b/apps/core/src/domain/permissions/permissions.ts
@@ -44,6 +44,8 @@ export interface PermissionDecision {
   toolId?: ToolId;
   effect: PermissionEffect;
   reason: string;
+  actorContext?: Record<string, unknown>;
+  actionPreview?: string;
   approverRef?: string;
   expiresAt?: IsoTimestamp;
   createdAt: IsoTimestamp;

--- a/apps/core/src/domain/ports/repositories.ts
+++ b/apps/core/src/domain/ports/repositories.ts
@@ -10,12 +10,15 @@ import type {
   AgentChannelBinding,
   ChannelInstallation,
   ChannelInstallationId,
+  ChannelProviderId,
 } from '../channel/channel.js';
 import type {
   Conversation,
   ConversationId,
   ConversationThread,
   ConversationThreadId,
+  ExternalConversationId,
+  UserId,
 } from '../conversation/conversation.js';
 import type { AgentRun, AgentRunEvent, AgentRunId } from '../events/events.js';
 import type { Job, JobId, JobTrigger } from '../jobs/jobs.js';
@@ -72,12 +75,36 @@ export interface ChannelInstallationRepository {
   ): Promise<ChannelInstallation | null>;
   saveChannelInstallation(installation: ChannelInstallation): Promise<void>;
   saveAgentChannelBinding(binding: AgentChannelBinding): Promise<void>;
+  getAgentChannelBinding(input: {
+    appId: AppId;
+    agentId: AgentId;
+    conversationId: ConversationId;
+    threadId?: ConversationThreadId;
+  }): Promise<AgentChannelBinding | null>;
+  isAgentEnabledInConversation(input: {
+    appId: AppId;
+    agentId: AgentId;
+    conversationId: ConversationId;
+    threadId?: ConversationThreadId;
+  }): Promise<boolean>;
   listAgentChannelBindings(appId: AppId): Promise<AgentChannelBinding[]>;
 }
 
 export interface ConversationRepository {
   getConversation(id: ConversationId): Promise<Conversation | null>;
+  getConversationByExternalRef(input: {
+    appId: AppId;
+    providerId: ChannelProviderId;
+    channelInstallationId: ChannelInstallationId;
+    externalConversationId: ExternalConversationId | string;
+  }): Promise<Conversation | null>;
   getThread(id: ConversationThreadId): Promise<ConversationThread | null>;
+  getThreadByExternalRef(input: {
+    appId: AppId;
+    providerId: ChannelProviderId;
+    conversationId: ConversationId;
+    externalThreadId: string;
+  }): Promise<ConversationThread | null>;
   saveConversation(conversation: Conversation): Promise<void>;
   saveThread(thread: ConversationThread): Promise<void>;
 }
@@ -95,11 +122,22 @@ export interface MessageRepository {
 
 export interface AgentSessionRepository {
   getAgentSession(id: AgentSessionId): Promise<AgentSession | null>;
+  getAgentSessionByKey(input: {
+    appId: AppId;
+    agentId: AgentId;
+    conversationId: ConversationId;
+    threadId?: ConversationThreadId;
+    userId?: UserId;
+  }): Promise<AgentSession | null>;
   saveAgentSession(session: AgentSession): Promise<void>;
 }
 
 export interface ProviderSessionRepository {
   getProviderSession(id: ProviderSessionId): Promise<ProviderSession | null>;
+  getLatestProviderSession(input: {
+    agentSessionId: AgentSessionId;
+    provider?: string;
+  }): Promise<ProviderSession | null>;
   saveProviderSession(session: ProviderSession): Promise<void>;
 }
 

--- a/apps/core/test/integration/postgres-domain-repositories.integration.test.ts
+++ b/apps/core/test/integration/postgres-domain-repositories.integration.test.ts
@@ -1,0 +1,329 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createPostgresDomainRepositories,
+  type PostgresDomainRepositoryBundle,
+} from '@core/adapters/storage/postgres/repositories/domain-repositories.postgres.js';
+import {
+  PostgresStorageService,
+  quotePostgresIdentifier,
+} from '@core/adapters/storage/postgres/storage-service.js';
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_APP_ID,
+  DEFAULT_LLM_PROFILE_ID,
+  DEFAULT_PERMISSION_POLICY_ID,
+} from '@core/adapters/storage/postgres/seeds.js';
+import type { AgentId } from '@core/domain/agent/agent.js';
+import type { AppId } from '@core/domain/app/app.js';
+import type {
+  ChannelInstallationId,
+  ChannelProviderId,
+} from '@core/domain/channel/channel.js';
+import type {
+  ConversationId,
+  ConversationThreadId,
+  UserId,
+} from '@core/domain/conversation/conversation.js';
+import type {
+  AgentRunEventId,
+  AgentRunId,
+} from '@core/domain/events/events.js';
+import type { MessageId } from '@core/domain/messages/messages.js';
+import type { PermissionDecisionId } from '@core/domain/permissions/permissions.js';
+import type {
+  AgentSessionId,
+  ProviderSessionId,
+} from '@core/domain/sessions/sessions.js';
+
+const maybeDescribe = process.env.MYCLAW_TEST_DATABASE_URL
+  ? describe
+  : describe.skip;
+
+const appId = DEFAULT_APP_ID as AppId;
+const agentId = DEFAULT_AGENT_ID as AgentId;
+const providerId = 'slack' as ChannelProviderId;
+const installationId =
+  'channel-installation:test:slack' as ChannelInstallationId;
+const conversationId = 'conversation:test:slack:C123' as ConversationId;
+const threadId = 'thread:test:slack:C123:1700.1' as ConversationThreadId;
+const userId = 'user:test:U123' as UserId;
+const now = '2026-04-27T00:00:00.000Z';
+
+maybeDescribe('Postgres domain repositories', () => {
+  let service: PostgresStorageService;
+  let repositories: PostgresDomainRepositoryBundle;
+  let schemaName: string;
+
+  beforeAll(async () => {
+    schemaName = `repo_test_${process.pid}_${Date.now()}`;
+    service = new PostgresStorageService(
+      process.env.MYCLAW_TEST_DATABASE_URL ?? '',
+      schemaName,
+    );
+    await service.migrate();
+    repositories = createPostgresDomainRepositories(service.db);
+
+    await repositories.channelInstallations.saveChannelInstallation({
+      id: installationId,
+      appId,
+      providerId,
+      externalInstallationRef: {
+        kind: 'channel_installation',
+        value: 'T123',
+      },
+      label: 'Test Slack',
+      status: 'active',
+      runtimeSecretRefs: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+    await repositories.conversations.saveConversation({
+      id: conversationId,
+      appId,
+      channelInstallationId: installationId,
+      externalRef: { kind: 'conversation', value: 'C123' },
+      kind: 'channel',
+      title: 'engineering',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    });
+    await repositories.conversations.saveThread({
+      id: threadId,
+      appId,
+      conversationId,
+      externalRef: { kind: 'conversation_thread', value: '1700.1' },
+      title: 'incident',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (!service) return;
+    await service.pool.query(
+      `DROP SCHEMA IF EXISTS ${quotePostgresIdentifier(schemaName)} CASCADE`,
+    );
+    await service.close();
+  });
+
+  it('finds conversations and threads by provider external references', async () => {
+    await expect(
+      repositories.conversations.getConversationByExternalRef({
+        appId,
+        providerId,
+        channelInstallationId: installationId,
+        externalConversationId: 'C123',
+      }),
+    ).resolves.toMatchObject({ id: conversationId });
+
+    await expect(
+      repositories.conversations.getThreadByExternalRef({
+        appId,
+        providerId,
+        conversationId,
+        externalThreadId: '1700.1',
+      }),
+    ).resolves.toMatchObject({ id: threadId });
+  });
+
+  it('inserts messages idempotently by provider redelivery key', async () => {
+    await repositories.messages.saveMessage({
+      id: 'message:test:first' as MessageId,
+      appId,
+      conversationId,
+      externalRef: { kind: 'message', value: 'evt-1' },
+      direction: 'inbound',
+      senderUserId: userId,
+      senderDisplayName: 'Ravi',
+      trust: 'trusted',
+      createdAt: '2026-04-27T00:01:00.000Z',
+      receivedAt: '2026-04-27T00:01:01.000Z',
+      parts: [{ kind: 'text', text: 'hello' }],
+      attachments: [],
+    });
+    await repositories.messages.saveMessage({
+      id: 'message:test:redelivery' as MessageId,
+      appId,
+      conversationId,
+      externalRef: { kind: 'message', value: 'evt-1' },
+      direction: 'inbound',
+      senderUserId: userId,
+      senderDisplayName: 'Ravi',
+      trust: 'trusted',
+      createdAt: '2026-04-27T00:01:00.000Z',
+      receivedAt: '2026-04-27T00:01:02.000Z',
+      parts: [{ kind: 'text', text: 'hello redelivered' }],
+      attachments: [],
+    });
+
+    const messages = await repositories.messages.listMessages({
+      conversationId,
+      limit: 10,
+    });
+    const matching = messages.filter(
+      (message) => message.externalRef?.value === 'evt-1',
+    );
+    expect(matching).toHaveLength(1);
+    expect(matching[0]?.id).toBe('message:test:first');
+    expect(matching[0]?.parts).toEqual([
+      { kind: 'text', text: 'hello redelivered' },
+    ]);
+  });
+
+  it('looks up deterministic agent sessions and latest provider sessions', async () => {
+    const sessionId = 'agent-session:test:conversation' as AgentSessionId;
+    await repositories.agentSessions.saveAgentSession({
+      id: sessionId,
+      appId,
+      agentId,
+      conversationId,
+      threadId,
+      userId,
+      status: 'active',
+      modelOverride: 'opus',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await expect(
+      repositories.agentSessions.getAgentSessionByKey({
+        appId,
+        agentId,
+        conversationId,
+        threadId,
+        userId,
+      }),
+    ).resolves.toMatchObject({ id: sessionId, modelOverride: 'opus' });
+
+    await repositories.providerSessions.saveProviderSession({
+      id: 'provider-session:test:older' as ProviderSessionId,
+      appId,
+      agentSessionId: sessionId,
+      providerRef: { kind: 'provider_session', value: 'anthropic:older' },
+      status: 'active',
+      createdAt: '2026-04-27T00:02:00.000Z',
+      updatedAt: '2026-04-27T00:02:00.000Z',
+    });
+    await repositories.providerSessions.saveProviderSession({
+      id: 'provider-session:test:newer' as ProviderSessionId,
+      appId,
+      agentSessionId: sessionId,
+      providerRef: { kind: 'provider_session', value: 'anthropic:newer' },
+      status: 'active',
+      createdAt: '2026-04-27T00:03:00.000Z',
+      updatedAt: '2026-04-27T00:03:00.000Z',
+    });
+
+    await expect(
+      repositories.providerSessions.getLatestProviderSession({
+        agentSessionId: sessionId,
+        provider: 'anthropic',
+      }),
+    ).resolves.toMatchObject({
+      id: 'provider-session:test:newer',
+      providerRef: { kind: 'provider_session', value: 'anthropic:newer' },
+    });
+  });
+
+  it('appends run events and reads them in cursor order', async () => {
+    const runId = 'agent-run:test:1' as AgentRunId;
+    await repositories.agentRuns.saveAgentRun({
+      id: runId,
+      appId,
+      agentId,
+      configVersionId: `config:${DEFAULT_AGENT_ID}:1`,
+      conversationId,
+      threadId,
+      llmProfileId: DEFAULT_LLM_PROFILE_ID,
+      permissionDecisionIds: [],
+      cause: 'message',
+      status: 'running',
+      createdAt: '2026-04-27T00:04:00.000Z',
+      startedAt: '2026-04-27T00:04:01.000Z',
+    });
+
+    await repositories.agentRuns.appendAgentRunEvent({
+      id: 'agent-run-event:test:2' as AgentRunEventId,
+      appId,
+      runId,
+      type: 'output_chunk',
+      payload: { text: 'second' },
+      createdAt: '2026-04-27T00:04:03.000Z',
+    });
+    await repositories.agentRuns.appendAgentRunEvent({
+      id: 'agent-run-event:test:1' as AgentRunEventId,
+      appId,
+      runId,
+      type: 'started',
+      payload: { text: 'first' },
+      createdAt: '2026-04-27T00:04:02.000Z',
+    });
+
+    await expect(
+      repositories.agentRuns.listAgentRunEvents(runId),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: 'agent-run-event:test:1' }),
+      expect.objectContaining({ id: 'agent-run-event:test:2' }),
+    ]);
+  });
+
+  it('answers agent-channel binding enablement for conversations and threads', async () => {
+    await repositories.channelInstallations.saveAgentChannelBinding({
+      id: 'agent-channel-binding:test:conversation',
+      appId,
+      agentId,
+      channelInstallationId: installationId,
+      conversationId,
+      displayName: 'Personal Agent',
+      requiresTrigger: false,
+      isAdminBinding: false,
+      memorySubject: { kind: 'conversation', appId, conversationId },
+      permissionPolicyIds: [DEFAULT_PERMISSION_POLICY_ID],
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await expect(
+      repositories.channelInstallations.isAgentEnabledInConversation({
+        appId,
+        agentId,
+        conversationId,
+        threadId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it('persists permission decisions with audit context', async () => {
+    const decisionId = 'permission-decision:test:1' as PermissionDecisionId;
+    await repositories.permissions.saveDecision({
+      id: decisionId,
+      appId,
+      policyId: DEFAULT_PERMISSION_POLICY_ID,
+      ruleIds: ['permission-rule:default:approval-required'],
+      effect: 'require_approval',
+      reason: 'Write operation needs approval',
+      actorContext: {
+        provider: 'slack',
+        userId: 'U123',
+      },
+      actionPreview: 'write file /tmp/example',
+      createdAt: '2026-04-27T00:05:00.000Z',
+    });
+
+    await expect(
+      repositories.permissions.getDecision(decisionId),
+    ).resolves.toMatchObject({
+      id: decisionId,
+      reason: 'Write operation needs approval',
+      ruleIds: ['permission-rule:default:approval-required'],
+      actorContext: {
+        provider: 'slack',
+        userId: 'U123',
+      },
+      actionPreview: 'write file /tmp/example',
+    });
+  });
+});

--- a/apps/core/test/unit/domain/canonical-domain.test.ts
+++ b/apps/core/test/unit/domain/canonical-domain.test.ts
@@ -31,6 +31,21 @@ describe('canonical Postgres persistence cut', () => {
     ).toBe(false);
   });
 
+  it('keeps application services behind repository ports', () => {
+    const root = path.resolve('apps/core/src/application');
+    const files = fs
+      .readdirSync(root, { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'));
+
+    for (const file of files) {
+      const filePath = path.join(file.parentPath, file.name);
+      const source = fs.readFileSync(filePath, 'utf8');
+      expect(source).not.toMatch(
+        /from ['"].*adapters\/storage\/postgres\/schema/,
+      );
+    }
+  });
+
   it('splits active schema by canonical responsibility', () => {
     for (const file of [
       'apps',
@@ -96,6 +111,31 @@ describe('canonical Postgres persistence cut', () => {
     expect(schema).toContain("externalMessageId: text('external_message_id')");
     expect(migration).toContain('idx_messages_external_redelivery_unique');
     expect(migration).toContain('WHERE external_message_id IS NOT NULL');
+  });
+
+  it('records repository contract indexes and permission audit context', () => {
+    const migration = fs.readFileSync(
+      path.join(
+        adapterRoot,
+        'schema/migrations/0010_repository_contract_indexes.sql',
+      ),
+      'utf8',
+    );
+    const permissionsSchema = fs.readFileSync(
+      path.join(adapterRoot, 'schema/permissions.ts'),
+      'utf8',
+    );
+
+    expect(migration).toContain('actor_context_json');
+    expect(migration).toContain('action_preview');
+    expect(migration).toContain("COALESCE(thread_id, '')");
+    expect(migration).toContain('idx_agent_sessions_deterministic_key');
+    expect(permissionsSchema).toContain(
+      "actorContextJson: text('actor_context_json')",
+    );
+    expect(permissionsSchema).toContain(
+      "actionPreview: text('action_preview')",
+    );
   });
 
   it('keeps sessions provider-neutral and provider resume metadata explicit', () => {


### PR DESCRIPTION
## Summary

- add canonical domain-port Postgres repository adapters and wire them from the storage factory
- extend repository ports for external conversation/thread lookup, deterministic session lookup, provider-session latest lookup, and agent-channel enabled checks
- add permission decision audit context persistence plus migration/index support for idempotent messages and deterministic sessions
- add repository integration coverage with MYCLAW_TEST_DATABASE_URL gating and unit architecture assertions for application schema imports

## Validation

- npm run typecheck
- npm run test:unit -- apps/core/test/unit/domain/canonical-domain.test.ts
- npm run test:integration (DB-backed repository tests skipped because MYCLAW_TEST_DATABASE_URL is not configured)
- npm test
- npm run build
- single-file eslint for apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts

## Known follow-up

- python3 .codex/scripts/verify.py still fails at the existing repository-wide architecture backlog in check_architecture.py. The new adapter file has no single-file lint failure, but the global architecture gate remains red from pre-existing layer/provider/old-term findings.
