### PR TITLE
[codex] Persist durable chat messages

### DIFF
--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
@@ -29,6 +29,11 @@ export function providerIdForJid(jid: string): string {
   return idx > 0 ? jid.slice(0, idx) : 'app';
 }
 
+export function externalConversationIdForJid(jid: string): string {
+  const idx = jid.indexOf(':');
+  return idx > 0 ? jid.slice(idx + 1) : jid;
+}
+
 export function conversationIdForJid(jid: string): string {
   return `conversation:${jid}`;
 }
@@ -141,9 +146,13 @@ export class PostgresCanonicalGraphRepository {
     const title = input.name || jid;
     const now = input.timestamp || currentIso();
     const hasKnownKind = input.isGroup !== undefined && input.isGroup !== null;
+    const externalConversationId = externalConversationIdForJid(jid);
     const externalRefJson = json({
+      kind: 'conversation',
+      value: externalConversationId,
       jid,
       providerId,
+      externalConversationId,
       ...(hasKnownKind ? { isGroup: Boolean(input.isGroup) } : {}),
     });
     await executor
@@ -187,20 +196,117 @@ export class PostgresCanonicalGraphRepository {
     chatJid: string,
     threadId?: string | null,
     executor: CanonicalExecutor = this.db,
+    input: { channel?: string | null } = {},
   ): Promise<string | null> {
     const canonicalThreadId = threadIdFor(chatJid, threadId);
     if (!canonicalThreadId) return null;
-    const conversationId = await this.ensureConversation(chatJid, {}, executor);
+    const conversationId = await this.ensureConversation(
+      chatJid,
+      { channel: input.channel },
+      executor,
+    );
     await executor
       .insert(pgSchema.conversationThreadsPostgres)
       .values({
         id: canonicalThreadId,
         appId: CANONICAL_APP_ID,
         conversationId,
-        externalRefJson: json({ jid: chatJid, threadId }),
+        externalRefJson: json({
+          kind: 'conversation_thread',
+          value: threadId,
+          jid: chatJid,
+          threadId,
+          externalThreadId: threadId,
+        }),
       })
       .onConflictDoNothing();
     return canonicalThreadId;
+  }
+
+  async ensureParticipant(
+    input: {
+      conversationId: string;
+      providerId: string;
+      channelInstallationId: string;
+      externalUserId: string;
+      displayName?: string | null;
+      timestamp?: string | null;
+    },
+    executor: CanonicalExecutor = this.db,
+  ): Promise<string | null> {
+    const externalUserId = input.externalUserId.trim();
+    if (!externalUserId) return null;
+    const safeProvider = input.providerId.replace(/[^a-zA-Z0-9._:-]/g, '_');
+    const safeUser = externalUserId.replace(/[^a-zA-Z0-9._:-]/g, '_');
+    const userId = `user:${CANONICAL_APP_ID}:${safeProvider}:${safeUser}`;
+    const aliasId = `user-alias:${CANONICAL_APP_ID}:${safeProvider}:${input.channelInstallationId}:${safeUser}`;
+    const participantId = `participant:${input.conversationId}:${safeUser}`;
+    const now = input.timestamp || currentIso();
+    const displayName = input.displayName
+      ? `${input.displayName} (${input.providerId}:${externalUserId})`
+      : `${input.providerId}:${externalUserId}`;
+    await executor
+      .insert(pgSchema.usersPostgres)
+      .values({
+        id: userId,
+        appId: CANONICAL_APP_ID,
+        kind: 'human',
+        displayName,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.usersPostgres.id,
+        set: {
+          displayName,
+          updatedAt: now,
+        },
+      });
+    await executor
+      .insert(pgSchema.userAliasesPostgres)
+      .values({
+        id: aliasId,
+        appId: CANONICAL_APP_ID,
+        userId,
+        provider: input.providerId,
+        channelInstallationId: input.channelInstallationId,
+        externalUserId,
+        displayName: input.displayName ?? externalUserId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.userAliasesPostgres.id,
+        set: {
+          userId,
+          displayName: input.displayName ?? externalUserId,
+          updatedAt: now,
+        },
+      });
+    await executor
+      .insert(pgSchema.conversationParticipantsPostgres)
+      .values({
+        id: participantId,
+        appId: CANONICAL_APP_ID,
+        conversationId: input.conversationId,
+        userId,
+        externalUserId,
+        role: 'member',
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: pgSchema.conversationParticipantsPostgres.id,
+        set: {
+          userId,
+          externalUserId,
+          status: 'active',
+          updatedAt: now,
+        },
+      });
+    return userId;
   }
 
   async listChats(): Promise<ChatInfo[]> {

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
@@ -23,6 +23,9 @@ export interface CanonicalOpsMessageRow {
   trust: string;
   created_at: string;
   received_at: string | null;
+  delivery_status: string | null;
+  delivered_at: string | null;
+  delivery_error: string | null;
   payload_json: string | null;
 }
 
@@ -39,10 +42,13 @@ export class PostgresCanonicalMessageRepository {
 
   async saveMessage(msg: NewMessage): Promise<void> {
     await this.db.transaction(async (tx) => {
+      const channelProvider =
+        msg.channel_provider ?? providerIdForJid(msg.chat_jid);
       const conversationId = await this.graph.ensureConversation(
         msg.chat_jid,
         {
           timestamp: msg.timestamp,
+          channel: channelProvider,
         },
         tx,
       );
@@ -50,14 +56,28 @@ export class PostgresCanonicalMessageRepository {
         msg.chat_jid,
         msg.thread_id,
         tx,
+        { channel: channelProvider },
       );
-      const channelProvider = providerIdForJid(msg.chat_jid);
       const channelInstallationId =
         (await this.graph.getConversationInstallationId(conversationId, tx)) ??
         `channel-installation:${CANONICAL_APP_ID}:${channelProvider}`;
       const canonicalMessageId = messageIdFor(msg.chat_jid, msg.id);
       const direction =
         msg.is_from_me || msg.is_bot_message ? 'outbound' : 'inbound';
+      const externalMessageId =
+        msg.external_message_id ??
+        (direction === 'inbound' ? msg.id || null : null);
+      const senderUserId = await this.graph.ensureParticipant(
+        {
+          conversationId,
+          providerId: channelProvider,
+          channelInstallationId,
+          externalUserId: msg.sender,
+          displayName: msg.sender_name,
+          timestamp: msg.timestamp,
+        },
+        tx,
+      );
       await tx
         .insert(pgSchema.messagesPostgres)
         .values({
@@ -67,23 +87,30 @@ export class PostgresCanonicalMessageRepository {
           channelInstallationId,
           conversationId,
           threadId: canonicalThreadId,
-          externalMessageId: msg.id || null,
+          externalMessageId,
           externalRefJson: json(msg),
           direction,
-          senderUserId: msg.sender,
+          senderUserId: senderUserId ?? msg.sender,
           senderDisplayName: msg.sender_name,
           trust: msg.is_bot_message ? 'system' : 'trusted',
           createdAt: msg.timestamp,
           receivedAt: msg.timestamp,
+          deliveryStatus: msg.delivery_status ?? null,
+          deliveredAt: msg.delivered_at ?? null,
+          deliveryError: msg.delivery_error ?? null,
         })
         .onConflictDoUpdate({
           target: pgSchema.messagesPostgres.id,
           set: {
+            externalMessageId,
             externalRefJson: json(msg),
             direction,
-            senderUserId: msg.sender,
+            senderUserId: senderUserId ?? msg.sender,
             senderDisplayName: msg.sender_name,
             trust: msg.is_bot_message ? 'system' : 'trusted',
+            deliveryStatus: msg.delivery_status ?? null,
+            deliveredAt: msg.delivered_at ?? null,
+            deliveryError: msg.delivery_error ?? null,
           },
         });
       await tx
@@ -104,6 +131,32 @@ export class PostgresCanonicalMessageRepository {
             payloadJson: sql`excluded.payload_json`,
           },
         });
+      await tx
+        .delete(pgSchema.messageAttachmentsPostgres)
+        .where(
+          eq(pgSchema.messageAttachmentsPostgres.messageId, canonicalMessageId),
+        );
+      if (msg.attachments && msg.attachments.length > 0) {
+        await tx.insert(pgSchema.messageAttachmentsPostgres).values(
+          msg.attachments.map((attachment, index) => ({
+            id:
+              attachment.id ??
+              `message-attachment:${canonicalMessageId}:${index}`,
+            messageId: canonicalMessageId,
+            kind: attachment.kind,
+            contentType: attachment.contentType ?? null,
+            sizeBytes: attachment.sizeBytes ?? null,
+            externalRefJson: attachment.externalId
+              ? json({
+                  kind: 'message_attachment',
+                  value: attachment.externalId,
+                })
+              : null,
+            storageRef: attachment.storageRef ?? null,
+            trust: msg.is_bot_message ? 'system' : 'trusted',
+          })),
+        );
+      }
     });
   }
 
@@ -170,6 +223,9 @@ export class PostgresCanonicalMessageRepository {
         trust: m.trust,
         created_at: m.createdAt,
         received_at: m.receivedAt,
+        delivery_status: m.deliveryStatus,
+        delivered_at: m.deliveredAt,
+        delivery_error: m.deliveryError,
         payload_json: firstPart.payloadJson,
       })
       .from(m)
@@ -222,6 +278,9 @@ export class PostgresCanonicalMessageRepository {
         trust: m.trust,
         created_at: m.createdAt,
         received_at: m.receivedAt,
+        delivery_status: m.deliveryStatus,
+        delivered_at: m.deliveredAt,
+        delivery_error: m.deliveryError,
         payload_json: p.payloadJson,
       })
       .from(m)

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
@@ -67,17 +67,19 @@ export class PostgresCanonicalMessageRepository {
       const externalMessageId =
         msg.external_message_id ??
         (direction === 'inbound' ? msg.id || null : null);
-      const senderUserId = await this.graph.ensureParticipant(
-        {
-          conversationId,
-          providerId: channelProvider,
-          channelInstallationId,
-          externalUserId: msg.sender,
-          displayName: msg.sender_name,
-          timestamp: msg.timestamp,
-        },
-        tx,
-      );
+      if (direction === 'inbound') {
+        await this.graph.ensureParticipant(
+          {
+            conversationId,
+            providerId: channelProvider,
+            channelInstallationId,
+            externalUserId: msg.sender,
+            displayName: msg.sender_name,
+            timestamp: msg.timestamp,
+          },
+          tx,
+        );
+      }
       await tx
         .insert(pgSchema.messagesPostgres)
         .values({
@@ -90,7 +92,7 @@ export class PostgresCanonicalMessageRepository {
           externalMessageId,
           externalRefJson: json(msg),
           direction,
-          senderUserId: senderUserId ?? msg.sender,
+          senderUserId: msg.sender,
           senderDisplayName: msg.sender_name,
           trust: msg.is_bot_message ? 'system' : 'trusted',
           createdAt: msg.timestamp,
@@ -105,7 +107,7 @@ export class PostgresCanonicalMessageRepository {
             externalMessageId,
             externalRefJson: json(msg),
             direction,
-            senderUserId: senderUserId ?? msg.sender,
+            senderUserId: msg.sender,
             senderDisplayName: msg.sender_name,
             trust: msg.is_bot_message ? 'system' : 'trusted',
             deliveryStatus: msg.delivery_status ?? null,

--- a/apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts
@@ -900,16 +900,23 @@ export class PostgresMessageRepository implements MessageRepository {
           trust: message.trust,
           createdAt: message.createdAt,
           receivedAt: message.receivedAt ?? null,
+          deliveryStatus: message.deliveryStatus ?? null,
+          deliveredAt: message.deliveredAt ?? null,
+          deliveryError: message.deliveryError ?? null,
         })
         .onConflictDoUpdate({
           target: pgSchema.messagesPostgres.id,
           set: {
+            externalMessageId,
             externalRefJson: encodeJsonOrNull(message.externalRef),
             direction: message.direction,
             senderUserId: message.senderUserId ?? null,
             senderDisplayName: message.senderDisplayName ?? null,
             trust: message.trust,
             receivedAt: message.receivedAt ?? null,
+            deliveryStatus: message.deliveryStatus ?? null,
+            deliveredAt: message.deliveredAt ?? null,
+            deliveryError: message.deliveryError ?? null,
           },
         });
 
@@ -1048,6 +1055,9 @@ export class PostgresMessageRepository implements MessageRepository {
       trust: row.trust as Message['trust'],
       createdAt: row.createdAt,
       receivedAt: row.receivedAt ?? undefined,
+      deliveryStatus: row.deliveryStatus ?? undefined,
+      deliveredAt: row.deliveredAt ?? undefined,
+      deliveryError: row.deliveryError ?? undefined,
       parts: parts.map((part) =>
         payloadToMessagePart(part.kind, part.payloadJson),
       ),

--- a/apps/core/src/adapters/storage/postgres/schema/messages.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/messages.ts
@@ -50,6 +50,12 @@ export const messagesPostgres = pgTable(
       withTimezone: true,
       mode: 'string',
     }),
+    deliveryStatus: text('delivery_status'),
+    deliveredAt: timestamp('delivered_at', {
+      withTimezone: true,
+      mode: 'string',
+    }),
+    deliveryError: text('delivery_error'),
   },
   (table) => ({
     conversationCursorIdx: index('idx_messages_conversation_cursor').on(

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0011_message_delivery_status.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0011_message_delivery_status.sql
@@ -1,0 +1,7 @@
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS delivery_status text,
+  ADD COLUMN IF NOT EXISTS delivered_at timestamptz,
+  ADD COLUMN IF NOT EXISTS delivery_error text;
+
+CREATE INDEX IF NOT EXISTS idx_messages_delivery_status
+  ON messages(delivery_status, delivered_at);

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777021800000,
       "tag": "0010_repository_contract_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777025400000,
+      "tag": "0011_message_delivery_status",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/adapters/storage/postgres/services/canonical-message-ops-service.ts
+++ b/apps/core/src/adapters/storage/postgres/services/canonical-message-ops-service.ts
@@ -104,6 +104,12 @@ export class CanonicalMessageOpsService {
       reply_to_message_id: ref.reply_to_message_id,
       reply_to_message_content: ref.reply_to_message_content,
       reply_to_sender_name: ref.reply_to_sender_name,
+      external_message_id: ref.external_message_id,
+      delivery_status:
+        ref.delivery_status ??
+        (row.delivery_status as NewMessage['delivery_status']),
+      delivered_at: ref.delivered_at ?? row.delivered_at ?? undefined,
+      delivery_error: ref.delivery_error ?? row.delivery_error ?? undefined,
     };
   }
 }

--- a/apps/core/src/app/bootstrap/channel-persistence-handlers.ts
+++ b/apps/core/src/app/bootstrap/channel-persistence-handlers.ts
@@ -13,6 +13,33 @@ interface ChannelPersistenceHandlerDeps {
   persistenceQueue: AsyncTaskQueue;
 }
 
+async function enqueueAndWait(
+  queue: AsyncTaskQueue,
+  task: () => Promise<void>,
+  onFull: () => void,
+): Promise<void> {
+  let resolveCompletion!: () => void;
+  let rejectCompletion!: (err: unknown) => void;
+  const completion = new Promise<void>((resolve, reject) => {
+    resolveCompletion = resolve;
+    rejectCompletion = reject;
+  });
+  const wrapped = async () => {
+    try {
+      await task();
+      resolveCompletion();
+    } catch (err) {
+      rejectCompletion(err);
+    }
+  };
+  const admitted = queue.enqueue(wrapped);
+  if (!admitted) {
+    onFull();
+    await queue.enqueueWhenAvailable(wrapped);
+  }
+  await completion;
+}
+
 export function createChannelPersistenceHandlers({
   app,
   resolved,
@@ -81,16 +108,15 @@ export function createChannelPersistenceHandlers({
           await ops().storeMessage(msg);
         } catch (err) {
           resolved.logger.error({ err, chatJid }, 'Failed to store message');
+          throw err;
         }
       };
-      const admitted = persistenceQueue.enqueue(persistMessage);
-      if (!admitted) {
+      await enqueueAndWait(persistenceQueue, persistMessage, () =>
         resolved.logger.warn(
           { chatJid, queueSize: persistenceQueue.size() },
           'Persistence queue full; waiting to enqueue message persistence',
-        );
-        await persistenceQueue.enqueueWhenAvailable(persistMessage);
-      }
+        ),
+      );
     },
     onChatMetadata: async (
       chatJid: string,
@@ -113,16 +139,15 @@ export function createChannelPersistenceHandlers({
             { err, chatJid },
             'Failed to store chat metadata',
           );
+          throw err;
         }
       };
-      const admitted = persistenceQueue.enqueue(persistMetadata);
-      if (!admitted) {
+      await enqueueAndWait(persistenceQueue, persistMetadata, () =>
         resolved.logger.warn(
           { chatJid, queueSize: persistenceQueue.size() },
           'Persistence queue full; waiting to enqueue chat metadata persistence',
-        );
-        await persistenceQueue.enqueueWhenAvailable(persistMetadata);
-      }
+        ),
+      );
     },
   };
 }

--- a/apps/core/src/app/bootstrap/channel-wiring.ts
+++ b/apps/core/src/app/bootstrap/channel-wiring.ts
@@ -1,8 +1,11 @@
+import { randomUUID } from 'node:crypto';
+
 import { RuntimeSettings } from '../../config/settings/runtime-settings.js';
 import { logger } from '../../infrastructure/logging/logger.js';
 import '../../channels/register-builtins.js';
 import {
   GroupDiscoverySource,
+  MessageDeliveryResult,
   MessageSendOptions,
   PermissionApprovalDecision,
   PermissionApprovalRequest,
@@ -28,6 +31,7 @@ import {
   asRemoteControlCommand,
   handleRemoteControlCommand,
 } from '../../runtime/remote-control-command.js';
+import { isPartialMessageDeliveryError } from '../../runtime/partial-delivery.js';
 import { getRuntimeOpsRepository } from '../../adapters/storage/postgres/runtime-store.js';
 import { ChannelAdapter } from '../../channels/channel-provider.js';
 import { RuntimeApp } from './runtime-app.js';
@@ -54,6 +58,22 @@ import { createChannelPersistenceHandlers } from './channel-persistence-handlers
 
 export type { ChannelWiring } from './channel-wiring-types.js';
 
+function sanitizeDeliveryError(err: unknown, provider: string): string {
+  const raw =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : String(err);
+  return (
+    raw
+      .replace(/xox[baprs]-[A-Za-z0-9-]+/g, '[REDACTED_SLACK_TOKEN]')
+      .replace(/\b\d{6,}:[A-Za-z0-9_-]{20,}\b/g, '[REDACTED_TELEGRAM_TOKEN]')
+      .slice(0, 500)
+      .trim() || `${provider} delivery failed`
+  );
+}
+
 export function createChannelWiring(
   app: RuntimeApp,
   deps: Partial<ChannelWiringDeps> = {},
@@ -75,6 +95,17 @@ export function createChannelWiring(
   const connectedChannels: ChannelAdapter[] = [];
   const persistenceQueue = new AsyncTaskQueue(4, 5_000);
   const ops = () => resolved.opsRepository ?? getRuntimeOpsRepository();
+  const optionalOps = () => {
+    try {
+      return ops();
+    } catch (err) {
+      resolved.logger.debug(
+        { err },
+        'Runtime storage unavailable; skipping outbound message persistence',
+      );
+      return undefined;
+    }
+  };
 
   const channelOpts = {
     ...createChannelPersistenceHandlers({
@@ -161,11 +192,49 @@ export function createChannelWiring(
       providerForJid(jid)?.id ?? channel.name,
     );
     if (!formatted) return;
-    if (options.messageOptions) {
-      await channel.sendMessage(jid, formatted, options.messageOptions);
-      return;
+    const provider = providerForJid(jid)?.id ?? channel.name;
+    const now = new Date().toISOString();
+    const messageId = `outbound:${randomUUID()}`;
+    const baseMessage = {
+      id: messageId,
+      chat_jid: jid,
+      channel_provider: provider,
+      sender: 'myclaw',
+      sender_name: 'MyClaw',
+      content: formatted,
+      timestamp: now,
+      is_from_me: true,
+      is_bot_message: true,
+      thread_id: options.messageOptions?.threadId,
+    };
+
+    const outboundOps = optionalOps();
+    await outboundOps?.storeMessage({
+      ...baseMessage,
+      delivery_status: 'pending',
+    });
+
+    try {
+      const delivery = options.messageOptions
+        ? await channel.sendMessage(jid, formatted, options.messageOptions)
+        : await channel.sendMessage(jid, formatted);
+      const result = delivery as MessageDeliveryResult | undefined;
+      await outboundOps?.storeMessage({
+        ...baseMessage,
+        external_message_id: result?.externalMessageId,
+        delivery_status: 'sent',
+        delivered_at: new Date().toISOString(),
+      });
+    } catch (err) {
+      const partial = isPartialMessageDeliveryError(err);
+      await outboundOps?.storeMessage({
+        ...baseMessage,
+        delivery_status: partial ? 'partially_sent' : 'failed',
+        delivered_at: partial ? new Date().toISOString() : undefined,
+        delivery_error: sanitizeDeliveryError(err, provider),
+      });
+      throw err;
     }
-    await channel.sendMessage(jid, formatted);
   }
 
   async function sendStreamingChunk(

--- a/apps/core/src/app/bootstrap/channel-wiring.ts
+++ b/apps/core/src/app/bootstrap/channel-wiring.ts
@@ -227,12 +227,19 @@ export function createChannelWiring(
       });
     } catch (err) {
       const partial = isPartialMessageDeliveryError(err);
-      await outboundOps?.storeMessage({
-        ...baseMessage,
-        delivery_status: partial ? 'partially_sent' : 'failed',
-        delivered_at: partial ? new Date().toISOString() : undefined,
-        delivery_error: sanitizeDeliveryError(err, provider),
-      });
+      try {
+        await outboundOps?.storeMessage({
+          ...baseMessage,
+          delivery_status: partial ? 'partially_sent' : 'failed',
+          delivered_at: partial ? new Date().toISOString() : undefined,
+          delivery_error: sanitizeDeliveryError(err, provider),
+        });
+      } catch (persistErr) {
+        resolved.logger.error(
+          { err: persistErr, jid },
+          'Failed to persist outbound delivery failure',
+        );
+      }
       throw err;
     }
   }

--- a/apps/core/src/channels/app.ts
+++ b/apps/core/src/channels/app.ts
@@ -11,7 +11,7 @@ async function emitSessionEvent(
   chatJid: string,
   eventType: string,
   payload: Record<string, unknown>,
-): Promise<boolean> {
+): Promise<{ emitted: boolean; eventId?: number }> {
   const control = getRuntimeControlRepository();
   const session = await control.getAppSessionByChatJid(chatJid);
   if (!session) {
@@ -19,7 +19,7 @@ async function emitSessionEvent(
       { chatJid, eventType },
       'App channel event dropped without session',
     );
-    return false;
+    return { emitted: false };
   }
   const threadId =
     typeof payload.threadId === 'string' ? payload.threadId : null;
@@ -27,7 +27,7 @@ async function emitSessionEvent(
     sessionId: session.sessionId,
     threadId,
   });
-  await control.addControlEvent({
+  const event = await control.addControlEvent({
     eventType,
     payload: JSON.stringify(payload),
     actor: 'agent',
@@ -36,7 +36,7 @@ async function emitSessionEvent(
     responseMode: route?.responseMode ?? session.defaultResponseMode,
     webhookId: route ? route.webhookId : session.defaultWebhookId,
   });
-  return true;
+  return { emitted: true, eventId: event.eventId };
 }
 
 export async function createAppChannel(
@@ -48,11 +48,14 @@ export async function createAppChannel(
     jid: string,
     text: string,
     options?: MessageSendOptions,
-  ): Promise<void> => {
-    await emitSessionEvent(jid, 'session.message.outbound', {
+  ): Promise<{ externalMessageId?: string }> => {
+    const result = await emitSessionEvent(jid, 'session.message.outbound', {
       text,
       threadId: options?.threadId ?? null,
     });
+    return result.eventId !== undefined
+      ? { externalMessageId: String(result.eventId) }
+      : {};
   };
 
   return {
@@ -75,12 +78,13 @@ export async function createAppChannel(
       text: string,
       options?: StreamingChunkOptions,
     ): Promise<boolean> {
-      return emitSessionEvent(jid, 'session.message.streaming', {
+      const result = await emitSessionEvent(jid, 'session.message.streaming', {
         text,
         threadId: options?.threadId ?? null,
         done: options?.done === true,
         generation: options?.generation ?? null,
       });
+      return result.emitted;
     },
     resetStreaming(_jid: string) {},
     async setTyping(jid: string, isTyping: boolean): Promise<void> {

--- a/apps/core/src/channels/slack/channel-delivery.ts
+++ b/apps/core/src/channels/slack/channel-delivery.ts
@@ -63,7 +63,7 @@ export abstract class SlackChannelDelivery extends SlackChannelInteractions {
     jid: string,
     text: string,
     options: MessageSendOptions = {},
-  ): Promise<void> {
+  ): Promise<{ externalMessageId?: string } | void> {
     if (!this.app) return;
     const parsed = this.parseJid(jid);
     if (!parsed) return;
@@ -71,11 +71,12 @@ export abstract class SlackChannelDelivery extends SlackChannelInteractions {
     const formatted = formatOutboundForChannel(text, 'slack');
     if (!formatted) return;
 
-    await this.app.client.chat.postMessage({
+    const posted = (await this.app.client.chat.postMessage({
       channel: parsed.channelId,
       text: formatted,
       ...(options.threadId ? { thread_ts: options.threadId } : {}),
-    });
+    })) as { ts?: string };
+    return posted.ts ? { externalMessageId: posted.ts } : {};
   }
 
   async sendStreamingChunk(

--- a/apps/core/src/channels/slack/channel-interactions.ts
+++ b/apps/core/src/channels/slack/channel-interactions.ts
@@ -54,21 +54,25 @@ export abstract class SlackChannelInteractions extends SlackChannelState {
       return;
     }
 
-    const content = await this.enrichMessageText(jid, event);
+    const enriched = await this.enrichMessage(jid, event);
+    const content = enriched.text;
     if (!content) return;
 
     const sender = event.user || 'unknown';
     const senderName = await this.resolveUserName(event.user);
 
     await this.opts.onMessage(jid, {
-      id: event.client_msg_id || event.ts,
+      id: event.ts,
       chat_jid: jid,
+      channel_provider: 'slack',
       sender,
       sender_name: senderName,
       content,
       timestamp: new Date(Math.round(Number(event.ts) * 1000)).toISOString(),
       is_from_me: this.botUserId ? sender === this.botUserId : false,
+      external_message_id: event.ts,
       thread_id: event.thread_ts || undefined,
+      attachments: enriched.attachments,
       reply_to_message_id:
         event.thread_ts && event.thread_ts !== event.ts
           ? event.thread_ts

--- a/apps/core/src/channels/slack/channel-state.ts
+++ b/apps/core/src/channels/slack/channel-state.ts
@@ -652,11 +652,19 @@ export abstract class SlackChannelState {
     }
   }
 
-  protected async enrichMessageText(
+  protected async enrichMessage(
     jid: string,
     event: SlackMessageLike,
-  ): Promise<string> {
+  ): Promise<{
+    text: string;
+    attachments: NonNullable<
+      import('../../domain/types.js').NewMessage['attachments']
+    >;
+  }> {
     const lines: string[] = [];
+    const attachments: NonNullable<
+      import('../../domain/types.js').NewMessage['attachments']
+    > = [];
     const text = typeof event.text === 'string' ? event.text.trim() : '';
     if (text) lines.push(text);
 
@@ -666,10 +674,17 @@ export abstract class SlackChannelState {
         if (!location) continue;
         const label = file.name || file.title || 'attachment';
         lines.push(`Attachment: ${label} (${location})`);
+        attachments.push({
+          id: file.id ? `slack-file:${file.id}` : undefined,
+          kind: file.mimetype?.startsWith('image/') ? 'image' : 'file',
+          contentType: file.mimetype,
+          externalId: file.id,
+          storageRef: location,
+        });
       }
     }
 
-    return lines.join('\n').trim();
+    return { text: lines.join('\n').trim(), attachments };
   }
 
   protected abstract tryNativeStreamStop(

--- a/apps/core/src/channels/telegram/channel-connect.ts
+++ b/apps/core/src/channels/telegram/channel-connect.ts
@@ -327,11 +327,13 @@ export abstract class TelegramChannelConnect extends TelegramChannelPrompts {
       await this.opts.onMessage(chatJid, {
         id: msgId,
         chat_jid: chatJid,
+        channel_provider: 'telegram',
         sender,
         sender_name: senderName,
         content,
         timestamp,
         is_from_me: false,
+        external_message_id: msgId,
         thread_id: threadId ? threadId.toString() : undefined,
         reply_to_message_id: replyToMessageId,
         reply_to_message_content: replyToContent,
@@ -372,15 +374,37 @@ export abstract class TelegramChannelConnect extends TelegramChannelPrompts {
         isGroup,
       );
 
-      const deliver = async (content: string) => {
+      const deliver = async (
+        content: string,
+        attachment?: {
+          kind: 'image' | 'file' | 'audio' | 'video' | 'other';
+          externalId?: string;
+          storageRef?: string;
+        },
+      ) => {
+        const threadId = ctx.message.message_thread_id;
+        const msgId = ctx.message.message_id.toString();
         await this.opts.onMessage(chatJid, {
-          id: ctx.message.message_id.toString(),
+          id: msgId,
           chat_jid: chatJid,
+          channel_provider: 'telegram',
           sender: ctx.from?.id?.toString() || '',
           sender_name: senderName,
           content,
           timestamp,
           is_from_me: false,
+          external_message_id: msgId,
+          thread_id: threadId ? threadId.toString() : undefined,
+          attachments: attachment
+            ? [
+                {
+                  id: `telegram-attachment:${chatJid}:${msgId}`,
+                  kind: attachment.kind,
+                  externalId: attachment.externalId,
+                  storageRef: attachment.storageRef,
+                },
+              ]
+            : undefined,
         });
       };
 
@@ -395,10 +419,25 @@ export abstract class TelegramChannelConnect extends TelegramChannelPrompts {
           group.folder,
           filename,
         );
+        const kind =
+          placeholder === '[Photo]'
+            ? 'image'
+            : placeholder === '[Video]'
+              ? 'video'
+              : placeholder === '[Voice message]' || placeholder === '[Audio]'
+                ? 'audio'
+                : 'file';
         if (filePath) {
-          await deliver(`${placeholder} (${filePath})${caption}`);
+          await deliver(`${placeholder} (${filePath})${caption}`, {
+            kind,
+            externalId: opts.fileId,
+            storageRef: filePath,
+          });
         } else {
-          await deliver(`${placeholder}${caption}`);
+          await deliver(`${placeholder}${caption}`, {
+            kind,
+            externalId: opts.fileId,
+          });
         }
         return;
       }

--- a/apps/core/src/channels/telegram/channel-delivery.ts
+++ b/apps/core/src/channels/telegram/channel-delivery.ts
@@ -40,7 +40,6 @@ import {
   editTelegramMessage,
   escapeTelegramMarkdownV2,
   iterTelegramTextChunks,
-  sendTelegramMessage,
   sendTelegramMessageWithResult,
   telegramThreadOptionsFromString,
 } from './channel-shared.js';
@@ -50,7 +49,7 @@ export abstract class TelegramChannelDelivery extends TelegramChannelConnect {
     jid: string,
     text: string,
     options: MessageSendOptions = {},
-  ): Promise<void> {
+  ): Promise<{ externalMessageId?: string }> {
     if (!this.bot) {
       logger.warn('Telegram bot not initialized');
       throw new Error('Telegram bot not initialized');
@@ -63,17 +62,19 @@ export abstract class TelegramChannelDelivery extends TelegramChannelConnect {
       // Telegram has a 4096 character limit per message. Split on code-point
       // boundaries so emoji/surrogate pairs are not corrupted between chunks.
       let deliveredChunks = 0;
+      let firstMessageId: number | undefined;
       for (const chunk of iterTelegramTextChunks(
         text,
         TELEGRAM_MESSAGE_MAX_LENGTH,
       )) {
         try {
-          await sendTelegramMessage(
+          const messageId = await sendTelegramMessageWithResult(
             this.bot.api,
             numericId,
             chunk,
             sendOptions,
           );
+          firstMessageId ??= messageId;
           deliveredChunks += 1;
         } catch (err) {
           if (deliveredChunks > 0) {
@@ -96,6 +97,9 @@ export abstract class TelegramChannelDelivery extends TelegramChannelConnect {
         { jid, length: text.length, threadId: options.threadId },
         'Telegram message sent',
       );
+      return firstMessageId !== undefined
+        ? { externalMessageId: String(firstMessageId) }
+        : {};
     } catch (err) {
       logger.error(
         { jid, error: this.sanitizeErrorMessage(err) },

--- a/apps/core/src/channels/telegram/channel-state.ts
+++ b/apps/core/src/channels/telegram/channel-state.ts
@@ -395,7 +395,7 @@ export abstract class TelegramChannelState implements ChannelAdapter {
     jid: string,
     text: string,
     options?: MessageSendOptions,
-  ): Promise<void>;
+  ): Promise<{ externalMessageId?: string }>;
   abstract sendStreamingChunk(
     jid: string,
     text: string,

--- a/apps/core/src/control/server/routes/sessions.ts
+++ b/apps/core/src/control/server/routes/sessions.ts
@@ -131,6 +131,7 @@ export async function handleSessionRoutes(
     const message: NewMessage = {
       id: messageId,
       chat_jid: session.chatJid,
+      channel_provider: 'app',
       sender: typeof body.senderId === 'string' ? body.senderId : 'sdk',
       sender_name:
         typeof body.senderName === 'string' ? body.senderName : 'SDK',
@@ -138,6 +139,7 @@ export async function handleSessionRoutes(
       timestamp: now,
       is_from_me: false,
       is_bot_message: false,
+      external_message_id: messageId,
       thread_id: threadId || undefined,
     };
     const ops = getRuntimeOpsRepository();

--- a/apps/core/src/domain/messages/messages.ts
+++ b/apps/core/src/domain/messages/messages.ts
@@ -12,6 +12,11 @@ export type ExternalMessageId = BrandedId<'ExternalMessageId'>;
 
 export type MessageDirection = 'inbound' | 'outbound' | 'system' | 'tool';
 export type MessageTrust = 'trusted' | 'untrusted' | 'system';
+export type MessageDeliveryStatus =
+  | 'pending'
+  | 'sent'
+  | 'failed'
+  | 'partially_sent';
 
 export interface Message {
   id: MessageId;
@@ -25,6 +30,9 @@ export interface Message {
   trust: MessageTrust;
   createdAt: IsoTimestamp;
   receivedAt?: IsoTimestamp;
+  deliveryStatus?: MessageDeliveryStatus;
+  deliveredAt?: IsoTimestamp;
+  deliveryError?: string;
   parts: MessagePart[];
   attachments: MessageAttachment[];
 }

--- a/apps/core/src/domain/types.ts
+++ b/apps/core/src/domain/types.ts
@@ -56,6 +56,7 @@ export interface RegisteredGroup {
 export interface NewMessage {
   id: string;
   chat_jid: string;
+  channel_provider?: string;
   sender: string;
   sender_name: string;
   content: string;
@@ -66,6 +67,20 @@ export interface NewMessage {
   reply_to_message_id?: string;
   reply_to_message_content?: string;
   reply_to_sender_name?: string;
+  external_message_id?: string;
+  delivery_status?: MessageDeliveryStatus;
+  delivered_at?: string;
+  delivery_error?: string;
+  attachments?: NewMessageAttachment[];
+}
+
+export interface NewMessageAttachment {
+  id?: string;
+  kind: 'image' | 'file' | 'audio' | 'video' | 'other';
+  contentType?: string;
+  sizeBytes?: number;
+  externalId?: string;
+  storageRef?: string;
 }
 
 export type JobScheduleType = 'manual' | 'cron' | 'interval' | 'once';
@@ -199,6 +214,16 @@ export interface MessageSendOptions {
   threadId?: string;
 }
 
+export type MessageDeliveryStatus =
+  | 'pending'
+  | 'sent'
+  | 'failed'
+  | 'partially_sent';
+
+export interface MessageDeliveryResult {
+  externalMessageId?: string;
+}
+
 // Callback type that channels use to deliver inbound messages
 export type OnInboundMessage = (
   chatJid: string,
@@ -206,8 +231,8 @@ export type OnInboundMessage = (
 ) => Promise<void>;
 
 // Callback for chat metadata discovery.
-// name is optional — channels that deliver names inline (Telegram) pass it here;
-// channels that sync names separately (via syncGroups) omit it.
+// name is optional for providers that deliver names inline; channels that sync
+// names separately omit it.
 export type OnChatMetadata = (
   chatJid: string,
   timestamp: string,
@@ -239,7 +264,7 @@ export interface MessageSink {
     jid: string,
     text: string,
     options?: MessageSendOptions,
-  ): Promise<void>;
+  ): Promise<void | MessageDeliveryResult>;
 }
 
 export interface TypingSink {

--- a/apps/core/src/runtime/partial-delivery.ts
+++ b/apps/core/src/runtime/partial-delivery.ts
@@ -34,7 +34,7 @@ export class PartialMessageDeliveryError
   }
 }
 
-function isPartialMessageDeliveryError(
+export function isPartialMessageDeliveryError(
   err: unknown,
 ): err is BrandedPartialMessageDeliveryError {
   return (

--- a/apps/core/test/integration/postgres-domain-repositories.integration.test.ts
+++ b/apps/core/test/integration/postgres-domain-repositories.integration.test.ts
@@ -173,6 +173,94 @@ maybeDescribe('Postgres domain repositories', () => {
     ]);
   });
 
+  it('inserts threaded messages idempotently by provider redelivery key', async () => {
+    await repositories.messages.saveMessage({
+      id: 'message:test:thread:first' as MessageId,
+      appId,
+      conversationId,
+      threadId,
+      externalRef: { kind: 'message', value: 'evt-thread-1' },
+      direction: 'inbound',
+      senderUserId: userId,
+      senderDisplayName: 'Ravi',
+      trust: 'trusted',
+      createdAt: '2026-04-27T00:01:10.000Z',
+      receivedAt: '2026-04-27T00:01:11.000Z',
+      parts: [{ kind: 'text', text: 'thread hello' }],
+      attachments: [],
+    });
+    await repositories.messages.saveMessage({
+      id: 'message:test:thread:redelivery' as MessageId,
+      appId,
+      conversationId,
+      threadId,
+      externalRef: { kind: 'message', value: 'evt-thread-1' },
+      direction: 'inbound',
+      senderUserId: userId,
+      senderDisplayName: 'Ravi',
+      trust: 'trusted',
+      createdAt: '2026-04-27T00:01:10.000Z',
+      receivedAt: '2026-04-27T00:01:12.000Z',
+      parts: [{ kind: 'text', text: 'thread redelivered' }],
+      attachments: [],
+    });
+
+    const messages = await repositories.messages.listMessages({
+      conversationId,
+      threadId,
+      limit: 10,
+    });
+    const matching = messages.filter(
+      (message) => message.externalRef?.value === 'evt-thread-1',
+    );
+    expect(matching).toHaveLength(1);
+    expect(matching[0]?.id).toBe('message:test:thread:first');
+    expect(matching[0]?.parts).toEqual([
+      { kind: 'text', text: 'thread redelivered' },
+    ]);
+  });
+
+  it('persists outbound delivery status and provider message id', async () => {
+    const outboundId = 'message:test:outbound' as MessageId;
+    await repositories.messages.saveMessage({
+      id: outboundId,
+      appId,
+      conversationId,
+      threadId,
+      direction: 'outbound',
+      senderDisplayName: 'MyClaw',
+      trust: 'system',
+      createdAt: '2026-04-27T00:01:20.000Z',
+      deliveryStatus: 'pending',
+      parts: [{ kind: 'text', text: 'working' }],
+      attachments: [],
+    });
+    await repositories.messages.saveMessage({
+      id: outboundId,
+      appId,
+      conversationId,
+      threadId,
+      externalRef: { kind: 'message', value: '1710000000.200' },
+      direction: 'outbound',
+      senderDisplayName: 'MyClaw',
+      trust: 'system',
+      createdAt: '2026-04-27T00:01:20.000Z',
+      deliveryStatus: 'sent',
+      deliveredAt: '2026-04-27T00:01:21.000Z',
+      parts: [{ kind: 'text', text: 'working' }],
+      attachments: [],
+    });
+
+    await expect(repositories.messages.getMessage(outboundId)).resolves.toEqual(
+      expect.objectContaining({
+        id: outboundId,
+        externalRef: { kind: 'message', value: '1710000000.200' },
+        deliveryStatus: 'sent',
+        deliveredAt: '2026-04-27T00:01:21.000Z',
+      }),
+    );
+  });
+
   it('handles concurrent message redelivery saves with different ids', async () => {
     await Promise.all([
       repositories.messages.saveMessage({

--- a/apps/core/test/unit/bootstrap/channel-wiring.test.ts
+++ b/apps/core/test/unit/bootstrap/channel-wiring.test.ts
@@ -371,6 +371,53 @@ describe('createChannelWiring', () => {
     expect(outbound.sendMessage).toHaveBeenCalledWith('tg:123', '*done*');
   });
 
+  it('records outbound final messages as pending and then sent', async () => {
+    const app = makeApp();
+    const storeMessage = vi.fn(async () => {});
+    const outbound = makeChannel({
+      ownsJid: vi.fn((jid: string) => jid === 'sl:C123'),
+      sendMessage: vi.fn(async () => ({ externalMessageId: '171.123' })),
+    });
+
+    const wiring = createChannelWiring(app, {
+      channelProviders: [
+        makeProvider(
+          'slack',
+          vi.fn(() => outbound),
+        ),
+      ],
+      opsRepository: { storeMessage } as any,
+    });
+    await wiring.connectEnabledChannels(
+      makeRuntimeSettings({ telegram: false, slack: true }),
+    );
+
+    await wiring.sendMessage('sl:C123', 'done', {
+      messageOptions: { threadId: '1700.1' },
+    });
+
+    expect(storeMessage).toHaveBeenCalledTimes(2);
+    expect(storeMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        chat_jid: 'sl:C123',
+        content: 'done',
+        thread_id: '1700.1',
+        delivery_status: 'pending',
+        is_bot_message: true,
+      }),
+    );
+    expect(storeMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        chat_jid: 'sl:C123',
+        external_message_id: '171.123',
+        delivery_status: 'sent',
+        delivered_at: expect.any(String),
+      }),
+    );
+  });
+
   it('streams group chunks with internal tags removed but without markdown conversion', async () => {
     const app = makeApp();
     const outbound = makeChannel({

--- a/apps/core/test/unit/bootstrap/channel-wiring.test.ts
+++ b/apps/core/test/unit/bootstrap/channel-wiring.test.ts
@@ -418,6 +418,60 @@ describe('createChannelWiring', () => {
     );
   });
 
+  it('preserves provider send errors when failure-state persistence fails', async () => {
+    const app = makeApp();
+    const providerErr = new Error('provider send failed');
+    const persistErr = new Error('persist failed');
+    const storeMessage = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(persistErr);
+    const error = vi.fn();
+    const outbound = makeChannel({
+      ownsJid: vi.fn((jid: string) => jid === 'sl:C123'),
+      sendMessage: vi.fn(async () => {
+        throw providerErr;
+      }),
+    });
+
+    const wiring = createChannelWiring(app, {
+      channelProviders: [
+        makeProvider(
+          'slack',
+          vi.fn(() => outbound),
+        ),
+      ],
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        error,
+      },
+      opsRepository: { storeMessage } as any,
+    });
+    await wiring.connectEnabledChannels(
+      makeRuntimeSettings({ telegram: false, slack: true }),
+    );
+
+    await expect(wiring.sendMessage('sl:C123', 'done')).rejects.toThrow(
+      providerErr,
+    );
+
+    expect(storeMessage).toHaveBeenCalledTimes(2);
+    expect(storeMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        chat_jid: 'sl:C123',
+        delivery_status: 'failed',
+        delivery_error: 'provider send failed',
+      }),
+    );
+    expect(error).toHaveBeenCalledWith(
+      { err: persistErr, jid: 'sl:C123' },
+      'Failed to persist outbound delivery failure',
+    );
+  });
+
   it('streams group chunks with internal tags removed but without markdown conversion', async () => {
     const app = makeApp();
     const outbound = makeChannel({

--- a/apps/core/test/unit/channels/telegram.test.ts
+++ b/apps/core/test/unit/channels/telegram.test.ts
@@ -1410,7 +1410,7 @@ describe('TelegramChannel', () => {
 
       await expect(
         channel.sendMessage('tg:100200300', 'Will fail'),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({ externalMessageId: '987' });
       expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/contracts/src/messages/index.ts
+++ b/packages/contracts/src/messages/index.ts
@@ -15,6 +15,14 @@ export const MessageDirectionSchema = z.enum([
 ]);
 export type MessageDirection = z.infer<typeof MessageDirectionSchema>;
 
+export const MessageDeliveryStatusSchema = z.enum([
+  'pending',
+  'sent',
+  'failed',
+  'partially_sent',
+]);
+export type MessageDeliveryStatus = z.infer<typeof MessageDeliveryStatusSchema>;
+
 export const MessageTrustSchema = z.enum([
   'trusted',
   'untrusted',
@@ -77,6 +85,9 @@ export const MessageResponseSchema = z.object({
   senderUserId: z.string().nullable().optional(),
   senderDisplayName: z.string().nullable().optional(),
   trust: MessageTrustSchema,
+  deliveryStatus: MessageDeliveryStatusSchema.nullable().optional(),
+  deliveredAt: IsoDateTimeSchema.nullable().optional(),
+  deliveryError: z.string().nullable().optional(),
   parts: z.array(MessagePartSchema),
   attachments: z.array(MessageAttachmentSchema).optional(),
   createdAt: IsoDateTimeSchema,


### PR DESCRIPTION
## Summary
- persist inbound Telegram, Slack, and app/session messages through canonical conversation/message storage before runtime handling
- record final outbound replies as pending, then update sent/failed/partially_sent delivery status with provider message IDs
- preserve provider conversation/thread/message IDs and store best-effort participants/attachments
- add the message delivery status migration and repository/contract support

## Validation
- npm run typecheck
- npm run build
- npm test
- git diff --check
- python3 .codex/scripts/check_task_completion.py (fails on existing repo-wide architecture gate findings; no completion warnings, and the new storage-layer provider-specific literals were removed)

## Notes
- Database-backed Postgres integration cases that require MYCLAW_TEST_DATABASE_URL were skipped by the test harness in this environment.