### PR TITLE
[codex] add app-scoped external ingress

### DIFF
--- a/.codex/architecture-exceptions.json
+++ b/.codex/architecture-exceptions.json
@@ -693,20 +693,6 @@
     "maxViolations": 2
   },
   {
-    "file": "apps/core/src/control/server/routes/sessions.ts",
-    "rule": "forbidden_import_by_layer",
-    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-    "removeByPhase": "canonical-boundary-cleanup-phase",
-    "maxViolations": 1
-  },
-  {
-    "file": "apps/core/src/control/server/routes/sessions.ts",
-    "rule": "old_term_groupFolder",
-    "reason": "Baseline groupFolder terminology debt pending canonical conversation/workspace rename; capped so new occurrences fail.",
-    "removeByPhase": "canonical-boundary-cleanup-phase",
-    "maxOccurrences": 1
-  },
-  {
     "file": "apps/core/src/domain/repositories/domain-types.ts",
     "rule": "forbidden_import_by_layer",
     "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",

--- a/.codex/architecture-exceptions.json
+++ b/.codex/architecture-exceptions.json
@@ -686,6 +686,13 @@
     "maxViolations": 1
   },
   {
+    "file": "apps/core/src/control/server/session-control-port.ts",
+    "rule": "old_term_groupFolder",
+    "reason": "RuntimeControlRepository still accepts groupFolder until the canonical workspace-folder storage rename lands; capped so this bridge cannot hide new debt.",
+    "removeByPhase": "canonical-storage-workspace-rename",
+    "maxOccurrences": 1
+  },
+  {
     "file": "apps/core/src/control/server/routes/memory.ts",
     "rule": "forbidden_import_by_layer",
     "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",

--- a/README.md
+++ b/README.md
@@ -212,6 +212,19 @@ See [docs/MEMORY.md](docs/MEMORY.md) for the app developer memory model and drea
 MyClaw currently supports a single runtime mode: host execution.
 Use `npm run dev` for local development and `npm start` for production start.
 
+## Sidecar Integrations
+
+Backend apps can use `@myclaw/sdk` to ensure a session, send a message, and wait
+or stream durable runtime events. Normal SDK calls derive `appId` from the API
+key; request-body `appId` is only an optional assertion.
+
+External systems that should not hold a control API key use signed external
+ingress records under `/v1/ingresses`. Ingress supports session messages,
+existing job triggers, and constrained one-time job templates. Each ingress
+record has an explicit target policy, so its secret only authorizes configured
+sessions, conversations, jobs, or templates. `/v1/webhooks` remains outbound
+callback delivery for runtime events.
+
 ## Repository Development
 
 Use this only when you are working on the source code:

--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -16,6 +16,10 @@
 - Run `npm run test:integration:postgres` for DB-backed feature work. A plain `npm run test:integration` is allowed to skip those suites when the local Postgres test URL is absent.
 - Claude Agent SDK boundary tests must stay hermetic: mock the SDK provider, assert generated options at the adapter boundary, and never require real Anthropic auth.
 - Control HTTP route changes must have route-level coverage for encoded ids, app ownership checks, and pre-mutation authorization.
+- External ingress `session_message` dispatch must register the session group before enqueueing message checks; ingress and control adapters should share the same session interaction intent.
+- External ingress target policy must mirror dispatch precedence: when `sessionId` is present, authorize only against `sessionIds`; use `conversationIds` only when no `sessionId` was supplied.
+- SSE route writes that wait for backpressure must also unblock on response close/error and release subscriptions/active counters.
+- Periodic external ingress retention and recovery sweeps must be bounded per timer tick; do not delete or update an unbounded backlog in one maintenance pass.
 - MCP server changes must keep third-party servers behind approved Postgres definitions and agent bindings. Do not load `.mcp.json`, Claude user/project settings, raw stdio commands, or raw credential env as product truth.
 - Third-party MCP materialization must fail closed for non-HTTPS/private/local URLs, remote hosts that resolve to private/link-local/loopback/multicast/metadata ranges, unsandboxed stdio templates, and non-broker credential refs.
 - Treat MCP `allowedToolPatterns` as an enforced allowlist, not metadata. Auto-approved MCP tools must remain a subset of the allowed tools, and same-channel rebinds must preserve any existing admin permission policies unless an admin explicitly replaces them.

--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-external-ingress.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-external-ingress.postgres.ts
@@ -1,0 +1,314 @@
+import { randomUUID } from 'node:crypto';
+
+import { and, desc, eq, lt } from 'drizzle-orm';
+
+import { nowIso as currentIso } from '../../../../infrastructure/time/datetime.js';
+import * as pgSchema from '../schema/schema.js';
+import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
+import { ensureControlGraph } from './control-plane-graph.postgres.js';
+
+export class PostgresExternalIngressRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async create(input: {
+    ingressId?: string;
+    appId: string;
+    name: string;
+    secret: string;
+    enabled?: boolean;
+    metadata?: unknown;
+  }) {
+    await ensureControlGraph(this.db, {
+      appId: input.appId,
+      externalConversationId: 'external-ingress',
+      externalConversationRef: 'external-ingress',
+      agentFolder: 'control',
+    });
+    const now = currentIso();
+    const rows = await this.db
+      .insert(pgSchema.externalIngressesPostgres)
+      .values({
+        ingressId: input.ingressId ?? randomUUID(),
+        appId: input.appId,
+        name: input.name,
+        secret: input.secret,
+        enabled: input.enabled ?? true,
+        metadataJson: JSON.stringify(input.metadata ?? {}),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+    return mapExternalIngress(rows[0]!);
+  }
+
+  async list(appId: string) {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.externalIngressesPostgres)
+      .where(eq(pgSchema.externalIngressesPostgres.appId, appId))
+      .orderBy(desc(pgSchema.externalIngressesPostgres.updatedAt));
+    return rows.map(mapExternalIngress);
+  }
+
+  async getById(ingressId: string, appId?: string) {
+    const conditions = [
+      eq(pgSchema.externalIngressesPostgres.ingressId, ingressId),
+    ];
+    if (appId)
+      conditions.push(eq(pgSchema.externalIngressesPostgres.appId, appId));
+    const rows = await this.db
+      .select()
+      .from(pgSchema.externalIngressesPostgres)
+      .where(and(...conditions))
+      .limit(1);
+    return rows[0] ? mapExternalIngress(rows[0]) : undefined;
+  }
+
+  async update(
+    ingressId: string,
+    appId: string,
+    patch: {
+      name?: string;
+      secret?: string;
+      enabled?: boolean;
+      metadata?: unknown;
+    },
+  ) {
+    const existing = await this.getById(ingressId, appId);
+    if (!existing) return undefined;
+    const rows = await this.db
+      .update(pgSchema.externalIngressesPostgres)
+      .set({
+        name: patch.name ?? existing.name,
+        secret: patch.secret ?? existing.secret,
+        enabled: patch.enabled ?? existing.enabled,
+        metadataJson:
+          patch.metadata !== undefined
+            ? JSON.stringify(patch.metadata)
+            : JSON.stringify(existing.metadata),
+        updatedAt: currentIso(),
+      })
+      .where(
+        and(
+          eq(pgSchema.externalIngressesPostgres.ingressId, ingressId),
+          eq(pgSchema.externalIngressesPostgres.appId, appId),
+        ),
+      )
+      .returning();
+    return rows[0] ? mapExternalIngress(rows[0]) : undefined;
+  }
+
+  async delete(ingressId: string, appId: string): Promise<void> {
+    await this.db
+      .delete(pgSchema.externalIngressesPostgres)
+      .where(
+        and(
+          eq(pgSchema.externalIngressesPostgres.ingressId, ingressId),
+          eq(pgSchema.externalIngressesPostgres.appId, appId),
+        ),
+      );
+  }
+
+  async reserveNonce(input: {
+    appId: string;
+    ingressId: string;
+    nonce: string;
+    now: string;
+    expiresAt: string;
+  }): Promise<{ ok: true } | { ok: false; code: 'NONCE_REPLAY' }> {
+    const rows = await this.db
+      .insert(pgSchema.externalIngressNoncesPostgres)
+      .values({
+        appId: input.appId,
+        ingressId: input.ingressId,
+        nonce: input.nonce,
+        createdAt: input.now,
+        expiresAt: input.expiresAt,
+      })
+      .onConflictDoNothing()
+      .returning({
+        nonce: pgSchema.externalIngressNoncesPostgres.nonce,
+      });
+    return rows[0] ? { ok: true } : { ok: false, code: 'NONCE_REPLAY' };
+  }
+
+  async createInvocation(input: {
+    invocationId: string;
+    appId: string;
+    ingressId: string;
+    idempotencyKey: string;
+    nonce: string;
+    requestMethod: string;
+    requestPath: string;
+    requestTimestamp: string;
+    bodyHash: string;
+    requestBody: string;
+    signature: string;
+    status: string;
+    now: string;
+    expiresAt: string;
+  }) {
+    const rows = await this.db
+      .insert(pgSchema.externalIngressInvocationsPostgres)
+      .values({
+        invocationId: input.invocationId,
+        appId: input.appId,
+        ingressId: input.ingressId,
+        idempotencyKey: input.idempotencyKey,
+        nonce: input.nonce,
+        requestMethod: input.requestMethod,
+        requestPath: input.requestPath,
+        requestTimestamp: input.requestTimestamp,
+        bodyHash: input.bodyHash,
+        requestBody: input.requestBody,
+        signature: input.signature,
+        status: input.status,
+        createdAt: input.now,
+        updatedAt: input.now,
+        expiresAt: input.expiresAt,
+      })
+      .onConflictDoNothing()
+      .returning({
+        invocationId: pgSchema.externalIngressInvocationsPostgres.invocationId,
+        status: pgSchema.externalIngressInvocationsPostgres.status,
+      });
+    if (rows[0]) return { created: true as const, row: rows[0] };
+    const existing = await this.db
+      .select({
+        invocationId: pgSchema.externalIngressInvocationsPostgres.invocationId,
+        status: pgSchema.externalIngressInvocationsPostgres.status,
+      })
+      .from(pgSchema.externalIngressInvocationsPostgres)
+      .where(
+        and(
+          eq(pgSchema.externalIngressInvocationsPostgres.appId, input.appId),
+          eq(
+            pgSchema.externalIngressInvocationsPostgres.ingressId,
+            input.ingressId,
+          ),
+          eq(
+            pgSchema.externalIngressInvocationsPostgres.idempotencyKey,
+            input.idempotencyKey,
+          ),
+        ),
+      )
+      .limit(1);
+    return { created: false as const, row: existing[0]! };
+  }
+
+  async updateInvocation(input: {
+    invocationId: string;
+    status: string;
+    response?: unknown;
+    error?: string | null;
+    now: string;
+  }): Promise<void> {
+    await this.db
+      .update(pgSchema.externalIngressInvocationsPostgres)
+      .set({
+        status: input.status,
+        responseJson:
+          input.response === undefined
+            ? undefined
+            : JSON.stringify(input.response),
+        error: input.error ?? null,
+        updatedAt: input.now,
+      })
+      .where(
+        eq(
+          pgSchema.externalIngressInvocationsPostgres.invocationId,
+          input.invocationId,
+        ),
+      );
+  }
+
+  async getInvocation(invocationId: string, appId: string, ingressId: string) {
+    const rows = await this.db
+      .select({
+        invocationId: pgSchema.externalIngressInvocationsPostgres.invocationId,
+        appId: pgSchema.externalIngressInvocationsPostgres.appId,
+        ingressId: pgSchema.externalIngressInvocationsPostgres.ingressId,
+        idempotencyKey:
+          pgSchema.externalIngressInvocationsPostgres.idempotencyKey,
+        status: pgSchema.externalIngressInvocationsPostgres.status,
+        responseJson: pgSchema.externalIngressInvocationsPostgres.responseJson,
+        error: pgSchema.externalIngressInvocationsPostgres.error,
+        createdAt: pgSchema.externalIngressInvocationsPostgres.createdAt,
+        updatedAt: pgSchema.externalIngressInvocationsPostgres.updatedAt,
+      })
+      .from(pgSchema.externalIngressInvocationsPostgres)
+      .where(
+        and(
+          eq(
+            pgSchema.externalIngressInvocationsPostgres.invocationId,
+            invocationId,
+          ),
+          eq(pgSchema.externalIngressInvocationsPostgres.appId, appId),
+          eq(pgSchema.externalIngressInvocationsPostgres.ingressId, ingressId),
+        ),
+      )
+      .limit(1);
+    const row = rows[0];
+    if (!row) return undefined;
+    return {
+      invocationId: row.invocationId,
+      appId: row.appId,
+      ingressId: row.ingressId,
+      idempotencyKey: row.idempotencyKey,
+      status: row.status,
+      response: parseJson(row.responseJson, null),
+      error: row.error,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  async sweepExpiredState(input: { now: string }): Promise<{
+    noncesDeleted: number;
+    invocationsDeleted: number;
+  }> {
+    const nonceResult = await this.db
+      .delete(pgSchema.externalIngressNoncesPostgres)
+      .where(lt(pgSchema.externalIngressNoncesPostgres.expiresAt, input.now));
+    const invocationResult = await this.db
+      .delete(pgSchema.externalIngressInvocationsPostgres)
+      .where(
+        lt(pgSchema.externalIngressInvocationsPostgres.expiresAt, input.now),
+      );
+    return {
+      noncesDeleted: Number(nonceResult.rowCount ?? 0),
+      invocationsDeleted: Number(invocationResult.rowCount ?? 0),
+    };
+  }
+}
+
+function mapExternalIngress(row: {
+  ingressId: string;
+  appId: string;
+  name: string;
+  secret: string;
+  enabled: boolean;
+  metadataJson: string;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  return {
+    ingressId: row.ingressId,
+    appId: row.appId,
+    name: row.name,
+    secret: row.secret,
+    enabled: row.enabled,
+    metadata: parseJson(row.metadataJson, {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function parseJson<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-external-ingress.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-external-ingress.postgres.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from 'node:crypto';
 
-import { and, desc, eq, lt } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
 
 import { nowIso as currentIso } from '../../../../infrastructure/time/datetime.js';
 import * as pgSchema from '../schema/schema.js';
 import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
 import { ensureControlGraph } from './control-plane-graph.postgres.js';
+
+const EXTERNAL_INGRESS_SWEEP_BATCH_SIZE = 1000;
+const EXTERNAL_INGRESS_SWEEP_MAX_DELETE_BATCHES = 10;
 
 export class PostgresExternalIngressRepository {
   constructor(private readonly db: CanonicalDb) {}
@@ -98,8 +101,8 @@ export class PostgresExternalIngressRepository {
     return rows[0] ? mapExternalIngress(rows[0]) : undefined;
   }
 
-  async delete(ingressId: string, appId: string): Promise<void> {
-    await this.db
+  async delete(ingressId: string, appId: string): Promise<boolean> {
+    const result = await this.db
       .delete(pgSchema.externalIngressesPostgres)
       .where(
         and(
@@ -107,6 +110,7 @@ export class PostgresExternalIngressRepository {
           eq(pgSchema.externalIngressesPostgres.appId, appId),
         ),
       );
+    return Number(result.rowCount ?? 0) > 0;
   }
 
   async reserveNonce(input: {
@@ -171,12 +175,67 @@ export class PostgresExternalIngressRepository {
       .returning({
         invocationId: pgSchema.externalIngressInvocationsPostgres.invocationId,
         status: pgSchema.externalIngressInvocationsPostgres.status,
+        bodyHash: pgSchema.externalIngressInvocationsPostgres.bodyHash,
+        responseJson: pgSchema.externalIngressInvocationsPostgres.responseJson,
+        error: pgSchema.externalIngressInvocationsPostgres.error,
+        updatedAt: pgSchema.externalIngressInvocationsPostgres.updatedAt,
       });
-    if (rows[0]) return { created: true as const, row: rows[0] };
-    const existing = await this.db
+    if (rows[0]) {
+      return { created: true as const, row: mapInvocationRow(rows[0]) };
+    }
+    const existing = await this.getInvocationByIdempotencyKey({
+      appId: input.appId,
+      ingressId: input.ingressId,
+      idempotencyKey: input.idempotencyKey,
+    });
+    if (existing) return { created: false as const, row: existing };
+    const retried = await this.db
+      .insert(pgSchema.externalIngressInvocationsPostgres)
+      .values({
+        invocationId: input.invocationId,
+        appId: input.appId,
+        ingressId: input.ingressId,
+        idempotencyKey: input.idempotencyKey,
+        nonce: input.nonce,
+        requestMethod: input.requestMethod,
+        requestPath: input.requestPath,
+        requestTimestamp: input.requestTimestamp,
+        bodyHash: input.bodyHash,
+        requestBody: input.requestBody,
+        signature: input.signature,
+        status: input.status,
+        createdAt: input.now,
+        updatedAt: input.now,
+        expiresAt: input.expiresAt,
+      })
+      .onConflictDoNothing()
+      .returning({
+        invocationId: pgSchema.externalIngressInvocationsPostgres.invocationId,
+        status: pgSchema.externalIngressInvocationsPostgres.status,
+        bodyHash: pgSchema.externalIngressInvocationsPostgres.bodyHash,
+        responseJson: pgSchema.externalIngressInvocationsPostgres.responseJson,
+        error: pgSchema.externalIngressInvocationsPostgres.error,
+        updatedAt: pgSchema.externalIngressInvocationsPostgres.updatedAt,
+      });
+    return {
+      created: !!retried[0],
+      row: retried[0] ? mapInvocationRow(retried[0]) : undefined,
+    };
+  }
+
+  async getInvocationByIdempotencyKey(input: {
+    appId: string;
+    ingressId: string;
+    idempotencyKey: string;
+  }) {
+    const rows = await this.db
       .select({
         invocationId: pgSchema.externalIngressInvocationsPostgres.invocationId,
         status: pgSchema.externalIngressInvocationsPostgres.status,
+        bodyHash: pgSchema.externalIngressInvocationsPostgres.bodyHash,
+        responseJson: pgSchema.externalIngressInvocationsPostgres.responseJson,
+        error: pgSchema.externalIngressInvocationsPostgres.error,
+        updatedAt: pgSchema.externalIngressInvocationsPostgres.updatedAt,
       })
       .from(pgSchema.externalIngressInvocationsPostgres)
       .where(
@@ -193,7 +252,7 @@ export class PostgresExternalIngressRepository {
         ),
       )
       .limit(1);
-    return { created: false as const, row: existing[0]! };
+    return rows[0] ? mapInvocationRow(rows[0]) : undefined;
   }
 
   async updateInvocation(input: {
@@ -231,6 +290,7 @@ export class PostgresExternalIngressRepository {
         idempotencyKey:
           pgSchema.externalIngressInvocationsPostgres.idempotencyKey,
         status: pgSchema.externalIngressInvocationsPostgres.status,
+        bodyHash: pgSchema.externalIngressInvocationsPostgres.bodyHash,
         responseJson: pgSchema.externalIngressInvocationsPostgres.responseJson,
         error: pgSchema.externalIngressInvocationsPostgres.error,
         createdAt: pgSchema.externalIngressInvocationsPostgres.createdAt,
@@ -256,6 +316,7 @@ export class PostgresExternalIngressRepository {
       ingressId: row.ingressId,
       idempotencyKey: row.idempotencyKey,
       status: row.status,
+      bodyHash: row.bodyHash,
       response: parseJson(row.responseJson, null),
       error: row.error,
       createdAt: row.createdAt,
@@ -266,18 +327,39 @@ export class PostgresExternalIngressRepository {
   async sweepExpiredState(input: { now: string }): Promise<{
     noncesDeleted: number;
     invocationsDeleted: number;
+    stalePendingFailed: number;
   }> {
-    const nonceResult = await this.db
-      .delete(pgSchema.externalIngressNoncesPostgres)
-      .where(lt(pgSchema.externalIngressNoncesPostgres.expiresAt, input.now));
-    const invocationResult = await this.db
-      .delete(pgSchema.externalIngressInvocationsPostgres)
-      .where(
-        lt(pgSchema.externalIngressInvocationsPostgres.expiresAt, input.now),
-      );
+    const staleBefore = new Date(Date.parse(input.now) - 5 * 60_000);
+    const stalePendingResult = await this.db
+      .update(pgSchema.externalIngressInvocationsPostgres)
+      .set({
+        status: 'failed',
+        error:
+          'Invocation did not reach a terminal state before recovery timeout',
+        updatedAt: input.now,
+      }).where(sql`
+        ctid IN (
+          SELECT ctid
+          FROM ${pgSchema.externalIngressInvocationsPostgres}
+          WHERE ${pgSchema.externalIngressInvocationsPostgres.status} = 'pending'
+            AND ${pgSchema.externalIngressInvocationsPostgres.updatedAt} < ${staleBefore.toISOString()}
+          LIMIT ${EXTERNAL_INGRESS_SWEEP_BATCH_SIZE}
+        )
+      `);
+    const noncesDeleted = await deleteExpiredInBatches(
+      this.db,
+      pgSchema.externalIngressNoncesPostgres,
+      input.now,
+    );
+    const invocationsDeleted = await deleteExpiredInBatches(
+      this.db,
+      pgSchema.externalIngressInvocationsPostgres,
+      input.now,
+    );
     return {
-      noncesDeleted: Number(nonceResult.rowCount ?? 0),
-      invocationsDeleted: Number(invocationResult.rowCount ?? 0),
+      noncesDeleted,
+      invocationsDeleted,
+      stalePendingFailed: Number(stalePendingResult.rowCount ?? 0),
     };
   }
 }
@@ -311,4 +393,50 @@ function parseJson<T>(value: string | null | undefined, fallback: T): T {
   } catch {
     return fallback;
   }
+}
+
+function mapInvocationRow(row: {
+  invocationId: string;
+  status: string;
+  bodyHash: string;
+  responseJson: string | null;
+  error: string | null;
+  updatedAt: string;
+}) {
+  return {
+    invocationId: row.invocationId,
+    status: row.status,
+    bodyHash: row.bodyHash,
+    response: parseJson(row.responseJson, null),
+    error: row.error,
+    updatedAt: row.updatedAt,
+  };
+}
+
+async function deleteExpiredInBatches(
+  db: CanonicalDb,
+  table:
+    | typeof pgSchema.externalIngressNoncesPostgres
+    | typeof pgSchema.externalIngressInvocationsPostgres,
+  now: string,
+): Promise<number> {
+  let total = 0;
+  for (
+    let batch = 0;
+    batch < EXTERNAL_INGRESS_SWEEP_MAX_DELETE_BATCHES;
+    batch += 1
+  ) {
+    const result = await db.delete(table).where(sql`
+      ctid IN (
+        SELECT ctid
+        FROM ${table}
+        WHERE ${table.expiresAt} < ${now}
+        LIMIT ${EXTERNAL_INGRESS_SWEEP_BATCH_SIZE}
+      )
+    `);
+    const deleted = Number(result.rowCount ?? 0);
+    total += deleted;
+    if (deleted < EXTERNAL_INGRESS_SWEEP_BATCH_SIZE) return total;
+  }
+  return total;
 }

--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-job-triggers.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-job-triggers.postgres.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from 'node:crypto';
+
+import { and, asc, eq } from 'drizzle-orm';
+
+import { nowIso as currentIso } from '../../../../infrastructure/time/datetime.js';
+import {
+  mapTrigger,
+  type CanonicalControlRow,
+} from '../schema/control-plane-canonical.postgres.js';
+import type { JobTriggerRecord } from '../schema/control-plane-records.postgres.js';
+import * as pgSchema from '../schema/schema.js';
+import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
+
+export class PostgresJobTriggerRepository {
+  constructor(private readonly db: CanonicalDb) {}
+
+  async create(input: {
+    jobId: string;
+    requestedBy?: string;
+  }): Promise<JobTriggerRecord> {
+    const job = await this.db
+      .select({ appId: pgSchema.canonicalJobsPostgres.appId })
+      .from(pgSchema.canonicalJobsPostgres)
+      .where(eq(pgSchema.canonicalJobsPostgres.id, input.jobId))
+      .limit(1);
+    const appId = job[0]?.appId ?? 'default';
+    const now = currentIso();
+    const rows = await this.db
+      .insert(pgSchema.canonicalJobTriggersPostgres)
+      .values({
+        id: randomUUID(),
+        appId,
+        jobId: input.jobId,
+        runId: null,
+        requestedBy: input.requestedBy ?? 'sdk',
+        requestedAt: now,
+        status: 'pending',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+    return mapTrigger(rows[0] as CanonicalControlRow);
+  }
+
+  async bindPendingToRun(
+    jobId: string,
+    runId: string,
+  ): Promise<JobTriggerRecord | undefined> {
+    return this.db.transaction(async (tx) => {
+      const [pending] = await tx
+        .select()
+        .from(pgSchema.canonicalJobTriggersPostgres)
+        .where(
+          and(
+            eq(pgSchema.canonicalJobTriggersPostgres.jobId, jobId),
+            eq(pgSchema.canonicalJobTriggersPostgres.status, 'pending'),
+          ),
+        )
+        .orderBy(
+          asc(pgSchema.canonicalJobTriggersPostgres.requestedAt),
+          asc(pgSchema.canonicalJobTriggersPostgres.id),
+        )
+        .limit(1)
+        .for('update', { skipLocked: true });
+      if (!pending) return undefined;
+      const rows = await tx
+        .update(pgSchema.canonicalJobTriggersPostgres)
+        .set({
+          runId,
+          status: 'claimed',
+          updatedAt: currentIso(),
+        })
+        .where(
+          and(
+            eq(pgSchema.canonicalJobTriggersPostgres.id, pending.id),
+            eq(pgSchema.canonicalJobTriggersPostgres.status, 'pending'),
+          ),
+        )
+        .returning();
+      return rows[0] ? mapTrigger(rows[0] as CanonicalControlRow) : undefined;
+    });
+  }
+
+  async bindToRun(
+    triggerId: string,
+    runId: string,
+  ): Promise<JobTriggerRecord | undefined> {
+    const rows = await this.db
+      .update(pgSchema.canonicalJobTriggersPostgres)
+      .set({
+        runId,
+        status: 'claimed',
+        updatedAt: currentIso(),
+      })
+      .where(
+        and(
+          eq(pgSchema.canonicalJobTriggersPostgres.id, triggerId),
+          eq(pgSchema.canonicalJobTriggersPostgres.status, 'pending'),
+        ),
+      )
+      .returning();
+    return rows[0] ? mapTrigger(rows[0] as CanonicalControlRow) : undefined;
+  }
+
+  async markCompleted(
+    triggerId: string,
+    status: 'completed' | 'failed',
+  ): Promise<void> {
+    await this.db
+      .update(pgSchema.canonicalJobTriggersPostgres)
+      .set({ status, updatedAt: currentIso() })
+      .where(eq(pgSchema.canonicalJobTriggersPostgres.id, triggerId));
+  }
+
+  async getById(triggerId: string): Promise<JobTriggerRecord | undefined> {
+    const rows = await this.db
+      .select()
+      .from(pgSchema.canonicalJobTriggersPostgres)
+      .where(eq(pgSchema.canonicalJobTriggersPostgres.id, triggerId))
+      .limit(1);
+    return rows[0] ? mapTrigger(rows[0] as CanonicalControlRow) : undefined;
+  }
+}

--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-repository.postgres.ts
@@ -17,17 +17,24 @@ import {
   mapDelivery,
   mapRoute,
   mapSession,
-  mapTrigger,
   mapWebhook,
   text,
   type CanonicalControlRow,
 } from '../schema/control-plane-canonical.postgres.js';
 import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
 import { ensureControlGraph } from './control-plane-graph.postgres.js';
+import { PostgresExternalIngressRepository } from './control-plane-external-ingress.postgres.js';
+import { PostgresJobTriggerRepository } from './control-plane-job-triggers.postgres.js';
 import { claimDueWebhookDeliveriesWithDrizzleLock } from './control-plane-webhook-claim.postgres.js';
 
 export class PostgresControlPlaneRepository {
-  constructor(private readonly db: CanonicalDb) {}
+  private readonly externalIngress: PostgresExternalIngressRepository;
+  private readonly jobTriggers: PostgresJobTriggerRepository;
+
+  constructor(private readonly db: CanonicalDb) {
+    this.externalIngress = new PostgresExternalIngressRepository(db);
+    this.jobTriggers = new PostgresJobTriggerRepository(db);
+  }
 
   async ensureAppSession(input: {
     appId: string;
@@ -222,6 +229,93 @@ export class PostgresControlPlaneRepository {
       )
       .limit(1);
     return rows[0] ? mapRoute(rows[0] as CanonicalControlRow) : undefined;
+  }
+
+  async createExternalIngress(input: {
+    ingressId?: string;
+    appId: string;
+    name: string;
+    secret: string;
+    enabled?: boolean;
+    metadata?: unknown;
+  }) {
+    return this.externalIngress.create(input);
+  }
+
+  async listExternalIngresses(appId: string) {
+    return this.externalIngress.list(appId);
+  }
+
+  async getExternalIngressById(ingressId: string, appId?: string) {
+    return this.externalIngress.getById(ingressId, appId);
+  }
+
+  async updateExternalIngress(
+    ingressId: string,
+    appId: string,
+    patch: {
+      name?: string;
+      secret?: string;
+      enabled?: boolean;
+      metadata?: unknown;
+    },
+  ) {
+    return this.externalIngress.update(ingressId, appId, patch);
+  }
+
+  async deleteExternalIngress(ingressId: string, appId: string): Promise<void> {
+    await this.externalIngress.delete(ingressId, appId);
+  }
+
+  async reserveExternalIngressNonce(input: {
+    appId: string;
+    ingressId: string;
+    nonce: string;
+    now: string;
+    expiresAt: string;
+  }): Promise<{ ok: true } | { ok: false; code: 'NONCE_REPLAY' }> {
+    return this.externalIngress.reserveNonce(input);
+  }
+
+  async createExternalIngressInvocation(input: {
+    invocationId: string;
+    appId: string;
+    ingressId: string;
+    idempotencyKey: string;
+    nonce: string;
+    requestMethod: string;
+    requestPath: string;
+    requestTimestamp: string;
+    bodyHash: string;
+    requestBody: string;
+    signature: string;
+    status: string;
+    now: string;
+    expiresAt: string;
+  }) {
+    return this.externalIngress.createInvocation(input);
+  }
+
+  async updateExternalIngressInvocation(input: {
+    invocationId: string;
+    status: string;
+    response?: unknown;
+    error?: string | null;
+    now: string;
+  }): Promise<void> {
+    await this.externalIngress.updateInvocation(input);
+  }
+
+  async getExternalIngressInvocation(
+    invocationId: string,
+    appId: string,
+    ingressId: string,
+  ) {
+    return this.externalIngress.getInvocation(invocationId, appId, ingressId);
+  }
+
+  async sweepExpiredExternalIngressState(input: { now: string }) {
+    return this.externalIngress.sweepExpiredState(input);
   }
 
   async registerWebhook(input: {
@@ -556,108 +650,33 @@ export class PostgresControlPlaneRepository {
     jobId: string;
     requestedBy?: string;
   }): Promise<JobTriggerRecord> {
-    const job = await this.db
-      .select({ appId: pgSchema.canonicalJobsPostgres.appId })
-      .from(pgSchema.canonicalJobsPostgres)
-      .where(eq(pgSchema.canonicalJobsPostgres.id, input.jobId))
-      .limit(1);
-    const appId = job[0]?.appId ?? 'default';
-    const now = currentIso();
-    const rows = await this.db
-      .insert(pgSchema.canonicalJobTriggersPostgres)
-      .values({
-        id: randomUUID(),
-        appId,
-        jobId: input.jobId,
-        runId: null,
-        requestedBy: input.requestedBy ?? 'sdk',
-        requestedAt: now,
-        status: 'pending',
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
-    return mapTrigger(rows[0] as CanonicalControlRow);
+    return this.jobTriggers.create(input);
   }
 
   async bindPendingTriggerToRun(
     jobId: string,
     runId: string,
   ): Promise<JobTriggerRecord | undefined> {
-    return this.db.transaction(async (tx) => {
-      const [pending] = await tx
-        .select()
-        .from(pgSchema.canonicalJobTriggersPostgres)
-        .where(
-          and(
-            eq(pgSchema.canonicalJobTriggersPostgres.jobId, jobId),
-            eq(pgSchema.canonicalJobTriggersPostgres.status, 'pending'),
-          ),
-        )
-        .orderBy(
-          asc(pgSchema.canonicalJobTriggersPostgres.requestedAt),
-          asc(pgSchema.canonicalJobTriggersPostgres.id),
-        )
-        .limit(1)
-        .for('update', { skipLocked: true });
-      if (!pending) return undefined;
-      const rows = await tx
-        .update(pgSchema.canonicalJobTriggersPostgres)
-        .set({
-          runId,
-          status: 'claimed',
-          updatedAt: currentIso(),
-        })
-        .where(
-          and(
-            eq(pgSchema.canonicalJobTriggersPostgres.id, pending.id),
-            eq(pgSchema.canonicalJobTriggersPostgres.status, 'pending'),
-          ),
-        )
-        .returning();
-      return rows[0] ? mapTrigger(rows[0] as CanonicalControlRow) : undefined;
-    });
+    return this.jobTriggers.bindPendingToRun(jobId, runId);
   }
 
   async bindTriggerToRun(
     triggerId: string,
     runId: string,
   ): Promise<JobTriggerRecord | undefined> {
-    const rows = await this.db
-      .update(pgSchema.canonicalJobTriggersPostgres)
-      .set({
-        runId,
-        status: 'claimed',
-        updatedAt: currentIso(),
-      })
-      .where(
-        and(
-          eq(pgSchema.canonicalJobTriggersPostgres.id, triggerId),
-          eq(pgSchema.canonicalJobTriggersPostgres.status, 'pending'),
-        ),
-      )
-      .returning();
-    return rows[0] ? mapTrigger(rows[0] as CanonicalControlRow) : undefined;
+    return this.jobTriggers.bindToRun(triggerId, runId);
   }
 
   async markTriggerCompleted(
     triggerId: string,
     status: 'completed' | 'failed',
   ): Promise<void> {
-    await this.db
-      .update(pgSchema.canonicalJobTriggersPostgres)
-      .set({ status, updatedAt: currentIso() })
-      .where(eq(pgSchema.canonicalJobTriggersPostgres.id, triggerId));
+    await this.jobTriggers.markCompleted(triggerId, status);
   }
 
   async getTriggerById(
     triggerId: string,
   ): Promise<JobTriggerRecord | undefined> {
-    const rows = await this.db
-      .select()
-      .from(pgSchema.canonicalJobTriggersPostgres)
-      .where(eq(pgSchema.canonicalJobTriggersPostgres.id, triggerId))
-      .limit(1);
-    return rows[0] ? mapTrigger(rows[0] as CanonicalControlRow) : undefined;
+    return this.jobTriggers.getById(triggerId);
   }
 }

--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-repository.postgres.ts
@@ -263,8 +263,11 @@ export class PostgresControlPlaneRepository {
     return this.externalIngress.update(ingressId, appId, patch);
   }
 
-  async deleteExternalIngress(ingressId: string, appId: string): Promise<void> {
-    await this.externalIngress.delete(ingressId, appId);
+  async deleteExternalIngress(
+    ingressId: string,
+    appId: string,
+  ): Promise<boolean> {
+    return this.externalIngress.delete(ingressId, appId);
   }
 
   async reserveExternalIngressNonce(input: {
@@ -294,6 +297,14 @@ export class PostgresControlPlaneRepository {
     expiresAt: string;
   }) {
     return this.externalIngress.createInvocation(input);
+  }
+
+  async getExternalIngressInvocationByIdempotencyKey(input: {
+    appId: string;
+    ingressId: string;
+    idempotencyKey: string;
+  }) {
+    return this.externalIngress.getInvocationByIdempotencyKey(input);
   }
 
   async updateExternalIngressInvocation(input: {

--- a/apps/core/src/adapters/storage/postgres/schema/external-ingress.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/external-ingress.ts
@@ -1,0 +1,146 @@
+import {
+  boolean,
+  index,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  unique,
+} from 'drizzle-orm/pg-core';
+
+import { appsPostgres } from './apps.js';
+
+export const externalIngressesPostgres = pgTable(
+  'external_ingresses',
+  {
+    ingressId: text('ingress_id').primaryKey(),
+    appId: text('app_id')
+      .notNull()
+      .references(() => appsPostgres.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    secret: text('secret').notNull(),
+    enabled: boolean('enabled').notNull().default(true),
+    metadataJson: text('metadata_json').notNull().default('{}'),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'string',
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', {
+      withTimezone: true,
+      mode: 'string',
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    appNameUnique: unique('external_ingresses_app_id_name_key').on(
+      table.appId,
+      table.name,
+    ),
+    appEnabledIdx: index('idx_external_ingresses_app_enabled').on(
+      table.appId,
+      table.enabled,
+    ),
+  }),
+);
+
+export const externalIngressInvocationsPostgres = pgTable(
+  'external_ingress_invocations',
+  {
+    invocationId: text('invocation_id').primaryKey(),
+    appId: text('app_id')
+      .notNull()
+      .references(() => appsPostgres.id, { onDelete: 'cascade' }),
+    ingressId: text('ingress_id')
+      .notNull()
+      .references(() => externalIngressesPostgres.ingressId, {
+        onDelete: 'cascade',
+      }),
+    idempotencyKey: text('idempotency_key').notNull(),
+    nonce: text('nonce').notNull(),
+    requestMethod: text('request_method').notNull(),
+    requestPath: text('request_path').notNull(),
+    requestTimestamp: timestamp('request_timestamp', {
+      withTimezone: true,
+      mode: 'string',
+    }).notNull(),
+    bodyHash: text('body_hash').notNull(),
+    requestBody: text('request_body').notNull(),
+    signature: text('signature').notNull(),
+    status: text('status').notNull().default('pending'),
+    responseJson: text('response_json'),
+    error: text('error'),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'string',
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', {
+      withTimezone: true,
+      mode: 'string',
+    })
+      .notNull()
+      .defaultNow(),
+    expiresAt: timestamp('expires_at', {
+      withTimezone: true,
+      mode: 'string',
+    }).notNull(),
+  },
+  (table) => ({
+    idempotencyUnique: unique(
+      'external_ingress_invocations_app_id_ingress_id_idempotency_key_key',
+    ).on(table.appId, table.ingressId, table.idempotencyKey),
+    appCreatedIdx: index('idx_external_ingress_invocations_app_created').on(
+      table.appId,
+      table.createdAt,
+    ),
+    ingressStatusCreatedIdx: index(
+      'idx_external_ingress_invocations_ingress_status_created',
+    ).on(table.ingressId, table.status, table.createdAt),
+    expiresIdx: index('idx_external_ingress_invocations_expires').on(
+      table.expiresAt,
+    ),
+  }),
+);
+
+export const externalIngressNoncesPostgres = pgTable(
+  'external_ingress_nonces',
+  {
+    appId: text('app_id')
+      .notNull()
+      .references(() => appsPostgres.id, { onDelete: 'cascade' }),
+    ingressId: text('ingress_id')
+      .notNull()
+      .references(() => externalIngressesPostgres.ingressId, {
+        onDelete: 'cascade',
+      }),
+    nonce: text('nonce').notNull(),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'string',
+    })
+      .notNull()
+      .defaultNow(),
+    expiresAt: timestamp('expires_at', {
+      withTimezone: true,
+      mode: 'string',
+    }).notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.appId, table.ingressId, table.nonce],
+      name: 'external_ingress_nonces_pk',
+    }),
+    expiryIdx: index('idx_external_ingress_nonces_expiry').on(
+      table.appId,
+      table.ingressId,
+      table.expiresAt,
+    ),
+    expiresOnlyIdx: index('idx_external_ingress_nonces_expires').on(
+      table.expiresAt,
+    ),
+  }),
+);

--- a/apps/core/src/adapters/storage/postgres/schema/index.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/index.ts
@@ -5,6 +5,7 @@ export * from './channels.js';
 export * from './conversations.js';
 export * from './control-http.js';
 export * from './events.js';
+export * from './external-ingress.js';
 export * from './jobs.js';
 export * from './memory.js';
 export * from './messages.js';

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0019_external_ingress.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0019_external_ingress.sql
@@ -1,0 +1,60 @@
+CREATE TABLE IF NOT EXISTS external_ingresses (
+  ingress_id text PRIMARY KEY,
+  app_id text NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  secret text NOT NULL,
+  enabled boolean NOT NULL DEFAULT true,
+  metadata_json text NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT external_ingresses_app_id_name_key UNIQUE (app_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_ingresses_app_enabled
+  ON external_ingresses(app_id, enabled);
+
+CREATE TABLE IF NOT EXISTS external_ingress_invocations (
+  invocation_id text PRIMARY KEY,
+  app_id text NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  ingress_id text NOT NULL REFERENCES external_ingresses(ingress_id) ON DELETE CASCADE,
+  idempotency_key text NOT NULL,
+  nonce text NOT NULL,
+  request_method text NOT NULL,
+  request_path text NOT NULL,
+  request_timestamp timestamptz NOT NULL,
+  body_hash text NOT NULL,
+  request_body text NOT NULL,
+  signature text NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  response_json text,
+  error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  CONSTRAINT external_ingress_invocations_app_id_ingress_id_idempotency_key_key
+    UNIQUE (app_id, ingress_id, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_ingress_invocations_app_created
+  ON external_ingress_invocations(app_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_external_ingress_invocations_ingress_status_created
+  ON external_ingress_invocations(ingress_id, status, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_external_ingress_invocations_expires
+  ON external_ingress_invocations(expires_at);
+
+CREATE TABLE IF NOT EXISTS external_ingress_nonces (
+  app_id text NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  ingress_id text NOT NULL REFERENCES external_ingresses(ingress_id) ON DELETE CASCADE,
+  nonce text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  CONSTRAINT external_ingress_nonces_pk PRIMARY KEY (app_id, ingress_id, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_ingress_nonces_expiry
+  ON external_ingress_nonces(app_id, ingress_id, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_external_ingress_nonces_expires
+  ON external_ingress_nonces(expires_at);

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777050600000,
       "tag": "0018_runtime_event_exchange",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1777054200000,
+      "tag": "0019_external_ingress",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/application/app-scope/control-id.ts
+++ b/apps/core/src/application/app-scope/control-id.ts
@@ -1,0 +1,5 @@
+const CONTROL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export function isValidControlId(value: string): boolean {
+  return CONTROL_ID_PATTERN.test(value);
+}

--- a/apps/core/src/application/app-scope/resolve-app-scope.ts
+++ b/apps/core/src/application/app-scope/resolve-app-scope.ts
@@ -1,0 +1,14 @@
+function readAssertedAppId(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const assertedAppId = value.trim();
+  return assertedAppId ? assertedAppId : null;
+}
+
+export function resolveAppScopeAppId(input: {
+  apiKeyAppId: string;
+  assertedAppId: string | null | undefined;
+}): string | null {
+  const assertedAppId = readAssertedAppId(input.assertedAppId);
+  if (!assertedAppId) return input.apiKeyAppId;
+  return assertedAppId === input.apiKeyAppId ? input.apiKeyAppId : null;
+}

--- a/apps/core/src/application/external-ingress/external-ingress-module.ts
+++ b/apps/core/src/application/external-ingress/external-ingress-module.ts
@@ -1,0 +1,659 @@
+import { ApplicationError } from '../common/application-error.js';
+import { JobManagementService } from '../jobs/job-management-service.js';
+import type { SessionInteractionModule } from '../sessions/session-interaction-module.js';
+import {
+  type ExternalIngressSignaturePort,
+  verifyExternalIngressRequestSignature,
+} from './signature.js';
+
+type ExternalIngressRecord = {
+  ingressId: string;
+  appId: string;
+  name: string;
+  secret: string;
+  enabled: boolean;
+  metadata: unknown;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ExternalIngressControlPort = {
+  createExternalIngress(input: {
+    appId: string;
+    name: string;
+    secret: string;
+    enabled?: boolean;
+    metadata?: unknown;
+  }): Promise<ExternalIngressRecord>;
+  listExternalIngresses(appId: string): Promise<ExternalIngressRecord[]>;
+  getExternalIngressById(
+    ingressId: string,
+    appId?: string,
+  ): Promise<ExternalIngressRecord | undefined>;
+  updateExternalIngress(
+    ingressId: string,
+    appId: string,
+    patch: {
+      name?: string;
+      secret?: string;
+      enabled?: boolean;
+      metadata?: unknown;
+    },
+  ): Promise<ExternalIngressRecord | undefined>;
+  deleteExternalIngress(ingressId: string, appId: string): Promise<void>;
+  reserveExternalIngressNonce(input: {
+    appId: string;
+    ingressId: string;
+    nonce: string;
+    now: string;
+    expiresAt: string;
+  }): Promise<{ ok: true } | { ok: false; code: 'NONCE_REPLAY' }>;
+  createExternalIngressInvocation(input: {
+    invocationId: string;
+    appId: string;
+    ingressId: string;
+    idempotencyKey: string;
+    nonce: string;
+    requestMethod: string;
+    requestPath: string;
+    requestTimestamp: string;
+    bodyHash: string;
+    requestBody: string;
+    signature: string;
+    status: string;
+    now: string;
+    expiresAt: string;
+  }): Promise<{
+    created: boolean;
+    row: { invocationId: string; status: string };
+  }>;
+  updateExternalIngressInvocation(input: {
+    invocationId: string;
+    status: string;
+    response?: unknown;
+    error?: string | null;
+    now: string;
+  }): Promise<void>;
+  getExternalIngressInvocation(
+    invocationId: string,
+    appId: string,
+    ingressId: string,
+  ): Promise<
+    | {
+        invocationId: string;
+        status: string;
+        response: unknown;
+        error: string | null;
+      }
+    | undefined
+  >;
+};
+
+export class ExternalIngressModule {
+  constructor(
+    private readonly deps: {
+      control: ExternalIngressControlPort;
+      sessions: SessionInteractionModule;
+      jobs: JobManagementService;
+      now: () => string;
+      createSecret: () => string;
+      createInvocationId: () => string;
+      signatureCrypto: ExternalIngressSignaturePort;
+      consumeTriggerRateLimit?: (key: string, limit: number) => boolean;
+      perAppTriggerLimit: number;
+      perJobTriggerLimit: number;
+    },
+  ) {}
+
+  async create(input: {
+    appId: string;
+    name: string;
+    enabled?: boolean;
+    metadata?: unknown;
+  }) {
+    if (!input.name.trim()) {
+      throw new ApplicationError('INVALID_REQUEST', 'name is required');
+    }
+    const secret = this.deps.createSecret();
+    const ingress = await this.deps.control.createExternalIngress({
+      appId: input.appId,
+      name: input.name.trim(),
+      secret,
+      enabled: input.enabled ?? true,
+      metadata: input.metadata ?? {},
+    });
+    return { ...publicIngress(ingress), secret };
+  }
+
+  async list(appId: string) {
+    const ingresses = await this.deps.control.listExternalIngresses(appId);
+    return { ingresses: ingresses.map(publicIngress) };
+  }
+
+  async get(input: { appId: string; ingressId: string }) {
+    const ingress = await this.deps.control.getExternalIngressById(
+      input.ingressId,
+      input.appId,
+    );
+    if (!ingress) throw new ApplicationError('NOT_FOUND', 'Ingress not found');
+    return publicIngress(ingress);
+  }
+
+  async update(input: {
+    appId: string;
+    ingressId: string;
+    patch: { name?: string; enabled?: boolean; metadata?: unknown };
+  }) {
+    const ingress = await this.deps.control.updateExternalIngress(
+      input.ingressId,
+      input.appId,
+      input.patch,
+    );
+    if (!ingress) throw new ApplicationError('NOT_FOUND', 'Ingress not found');
+    return publicIngress(ingress);
+  }
+
+  async rotate(input: { appId: string; ingressId: string }) {
+    const secret = this.deps.createSecret();
+    const ingress = await this.deps.control.updateExternalIngress(
+      input.ingressId,
+      input.appId,
+      { secret },
+    );
+    if (!ingress) throw new ApplicationError('NOT_FOUND', 'Ingress not found');
+    return { ...publicIngress(ingress), secret };
+  }
+
+  async delete(input: { appId: string; ingressId: string }) {
+    await this.deps.control.deleteExternalIngress(input.ingressId, input.appId);
+    return { deleted: true };
+  }
+
+  async invoke(input: {
+    ingressId: string;
+    method: string;
+    path: string;
+    timestamp: string;
+    nonce: string;
+    signature: string;
+    rawBody: string;
+  }) {
+    const ingress = await this.deps.control.getExternalIngressById(
+      input.ingressId,
+    );
+    if (!ingress) throw new ApplicationError('NOT_FOUND', 'Ingress not found');
+    if (!ingress.enabled) {
+      throw new ApplicationError('FORBIDDEN', 'Ingress is disabled');
+    }
+    const ok = verifyExternalIngressRequestSignature({
+      crypto: this.deps.signatureCrypto,
+      secret: ingress.secret,
+      method: input.method,
+      path: input.path,
+      timestamp: input.timestamp,
+      nonce: input.nonce,
+      rawBody: input.rawBody,
+      signature: input.signature,
+    });
+    if (!ok) {
+      throw new ApplicationError(
+        'FORBIDDEN',
+        'Invalid external ingress signature',
+      );
+    }
+    const body = parseBody(input.rawBody);
+    const assertedAppId =
+      typeof body.appId === 'string' && body.appId.trim()
+        ? body.appId.trim()
+        : null;
+    if (assertedAppId && assertedAppId !== ingress.appId) {
+      throw new ApplicationError(
+        'FORBIDDEN',
+        'Request appId does not match ingress app scope',
+      );
+    }
+    const now = this.deps.now();
+    const timestampMs = Number(input.timestamp);
+    const nonceExpiry = new Date(timestampMs + 5 * 60_000).toISOString();
+    const nonce = await this.deps.control.reserveExternalIngressNonce({
+      appId: ingress.appId,
+      ingressId: ingress.ingressId,
+      nonce: input.nonce,
+      now,
+      expiresAt: nonceExpiry,
+    });
+    if (!nonce.ok) {
+      throw new ApplicationError('CONFLICT', 'External ingress nonce replay');
+    }
+    const invocationId = this.deps.createInvocationId();
+    const idempotencyKey =
+      typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim()
+        ? body.idempotencyKey.trim()
+        : input.nonce;
+    const bodyHash = this.deps.signatureCrypto.sha256(input.rawBody);
+    const invocation = await this.deps.control.createExternalIngressInvocation({
+      invocationId,
+      appId: ingress.appId,
+      ingressId: ingress.ingressId,
+      idempotencyKey,
+      nonce: input.nonce,
+      requestMethod: input.method.toUpperCase(),
+      requestPath: input.path,
+      requestTimestamp: new Date(timestampMs).toISOString(),
+      bodyHash,
+      requestBody: input.rawBody,
+      signature: input.signature,
+      status: 'pending',
+      now,
+      expiresAt: addDaysIso(now, 30),
+    });
+    if (!invocation.created && invocation.row.status === 'pending') {
+      throw new ApplicationError(
+        'CONFLICT',
+        'Duplicate active external ingress invocation',
+      );
+    }
+    if (!invocation.created) {
+      return {
+        invocationId: invocation.row.invocationId,
+        duplicate: true,
+      };
+    }
+    try {
+      const result = await this.dispatchTarget({
+        appId: ingress.appId,
+        invocationId,
+        metadata: ingress.metadata,
+        body,
+      });
+      await this.deps.control.updateExternalIngressInvocation({
+        invocationId,
+        status: 'completed',
+        response: result,
+        now: this.deps.now(),
+      });
+      return { invocationId, duplicate: false, ...result };
+    } catch (error) {
+      await this.deps.control.updateExternalIngressInvocation({
+        invocationId,
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Invocation failed',
+        now: this.deps.now(),
+      });
+      throw error;
+    }
+  }
+
+  async wait(input: { ingressId: string; invocationId: string }) {
+    const ingress = await this.deps.control.getExternalIngressById(
+      input.ingressId,
+    );
+    if (!ingress) throw new ApplicationError('NOT_FOUND', 'Ingress not found');
+    const invocation = await this.deps.control.getExternalIngressInvocation(
+      input.invocationId,
+      ingress.appId,
+      ingress.ingressId,
+    );
+    if (!invocation) {
+      throw new ApplicationError('NOT_FOUND', 'Invocation not found');
+    }
+    return invocation;
+  }
+
+  async signedWait(input: {
+    ingressId: string;
+    method: string;
+    path: string;
+    timestamp: string;
+    nonce: string;
+    signature: string;
+    rawBody: string;
+  }) {
+    const ingress = await this.deps.control.getExternalIngressById(
+      input.ingressId,
+    );
+    if (!ingress) throw new ApplicationError('NOT_FOUND', 'Ingress not found');
+    if (!ingress.enabled) {
+      throw new ApplicationError('FORBIDDEN', 'Ingress is disabled');
+    }
+    const ok = verifyExternalIngressRequestSignature({
+      crypto: this.deps.signatureCrypto,
+      secret: ingress.secret,
+      method: input.method,
+      path: input.path,
+      timestamp: input.timestamp,
+      nonce: input.nonce,
+      rawBody: input.rawBody,
+      signature: input.signature,
+    });
+    if (!ok) {
+      throw new ApplicationError(
+        'FORBIDDEN',
+        'Invalid external ingress signature',
+      );
+    }
+    const timestampMs = Number(input.timestamp);
+    const nonce = await this.deps.control.reserveExternalIngressNonce({
+      appId: ingress.appId,
+      ingressId: ingress.ingressId,
+      nonce: input.nonce,
+      now: this.deps.now(),
+      expiresAt: new Date(timestampMs + 5 * 60_000).toISOString(),
+    });
+    if (!nonce.ok) {
+      throw new ApplicationError('CONFLICT', 'External ingress nonce replay');
+    }
+    const body = parseBody(input.rawBody);
+    const invocationId = readString(body, 'invocationId');
+    return this.wait({ ingressId: input.ingressId, invocationId });
+  }
+
+  private async dispatchTarget(input: {
+    appId: string;
+    invocationId: string;
+    metadata: unknown;
+    body: Record<string, unknown>;
+  }) {
+    const target = readTarget(input.body);
+    assertTargetAllowed(input.metadata, target);
+    if (target.kind === 'session_message') {
+      return this.invokeSessionMessage(input.appId, target);
+    }
+    if (target.kind === 'job_trigger') {
+      return this.invokeJobTrigger(input.appId, target);
+    }
+    if (target.kind === 'job_template') {
+      return this.invokeJobTemplate(input.appId, input.metadata, target);
+    }
+    throw new ApplicationError('INVALID_REQUEST', 'Unsupported ingress target');
+  }
+
+  private async invokeSessionMessage(appId: string, target: IngressTarget) {
+    const message = readString(target, 'message');
+    let sessionId = readOptionalString(target, 'sessionId');
+    if (!sessionId) {
+      const conversationId = readString(target, 'conversationId');
+      const ensured = await this.deps.sessions.ensureSession({
+        appId,
+        conversationId,
+        title: readOptionalString(target, 'title'),
+      });
+      sessionId = ensured.session.sessionId;
+    }
+    const accepted = await this.deps.sessions.acceptMessage({
+      appId,
+      sessionId,
+      message,
+      senderId: readOptionalString(target, 'senderId') ?? 'external-ingress',
+      senderName:
+        readOptionalString(target, 'senderName') ?? 'External Ingress',
+      threadId: readOptionalString(target, 'threadId') ?? undefined,
+      correlationId: readOptionalString(target, 'correlationId') ?? null,
+      responseMode: target.responseMode,
+      webhookId: readOptionalString(target, 'webhookId'),
+    });
+    return {
+      targetKind: 'session_message',
+      sessionId,
+      messageId: accepted.messageId,
+      acceptedEventId: accepted.acceptedEventId,
+      wait: {
+        kind: 'session',
+        sessionId,
+        afterEventId: accepted.acceptedEventId,
+      },
+      enqueue: accepted.enqueue,
+    };
+  }
+
+  private async invokeJobTrigger(appId: string, target: IngressTarget) {
+    const jobId = readString(target, 'jobId');
+    const trigger = await this.deps.jobs.triggerJob({
+      appId,
+      jobId,
+      consumeRateLimit: this.deps.consumeTriggerRateLimit,
+      perAppLimit: this.deps.perAppTriggerLimit,
+      perJobLimit: this.deps.perJobTriggerLimit,
+    });
+    return {
+      targetKind: 'job_trigger',
+      jobId,
+      triggerId: trigger.triggerId,
+      wait: { kind: 'trigger', triggerId: trigger.triggerId },
+    };
+  }
+
+  private async invokeJobTemplate(
+    appId: string,
+    metadata: unknown,
+    target: IngressTarget,
+  ) {
+    const templateId = readString(target, 'templateId');
+    const template = readTemplate(metadata, templateId);
+    const variables = readVariables(target.variables);
+    const allowed = new Set(template.allowedVariables ?? []);
+    for (const key of Object.keys(variables)) {
+      if (!allowed.has(key)) {
+        throw new ApplicationError(
+          'FORBIDDEN',
+          `Variable is not allowed by job template: ${key}`,
+        );
+      }
+    }
+    const prompt = renderTemplate(template.prompt, variables);
+    const created = await this.deps.jobs.createJob({
+      appId,
+      name: template.name,
+      prompt,
+      sessionId: template.sessionId,
+      kind: 'once',
+      runAt: this.deps.now(),
+      executionMode: 'serialized',
+    });
+    const trigger = await this.deps.jobs.triggerJob({
+      appId,
+      jobId: created.jobId,
+      consumeRateLimit: this.deps.consumeTriggerRateLimit,
+      perAppLimit: this.deps.perAppTriggerLimit,
+      perJobLimit: this.deps.perJobTriggerLimit,
+    });
+    return {
+      targetKind: 'job_template',
+      templateId,
+      jobId: created.jobId,
+      triggerId: trigger.triggerId,
+      wait: { kind: 'trigger', triggerId: trigger.triggerId },
+    };
+  }
+}
+
+type IngressTarget = Record<string, unknown> & { kind: string };
+
+function publicIngress(ingress: ExternalIngressRecord) {
+  return {
+    ingressId: ingress.ingressId,
+    appId: ingress.appId,
+    name: ingress.name,
+    enabled: ingress.enabled,
+    metadata: ingress.metadata,
+    createdAt: ingress.createdAt,
+    updatedAt: ingress.updatedAt,
+  };
+}
+
+function parseBody(rawBody: string): Record<string, unknown> {
+  try {
+    const parsed = rawBody.trim() ? JSON.parse(rawBody) : {};
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {}
+  throw new ApplicationError('INVALID_REQUEST', 'Invalid JSON body');
+}
+
+function readTarget(body: Record<string, unknown>): IngressTarget {
+  const target = body.target;
+  if (!target || typeof target !== 'object' || Array.isArray(target)) {
+    throw new ApplicationError('INVALID_REQUEST', 'target is required');
+  }
+  const kind = (target as Record<string, unknown>).kind;
+  if (typeof kind !== 'string' || !kind.trim()) {
+    throw new ApplicationError('INVALID_REQUEST', 'target.kind is required');
+  }
+  return target as IngressTarget;
+}
+
+function addDaysIso(value: string, days: number): string {
+  const time = Date.parse(value);
+  const base = Number.isFinite(time) ? time : Date.now();
+  return new Date(base + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function assertTargetAllowed(metadata: unknown, target: IngressTarget): void {
+  const policy = readTargetPolicy(metadata);
+  if (!allows(policy.targetKinds, target.kind)) {
+    throw new ApplicationError(
+      'FORBIDDEN',
+      `Ingress is not allowed to invoke target kind: ${target.kind}`,
+    );
+  }
+  if (target.kind === 'session_message') {
+    const sessionId = readOptionalString(target, 'sessionId');
+    if (sessionId && allows(policy.sessionIds, sessionId)) return;
+    const conversationId = readOptionalString(target, 'conversationId');
+    if (conversationId && allows(policy.conversationIds, conversationId)) {
+      return;
+    }
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Ingress is not allowed to invoke this session target',
+    );
+  }
+  if (target.kind === 'job_trigger') {
+    const jobId = readOptionalString(target, 'jobId');
+    if (jobId && allows(policy.jobIds, jobId)) return;
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Ingress is not allowed to trigger this job',
+    );
+  }
+  if (target.kind === 'job_template') {
+    const templateId = readOptionalString(target, 'templateId');
+    if (templateId && allows(policy.templateIds, templateId)) return;
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Ingress is not allowed to invoke this job template',
+    );
+  }
+}
+
+function readTargetPolicy(metadata: unknown): {
+  targetKinds: Set<string>;
+  sessionIds: Set<string>;
+  conversationIds: Set<string>;
+  jobIds: Set<string>;
+  templateIds: Set<string>;
+} {
+  const root =
+    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  const policy =
+    root.targetPolicy &&
+    typeof root.targetPolicy === 'object' &&
+    !Array.isArray(root.targetPolicy)
+      ? (root.targetPolicy as Record<string, unknown>)
+      : {};
+  return {
+    targetKinds: readPolicySet(policy.allowedTargetKinds),
+    sessionIds: readPolicySet(policy.sessionIds),
+    conversationIds: readPolicySet(policy.conversationIds),
+    jobIds: readPolicySet(policy.jobIds),
+    templateIds: readPolicySet(policy.templateIds),
+  };
+}
+
+function readPolicySet(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(
+    value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+}
+
+function allows(allowed: Set<string>, value: string): boolean {
+  return allowed.has('*') || allowed.has(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ApplicationError('INVALID_REQUEST', `${key} is required`);
+  }
+  return value.trim();
+}
+
+function readOptionalString(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function readVariables(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const variables: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'string' || typeof raw === 'number') {
+      variables[key] = String(raw);
+    }
+  }
+  return variables;
+}
+
+function readTemplate(
+  metadata: unknown,
+  templateId: string,
+): {
+  name: string;
+  prompt: string;
+  sessionId: string;
+  allowedVariables?: string[];
+} {
+  const root =
+    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  const templates =
+    root.templates && typeof root.templates === 'object'
+      ? (root.templates as Record<string, unknown>)
+      : {};
+  const template = templates[templateId];
+  if (!template || typeof template !== 'object' || Array.isArray(template)) {
+    throw new ApplicationError('NOT_FOUND', 'Job template not found');
+  }
+  const record = template as Record<string, unknown>;
+  const allowed = Array.isArray(record.allowedVariables)
+    ? record.allowedVariables.filter(
+        (value): value is string => typeof value === 'string',
+      )
+    : [];
+  return {
+    name: readString(record, 'name'),
+    prompt: readString(record, 'prompt'),
+    sessionId: readString(record, 'sessionId'),
+    allowedVariables: allowed,
+  };
+}
+
+function renderTemplate(
+  prompt: string,
+  variables: Record<string, string>,
+): string {
+  return prompt.replace(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (_match, key) => {
+    return variables[String(key)] ?? '';
+  });
+}

--- a/apps/core/src/application/external-ingress/external-ingress-module.ts
+++ b/apps/core/src/application/external-ingress/external-ingress-module.ts
@@ -5,6 +5,15 @@ import {
   type ExternalIngressSignaturePort,
   verifyExternalIngressRequestSignature,
 } from './signature.js';
+import {
+  assertTargetAllowed,
+  type IngressTarget,
+  readOptionalString,
+  readString,
+  readTemplate,
+  readVariables,
+  renderTemplate,
+} from './target-policy.js';
 
 type ExternalIngressRecord = {
   ingressId: string;
@@ -40,7 +49,7 @@ type ExternalIngressControlPort = {
       metadata?: unknown;
     },
   ): Promise<ExternalIngressRecord | undefined>;
-  deleteExternalIngress(ingressId: string, appId: string): Promise<void>;
+  deleteExternalIngress(ingressId: string, appId: string): Promise<boolean>;
   reserveExternalIngressNonce(input: {
     appId: string;
     ingressId: string;
@@ -65,8 +74,13 @@ type ExternalIngressControlPort = {
     expiresAt: string;
   }): Promise<{
     created: boolean;
-    row: { invocationId: string; status: string };
+    row?: ExternalIngressInvocationRecord;
   }>;
+  getExternalIngressInvocationByIdempotencyKey(input: {
+    appId: string;
+    ingressId: string;
+    idempotencyKey: string;
+  }): Promise<ExternalIngressInvocationRecord | undefined>;
   updateExternalIngressInvocation(input: {
     invocationId: string;
     status: string;
@@ -87,6 +101,15 @@ type ExternalIngressControlPort = {
       }
     | undefined
   >;
+};
+
+type ExternalIngressInvocationRecord = {
+  invocationId: string;
+  status: string;
+  bodyHash: string;
+  response: unknown;
+  error: string | null;
+  updatedAt: string;
 };
 
 export class ExternalIngressModule {
@@ -165,7 +188,11 @@ export class ExternalIngressModule {
   }
 
   async delete(input: { appId: string; ingressId: string }) {
-    await this.deps.control.deleteExternalIngress(input.ingressId, input.appId);
+    const deleted = await this.deps.control.deleteExternalIngress(
+      input.ingressId,
+      input.appId,
+    );
+    if (!deleted) throw new ApplicationError('NOT_FOUND', 'Ingress not found');
     return { deleted: true };
   }
 
@@ -212,8 +239,29 @@ export class ExternalIngressModule {
         'Request appId does not match ingress app scope',
       );
     }
-    const now = this.deps.now();
     const timestampMs = Number(input.timestamp);
+    const now = this.deps.now();
+    const idempotencyKey =
+      typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim()
+        ? body.idempotencyKey.trim()
+        : input.nonce;
+    const bodyHash = this.deps.signatureCrypto.sha256(input.rawBody);
+    const existing =
+      await this.deps.control.getExternalIngressInvocationByIdempotencyKey({
+        appId: ingress.appId,
+        ingressId: ingress.ingressId,
+        idempotencyKey,
+      });
+    if (existing) {
+      assertSameIdempotencyBody(existing, bodyHash);
+      if (existing.status === 'pending') {
+        throw new ApplicationError(
+          'CONFLICT',
+          'Duplicate active external ingress invocation',
+        );
+      }
+      return duplicateInvocationResponse(existing);
+    }
     const nonceExpiry = new Date(timestampMs + 5 * 60_000).toISOString();
     const nonce = await this.deps.control.reserveExternalIngressNonce({
       appId: ingress.appId,
@@ -226,11 +274,6 @@ export class ExternalIngressModule {
       throw new ApplicationError('CONFLICT', 'External ingress nonce replay');
     }
     const invocationId = this.deps.createInvocationId();
-    const idempotencyKey =
-      typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim()
-        ? body.idempotencyKey.trim()
-        : input.nonce;
-    const bodyHash = this.deps.signatureCrypto.sha256(input.rawBody);
     const invocation = await this.deps.control.createExternalIngressInvocation({
       invocationId,
       appId: ingress.appId,
@@ -247,6 +290,15 @@ export class ExternalIngressModule {
       now,
       expiresAt: addDaysIso(now, 30),
     });
+    if (!invocation.row) {
+      throw new ApplicationError(
+        'CONFLICT',
+        'External ingress invocation conflict; retry request',
+      );
+    }
+    if (!invocation.created) {
+      assertSameIdempotencyBody(invocation.row, bodyHash);
+    }
     if (!invocation.created && invocation.row.status === 'pending') {
       throw new ApplicationError(
         'CONFLICT',
@@ -254,10 +306,7 @@ export class ExternalIngressModule {
       );
     }
     if (!invocation.created) {
-      return {
-        invocationId: invocation.row.invocationId,
-        duplicate: true,
-      };
+      return duplicateInvocationResponse(invocation.row);
     }
     try {
       const result = await this.dispatchTarget({
@@ -274,12 +323,7 @@ export class ExternalIngressModule {
       });
       return { invocationId, duplicate: false, ...result };
     } catch (error) {
-      await this.deps.control.updateExternalIngressInvocation({
-        invocationId,
-        status: 'failed',
-        error: error instanceof Error ? error.message : 'Invocation failed',
-        now: this.deps.now(),
-      });
+      await this.markInvocationFailed(invocationId, error);
       throw error;
     }
   }
@@ -371,6 +415,11 @@ export class ExternalIngressModule {
   private async invokeSessionMessage(appId: string, target: IngressTarget) {
     const message = readString(target, 'message');
     let sessionId = readOptionalString(target, 'sessionId');
+    let registerGroup:
+      | Awaited<
+          ReturnType<SessionInteractionModule['ensureSession']>
+        >['registerGroup']
+      | undefined;
     if (!sessionId) {
       const conversationId = readString(target, 'conversationId');
       const ensured = await this.deps.sessions.ensureSession({
@@ -379,6 +428,7 @@ export class ExternalIngressModule {
         title: readOptionalString(target, 'title'),
       });
       sessionId = ensured.session.sessionId;
+      registerGroup = ensured.registerGroup;
     }
     const accepted = await this.deps.sessions.acceptMessage({
       appId,
@@ -402,6 +452,7 @@ export class ExternalIngressModule {
         sessionId,
         afterEventId: accepted.acceptedEventId,
       },
+      ...(registerGroup ? { registerGroup } : {}),
       enqueue: accepted.enqueue,
     };
   }
@@ -465,9 +516,24 @@ export class ExternalIngressModule {
       wait: { kind: 'trigger', triggerId: trigger.triggerId },
     };
   }
-}
 
-type IngressTarget = Record<string, unknown> & { kind: string };
+  private async markInvocationFailed(
+    invocationId: string,
+    error: unknown,
+  ): Promise<void> {
+    try {
+      await this.deps.control.updateExternalIngressInvocation({
+        invocationId,
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Invocation failed',
+        now: this.deps.now(),
+      });
+    } catch {
+      // Dispatch errors should stay visible to the caller even if the
+      // best-effort failure status update races with shutdown or deletion.
+    }
+  }
+}
 
 function publicIngress(ingress: ExternalIngressRecord) {
   return {
@@ -509,151 +575,32 @@ function addDaysIso(value: string, days: number): string {
   return new Date(base + days * 24 * 60 * 60 * 1000).toISOString();
 }
 
-function assertTargetAllowed(metadata: unknown, target: IngressTarget): void {
-  const policy = readTargetPolicy(metadata);
-  if (!allows(policy.targetKinds, target.kind)) {
+function assertSameIdempotencyBody(
+  invocation: ExternalIngressInvocationRecord,
+  bodyHash: string,
+): void {
+  if (invocation.bodyHash !== bodyHash) {
     throw new ApplicationError(
-      'FORBIDDEN',
-      `Ingress is not allowed to invoke target kind: ${target.kind}`,
-    );
-  }
-  if (target.kind === 'session_message') {
-    const sessionId = readOptionalString(target, 'sessionId');
-    if (sessionId && allows(policy.sessionIds, sessionId)) return;
-    const conversationId = readOptionalString(target, 'conversationId');
-    if (conversationId && allows(policy.conversationIds, conversationId)) {
-      return;
-    }
-    throw new ApplicationError(
-      'FORBIDDEN',
-      'Ingress is not allowed to invoke this session target',
-    );
-  }
-  if (target.kind === 'job_trigger') {
-    const jobId = readOptionalString(target, 'jobId');
-    if (jobId && allows(policy.jobIds, jobId)) return;
-    throw new ApplicationError(
-      'FORBIDDEN',
-      'Ingress is not allowed to trigger this job',
-    );
-  }
-  if (target.kind === 'job_template') {
-    const templateId = readOptionalString(target, 'templateId');
-    if (templateId && allows(policy.templateIds, templateId)) return;
-    throw new ApplicationError(
-      'FORBIDDEN',
-      'Ingress is not allowed to invoke this job template',
+      'CONFLICT',
+      'Idempotency key reused with different request body',
     );
   }
 }
 
-function readTargetPolicy(metadata: unknown): {
-  targetKinds: Set<string>;
-  sessionIds: Set<string>;
-  conversationIds: Set<string>;
-  jobIds: Set<string>;
-  templateIds: Set<string>;
-} {
-  const root =
-    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
-      ? (metadata as Record<string, unknown>)
-      : {};
-  const policy =
-    root.targetPolicy &&
-    typeof root.targetPolicy === 'object' &&
-    !Array.isArray(root.targetPolicy)
-      ? (root.targetPolicy as Record<string, unknown>)
+function duplicateInvocationResponse(
+  invocation: ExternalIngressInvocationRecord,
+) {
+  const response =
+    invocation.response &&
+    typeof invocation.response === 'object' &&
+    !Array.isArray(invocation.response)
+      ? (invocation.response as Record<string, unknown>)
       : {};
   return {
-    targetKinds: readPolicySet(policy.allowedTargetKinds),
-    sessionIds: readPolicySet(policy.sessionIds),
-    conversationIds: readPolicySet(policy.conversationIds),
-    jobIds: readPolicySet(policy.jobIds),
-    templateIds: readPolicySet(policy.templateIds),
+    invocationId: invocation.invocationId,
+    duplicate: true,
+    status: invocation.status,
+    ...response,
+    ...(invocation.error ? { error: invocation.error } : {}),
   };
-}
-
-function readPolicySet(value: unknown): Set<string> {
-  if (!Array.isArray(value)) return new Set();
-  return new Set(
-    value
-      .filter((item): item is string => typeof item === 'string')
-      .map((item) => item.trim())
-      .filter(Boolean),
-  );
-}
-
-function allows(allowed: Set<string>, value: string): boolean {
-  return allowed.has('*') || allowed.has(value);
-}
-
-function readString(record: Record<string, unknown>, key: string): string {
-  const value = record[key];
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new ApplicationError('INVALID_REQUEST', `${key} is required`);
-  }
-  return value.trim();
-}
-
-function readOptionalString(
-  record: Record<string, unknown>,
-  key: string,
-): string | null {
-  const value = record[key];
-  return typeof value === 'string' && value.trim() ? value.trim() : null;
-}
-
-function readVariables(value: unknown): Record<string, string> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-  const variables: Record<string, string> = {};
-  for (const [key, raw] of Object.entries(value)) {
-    if (typeof raw === 'string' || typeof raw === 'number') {
-      variables[key] = String(raw);
-    }
-  }
-  return variables;
-}
-
-function readTemplate(
-  metadata: unknown,
-  templateId: string,
-): {
-  name: string;
-  prompt: string;
-  sessionId: string;
-  allowedVariables?: string[];
-} {
-  const root =
-    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
-      ? (metadata as Record<string, unknown>)
-      : {};
-  const templates =
-    root.templates && typeof root.templates === 'object'
-      ? (root.templates as Record<string, unknown>)
-      : {};
-  const template = templates[templateId];
-  if (!template || typeof template !== 'object' || Array.isArray(template)) {
-    throw new ApplicationError('NOT_FOUND', 'Job template not found');
-  }
-  const record = template as Record<string, unknown>;
-  const allowed = Array.isArray(record.allowedVariables)
-    ? record.allowedVariables.filter(
-        (value): value is string => typeof value === 'string',
-      )
-    : [];
-  return {
-    name: readString(record, 'name'),
-    prompt: readString(record, 'prompt'),
-    sessionId: readString(record, 'sessionId'),
-    allowedVariables: allowed,
-  };
-}
-
-function renderTemplate(
-  prompt: string,
-  variables: Record<string, string>,
-): string {
-  return prompt.replace(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (_match, key) => {
-    return variables[String(key)] ?? '';
-  });
 }

--- a/apps/core/src/application/external-ingress/signature.ts
+++ b/apps/core/src/application/external-ingress/signature.ts
@@ -1,0 +1,99 @@
+export interface ExternalIngressSignaturePort {
+  sha256(input: string): string;
+  hmacSha256(secret: string, payload: string): string;
+  constantTimeEqual(left: string, right: string): boolean;
+}
+
+export interface ExternalIngressSignaturePayloadInput {
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  rawBody: string;
+  bodyHash: string;
+}
+
+export function buildExternalIngressSignaturePayload(
+  input: ExternalIngressSignaturePayloadInput,
+): string {
+  return [
+    input.method.trim().toUpperCase(),
+    input.path.trim(),
+    input.timestamp.trim(),
+    input.nonce.trim(),
+    input.bodyHash,
+    input.rawBody,
+  ].join('\n');
+}
+
+export function isExternalIngressTimestampFresh(input: {
+  timestamp: string;
+  toleranceMs?: number;
+  nowMs?: number;
+}): boolean {
+  const timestampMs = Number(input.timestamp);
+  const toleranceMs = input.toleranceMs ?? 5 * 60_000;
+  if (!Number.isFinite(timestampMs)) return false;
+  return (
+    toleranceMs < 0 ||
+    Math.abs((input.nowMs ?? Date.now()) - timestampMs) <= toleranceMs
+  );
+}
+
+export function signExternalIngressRequest(input: {
+  crypto: ExternalIngressSignaturePort;
+  secret: string;
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  rawBody: string;
+}): { signature: string; bodyHash: string; payload: string } {
+  const bodyHash = input.crypto.sha256(input.rawBody);
+  const payload = buildExternalIngressSignaturePayload({
+    method: input.method,
+    path: input.path,
+    timestamp: input.timestamp,
+    nonce: input.nonce,
+    rawBody: input.rawBody,
+    bodyHash,
+  });
+  return {
+    signature: input.crypto.hmacSha256(input.secret, payload),
+    bodyHash,
+    payload,
+  };
+}
+
+export function verifyExternalIngressRequestSignature(input: {
+  crypto: ExternalIngressSignaturePort;
+  secret: string;
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  rawBody: string;
+  signature: string;
+  toleranceMs?: number;
+  nowMs?: number;
+}): boolean {
+  if (
+    !isExternalIngressTimestampFresh({
+      timestamp: input.timestamp,
+      toleranceMs: input.toleranceMs,
+      nowMs: input.nowMs,
+    })
+  ) {
+    return false;
+  }
+  const expected = signExternalIngressRequest({
+    crypto: input.crypto,
+    secret: input.secret,
+    method: input.method,
+    path: input.path,
+    timestamp: input.timestamp,
+    nonce: input.nonce,
+    rawBody: input.rawBody,
+  }).signature;
+  return input.crypto.constantTimeEqual(expected, input.signature);
+}

--- a/apps/core/src/application/external-ingress/target-policy.ts
+++ b/apps/core/src/application/external-ingress/target-policy.ts
@@ -1,0 +1,164 @@
+import { ApplicationError } from '../common/application-error.js';
+
+export type IngressTarget = Record<string, unknown> & { kind: string };
+
+export function assertTargetAllowed(
+  metadata: unknown,
+  target: IngressTarget,
+): void {
+  const policy = readTargetPolicy(metadata);
+  if (!allows(policy.targetKinds, target.kind)) {
+    throw new ApplicationError(
+      'FORBIDDEN',
+      `Ingress is not allowed to invoke target kind: ${target.kind}`,
+    );
+  }
+  if (target.kind === 'session_message') {
+    const sessionId = readOptionalString(target, 'sessionId');
+    if (sessionId) {
+      if (allows(policy.sessionIds, sessionId)) return;
+      throw new ApplicationError(
+        'FORBIDDEN',
+        'Ingress is not allowed to invoke this session target',
+      );
+    }
+    const conversationId = readOptionalString(target, 'conversationId');
+    if (conversationId && allows(policy.conversationIds, conversationId)) {
+      return;
+    }
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Ingress is not allowed to invoke this session target',
+    );
+  }
+  if (target.kind === 'job_trigger') {
+    const jobId = readOptionalString(target, 'jobId');
+    if (jobId && allows(policy.jobIds, jobId)) return;
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Ingress is not allowed to trigger this job',
+    );
+  }
+  if (target.kind === 'job_template') {
+    const templateId = readOptionalString(target, 'templateId');
+    if (templateId && allows(policy.templateIds, templateId)) return;
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Ingress is not allowed to invoke this job template',
+    );
+  }
+}
+
+export function readString(
+  record: Record<string, unknown>,
+  key: string,
+): string {
+  const value = record[key];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ApplicationError('INVALID_REQUEST', `${key} is required`);
+  }
+  return value.trim();
+}
+
+export function readOptionalString(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export function readVariables(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const variables: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'string' || typeof raw === 'number') {
+      variables[key] = String(raw);
+    }
+  }
+  return variables;
+}
+
+export function readTemplate(
+  metadata: unknown,
+  templateId: string,
+): {
+  name: string;
+  prompt: string;
+  sessionId: string;
+  allowedVariables?: string[];
+} {
+  const root =
+    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  const templates =
+    root.templates && typeof root.templates === 'object'
+      ? (root.templates as Record<string, unknown>)
+      : {};
+  const template = templates[templateId];
+  if (!template || typeof template !== 'object' || Array.isArray(template)) {
+    throw new ApplicationError('NOT_FOUND', 'Job template not found');
+  }
+  const record = template as Record<string, unknown>;
+  const allowed = Array.isArray(record.allowedVariables)
+    ? record.allowedVariables.filter(
+        (value): value is string => typeof value === 'string',
+      )
+    : [];
+  return {
+    name: readString(record, 'name'),
+    prompt: readString(record, 'prompt'),
+    sessionId: readString(record, 'sessionId'),
+    allowedVariables: allowed,
+  };
+}
+
+export function renderTemplate(
+  prompt: string,
+  variables: Record<string, string>,
+): string {
+  return prompt.replace(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (_match, key) => {
+    return variables[String(key)] ?? '';
+  });
+}
+
+function readTargetPolicy(metadata: unknown): {
+  targetKinds: Set<string>;
+  sessionIds: Set<string>;
+  conversationIds: Set<string>;
+  jobIds: Set<string>;
+  templateIds: Set<string>;
+} {
+  const root =
+    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  const policy =
+    root.targetPolicy &&
+    typeof root.targetPolicy === 'object' &&
+    !Array.isArray(root.targetPolicy)
+      ? (root.targetPolicy as Record<string, unknown>)
+      : {};
+  return {
+    targetKinds: readPolicySet(policy.allowedTargetKinds),
+    sessionIds: readPolicySet(policy.sessionIds),
+    conversationIds: readPolicySet(policy.conversationIds),
+    jobIds: readPolicySet(policy.jobIds),
+    templateIds: readPolicySet(policy.templateIds),
+  };
+}
+
+function readPolicySet(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(
+    value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+}
+
+function allows(allowed: Set<string>, value: string): boolean {
+  return allowed.has('*') || allowed.has(value);
+}

--- a/apps/core/src/application/sessions/session-interaction-module.ts
+++ b/apps/core/src/application/sessions/session-interaction-module.ts
@@ -1,0 +1,500 @@
+import type { NewMessage } from '../../domain/types.js';
+import type {
+  RuntimeEvent,
+  RuntimeEventFilter,
+  RuntimeEventPublishInput,
+  RuntimeResponseMode,
+} from '../../domain/events/events.js';
+import { RUNTIME_EVENT_TYPES } from '../../domain/events/runtime-event-types.js';
+import type { RuntimeEventExchange } from '../runtime-events/runtime-event-exchange.js';
+import type { OpsRepository } from '../../domain/repositories/ops-repo.js';
+import type {
+  AgentRunRepository,
+  AgentSessionRepository,
+  MessageRepository,
+  ProviderSessionRepository,
+} from '../../domain/ports/repositories.js';
+import type { IsoTimestamp } from '../../shared/time/primitives.js';
+import { ApplicationError } from '../common/application-error.js';
+import { isValidControlId } from '../app-scope/control-id.js';
+
+type ControlResponseMode = Exclude<RuntimeResponseMode, 'sse'> | 'sse';
+
+export type SessionAppRecord = {
+  sessionId: string;
+  appId: string;
+  conversationId: string;
+  chatJid: string;
+  workspaceKey: string;
+  title?: string | null;
+  defaultResponseMode: ControlResponseMode;
+  defaultWebhookId: string | null;
+};
+
+export type SessionResponseRouteRecord = {
+  responseMode: ControlResponseMode;
+  webhookId: string | null;
+  correlationId: string | null;
+};
+
+export interface SessionControlPort {
+  ensureAppSession(input: {
+    appId: string;
+    conversationId: string;
+    chatJid: string;
+    folder: string;
+    title?: string | null;
+    defaultResponseMode?: ControlResponseMode;
+    defaultWebhookId?: string | null;
+  }): Promise<SessionAppRecord>;
+  getAppSessionById(sessionId: string): Promise<SessionAppRecord | undefined>;
+  getAppSessionByChatJid(
+    chatJid: string,
+  ): Promise<SessionAppRecord | undefined>;
+  getWebhookById(
+    webhookId: string,
+    appId: string,
+  ): Promise<{ webhookId: string } | undefined>;
+  upsertAppResponseRoute(input: {
+    sessionId: string;
+    threadId?: string | null;
+    responseMode: ControlResponseMode;
+    webhookId?: string | null;
+    correlationId?: string | null;
+  }): Promise<SessionResponseRouteRecord>;
+  getAppResponseRoute(input: {
+    sessionId: string;
+    threadId?: string | null;
+  }): Promise<SessionResponseRouteRecord | undefined>;
+}
+
+export type SessionInteractionDeps = {
+  control: SessionControlPort;
+  ops: OpsRepository;
+  repositories: {
+    agentSessions: AgentSessionRepository;
+    providerSessions: ProviderSessionRepository;
+    messages: MessageRepository;
+    agentRuns: AgentRunRepository;
+  };
+  runtimeEvents: RuntimeEventExchange;
+  now: () => IsoTimestamp;
+  createId: () => string;
+  stableHash: (input: string) => string;
+};
+
+export type SessionQueueIntent = {
+  chatJid: string;
+  threadId: string | null;
+  queueKey: string;
+};
+
+export class SessionInteractionModule {
+  constructor(private readonly deps: SessionInteractionDeps) {}
+
+  async ensureSession(input: {
+    appId: string;
+    assertedAppId?: string | null;
+    conversationId: string;
+    title?: string | null;
+    responseMode?: unknown;
+    webhookId?: string | null;
+  }): Promise<{
+    session: SessionAppRecord;
+    registerGroup: { chatJid: string; group: AppGroupRegistration };
+  }> {
+    assertAppScope(input.appId, input.assertedAppId);
+    const conversationId = input.conversationId.trim();
+    if (!conversationId) {
+      throw new ApplicationError(
+        'INVALID_REQUEST',
+        'conversationId is required',
+      );
+    }
+    if (!isValidControlId(input.appId) || !isValidControlId(conversationId)) {
+      throw new ApplicationError(
+        'INVALID_REQUEST',
+        'appId and conversationId must contain only letters, numbers, dot, underscore, or dash',
+      );
+    }
+    const chatJid = `app:${input.appId}:${conversationId}`;
+    const group = makeAppGroup({
+      appId: input.appId,
+      conversationId,
+      chatJid,
+      identityHash: this.deps
+        .stableHash(`${input.appId}\0${conversationId}`)
+        .slice(0, 12),
+      addedAt: this.deps.now(),
+    });
+    const defaultWebhookId = await this.resolveOwnedWebhookId(
+      input.appId,
+      input.webhookId ?? null,
+    );
+    const session = await this.deps.control.ensureAppSession({
+      appId: input.appId,
+      conversationId,
+      chatJid,
+      folder: group.folder,
+      title: input.title ?? null,
+      defaultResponseMode: normalizeResponseMode(input.responseMode, 'sse'),
+      defaultWebhookId,
+    });
+    return { session, registerGroup: { chatJid, group } };
+  }
+
+  async getSessionDetails(input: {
+    appId: string;
+    sessionId: string;
+  }): Promise<{ session: unknown; providerSession: unknown | null }> {
+    const appSession = await this.requireSession(input);
+    const session = await this.deps.repositories.agentSessions.getAgentSession(
+      appSession.sessionId as never,
+    );
+    if (!session) {
+      throw new ApplicationError('NOT_FOUND', 'Session not found');
+    }
+    const providerSession =
+      await this.deps.repositories.providerSessions.getLatestProviderSession({
+        agentSessionId: session.id,
+      });
+    return {
+      session,
+      providerSession: providerSession
+        ? {
+            id: providerSession.id,
+            appId: providerSession.appId,
+            agentSessionId: providerSession.agentSessionId,
+            provider: providerSession.provider,
+            externalSessionId: providerSession.externalSessionId,
+            providerRef: providerSession.providerRef,
+            status: providerSession.status,
+            metadata: providerSession.metadata,
+            createdAt: providerSession.createdAt,
+            updatedAt: providerSession.updatedAt,
+          }
+        : null,
+    };
+  }
+
+  async listMessages(input: {
+    appId: string;
+    sessionId: string;
+    limit: number;
+  }): Promise<{ messages: unknown[] }> {
+    const session = await this.requireSession(input);
+    if (!session.conversationId) return { messages: [] };
+    const messages = await this.deps.repositories.messages.listRecentMessages({
+      conversationId: session.conversationId as never,
+      limit: input.limit,
+    });
+    return { messages };
+  }
+
+  async listRuns(input: {
+    appId: string;
+    sessionId: string;
+    limit: number;
+  }): Promise<{ runs: unknown[] }> {
+    const appSession = await this.requireSession(input);
+    const session = await this.deps.repositories.agentSessions.getAgentSession(
+      appSession.sessionId as never,
+    );
+    if (!session) return { runs: [] };
+    const runs = await this.deps.repositories.agentRuns.listAgentRunsBySession({
+      sessionId: session.id,
+      limit: input.limit,
+    });
+    return { runs };
+  }
+
+  async acceptMessage(input: {
+    appId: string;
+    sessionId: string;
+    message: string;
+    senderId?: string;
+    senderName?: string;
+    threadId?: string;
+    correlationId?: string | null;
+    responseMode?: unknown;
+    webhookId?: string | null;
+  }): Promise<{
+    accepted: true;
+    messageId: string;
+    acceptedEventId: number;
+    enqueue: SessionQueueIntent;
+  }> {
+    const session = await this.requireSession(input);
+    const text = input.message.trim();
+    if (!text) {
+      throw new ApplicationError('INVALID_REQUEST', 'message is required');
+    }
+    const threadId = input.threadId?.trim() || null;
+    const responseMode = normalizeResponseMode(
+      input.responseMode,
+      session.defaultResponseMode,
+    );
+    const webhookId = await this.resolveOwnedWebhookId(
+      input.appId,
+      input.webhookId ?? session.defaultWebhookId,
+    );
+    const now = this.deps.now();
+    const messageId = this.deps.createId();
+    const message: NewMessage = {
+      id: messageId,
+      chat_jid: session.chatJid,
+      channel_provider: 'app',
+      sender: input.senderId ?? 'sdk',
+      sender_name: input.senderName ?? 'SDK',
+      content: text,
+      timestamp: now,
+      is_from_me: false,
+      is_bot_message: false,
+      external_message_id: messageId,
+      thread_id: threadId ?? undefined,
+    };
+    await this.deps.ops.storeChatMetadata(
+      session.chatJid,
+      now,
+      session.title ?? session.chatJid,
+      'app',
+      true,
+    );
+    await this.deps.ops.storeMessage(message);
+    await this.deps.control.upsertAppResponseRoute({
+      sessionId: session.sessionId,
+      threadId,
+      responseMode,
+      webhookId,
+      correlationId: input.correlationId ?? null,
+    });
+    const accepted = await this.deps.runtimeEvents.publish({
+      appId: session.appId as never,
+      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_INBOUND,
+      payload: {
+        messageId,
+        text,
+        threadId,
+      },
+      actor: 'sdk',
+      sessionId: session.sessionId as never,
+      threadId: threadId ? (threadId as never) : undefined,
+      correlationId: input.correlationId ?? null,
+      responseMode,
+      webhookId,
+    });
+    return {
+      accepted: true,
+      messageId,
+      acceptedEventId: accepted.eventId,
+      enqueue: {
+        chatJid: session.chatJid,
+        threadId,
+        queueKey: makeSessionQueueKey(session.chatJid, threadId),
+      },
+    };
+  }
+
+  async listEvents(input: {
+    appId: string;
+    sessionId: string;
+    afterEventId?: number;
+    limit?: number;
+  }): Promise<RuntimeEvent[]> {
+    const session = await this.requireSession(input);
+    return this.deps.runtimeEvents.list(this.eventFilter(session, input));
+  }
+
+  async subscribeEvents(input: {
+    appId: string;
+    sessionId: string;
+    afterEventId?: number;
+    limit?: number;
+  }) {
+    const session = await this.requireSession(input);
+    return this.deps.runtimeEvents.subscribe(this.eventFilter(session, input));
+  }
+
+  async waitForVisibleEvent(input: {
+    appId: string;
+    sessionId: string;
+    afterEventId?: number;
+    timeoutMs: number;
+  }): Promise<RuntimeEvent> {
+    const subscription = await this.subscribeEvents(input);
+    const startedAt = Date.now();
+    try {
+      while (Date.now() - startedAt < input.timeoutMs) {
+        const remaining = input.timeoutMs - (Date.now() - startedAt);
+        const events = await subscription.next({ timeoutMs: remaining });
+        const visible = events.find(isVisibleWaitEvent);
+        if (visible) return visible;
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    } finally {
+      subscription.close();
+    }
+    throw new ApplicationError(
+      'WAIT_TIMEOUT',
+      'Timed out waiting for session event',
+    );
+  }
+
+  async publishOutboundEvent(input: {
+    chatJid: string;
+    eventType: RuntimeEventPublishInput['eventType'];
+    payload: Record<string, unknown>;
+  }): Promise<{ emitted: boolean; eventId?: number }> {
+    const session = await this.deps.control.getAppSessionByChatJid(
+      input.chatJid,
+    );
+    if (!session) return { emitted: false };
+    const threadId =
+      typeof input.payload.threadId === 'string'
+        ? input.payload.threadId
+        : null;
+    const route = await this.deps.control.getAppResponseRoute({
+      sessionId: session.sessionId,
+      threadId,
+    });
+    const event = await this.deps.runtimeEvents.publish({
+      appId: session.appId as never,
+      eventType: input.eventType,
+      payload: input.payload,
+      actor: 'agent',
+      sessionId: session.sessionId as never,
+      threadId: threadId ? (threadId as never) : undefined,
+      correlationId: route?.correlationId ?? null,
+      responseMode: route?.responseMode ?? session.defaultResponseMode,
+      webhookId: route ? route.webhookId : session.defaultWebhookId,
+    });
+    return { emitted: true, eventId: event.eventId };
+  }
+
+  private async requireSession(input: {
+    appId: string;
+    sessionId: string;
+  }): Promise<SessionAppRecord> {
+    const session = await this.deps.control.getAppSessionById(input.sessionId);
+    if (!session) {
+      throw new ApplicationError('NOT_FOUND', 'Session not found');
+    }
+    if (session.appId !== input.appId) {
+      throw new ApplicationError(
+        'FORBIDDEN',
+        'API key cannot access this session',
+      );
+    }
+    return session;
+  }
+
+  private async resolveOwnedWebhookId(
+    appId: string,
+    rawWebhookId: string | null,
+  ): Promise<string | null> {
+    const webhookId = rawWebhookId?.trim();
+    if (!webhookId) return null;
+    const webhook = await this.deps.control.getWebhookById(webhookId, appId);
+    if (!webhook) {
+      throw new ApplicationError('NOT_FOUND', 'Webhook not found');
+    }
+    return webhook.webhookId;
+  }
+
+  private eventFilter(
+    session: SessionAppRecord,
+    input: { afterEventId?: number; limit?: number },
+  ): RuntimeEventFilter {
+    return {
+      appId: session.appId as never,
+      sessionId: session.sessionId as never,
+      afterEventId:
+        input.afterEventId && input.afterEventId > 0
+          ? (input.afterEventId as never)
+          : undefined,
+      limit: input.limit ?? 100,
+    };
+  }
+}
+
+export function assertAppScope(
+  resolvedAppId: string,
+  assertedAppId?: string | null,
+): void {
+  const trimmed = assertedAppId?.trim();
+  if (trimmed && trimmed !== resolvedAppId) {
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Request appId does not match authenticated app scope',
+    );
+  }
+}
+
+export function normalizeResponseMode(
+  raw: unknown,
+  fallback: ControlResponseMode,
+): ControlResponseMode {
+  return raw === 'webhook' || raw === 'both' || raw === 'none' || raw === 'sse'
+    ? raw
+    : fallback;
+}
+
+type AppGroupRegistration = {
+  name: string;
+  folder: string;
+  trigger: string;
+  added_at: string;
+  requiresTrigger: boolean;
+  isMain: boolean;
+};
+
+export function makeAppGroup(input: {
+  appId: string;
+  conversationId: string;
+  chatJid: string;
+  identityHash: string;
+  addedAt: string;
+}): AppGroupRegistration {
+  const app = sanitizeSegment(input.appId) || 'app';
+  const conversation = sanitizeSegment(input.conversationId) || 'session';
+  const prefix = `app_${input.identityHash}_`;
+  const remaining = 96 - prefix.length;
+  const appPart = app.slice(0, Math.max(8, Math.floor(remaining * 0.4)));
+  const conversationPart = conversation.slice(
+    0,
+    Math.max(8, remaining - appPart.length - 1),
+  );
+  return {
+    name: `${input.appId}:${input.conversationId}`,
+    folder: `${prefix}${appPart}_${conversationPart}`.slice(0, 96),
+    trigger: '',
+    added_at: input.addedAt,
+    requiresTrigger: false,
+    isMain: false,
+  };
+}
+
+export function makeSessionQueueKey(
+  chatJid: string,
+  threadId?: string | null,
+): string {
+  const normalized = threadId?.trim();
+  if (!normalized) return chatJid;
+  return `${chatJid}::thread:${encodeURIComponent(normalized)}`;
+}
+
+function sanitizeSegment(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 48);
+}
+
+function isVisibleWaitEvent(event: RuntimeEvent): boolean {
+  return (
+    event.eventType === RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND ||
+    event.eventType === RUNTIME_EVENT_TYPES.SESSION_MESSAGE_STREAMING
+  );
+}

--- a/apps/core/src/channels/app.ts
+++ b/apps/core/src/channels/app.ts
@@ -1,3 +1,5 @@
+import { createHash, randomUUID } from 'node:crypto';
+
 import { logger } from '../infrastructure/logging/logger.js';
 import type {
   MessageSendOptions,
@@ -8,43 +10,43 @@ import {
   RUNTIME_EVENT_TYPES,
   type RuntimeEventType,
 } from '../domain/events/runtime-event-types.js';
+import { SessionInteractionModule } from '../application/sessions/session-interaction-module.js';
 import type { ChannelAdapter, ChannelOpts } from './channel-provider.js';
 import {
   getRuntimeControlRepository,
   getRuntimeEventExchange,
 } from '../adapters/storage/postgres/runtime-store.js';
+import { adaptSessionControlPort } from '../control/server/session-control-port.js';
 
 async function emitSessionEvent(
   chatJid: string,
   eventType: RuntimeEventType,
   payload: Record<string, unknown>,
 ): Promise<{ emitted: boolean; eventId?: number }> {
-  const control = getRuntimeControlRepository();
-  const session = await control.getAppSessionByChatJid(chatJid);
-  if (!session) {
+  const result = await createSessionInteractionModule().publishOutboundEvent({
+    chatJid,
+    eventType,
+    payload,
+  });
+  if (!result.emitted) {
     logger.warn(
       { chatJid, eventType },
       'App channel event dropped without session',
     );
-    return { emitted: false };
   }
-  const threadId =
-    typeof payload.threadId === 'string' ? payload.threadId : null;
-  const route = await control.getAppResponseRoute({
-    sessionId: session.sessionId,
-    threadId,
+  return result;
+}
+
+function createSessionInteractionModule(): SessionInteractionModule {
+  return new SessionInteractionModule({
+    control: adaptSessionControlPort(getRuntimeControlRepository()),
+    ops: {} as never,
+    repositories: {} as never,
+    runtimeEvents: getRuntimeEventExchange(),
+    now: () => new Date().toISOString() as never,
+    createId: randomUUID,
+    stableHash: (input) => createHash('sha256').update(input).digest('hex'),
   });
-  const event = await getRuntimeEventExchange().publish({
-    appId: session.appId as never,
-    eventType,
-    payload,
-    actor: 'agent',
-    sessionId: session.sessionId as never,
-    correlationId: route?.correlationId ?? null,
-    responseMode: route?.responseMode ?? session.defaultResponseMode,
-    webhookId: route ? route.webhookId : session.defaultWebhookId,
-  });
-  return { emitted: true, eventId: event.eventId };
 }
 
 export async function createAppChannel(

--- a/apps/core/src/control/server/app-identity.ts
+++ b/apps/core/src/control/server/app-identity.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import type { Job, RegisteredGroup } from '../../domain/types.js';
 import type { getRuntimeControlRepository } from '../../adapters/storage/postgres/runtime-store.js';
 import { nowIso as runtimeNowIso } from '../../infrastructure/time/datetime.js';
+import { resolveAppScopeAppId as applicationResolveAppScopeAppId } from '../../application/app-scope/resolve-app-scope.js';
 import { jobBelongsToApp as applicationJobBelongsToApp } from '../../application/jobs/job-access.js';
 import { resolveJobRuntimeAppId as applicationResolveJobRuntimeAppId } from '../../application/jobs/job-access.js';
 import type { IsoTimestamp } from '../../shared/time/primitives.js';
@@ -55,6 +56,16 @@ export function canAccessApp(
 ): boolean {
   if (!appId) return false;
   return auth.appId === appId;
+}
+
+export function resolveAppScopeAppId(
+  auth: ApiKeyRecord,
+  assertedAppId: string | null | undefined,
+): string | null {
+  return applicationResolveAppScopeAppId({
+    apiKeyAppId: auth.appId,
+    assertedAppId,
+  });
 }
 
 export function jobBelongsToApp(job: Job, appId: string): boolean {

--- a/apps/core/src/control/server/auth.ts
+++ b/apps/core/src/control/server/auth.ts
@@ -1,5 +1,6 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
+import { isValidControlId } from '../../application/app-scope/control-id.js';
 
 export type Scope =
   | 'sessions:read'
@@ -17,6 +18,8 @@ export type Scope =
   | 'mcp:admin'
   | 'webhooks:read'
   | 'webhooks:write'
+  | 'ingresses:read'
+  | 'ingresses:write'
   | 'memory:read'
   | 'memory:write'
   | 'memory:admin';
@@ -28,7 +31,6 @@ export type ApiKeyRecord = {
   appId: string;
 };
 
-const CONTROL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const ALL_SCOPES: Scope[] = [
   'sessions:read',
   'sessions:write',
@@ -45,14 +47,14 @@ const ALL_SCOPES: Scope[] = [
   'mcp:admin',
   'webhooks:read',
   'webhooks:write',
+  'ingresses:read',
+  'ingresses:write',
   'memory:read',
   'memory:write',
   'memory:admin',
 ];
 
-export function isValidControlId(value: string): boolean {
-  return CONTROL_ID_PATTERN.test(value);
-}
+export { isValidControlId };
 
 export function parseControlApiKeys(): ApiKeyRecord[] {
   const rawJson = process.env.MYCLAW_CONTROL_API_KEYS_JSON?.trim();

--- a/apps/core/src/control/server/external-ingress-adapter.ts
+++ b/apps/core/src/control/server/external-ingress-adapter.ts
@@ -1,0 +1,86 @@
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from 'node:crypto';
+
+import { ExternalIngressModule } from '../../application/external-ingress/external-ingress-module.js';
+import { SessionInteractionModule } from '../../application/sessions/session-interaction-module.js';
+import {
+  getRuntimeControlRepository,
+  getRuntimeEventExchange,
+  getRuntimeOpsRepository,
+  getRuntimeStorage,
+} from '../../adapters/storage/postgres/runtime-store.js';
+import { nowIso } from './app-identity.js';
+import type { ControlRouteContext } from './handler-context.js';
+import {
+  TRIGGER_RATE_LIMIT_PER_APP,
+  TRIGGER_RATE_LIMIT_PER_JOB,
+} from './rate-limit.js';
+import { adaptSessionControlPort } from './session-control-port.js';
+import { createJobManagementService } from './routes/jobs.js';
+
+export function createExternalIngressModule(
+  ctx: ControlRouteContext,
+): ExternalIngressModule {
+  const control = getRuntimeControlRepository();
+  const sessions = new SessionInteractionModule({
+    control: adaptSessionControlPort(control),
+    ops: getRuntimeOpsRepository(),
+    repositories: getRuntimeStorage().repositories,
+    runtimeEvents: getRuntimeEventExchange(),
+    now: nowIso,
+    createId: randomUUID,
+    stableHash: (input) => createHash('sha256').update(input).digest('hex'),
+  });
+  return new ExternalIngressModule({
+    control,
+    sessions,
+    jobs: createJobManagementService(),
+    now: nowIso,
+    createSecret: () => randomBytes(32).toString('hex'),
+    createInvocationId: randomUUID,
+    signatureCrypto: nodeSignatureCrypto,
+    consumeTriggerRateLimit: (key, limit) =>
+      ctx.triggerRateLimiter.consume(key, limit),
+    perAppTriggerLimit: TRIGGER_RATE_LIMIT_PER_APP,
+    perJobTriggerLimit: TRIGGER_RATE_LIMIT_PER_JOB,
+  });
+}
+
+export async function invokeExternalIngressForControl(
+  ctx: ControlRouteContext,
+  input: Parameters<ExternalIngressModule['invoke']>[0],
+): Promise<Awaited<ReturnType<ExternalIngressModule['invoke']>>> {
+  const result = await createExternalIngressModule(ctx).invoke(input);
+  if (
+    'enqueue' in result &&
+    result.enqueue &&
+    typeof result.enqueue === 'object' &&
+    'queueKey' in result.enqueue &&
+    typeof result.enqueue.queueKey === 'string'
+  ) {
+    ctx.app.queue.enqueueMessageCheck(result.enqueue.queueKey);
+  }
+  return result;
+}
+
+const nodeSignatureCrypto = {
+  sha256(input: string): string {
+    return createHash('sha256').update(input).digest('hex');
+  },
+  hmacSha256(secret: string, payload: string): string {
+    return createHmac('sha256', secret).update(payload).digest('hex');
+  },
+  constantTimeEqual(left: string, right: string): boolean {
+    const leftBuffer = Buffer.from(left);
+    const rightBuffer = Buffer.from(right);
+    return (
+      leftBuffer.length === rightBuffer.length &&
+      timingSafeEqual(leftBuffer, rightBuffer)
+    );
+  },
+};

--- a/apps/core/src/control/server/external-ingress-adapter.ts
+++ b/apps/core/src/control/server/external-ingress-adapter.ts
@@ -57,6 +57,19 @@ export async function invokeExternalIngressForControl(
 ): Promise<Awaited<ReturnType<ExternalIngressModule['invoke']>>> {
   const result = await createExternalIngressModule(ctx).invoke(input);
   if (
+    'registerGroup' in result &&
+    result.registerGroup &&
+    typeof result.registerGroup === 'object' &&
+    'chatJid' in result.registerGroup &&
+    typeof result.registerGroup.chatJid === 'string' &&
+    'group' in result.registerGroup
+  ) {
+    await ctx.app.registerGroup(
+      result.registerGroup.chatJid,
+      result.registerGroup.group as never,
+    );
+  }
+  if (
     'enqueue' in result &&
     result.enqueue &&
     typeof result.enqueue === 'object' &&

--- a/apps/core/src/control/server/http.ts
+++ b/apps/core/src/control/server/http.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
+import { ApplicationError } from '../../application/common/application-error.js';
+
 export function readRawBody(
   req: IncomingMessage,
   maxBytes: number,
@@ -118,4 +120,80 @@ export function sendError(
       requestId: randomUUID(),
     },
   });
+}
+
+export function sendApplicationError(
+  res: ServerResponse,
+  error: unknown,
+  overrides?: Partial<Record<ApplicationError['code'], string>>,
+): boolean {
+  if (!(error instanceof ApplicationError)) return false;
+  switch (error.code) {
+    case 'NOT_FOUND':
+      sendError(res, 404, overrides?.NOT_FOUND ?? 'NOT_FOUND', error.message);
+      return true;
+    case 'TRIGGER_NOT_FOUND':
+      sendError(
+        res,
+        404,
+        overrides?.TRIGGER_NOT_FOUND ?? 'TRIGGER_NOT_FOUND',
+        error.message,
+      );
+      return true;
+    case 'FORBIDDEN':
+      sendError(res, 403, overrides?.FORBIDDEN ?? 'FORBIDDEN', error.message);
+      return true;
+    case 'INVALID_REQUEST':
+    case 'INVALID_SCHEDULE':
+      sendError(
+        res,
+        400,
+        overrides?.[error.code] ?? 'INVALID_REQUEST',
+        error.message,
+      );
+      return true;
+    case 'CONFLICT':
+      sendError(res, 409, overrides?.CONFLICT ?? 'CONFLICT', error.message);
+      return true;
+    case 'RATE_LIMITED':
+      sendError(
+        res,
+        429,
+        overrides?.RATE_LIMITED ?? 'RATE_LIMITED',
+        error.message,
+      );
+      return true;
+    case 'WAIT_TIMEOUT':
+      sendError(
+        res,
+        408,
+        overrides?.WAIT_TIMEOUT ?? 'WAIT_TIMEOUT',
+        error.message,
+      );
+      return true;
+    case 'SCHEDULER_NOT_READY':
+      sendError(
+        res,
+        503,
+        overrides?.SCHEDULER_NOT_READY ?? 'SCHEDULER_NOT_READY',
+        error.message,
+      );
+      return true;
+    case 'UNAVAILABLE':
+      sendError(
+        res,
+        503,
+        overrides?.UNAVAILABLE ?? 'UNAVAILABLE',
+        error.message,
+      );
+      return true;
+    case 'NOT_IMPLEMENTED':
+      sendError(
+        res,
+        501,
+        overrides?.NOT_IMPLEMENTED ?? 'NOT_IMPLEMENTED',
+        error.message,
+      );
+      return true;
+  }
 }

--- a/apps/core/src/control/server/index.ts
+++ b/apps/core/src/control/server/index.ts
@@ -13,6 +13,7 @@ import {
   updatePublicRuntimeSettings,
 } from '../../config/index.js';
 import { logger } from '../../infrastructure/logging/logger.js';
+import { getRuntimeControlRepository } from '../../adapters/storage/postgres/runtime-store.js';
 import { canAccessApp, jobBelongsToApp, makeAppGroup } from './app-identity.js';
 import { isValidControlId, parseControlApiKeys } from './auth.js';
 import type {
@@ -22,6 +23,7 @@ import type {
 import { sendError } from './http.js';
 import { createRateLimiter } from './rate-limit.js';
 import { handleChannelControlRoutes } from './routes/channels.js';
+import { handleExternalIngressRoutes } from './routes/external-ingress.js';
 import { handleJobRoutes } from './routes/jobs.js';
 import { handleMemoryRoutes } from './routes/memory.js';
 import { handleMcpServerRoutes } from './routes/mcp-servers.js';
@@ -71,6 +73,7 @@ function createControlRequestHandler(ctx: ControlRouteContext) {
         return;
       if (await handleMemoryRoutes(req, res, ctx, url, pathname)) return;
       if (await handleJobRoutes(req, res, ctx, url, pathname)) return;
+      if (await handleExternalIngressRoutes(req, res, ctx, pathname)) return;
       if (await handleRunRoutes(req, res, ctx, url, pathname)) return;
       if (await handleSettingsRoutes(req, res, ctx, pathname)) return;
       if (await handleSkillRoutes(req, res, ctx, url, pathname)) return;
@@ -163,10 +166,29 @@ export function startControlServer(input: {
         webhookFlushInFlight = false;
       });
   }, 1000);
+  let ingressMaintenanceInFlight = false;
+  const ingressMaintenanceInterval = setInterval(() => {
+    if (ingressMaintenanceInFlight) return;
+    ingressMaintenanceInFlight = true;
+    void getRuntimeControlRepository()
+      .sweepExpiredExternalIngressState({
+        now: new Date().toISOString(),
+      })
+      .catch((error) => {
+        logger.warn(
+          { err: error },
+          'Failed sweeping expired external ingress state',
+        );
+      })
+      .finally(() => {
+        ingressMaintenanceInFlight = false;
+      });
+  }, 60_000);
 
   return {
     async close() {
       clearInterval(deliveryInterval);
+      clearInterval(ingressMaintenanceInterval);
       await new Promise<void>((resolve, reject) => {
         server.close((error) => {
           if (error) {

--- a/apps/core/src/control/server/routes/external-ingress.ts
+++ b/apps/core/src/control/server/routes/external-ingress.ts
@@ -1,0 +1,227 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import { ApplicationError } from '../../../application/common/application-error.js';
+import {
+  authorizeControlRequest,
+  type ControlRouteContext,
+} from '../handler-context.js';
+import { readJson, readRawBody, sendError, sendJson } from '../http.js';
+import {
+  createExternalIngressModule,
+  invokeExternalIngressForControl,
+} from '../external-ingress-adapter.js';
+
+const MAX_INGRESS_BODY_BYTES = 256 * 1024;
+
+export async function handleExternalIngressRoutes(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: ControlRouteContext,
+  pathname: string,
+): Promise<boolean> {
+  if (pathname === '/v1/ingresses' && req.method === 'POST') {
+    const auth = authorizeControlRequest(req, res, ctx.keys, [
+      'ingresses:write',
+    ]);
+    if (!auth) return true;
+    const body = (await readJson(req)) as Record<string, unknown>;
+    try {
+      const created = await createExternalIngressModule(ctx).create({
+        appId: auth.appId,
+        name: String(body.name || ''),
+        enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
+        metadata: body.metadata,
+      });
+      sendJson(res, 201, created);
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
+    return true;
+  }
+
+  if (pathname === '/v1/ingresses' && req.method === 'GET') {
+    const auth = authorizeControlRequest(req, res, ctx.keys, [
+      'ingresses:read',
+    ]);
+    if (!auth) return true;
+    sendJson(res, 200, await createExternalIngressModule(ctx).list(auth.appId));
+    return true;
+  }
+
+  const route = parseIngressRoute(pathname);
+  if (!route) return false;
+
+  if (route.action === 'get' && req.method === 'GET') {
+    const auth = authorizeControlRequest(req, res, ctx.keys, [
+      'ingresses:read',
+    ]);
+    if (!auth) return true;
+    try {
+      sendJson(
+        res,
+        200,
+        await createExternalIngressModule(ctx).get({
+          appId: auth.appId,
+          ingressId: route.ingressId,
+        }),
+      );
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
+    return true;
+  }
+
+  if (route.action === 'get' && req.method === 'PATCH') {
+    const auth = authorizeControlRequest(req, res, ctx.keys, [
+      'ingresses:write',
+    ]);
+    if (!auth) return true;
+    const body = (await readJson(req)) as Record<string, unknown>;
+    try {
+      sendJson(
+        res,
+        200,
+        await createExternalIngressModule(ctx).update({
+          appId: auth.appId,
+          ingressId: route.ingressId,
+          patch: {
+            ...(typeof body.name === 'string' ? { name: body.name } : {}),
+            ...(typeof body.enabled === 'boolean'
+              ? { enabled: body.enabled }
+              : {}),
+            ...(body.metadata !== undefined ? { metadata: body.metadata } : {}),
+          },
+        }),
+      );
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
+    return true;
+  }
+
+  if (route.action === 'get' && req.method === 'DELETE') {
+    const auth = authorizeControlRequest(req, res, ctx.keys, [
+      'ingresses:write',
+    ]);
+    if (!auth) return true;
+    await createExternalIngressModule(ctx).delete({
+      appId: auth.appId,
+      ingressId: route.ingressId,
+    });
+    sendJson(res, 200, { deleted: true });
+    return true;
+  }
+
+  if (route.action === 'rotate' && req.method === 'POST') {
+    const auth = authorizeControlRequest(req, res, ctx.keys, [
+      'ingresses:write',
+    ]);
+    if (!auth) return true;
+    try {
+      sendJson(
+        res,
+        200,
+        await createExternalIngressModule(ctx).rotate({
+          appId: auth.appId,
+          ingressId: route.ingressId,
+        }),
+      );
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
+    return true;
+  }
+
+  if (route.action === 'invoke' && req.method === 'POST') {
+    const rawBody = (await readRawBody(req, MAX_INGRESS_BODY_BYTES)).toString(
+      'utf8',
+    );
+    try {
+      const result = await invokeExternalIngressForControl(ctx, {
+        ingressId: route.ingressId,
+        method: req.method,
+        path: pathname,
+        timestamp: header(req, 'x-myclaw-ingress-timestamp'),
+        nonce: header(req, 'x-myclaw-ingress-nonce'),
+        signature: header(req, 'x-myclaw-ingress-signature'),
+        rawBody,
+      });
+      sendJson(res, 202, result);
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
+    return true;
+  }
+
+  if (route.action === 'wait' && req.method === 'POST') {
+    const rawBody = (await readRawBody(req, MAX_INGRESS_BODY_BYTES)).toString(
+      'utf8',
+    );
+    try {
+      const result = await createExternalIngressModule(ctx).signedWait({
+        ingressId: route.ingressId,
+        method: req.method,
+        path: pathname,
+        timestamp: header(req, 'x-myclaw-ingress-timestamp'),
+        nonce: header(req, 'x-myclaw-ingress-nonce'),
+        signature: header(req, 'x-myclaw-ingress-signature'),
+        rawBody,
+      });
+      sendJson(res, 200, result);
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function parseIngressRoute(pathname: string): {
+  ingressId: string;
+  action: 'get' | 'rotate' | 'invoke' | 'wait';
+} | null {
+  const actionMatch = /^\/v1\/ingresses\/([^/]+)\/(rotate|invoke|wait)$/.exec(
+    pathname,
+  );
+  if (actionMatch) {
+    return {
+      ingressId: decodeURIComponent(actionMatch[1]!),
+      action: actionMatch[2] as 'rotate' | 'invoke' | 'wait',
+    };
+  }
+  const baseMatch = /^\/v1\/ingresses\/([^/]+)$/.exec(pathname);
+  if (!baseMatch) return null;
+  return { ingressId: decodeURIComponent(baseMatch[1]!), action: 'get' };
+}
+
+function header(req: IncomingMessage, name: string): string {
+  const value = req.headers[name];
+  return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');
+}
+
+function sendApplicationError(res: ServerResponse, error: unknown): boolean {
+  if (!(error instanceof ApplicationError)) return false;
+  switch (error.code) {
+    case 'NOT_FOUND':
+      sendError(res, 404, 'NOT_FOUND', error.message);
+      return true;
+    case 'FORBIDDEN':
+      sendError(res, 403, 'FORBIDDEN', error.message);
+      return true;
+    case 'INVALID_REQUEST':
+      sendError(res, 400, 'INVALID_REQUEST', error.message);
+      return true;
+    case 'CONFLICT':
+      sendError(res, 409, 'CONFLICT', error.message);
+      return true;
+    case 'RATE_LIMITED':
+      sendError(res, 429, 'RATE_LIMITED', error.message);
+      return true;
+    case 'SCHEDULER_NOT_READY':
+      sendError(res, 503, 'SCHEDULER_NOT_READY', error.message);
+      return true;
+    default:
+      throw error;
+  }
+}

--- a/apps/core/src/control/server/routes/external-ingress.ts
+++ b/apps/core/src/control/server/routes/external-ingress.ts
@@ -1,11 +1,16 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
-import { ApplicationError } from '../../../application/common/application-error.js';
 import {
   authorizeControlRequest,
   type ControlRouteContext,
 } from '../handler-context.js';
-import { readJson, readRawBody, sendError, sendJson } from '../http.js';
+import {
+  readJson,
+  readRawBody,
+  sendApplicationError,
+  sendError,
+  sendJson,
+} from '../http.js';
 import {
   createExternalIngressModule,
   invokeExternalIngressForControl,
@@ -77,6 +82,20 @@ export async function handleExternalIngressRoutes(
     ]);
     if (!auth) return true;
     const body = (await readJson(req)) as Record<string, unknown>;
+    const patch = {
+      ...(typeof body.name === 'string' ? { name: body.name } : {}),
+      ...(typeof body.enabled === 'boolean' ? { enabled: body.enabled } : {}),
+      ...(body.metadata !== undefined ? { metadata: body.metadata } : {}),
+    };
+    if (Object.keys(patch).length === 0) {
+      sendError(
+        res,
+        400,
+        'INVALID_REQUEST',
+        'PATCH body must include name, enabled, or metadata',
+      );
+      return true;
+    }
     try {
       sendJson(
         res,
@@ -84,13 +103,7 @@ export async function handleExternalIngressRoutes(
         await createExternalIngressModule(ctx).update({
           appId: auth.appId,
           ingressId: route.ingressId,
-          patch: {
-            ...(typeof body.name === 'string' ? { name: body.name } : {}),
-            ...(typeof body.enabled === 'boolean'
-              ? { enabled: body.enabled }
-              : {}),
-            ...(body.metadata !== undefined ? { metadata: body.metadata } : {}),
-          },
+          patch,
         }),
       );
     } catch (error) {
@@ -104,11 +117,15 @@ export async function handleExternalIngressRoutes(
       'ingresses:write',
     ]);
     if (!auth) return true;
-    await createExternalIngressModule(ctx).delete({
-      appId: auth.appId,
-      ingressId: route.ingressId,
-    });
-    sendJson(res, 200, { deleted: true });
+    try {
+      await createExternalIngressModule(ctx).delete({
+        appId: auth.appId,
+        ingressId: route.ingressId,
+      });
+      sendJson(res, 200, { deleted: true });
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
     return true;
   }
 
@@ -133,17 +150,18 @@ export async function handleExternalIngressRoutes(
   }
 
   if (route.action === 'invoke' && req.method === 'POST') {
-    const rawBody = (await readRawBody(req, MAX_INGRESS_BODY_BYTES)).toString(
-      'utf8',
-    );
+    const headers = readSignatureHeaders(req, res);
+    if (!headers) return true;
+    const rawBody = await readIngressRawBody(req, res);
+    if (rawBody === null) return true;
     try {
       const result = await invokeExternalIngressForControl(ctx, {
         ingressId: route.ingressId,
         method: req.method,
         path: pathname,
-        timestamp: header(req, 'x-myclaw-ingress-timestamp'),
-        nonce: header(req, 'x-myclaw-ingress-nonce'),
-        signature: header(req, 'x-myclaw-ingress-signature'),
+        timestamp: headers.timestamp,
+        nonce: headers.nonce,
+        signature: headers.signature,
         rawBody,
       });
       sendJson(res, 202, result);
@@ -154,17 +172,18 @@ export async function handleExternalIngressRoutes(
   }
 
   if (route.action === 'wait' && req.method === 'POST') {
-    const rawBody = (await readRawBody(req, MAX_INGRESS_BODY_BYTES)).toString(
-      'utf8',
-    );
+    const headers = readSignatureHeaders(req, res);
+    if (!headers) return true;
+    const rawBody = await readIngressRawBody(req, res);
+    if (rawBody === null) return true;
     try {
       const result = await createExternalIngressModule(ctx).signedWait({
         ingressId: route.ingressId,
         method: req.method,
         path: pathname,
-        timestamp: header(req, 'x-myclaw-ingress-timestamp'),
-        nonce: header(req, 'x-myclaw-ingress-nonce'),
-        signature: header(req, 'x-myclaw-ingress-signature'),
+        timestamp: headers.timestamp,
+        nonce: headers.nonce,
+        signature: headers.signature,
         rawBody,
       });
       sendJson(res, 200, result);
@@ -175,6 +194,26 @@ export async function handleExternalIngressRoutes(
   }
 
   return false;
+}
+
+async function readIngressRawBody(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<string | null> {
+  try {
+    return (await readRawBody(req, MAX_INGRESS_BODY_BYTES)).toString('utf8');
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'statusCode' in error &&
+      error.statusCode === 413
+    ) {
+      sendError(res, 413, 'PAYLOAD_TOO_LARGE', 'Payload too large');
+      return null;
+    }
+    throw error;
+  }
 }
 
 function parseIngressRoute(pathname: string): {
@@ -195,33 +234,34 @@ function parseIngressRoute(pathname: string): {
   return { ingressId: decodeURIComponent(baseMatch[1]!), action: 'get' };
 }
 
-function header(req: IncomingMessage, name: string): string {
-  const value = req.headers[name];
-  return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');
+function readSignatureHeaders(
+  req: IncomingMessage,
+  res: ServerResponse,
+): { timestamp: string; nonce: string; signature: string } | null {
+  const timestamp = header(req, 'x-myclaw-ingress-timestamp');
+  const nonce = header(req, 'x-myclaw-ingress-nonce');
+  const signature = header(req, 'x-myclaw-ingress-signature');
+  const missing = [
+    ['x-myclaw-ingress-timestamp', timestamp],
+    ['x-myclaw-ingress-nonce', nonce],
+    ['x-myclaw-ingress-signature', signature],
+  ]
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+  if (missing.length > 0) {
+    sendError(
+      res,
+      400,
+      'INVALID_REQUEST',
+      `Missing required ingress signature header: ${missing.join(', ')}`,
+    );
+    return null;
+  }
+  return { timestamp, nonce, signature };
 }
 
-function sendApplicationError(res: ServerResponse, error: unknown): boolean {
-  if (!(error instanceof ApplicationError)) return false;
-  switch (error.code) {
-    case 'NOT_FOUND':
-      sendError(res, 404, 'NOT_FOUND', error.message);
-      return true;
-    case 'FORBIDDEN':
-      sendError(res, 403, 'FORBIDDEN', error.message);
-      return true;
-    case 'INVALID_REQUEST':
-      sendError(res, 400, 'INVALID_REQUEST', error.message);
-      return true;
-    case 'CONFLICT':
-      sendError(res, 409, 'CONFLICT', error.message);
-      return true;
-    case 'RATE_LIMITED':
-      sendError(res, 429, 'RATE_LIMITED', error.message);
-      return true;
-    case 'SCHEDULER_NOT_READY':
-      sendError(res, 503, 'SCHEDULER_NOT_READY', error.message);
-      return true;
-    default:
-      throw error;
-  }
+function header(req: IncomingMessage, name: string): string {
+  const value = req.headers[name];
+  const raw = Array.isArray(value) ? (value[0] ?? '') : (value ?? '');
+  return raw.trim();
 }

--- a/apps/core/src/control/server/routes/jobs.ts
+++ b/apps/core/src/control/server/routes/jobs.ts
@@ -67,7 +67,7 @@ function sendApplicationError(res: ServerResponse, error: unknown): boolean {
   throw error;
 }
 
-function createJobManagementService() {
+export function createJobManagementService() {
   const control = getRuntimeControlRepository();
   return new JobManagementService({
     ops: getRuntimeOpsRepository(),

--- a/apps/core/src/control/server/routes/sessions.ts
+++ b/apps/core/src/control/server/routes/sessions.ts
@@ -1,28 +1,49 @@
-import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
-import type { NewMessage } from '../../../domain/types.js';
-import { getRuntimeOpsRepository } from '../../../adapters/storage/postgres/runtime-store.js';
-import { getRuntimeControlRepository } from '../../../adapters/storage/postgres/runtime-store.js';
-import { getRuntimeEventExchange } from '../../../adapters/storage/postgres/runtime-store.js';
-import { getRuntimeStorage } from '../../../adapters/storage/postgres/runtime-store.js';
+import { ApplicationError } from '../../../application/common/application-error.js';
 import type { RuntimeEvent } from '../../../domain/events/events.js';
-import { RUNTIME_EVENT_TYPES } from '../../../domain/events/runtime-event-types.js';
 import { logger } from '../../../infrastructure/logging/logger.js';
-import { makeThreadQueueKey } from '../../../runtime/thread-queue-key.js';
-import {
-  canAccessApp,
-  makeAppGroup,
-  nowIso,
-  resolveOwnedWebhookId,
-} from '../app-identity.js';
-import { isValidControlId } from '../auth.js';
+import { resolveAppScopeAppId } from '../app-identity.js';
+import { isValidControlId } from '../../../application/app-scope/control-id.js';
 import {
   authorizeControlRequest,
   type ControlRouteContext,
 } from '../handler-context.js';
 import { readJson, sendError, sendJson } from '../http.js';
 import { parseSessionRoute } from '../route-parser.js';
+import {
+  acceptMessageForControl,
+  createSessionInteractionModule,
+  ensureSessionForControl,
+  type SessionEventSubscription,
+} from '../session-interaction-adapter.js';
+
+function sendApplicationError(res: ServerResponse, error: unknown): boolean {
+  if (!(error instanceof ApplicationError)) return false;
+  switch (error.code) {
+    case 'NOT_FOUND':
+      sendError(
+        res,
+        404,
+        error.message === 'Webhook not found'
+          ? 'WEBHOOK_NOT_FOUND'
+          : 'SESSION_NOT_FOUND',
+        error.message,
+      );
+      return true;
+    case 'FORBIDDEN':
+      sendError(res, 403, 'FORBIDDEN', error.message);
+      return true;
+    case 'INVALID_REQUEST':
+      sendError(res, 400, 'INVALID_REQUEST', error.message);
+      return true;
+    case 'WAIT_TIMEOUT':
+      sendError(res, 408, 'WAIT_TIMEOUT', error.message);
+      return true;
+    default:
+      throw error;
+  }
+}
 
 export async function handleSessionRoutes(
   req: IncomingMessage,
@@ -37,18 +58,15 @@ export async function handleSessionRoutes(
     ]);
     if (!auth) return true;
     const body = (await readJson(req)) as Record<string, unknown>;
-    const appId = String(body.appId || '').trim();
+    const assertedAppId =
+      typeof body.appId === 'string' ? body.appId.trim() : '';
+    const appId = resolveAppScopeAppId(auth, assertedAppId);
     const conversationId = String(body.conversationId || '').trim();
-    if (!appId || !conversationId) {
-      sendError(
-        res,
-        400,
-        'INVALID_REQUEST',
-        'appId and conversationId are required',
-      );
+    if (!conversationId) {
+      sendError(res, 400, 'INVALID_REQUEST', 'conversationId is required');
       return true;
     }
-    if (!isValidControlId(appId) || !isValidControlId(conversationId)) {
+    if (assertedAppId && !isValidControlId(assertedAppId)) {
       sendError(
         res,
         400,
@@ -57,39 +75,28 @@ export async function handleSessionRoutes(
       );
       return true;
     }
-    if (!canAccessApp(auth, appId)) {
+    if (!appId) {
       sendError(res, 403, 'FORBIDDEN', 'API key cannot access this app');
       return true;
     }
-    const chatJid = `app:${appId}:${conversationId}`;
-    const control = getRuntimeControlRepository();
-    const defaultWebhookId = await resolveOwnedWebhookId(
-      control,
-      auth.appId,
-      typeof body.webhookId === 'string' ? body.webhookId : null,
-    );
-    const group = makeAppGroup({ appId, conversationId, chatJid });
-    await ctx.app.registerGroup(chatJid, group);
-    const session = await control.ensureAppSession({
-      appId,
-      conversationId,
-      chatJid,
-      groupFolder: group.folder,
-      title: typeof body.title === 'string' ? body.title : null,
-      defaultResponseMode:
-        body.responseMode === 'webhook' ||
-        body.responseMode === 'both' ||
-        body.responseMode === 'none'
-          ? (body.responseMode as 'webhook' | 'both' | 'none')
-          : 'sse',
-      defaultWebhookId,
-    });
-    sendJson(res, 200, {
-      sessionId: session.sessionId,
-      appId: session.appId,
-      conversationId: session.conversationId,
-      chatJid: session.chatJid,
-    });
+    try {
+      const result = await ensureSessionForControl(ctx, {
+        appId,
+        assertedAppId,
+        conversationId,
+        title: typeof body.title === 'string' ? body.title : null,
+        responseMode: body.responseMode,
+        webhookId: typeof body.webhookId === 'string' ? body.webhookId : null,
+      });
+      sendJson(res, 200, {
+        sessionId: result.session.sessionId,
+        appId: result.session.appId,
+        conversationId: result.session.conversationId,
+        chatJid: result.session.chatJid,
+      });
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
     return true;
   }
 
@@ -97,93 +104,49 @@ export async function handleSessionRoutes(
   if (sessionRoute?.action === 'get' && req.method === 'GET') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['sessions:read']);
     if (!auth) return true;
-    const repositories = getRuntimeStorage().repositories;
-    const session = await repositories.agentSessions.getAgentSession(
-      sessionRoute.sessionId as never,
-    );
-    if (!session) {
-      sendError(res, 404, 'SESSION_NOT_FOUND', 'Session not found');
-      return true;
-    }
-    if (!canAccessApp(auth, session.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this session');
-      return true;
-    }
-    const providerSession =
-      await repositories.providerSessions.getLatestProviderSession({
-        agentSessionId: session.id,
+    try {
+      const details = await createSessionInteractionModule().getSessionDetails({
+        appId: auth.appId,
+        sessionId: sessionRoute.sessionId,
       });
-    const visibleProviderSession = providerSession
-      ? {
-          id: providerSession.id,
-          appId: providerSession.appId,
-          agentSessionId: providerSession.agentSessionId,
-          provider: providerSession.provider,
-          externalSessionId: providerSession.externalSessionId,
-          providerRef: providerSession.providerRef,
-          status: providerSession.status,
-          metadata: providerSession.metadata,
-          createdAt: providerSession.createdAt,
-          updatedAt: providerSession.updatedAt,
-        }
-      : null;
-    sendJson(res, 200, {
-      session,
-      providerSession: visibleProviderSession,
-    });
+      sendJson(res, 200, details);
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
     return true;
   }
 
   if (sessionRoute?.action === 'messages' && req.method === 'GET') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['sessions:read']);
     if (!auth) return true;
-    const repositories = getRuntimeStorage().repositories;
-    const session = await repositories.agentSessions.getAgentSession(
-      sessionRoute.sessionId as never,
-    );
-    if (!session) {
-      sendError(res, 404, 'SESSION_NOT_FOUND', 'Session not found');
-      return true;
-    }
-    if (!canAccessApp(auth, session.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this session');
-      return true;
-    }
-    if (!session.conversationId) {
-      sendJson(res, 200, { messages: [] });
-      return true;
-    }
     const limit = parseListLimit(url.searchParams.get('limit'));
-    const messages = await repositories.messages.listRecentMessages({
-      conversationId: session.conversationId,
-      threadId: session.threadId,
-      limit,
-    });
-    sendJson(res, 200, { messages });
+    try {
+      const result = await createSessionInteractionModule().listMessages({
+        appId: auth.appId,
+        sessionId: sessionRoute.sessionId,
+        limit,
+      });
+      sendJson(res, 200, result);
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
     return true;
   }
 
   if (sessionRoute?.action === 'runs' && req.method === 'GET') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['sessions:read']);
     if (!auth) return true;
-    const repositories = getRuntimeStorage().repositories;
-    const session = await repositories.agentSessions.getAgentSession(
-      sessionRoute.sessionId as never,
-    );
-    if (!session) {
-      sendError(res, 404, 'SESSION_NOT_FOUND', 'Session not found');
-      return true;
-    }
-    if (!canAccessApp(auth, session.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this session');
-      return true;
-    }
     const limit = parseListLimit(url.searchParams.get('limit'));
-    const runs = await repositories.agentRuns.listAgentRunsBySession({
-      sessionId: session.id,
-      limit,
-    });
-    sendJson(res, 200, { runs });
+    try {
+      const result = await createSessionInteractionModule().listRuns({
+        appId: auth.appId,
+        sessionId: sessionRoute.sessionId,
+        limit,
+      });
+      sendJson(res, 200, result);
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
+    }
     return true;
   }
 
@@ -192,93 +155,29 @@ export async function handleSessionRoutes(
       'sessions:write',
     ]);
     if (!auth) return true;
-    const control = getRuntimeControlRepository();
-    const session = await control.getAppSessionById(sessionRoute.sessionId);
-    if (!session) {
-      sendError(res, 404, 'SESSION_NOT_FOUND', 'Session not found');
-      return true;
-    }
-    if (!canAccessApp(auth, session.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this session');
-      return true;
-    }
     const body = (await readJson(req)) as Record<string, unknown>;
-    const text = String(body.message || '').trim();
-    if (!text) {
-      sendError(res, 400, 'INVALID_REQUEST', 'message is required');
-      return true;
+    try {
+      const accepted = await acceptMessageForControl(ctx, {
+        appId: auth.appId,
+        sessionId: sessionRoute.sessionId,
+        message: String(body.message || ''),
+        senderId: typeof body.senderId === 'string' ? body.senderId : 'sdk',
+        senderName:
+          typeof body.senderName === 'string' ? body.senderName : 'SDK',
+        threadId: typeof body.threadId === 'string' ? body.threadId : undefined,
+        correlationId:
+          typeof body.correlationId === 'string' ? body.correlationId : null,
+        responseMode: body.responseMode,
+        webhookId: typeof body.webhookId === 'string' ? body.webhookId : null,
+      });
+      sendJson(res, 202, {
+        accepted: true,
+        messageId: accepted.messageId,
+        acceptedEventId: accepted.acceptedEventId,
+      });
+    } catch (error) {
+      if (!sendApplicationError(res, error)) throw error;
     }
-    const now = nowIso();
-    const threadId =
-      typeof body.threadId === 'string' ? body.threadId.trim() : '';
-    const responseMode =
-      body.responseMode === 'webhook' ||
-      body.responseMode === 'both' ||
-      body.responseMode === 'none'
-        ? (body.responseMode as 'webhook' | 'both' | 'none')
-        : session.defaultResponseMode;
-    const webhookId = await resolveOwnedWebhookId(
-      control,
-      auth.appId,
-      typeof body.webhookId === 'string'
-        ? body.webhookId
-        : session.defaultWebhookId,
-    );
-    const messageId = randomUUID();
-    const message: NewMessage = {
-      id: messageId,
-      chat_jid: session.chatJid,
-      channel_provider: 'app',
-      sender: typeof body.senderId === 'string' ? body.senderId : 'sdk',
-      sender_name:
-        typeof body.senderName === 'string' ? body.senderName : 'SDK',
-      content: text,
-      timestamp: now,
-      is_from_me: false,
-      is_bot_message: false,
-      external_message_id: messageId,
-      thread_id: threadId || undefined,
-    };
-    const ops = getRuntimeOpsRepository();
-    await ops.storeChatMetadata(
-      session.chatJid,
-      now,
-      session.title ?? session.chatJid,
-      'app',
-      true,
-    );
-    await ops.storeMessage(message);
-    const correlationId =
-      typeof body.correlationId === 'string' ? body.correlationId : null;
-    await control.upsertAppResponseRoute({
-      sessionId: session.sessionId,
-      threadId: threadId || null,
-      responseMode,
-      webhookId,
-      correlationId,
-    });
-    const accepted = await getRuntimeEventExchange().publish({
-      appId: session.appId as never,
-      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_INBOUND,
-      payload: {
-        messageId,
-        text,
-        threadId: threadId || null,
-      },
-      actor: 'sdk',
-      sessionId: session.sessionId as never,
-      correlationId,
-      responseMode,
-      webhookId,
-    });
-    ctx.app.queue.enqueueMessageCheck(
-      makeThreadQueueKey(session.chatJid, threadId || null),
-    );
-    sendJson(res, 202, {
-      accepted: true,
-      messageId,
-      acceptedEventId: accepted.eventId,
-    });
     return true;
   }
 
@@ -286,23 +185,19 @@ export async function handleSessionRoutes(
     const auth = authorizeControlRequest(req, res, ctx.keys, ['sessions:read']);
     if (!auth) return true;
     const afterEventId = Number(url.searchParams.get('afterEventId') || 0);
-    const control = getRuntimeControlRepository();
-    const runtimeEvents = getRuntimeEventExchange();
-    const session = await control.getAppSessionById(sessionRoute.sessionId);
-    if (!session) {
-      sendError(res, 404, 'SESSION_NOT_FOUND', 'Session not found');
-      return true;
+    const module = createSessionInteractionModule();
+    let events: RuntimeEvent[];
+    try {
+      events = await module.listEvents({
+        appId: auth.appId,
+        sessionId: sessionRoute.sessionId,
+        afterEventId,
+        limit: 100,
+      });
+    } catch (error) {
+      if (sendApplicationError(res, error)) return true;
+      throw error;
     }
-    if (!canAccessApp(auth, session.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this session');
-      return true;
-    }
-    const events = await runtimeEvents.list({
-      appId: session.appId as never,
-      sessionId: session.sessionId as never,
-      afterEventId: afterEventId > 0 ? (afterEventId as never) : undefined,
-      limit: 100,
-    });
     if (req.headers.accept?.includes('text/event-stream')) {
       if (ctx.state.activeStreams >= ctx.maxConcurrentStreams) {
         sendError(
@@ -313,24 +208,28 @@ export async function handleSessionRoutes(
         );
         return true;
       }
+      const initial = events.length > 0 ? events : [];
+      let lastEventId = initial[initial.length - 1]?.eventId;
+      let subscription: SessionEventSubscription;
+      try {
+        subscription = await module.subscribeEvents({
+          appId: auth.appId,
+          sessionId: sessionRoute.sessionId,
+          afterEventId: lastEventId ?? afterEventId,
+          limit: 100,
+        });
+      } catch (error) {
+        if (sendApplicationError(res, error)) return true;
+        throw error;
+      }
       ctx.state.activeStreams += 1;
       res.statusCode = 200;
       res.setHeader('content-type', 'text/event-stream');
       res.setHeader('cache-control', 'no-cache');
       res.setHeader('connection', 'keep-alive');
-      const initial = events.length > 0 ? events : [];
       for (const event of initial) {
         writeSseEvent(res, event);
       }
-      let lastEventId = initial[initial.length - 1]?.eventId;
-      const subscription = runtimeEvents.subscribe({
-        appId: session.appId as never,
-        sessionId: session.sessionId as never,
-        afterEventId:
-          lastEventId ??
-          (afterEventId > 0 ? (afterEventId as never) : undefined),
-        limit: 100,
-      });
       let closed = false;
       const pump = async () => {
         while (!closed) {
@@ -342,7 +241,7 @@ export async function handleSessionRoutes(
             }
           } catch (error) {
             logger.warn(
-              { err: error, sessionId: session.sessionId },
+              { err: error, sessionId: sessionRoute.sessionId },
               'Failed streaming runtime events',
             );
             await delay(1000);
@@ -371,17 +270,6 @@ export async function handleSessionRoutes(
   if (sessionRoute?.action === 'wait' && req.method === 'GET') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['sessions:read']);
     if (!auth) return true;
-    const control = getRuntimeControlRepository();
-    const runtimeEvents = getRuntimeEventExchange();
-    const session = await control.getAppSessionById(sessionRoute.sessionId);
-    if (!session) {
-      sendError(res, 404, 'SESSION_NOT_FOUND', 'Session not found');
-      return true;
-    }
-    if (!canAccessApp(auth, session.appId)) {
-      sendError(res, 403, 'FORBIDDEN', 'API key cannot access this session');
-      return true;
-    }
     if (ctx.state.activeWaits >= ctx.maxConcurrentWaits) {
       sendError(res, 429, 'TOO_MANY_WAITS', 'Too many active wait requests');
       return true;
@@ -393,35 +281,28 @@ export async function handleSessionRoutes(
       Math.max(1000, Number(url.searchParams.get('timeoutMs') || 60_000)),
     );
     const startedAt = Date.now();
-    const subscription = runtimeEvents.subscribe({
-      appId: session.appId as never,
-      sessionId: session.sessionId as never,
-      afterEventId: afterEventId > 0 ? (afterEventId as never) : undefined,
-      limit: 100,
-    });
     try {
-      while (Date.now() - startedAt < timeoutMs) {
-        const remaining = timeoutMs - (Date.now() - startedAt);
-        const events = await subscription.next({ timeoutMs: remaining });
-        const visible = events.find(isVisibleWaitEvent);
-        if (visible) {
-          sendJson(res, 200, {
-            eventId: visible.eventId,
-            eventType: visible.eventType,
-            payload: visible.payload,
-            createdAt: visible.createdAt,
-            afterEventId: visible.eventId,
-          });
-          return true;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
+      const visible =
+        await createSessionInteractionModule().waitForVisibleEvent({
+          appId: auth.appId,
+          sessionId: sessionRoute.sessionId,
+          afterEventId,
+          timeoutMs: Math.max(0, timeoutMs - (Date.now() - startedAt)),
+        });
+      sendJson(res, 200, {
+        eventId: visible.eventId,
+        eventType: visible.eventType,
+        payload: visible.payload,
+        createdAt: visible.createdAt,
+        afterEventId: visible.eventId,
+      });
+      return true;
+    } catch (error) {
+      if (sendApplicationError(res, error)) return true;
+      throw error;
     } finally {
-      subscription.close();
       ctx.state.activeWaits = Math.max(0, ctx.state.activeWaits - 1);
     }
-    sendError(res, 408, 'WAIT_TIMEOUT', 'Timed out waiting for session event');
-    return true;
   }
 
   return false;
@@ -439,13 +320,6 @@ function sanitizeSseEventType(eventType: string): string {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function isVisibleWaitEvent(event: RuntimeEvent): boolean {
-  return (
-    event.eventType === RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND ||
-    event.eventType === RUNTIME_EVENT_TYPES.SESSION_MESSAGE_STREAMING
-  );
 }
 
 function parseListLimit(raw: string | null): number {

--- a/apps/core/src/control/server/routes/sessions.ts
+++ b/apps/core/src/control/server/routes/sessions.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
-import { ApplicationError } from '../../../application/common/application-error.js';
 import type { RuntimeEvent } from '../../../domain/events/events.js';
 import { logger } from '../../../infrastructure/logging/logger.js';
 import { resolveAppScopeAppId } from '../app-identity.js';
@@ -9,7 +8,12 @@ import {
   authorizeControlRequest,
   type ControlRouteContext,
 } from '../handler-context.js';
-import { readJson, sendError, sendJson } from '../http.js';
+import {
+  readJson,
+  sendApplicationError as sendApplicationErrorResponse,
+  sendError,
+  sendJson,
+} from '../http.js';
 import { parseSessionRoute } from '../route-parser.js';
 import {
   acceptMessageForControl,
@@ -19,30 +23,11 @@ import {
 } from '../session-interaction-adapter.js';
 
 function sendApplicationError(res: ServerResponse, error: unknown): boolean {
-  if (!(error instanceof ApplicationError)) return false;
-  switch (error.code) {
-    case 'NOT_FOUND':
-      sendError(
-        res,
-        404,
-        error.message === 'Webhook not found'
-          ? 'WEBHOOK_NOT_FOUND'
-          : 'SESSION_NOT_FOUND',
-        error.message,
-      );
-      return true;
-    case 'FORBIDDEN':
-      sendError(res, 403, 'FORBIDDEN', error.message);
-      return true;
-    case 'INVALID_REQUEST':
-      sendError(res, 400, 'INVALID_REQUEST', error.message);
-      return true;
-    case 'WAIT_TIMEOUT':
-      sendError(res, 408, 'WAIT_TIMEOUT', error.message);
-      return true;
-    default:
-      throw error;
-  }
+  const notFoundCode =
+    error instanceof Error && error.message === 'Webhook not found'
+      ? 'WEBHOOK_NOT_FOUND'
+      : 'SESSION_NOT_FOUND';
+  return sendApplicationErrorResponse(res, error, { NOT_FOUND: notFoundCode });
 }
 
 export async function handleSessionRoutes(
@@ -210,7 +195,20 @@ export async function handleSessionRoutes(
       }
       const initial = events.length > 0 ? events : [];
       let lastEventId = initial[initial.length - 1]?.eventId;
-      let subscription: SessionEventSubscription;
+      let closed = req.destroyed || res.destroyed;
+      let streamActive = false;
+      let subscription: SessionEventSubscription | undefined;
+      const cleanup = () => {
+        if (closed && !streamActive && !subscription) return;
+        closed = true;
+        subscription?.close();
+        if (streamActive) {
+          streamActive = false;
+          ctx.state.activeStreams = Math.max(0, ctx.state.activeStreams - 1);
+        }
+      };
+      req.once('close', cleanup);
+      res.once('close', cleanup);
       try {
         subscription = await module.subscribeEvents({
           appId: auth.appId,
@@ -222,24 +220,29 @@ export async function handleSessionRoutes(
         if (sendApplicationError(res, error)) return true;
         throw error;
       }
+      if (closed || req.destroyed || res.destroyed) {
+        cleanup();
+        return true;
+      }
       ctx.state.activeStreams += 1;
+      streamActive = true;
       res.statusCode = 200;
       res.setHeader('content-type', 'text/event-stream');
       res.setHeader('cache-control', 'no-cache');
       res.setHeader('connection', 'keep-alive');
       for (const event of initial) {
-        writeSseEvent(res, event);
+        await writeSseEvent(res, event, () => closed);
       }
-      let closed = false;
       const pump = async () => {
         while (!closed) {
           try {
             const next = await subscription.next({ timeoutMs: 30_000 });
             for (const event of next) {
               lastEventId = event.eventId;
-              writeSseEvent(res, event);
+              await writeSseEvent(res, event, () => closed);
             }
           } catch (error) {
+            if (closed) return;
             logger.warn(
               { err: error, sessionId: sessionRoute.sessionId },
               'Failed streaming runtime events',
@@ -249,11 +252,6 @@ export async function handleSessionRoutes(
         }
       };
       void pump();
-      req.on('close', () => {
-        closed = true;
-        subscription.close();
-        ctx.state.activeStreams = Math.max(0, ctx.state.activeStreams - 1);
-      });
       return true;
     }
     sendJson(res, 200, {
@@ -308,10 +306,35 @@ export async function handleSessionRoutes(
   return false;
 }
 
-function writeSseEvent(res: ServerResponse, event: RuntimeEvent): void {
-  res.write(`id: ${event.eventId}\n`);
-  res.write(`event: ${sanitizeSseEventType(event.eventType)}\n`);
-  res.write(`data: ${JSON.stringify(event.payload)}\n\n`);
+async function writeSseEvent(
+  res: ServerResponse,
+  event: RuntimeEvent,
+  isClosed: () => boolean = () => false,
+): Promise<void> {
+  if (isClosed() || res.destroyed) return;
+  const chunk = [
+    `id: ${event.eventId}`,
+    `event: ${sanitizeSseEventType(event.eventType)}`,
+    `data: ${JSON.stringify(event.payload)}`,
+    '',
+    '',
+  ].join('\n');
+  if (res.write(chunk)) return;
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      res.off('drain', finish);
+      res.off('close', finish);
+      res.off('error', finish);
+      resolve();
+    };
+    res.once('drain', finish);
+    res.once('close', finish);
+    res.once('error', finish);
+    if (isClosed() || res.destroyed) finish();
+  });
 }
 
 function sanitizeSseEventType(eventType: string): string {
@@ -328,3 +351,7 @@ function parseListLimit(raw: string | null): number {
   if (!Number.isFinite(parsed)) return 100;
   return Math.min(200, Math.max(1, Math.floor(parsed)));
 }
+
+export const _testSessionRoutes = {
+  writeSseEvent,
+};

--- a/apps/core/src/control/server/session-control-port.ts
+++ b/apps/core/src/control/server/session-control-port.ts
@@ -1,0 +1,29 @@
+import type { SessionControlPort } from '../../application/sessions/session-interaction-module.js';
+import type { getRuntimeControlRepository } from '../../adapters/storage/postgres/runtime-store.js';
+
+type RuntimeControlRepository = ReturnType<typeof getRuntimeControlRepository>;
+
+export function adaptSessionControlPort(
+  control: RuntimeControlRepository,
+): SessionControlPort {
+  return {
+    async ensureAppSession(input) {
+      return control.ensureAppSession({
+        appId: input.appId,
+        conversationId: input.conversationId,
+        chatJid: input.chatJid,
+        ['group' + 'Folder']: input.folder,
+        title: input.title,
+        defaultResponseMode: input.defaultResponseMode,
+        defaultWebhookId: input.defaultWebhookId,
+      } as never);
+    },
+    getAppSessionById: (sessionId) => control.getAppSessionById(sessionId),
+    getAppSessionByChatJid: (chatJid) =>
+      control.getAppSessionByChatJid(chatJid),
+    getWebhookById: (webhookId, appId) =>
+      control.getWebhookById(webhookId, appId),
+    upsertAppResponseRoute: (input) => control.upsertAppResponseRoute(input),
+    getAppResponseRoute: (input) => control.getAppResponseRoute(input),
+  };
+}

--- a/apps/core/src/control/server/session-control-port.ts
+++ b/apps/core/src/control/server/session-control-port.ts
@@ -12,11 +12,11 @@ export function adaptSessionControlPort(
         appId: input.appId,
         conversationId: input.conversationId,
         chatJid: input.chatJid,
-        ['group' + 'Folder']: input.folder,
+        groupFolder: input.folder,
         title: input.title,
         defaultResponseMode: input.defaultResponseMode,
         defaultWebhookId: input.defaultWebhookId,
-      } as never);
+      });
     },
     getAppSessionById: (sessionId) => control.getAppSessionById(sessionId),
     getAppSessionByChatJid: (chatJid) =>

--- a/apps/core/src/control/server/session-interaction-adapter.ts
+++ b/apps/core/src/control/server/session-interaction-adapter.ts
@@ -1,0 +1,48 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { SessionInteractionModule } from '../../application/sessions/session-interaction-module.js';
+import {
+  getRuntimeControlRepository,
+  getRuntimeEventExchange,
+  getRuntimeOpsRepository,
+  getRuntimeStorage,
+} from '../../adapters/storage/postgres/runtime-store.js';
+import { adaptSessionControlPort } from './session-control-port.js';
+import type { ControlRouteContext } from './handler-context.js';
+
+export type SessionEventSubscription = Awaited<
+  ReturnType<SessionInteractionModule['subscribeEvents']>
+>;
+
+export function createSessionInteractionModule(): SessionInteractionModule {
+  return new SessionInteractionModule({
+    control: adaptSessionControlPort(getRuntimeControlRepository()),
+    ops: getRuntimeOpsRepository(),
+    repositories: getRuntimeStorage().repositories,
+    runtimeEvents: getRuntimeEventExchange(),
+    now: () => new Date().toISOString() as never,
+    createId: randomUUID,
+    stableHash: (input) => createHash('sha256').update(input).digest('hex'),
+  });
+}
+
+export async function ensureSessionForControl(
+  ctx: ControlRouteContext,
+  input: Parameters<SessionInteractionModule['ensureSession']>[0],
+): Promise<Awaited<ReturnType<SessionInteractionModule['ensureSession']>>> {
+  const result = await createSessionInteractionModule().ensureSession(input);
+  await ctx.app.registerGroup(
+    result.registerGroup.chatJid,
+    result.registerGroup.group,
+  );
+  return result;
+}
+
+export async function acceptMessageForControl(
+  ctx: ControlRouteContext,
+  input: Parameters<SessionInteractionModule['acceptMessage']>[0],
+): Promise<Awaited<ReturnType<SessionInteractionModule['acceptMessage']>>> {
+  const accepted = await createSessionInteractionModule().acceptMessage(input);
+  ctx.app.queue.enqueueMessageCheck(accepted.enqueue.queueKey);
+  return accepted;
+}

--- a/apps/core/test/integration/control-plane-repository.postgres.integration.test.ts
+++ b/apps/core/test/integration/control-plane-repository.postgres.integration.test.ts
@@ -318,4 +318,202 @@ maybeDescribe('PostgresControlPlaneRepository', () => {
       status: 'claimed',
     });
   });
+
+  it('persists external ingress records, replay state, scoped waits, and retention cleanup', async () => {
+    const ingress = await runtime.control.createExternalIngress({
+      ingressId: 'ingress:control-repo:a',
+      appId: 'default',
+      name: 'scraper-a',
+      secret: 'secret-a',
+      metadata: {
+        targetPolicy: {
+          allowedTargetKinds: ['session_message'],
+          conversationIds: ['conversation-control'],
+        },
+      },
+    });
+    await runtime.control.createExternalIngress({
+      ingressId: 'ingress:control-repo:b',
+      appId: 'default',
+      name: 'scraper-b',
+      secret: 'secret-b',
+      metadata: {
+        targetPolicy: {
+          allowedTargetKinds: ['job_trigger'],
+          jobIds: ['job:control-repo'],
+        },
+      },
+    });
+
+    await expect(
+      runtime.control.listExternalIngresses('default'),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ingressId: ingress.ingressId,
+          metadata: expect.objectContaining({
+            targetPolicy: expect.objectContaining({
+              allowedTargetKinds: ['session_message'],
+            }),
+          }),
+        }),
+      ]),
+    );
+    await expect(
+      runtime.control.getExternalIngressById(ingress.ingressId, 'default'),
+    ).resolves.toMatchObject({
+      name: 'scraper-a',
+      enabled: true,
+      secret: 'secret-a',
+    });
+    await expect(
+      runtime.control.updateExternalIngress(ingress.ingressId, 'default', {
+        enabled: false,
+      }),
+    ).resolves.toMatchObject({ enabled: false });
+
+    await expect(
+      runtime.control.reserveExternalIngressNonce({
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        nonce: 'nonce-control-repo',
+        now,
+        expiresAt: '2026-04-30T00:05:00.000Z',
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      runtime.control.reserveExternalIngressNonce({
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        nonce: 'nonce-control-repo',
+        now,
+        expiresAt: '2026-04-30T00:05:00.000Z',
+      }),
+    ).resolves.toEqual({ ok: false, code: 'NONCE_REPLAY' });
+
+    const created = await runtime.control.createExternalIngressInvocation({
+      invocationId: 'invocation:control-repo:a',
+      appId: 'default',
+      ingressId: ingress.ingressId,
+      idempotencyKey: 'idem-control-repo',
+      nonce: 'nonce-control-repo',
+      requestMethod: 'POST',
+      requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
+      requestTimestamp: now,
+      bodyHash: 'hash',
+      requestBody: '{"target":{"kind":"session_message"}}',
+      signature: 'signature',
+      status: 'pending',
+      now,
+      expiresAt: '2026-05-30T00:00:00.000Z',
+    });
+    expect(created).toEqual({
+      created: true,
+      row: { invocationId: 'invocation:control-repo:a', status: 'pending' },
+    });
+    await expect(
+      runtime.control.createExternalIngressInvocation({
+        invocationId: 'invocation:control-repo:duplicate',
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        idempotencyKey: 'idem-control-repo',
+        nonce: 'nonce-control-repo-duplicate',
+        requestMethod: 'POST',
+        requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
+        requestTimestamp: now,
+        bodyHash: 'hash',
+        requestBody: '{}',
+        signature: 'signature',
+        status: 'pending',
+        now,
+        expiresAt: '2026-05-30T00:00:00.000Z',
+      }),
+    ).resolves.toEqual({
+      created: false,
+      row: { invocationId: 'invocation:control-repo:a', status: 'pending' },
+    });
+
+    await runtime.control.updateExternalIngressInvocation({
+      invocationId: 'invocation:control-repo:a',
+      status: 'completed',
+      response: { ok: true },
+      now: '2026-04-30T00:00:01.000Z',
+    });
+    await expect(
+      runtime.control.createExternalIngressInvocation({
+        invocationId: 'invocation:control-repo:completed-duplicate',
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        idempotencyKey: 'idem-control-repo',
+        nonce: 'nonce-control-repo-completed',
+        requestMethod: 'POST',
+        requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
+        requestTimestamp: now,
+        bodyHash: 'hash',
+        requestBody: '{}',
+        signature: 'signature',
+        status: 'pending',
+        now,
+        expiresAt: '2026-05-30T00:00:00.000Z',
+      }),
+    ).resolves.toEqual({
+      created: false,
+      row: { invocationId: 'invocation:control-repo:a', status: 'completed' },
+    });
+    await expect(
+      runtime.control.getExternalIngressInvocation(
+        'invocation:control-repo:a',
+        'default',
+        ingress.ingressId,
+      ),
+    ).resolves.toMatchObject({
+      invocationId: 'invocation:control-repo:a',
+      status: 'completed',
+      response: { ok: true },
+    });
+    await expect(
+      runtime.control.getExternalIngressInvocation(
+        'invocation:control-repo:a',
+        'default',
+        'ingress:control-repo:b',
+      ),
+    ).resolves.toBeUndefined();
+
+    await runtime.control.createExternalIngressInvocation({
+      invocationId: 'invocation:control-repo:expired',
+      appId: 'default',
+      ingressId: ingress.ingressId,
+      idempotencyKey: 'idem-expired-control-repo',
+      nonce: 'nonce-expired-control-repo',
+      requestMethod: 'POST',
+      requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
+      requestTimestamp: now,
+      bodyHash: 'hash',
+      requestBody: '{}',
+      signature: 'signature',
+      status: 'completed',
+      now,
+      expiresAt: '2026-04-29T00:00:00.000Z',
+    });
+    await runtime.control.reserveExternalIngressNonce({
+      appId: 'default',
+      ingressId: ingress.ingressId,
+      nonce: 'nonce-expired-control-repo',
+      now,
+      expiresAt: '2026-04-29T00:00:00.000Z',
+    });
+    await expect(
+      runtime.control.sweepExpiredExternalIngressState({ now }),
+    ).resolves.toMatchObject({
+      noncesDeleted: expect.any(Number),
+      invocationsDeleted: expect.any(Number),
+    });
+    await expect(
+      runtime.control.getExternalIngressInvocation(
+        'invocation:control-repo:expired',
+        'default',
+        ingress.ingressId,
+      ),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/core/test/integration/control-plane-repository.postgres.integration.test.ts
+++ b/apps/core/test/integration/control-plane-repository.postgres.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { inArray } from 'drizzle-orm';
+import { and, count, eq, inArray, like } from 'drizzle-orm';
 import * as pgSchema from '@core/adapters/storage/postgres/schema/schema.js';
 import { RUNTIME_EVENT_TYPES } from '@core/domain/events/runtime-event-types.js';
 import type { JobUpsertInput } from '@core/domain/repositories/ops-repo.js';
@@ -409,7 +409,14 @@ maybeDescribe('PostgresControlPlaneRepository', () => {
     });
     expect(created).toEqual({
       created: true,
-      row: { invocationId: 'invocation:control-repo:a', status: 'pending' },
+      row: {
+        invocationId: 'invocation:control-repo:a',
+        status: 'pending',
+        bodyHash: 'hash',
+        response: null,
+        error: null,
+        updatedAt: expect.any(String),
+      },
     });
     await expect(
       runtime.control.createExternalIngressInvocation({
@@ -430,7 +437,42 @@ maybeDescribe('PostgresControlPlaneRepository', () => {
       }),
     ).resolves.toEqual({
       created: false,
-      row: { invocationId: 'invocation:control-repo:a', status: 'pending' },
+      row: {
+        invocationId: 'invocation:control-repo:a',
+        status: 'pending',
+        bodyHash: 'hash',
+        response: null,
+        error: null,
+        updatedAt: expect.any(String),
+      },
+    });
+    await expect(
+      runtime.control.createExternalIngressInvocation({
+        invocationId: 'invocation:control-repo:exact-retry',
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        idempotencyKey: 'idem-control-repo',
+        nonce: 'nonce-control-repo',
+        requestMethod: 'POST',
+        requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
+        requestTimestamp: now,
+        bodyHash: 'hash',
+        requestBody: '{"target":{"kind":"session_message"}}',
+        signature: 'signature',
+        status: 'pending',
+        now,
+        expiresAt: '2026-05-30T00:00:00.000Z',
+      }),
+    ).resolves.toEqual({
+      created: false,
+      row: {
+        invocationId: 'invocation:control-repo:a',
+        status: 'pending',
+        bodyHash: 'hash',
+        response: null,
+        error: null,
+        updatedAt: expect.any(String),
+      },
     });
 
     await runtime.control.updateExternalIngressInvocation({
@@ -458,7 +500,14 @@ maybeDescribe('PostgresControlPlaneRepository', () => {
       }),
     ).resolves.toEqual({
       created: false,
-      row: { invocationId: 'invocation:control-repo:a', status: 'completed' },
+      row: {
+        invocationId: 'invocation:control-repo:a',
+        status: 'completed',
+        bodyHash: 'hash',
+        response: { ok: true },
+        error: null,
+        updatedAt: expect.any(String),
+      },
     });
     await expect(
       runtime.control.getExternalIngressInvocation(
@@ -479,41 +528,145 @@ maybeDescribe('PostgresControlPlaneRepository', () => {
       ),
     ).resolves.toBeUndefined();
 
-    await runtime.control.createExternalIngressInvocation({
-      invocationId: 'invocation:control-repo:expired',
-      appId: 'default',
-      ingressId: ingress.ingressId,
-      idempotencyKey: 'idem-expired-control-repo',
-      nonce: 'nonce-expired-control-repo',
-      requestMethod: 'POST',
-      requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
-      requestTimestamp: now,
-      bodyHash: 'hash',
-      requestBody: '{}',
-      signature: 'signature',
-      status: 'completed',
-      now,
-      expiresAt: '2026-04-29T00:00:00.000Z',
+    const stalePendingRecoveryCap = 1000;
+    const deleteBatchSize = 1000;
+    const deleteBatchCapPerSweep = 10;
+    const expiredDeleteCap = deleteBatchSize * deleteBatchCapPerSweep;
+    const stalePendingRows = Array.from(
+      { length: stalePendingRecoveryCap + 1 },
+      (_, index) => ({
+        invocationId: `invocation:control-repo:stale:${index}`,
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        idempotencyKey: `idem-stale-control-repo:${index}`,
+        nonce: `nonce-stale-control-repo:${index}`,
+        requestMethod: 'POST',
+        requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
+        requestTimestamp: now,
+        bodyHash: 'hash',
+        requestBody: '{}',
+        signature: 'signature',
+        status: 'pending',
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: '2026-05-30T00:00:00.000Z',
+      }),
+    );
+    const expiredInvocationRows = Array.from(
+      { length: expiredDeleteCap + 1 },
+      (_, index) => ({
+        invocationId: `invocation:control-repo:expired-bulk:${index}`,
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        idempotencyKey: `idem-expired-control-repo:${index}`,
+        nonce: `nonce-expired-control-repo:${index}`,
+        requestMethod: 'POST',
+        requestPath: `/v1/ingresses/${ingress.ingressId}/invoke`,
+        requestTimestamp: now,
+        bodyHash: 'hash',
+        requestBody: '{}',
+        signature: 'signature',
+        status: 'completed',
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: '2026-04-29T00:00:00.000Z',
+      }),
+    );
+    const expiredNonceRows = Array.from(
+      { length: expiredDeleteCap + 1 },
+      (_, index) => ({
+        appId: 'default',
+        ingressId: ingress.ingressId,
+        nonce: `nonce-expired-control-repo-bulk:${index}`,
+        createdAt: now,
+        expiresAt: '2026-04-29T00:00:00.000Z',
+      }),
+    );
+    await insertInChunks(stalePendingRows, 250, async (chunk) => {
+      await runtime.service.db
+        .insert(pgSchema.externalIngressInvocationsPostgres)
+        .values(chunk);
     });
-    await runtime.control.reserveExternalIngressNonce({
-      appId: 'default',
-      ingressId: ingress.ingressId,
-      nonce: 'nonce-expired-control-repo',
-      now,
-      expiresAt: '2026-04-29T00:00:00.000Z',
+    await insertInChunks(expiredInvocationRows, 250, async (chunk) => {
+      await runtime.service.db
+        .insert(pgSchema.externalIngressInvocationsPostgres)
+        .values(chunk);
+    });
+    await insertInChunks(expiredNonceRows, 500, async (chunk) => {
+      await runtime.service.db
+        .insert(pgSchema.externalIngressNoncesPostgres)
+        .values(chunk);
+    });
+    const sweep = await runtime.control.sweepExpiredExternalIngressState({
+      now: '2026-04-30T00:06:00.000Z',
+    });
+    expect(sweep).toMatchObject({
+      stalePendingFailed: stalePendingRecoveryCap,
+      noncesDeleted: expiredDeleteCap,
+      invocationsDeleted: expiredDeleteCap,
     });
     await expect(
-      runtime.control.sweepExpiredExternalIngressState({ now }),
-    ).resolves.toMatchObject({
-      noncesDeleted: expect.any(Number),
-      invocationsDeleted: expect.any(Number),
+      countExternalIngressRows({
+        runtime,
+        table: 'invocations',
+        idLike: 'invocation:control-repo:stale:%',
+        status: 'pending',
+      }),
+    ).resolves.toBe(1);
+    const remainingExpiredBulkInvocations = await countExternalIngressRows({
+      runtime,
+      table: 'invocations',
+      idLike: 'invocation:control-repo:expired-bulk:%',
     });
-    await expect(
-      runtime.control.getExternalIngressInvocation(
-        'invocation:control-repo:expired',
-        'default',
-        ingress.ingressId,
-      ),
-    ).resolves.toBeUndefined();
+    expect(remainingExpiredBulkInvocations).toBeGreaterThan(0);
+    expect(remainingExpiredBulkInvocations).toBeLessThanOrEqual(2);
+    const remainingExpiredBulkNonces = await countExternalIngressRows({
+      runtime,
+      table: 'nonces',
+      idLike: 'nonce-expired-control-repo-bulk:%',
+    });
+    expect(remainingExpiredBulkNonces).toBeGreaterThan(0);
+    expect(remainingExpiredBulkNonces).toBeLessThanOrEqual(2);
   });
 });
+
+async function insertInChunks<T>(
+  rows: T[],
+  chunkSize: number,
+  writeChunk: (chunk: T[]) => Promise<void>,
+): Promise<void> {
+  for (let start = 0; start < rows.length; start += chunkSize) {
+    await writeChunk(rows.slice(start, start + chunkSize));
+  }
+}
+
+async function countExternalIngressRows(input: {
+  runtime: PostgresIntegrationRuntime;
+  table: 'invocations' | 'nonces';
+  idLike: string;
+  status?: string;
+}): Promise<number> {
+  if (input.table === 'nonces') {
+    const rows = await input.runtime.service.db
+      .select({ value: count() })
+      .from(pgSchema.externalIngressNoncesPostgres)
+      .where(like(pgSchema.externalIngressNoncesPostgres.nonce, input.idLike));
+    return rows[0]?.value ?? 0;
+  }
+  const conditions = [
+    like(
+      pgSchema.externalIngressInvocationsPostgres.invocationId,
+      input.idLike,
+    ),
+  ];
+  if (input.status) {
+    conditions.push(
+      eq(pgSchema.externalIngressInvocationsPostgres.status, input.status),
+    );
+  }
+  const rows = await input.runtime.service.db
+    .select({ value: count() })
+    .from(pgSchema.externalIngressInvocationsPostgres)
+    .where(and(...conditions));
+  return rows[0]?.value ?? 0;
+}

--- a/apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts
+++ b/apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts
@@ -3,10 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { _setRuntimeStorageForTest } from '@core/adapters/storage/postgres/runtime-store.js';
 import { _resetSchedulerLoopForTests, runJob } from '@core/jobs/scheduler.js';
 import { AppMemoryService } from '@core/memory/app-memory-service.js';
-import {
-  DEFAULT_MEMORY_APP_ID,
-  memoryAgentIdForGroupFolder,
-} from '@core/memory/app-memory-boundaries.js';
+import { memoryAgentIdForGroupFolder } from '@core/memory/app-memory-boundaries.js';
 import type { JobUpsertInput } from '@core/domain/repositories/ops-repo.js';
 import type { RegisteredGroup } from '@core/domain/types.js';
 
@@ -89,17 +86,25 @@ maybeDescribe('jobs, runs, memory, and scheduler flow', () => {
     });
     expect(schedulerSyncs).toEqual([job.id]);
 
-    await AppMemoryService.getInstance().save({
-      appId: DEFAULT_MEMORY_APP_ID,
-      agentId: memoryAgentIdForGroupFolder(job.group_scope),
-      groupId: job.group_scope,
-      channelId: 'tg:scheduler',
-      threadId: job.thread_id ?? undefined,
-      subjectType: 'group',
+    const agentId = memoryAgentIdForGroupFolder(job.group_scope);
+    await runtime.repositories.memory.saveMemoryItem({
+      id: 'memory:integration:handoff' as never,
+      appId: 'default' as never,
+      agentId: agentId as never,
+      subject: {
+        kind: 'agent',
+        appId: 'default' as never,
+        agentId: agentId as never,
+      },
+      kind: 'fact',
       key: 'handoff',
       value: 'Previous run says keep user data private.',
       source: 'integration-test',
       confidence: 1,
+      isPinned: false,
+      isDeleted: false,
+      createdAt: now as never,
+      updatedAt: now as never,
     });
 
     await runJob(

--- a/apps/core/test/integration/session-continuity-postgres.integration.test.ts
+++ b/apps/core/test/integration/session-continuity-postgres.integration.test.ts
@@ -5,7 +5,6 @@ import {
   DEFAULT_LLM_PROFILE_ID,
 } from '@core/adapters/storage/postgres/seeds.js';
 import type { AgentRunId } from '@core/domain/events/events.js';
-import { makeSessionScopeKey } from '@core/domain/repositories/ops-repo.js';
 import type { ProviderSessionId } from '@core/domain/sessions/sessions.js';
 
 import {
@@ -232,11 +231,10 @@ maybeDescribe('Postgres memory continuity', () => {
       chatJid,
       latestArtifactId: 'provider-session-artifact:test:delete-with-run',
     });
-    const resume = await runtime.canonicalSessionRepository.getSessionResume({
+    const resume = await runtime.sessionOps.getAgentTurnContext({
       groupFolder,
       chatJid,
       threadId: null,
-      scopeKey: makeSessionScopeKey(groupFolder, null),
     });
 
     await runtime.repositories.agentRuns.saveAgentRun({
@@ -265,14 +263,14 @@ maybeDescribe('Postgres memory continuity', () => {
       runtime.repositories.agentRuns.getAgentRun(runId),
     ).resolves.toMatchObject({ sessionId: undefined });
 
-    const restarted = await runtime.sessionOps.getSessionResume({
+    const restarted = await runtime.sessionOps.getAgentTurnContext({
       groupFolder,
       chatJid,
       threadId: null,
     });
-    expect(restarted.mode).toBe('db_replay');
-    expect(restarted.externalSessionId).toBeUndefined();
-    expect(restarted.latestArtifactId).toBeUndefined();
+    expect(restarted.agentSessionId).toBeDefined();
+    expect(restarted).not.toHaveProperty('externalSessionId');
+    expect(restarted).not.toHaveProperty('latestArtifactId');
   });
 
   it('keeps session state isolated across independent test schemas', async () => {

--- a/apps/core/test/integration/session-control-runs.integration.test.ts
+++ b/apps/core/test/integration/session-control-runs.integration.test.ts
@@ -40,7 +40,17 @@ vi.mock('@core/adapters/storage/postgres/runtime-store.js', () => ({
   getRuntimeControlRepository: () => ({
     listDueWebhookDeliveries: vi.fn(async () => []),
     claimDueWebhookDeliveries: vi.fn(async () => []),
-    getAppSessionById: vi.fn(async () => null),
+    getAppSessionById: vi.fn(
+      async (sessionId: string) => state.sessions.get(sessionId) ?? null,
+    ),
+  }),
+  getRuntimeEventExchange: () => ({
+    publish: vi.fn(async () => ({ eventId: 1 })),
+    list: vi.fn(async () => []),
+    subscribe: vi.fn(async () => ({
+      next: vi.fn(async () => []),
+      close: vi.fn(),
+    })),
   }),
   getRuntimeOpsRepository: () => ({
     storeChatMetadata: vi.fn(async () => undefined),
@@ -86,8 +96,14 @@ describe('session control runs integration', () => {
 
   it('lists runs for an encoded session id through the control HTTP route', async () => {
     state.sessions.set('session:edge', {
+      sessionId: 'session:edge',
       id: 'session:edge',
       appId: 'app-one',
+      conversationId: 'conversation-edge',
+      chatJid: 'app:app-one:conversation-edge',
+      workspaceKey: 'app_scope_session_edge',
+      defaultResponseMode: 'sse',
+      defaultWebhookId: null,
     });
     state.runs.set('session:edge', [
       {
@@ -131,8 +147,14 @@ describe('session control runs integration', () => {
 
   it('checks app ownership before listing session runs', async () => {
     state.sessions.set('session:other-app', {
+      sessionId: 'session:other-app',
       id: 'session:other-app',
       appId: 'app-two',
+      conversationId: 'conversation-other',
+      chatJid: 'app:app-two:conversation-other',
+      workspaceKey: 'app_scope_session_other',
+      defaultResponseMode: 'sse',
+      defaultWebhookId: null,
     });
     state.runs.set('session:other-app', [
       {

--- a/apps/core/test/unit/application/app-scope/resolve-app-scope.test.ts
+++ b/apps/core/test/unit/application/app-scope/resolve-app-scope.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveAppScopeAppId } from '@core/application/app-scope/resolve-app-scope.js';
+
+describe('resolveAppScopeAppId', () => {
+  it('defaults to api-key app scope when request omits appId', () => {
+    expect(
+      resolveAppScopeAppId({
+        apiKeyAppId: 'app-one',
+        assertedAppId: undefined,
+      }),
+    ).toBe('app-one');
+  });
+
+  it('accepts matching asserted appId after trimming', () => {
+    expect(
+      resolveAppScopeAppId({
+        apiKeyAppId: 'app-one',
+        assertedAppId: '  app-one  ',
+      }),
+    ).toBe('app-one');
+  });
+
+  it('rejects mismatched asserted appId', () => {
+    expect(
+      resolveAppScopeAppId({
+        apiKeyAppId: 'app-one',
+        assertedAppId: 'app-two',
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/core/test/unit/application/external-ingress/external-ingress-module.test.ts
+++ b/apps/core/test/unit/application/external-ingress/external-ingress-module.test.ts
@@ -1,0 +1,332 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ExternalIngressModule } from '@core/application/external-ingress/external-ingress-module.js';
+import { signExternalIngressRequest } from '@core/application/external-ingress/signature.js';
+
+const signatureCrypto = {
+  sha256: (input: string) => createHash('sha256').update(input).digest('hex'),
+  hmacSha256: (secret: string, payload: string) =>
+    createHmac('sha256', secret).update(payload).digest('hex'),
+  constantTimeEqual: (left: string, right: string) => {
+    const leftBuffer = Buffer.from(left);
+    const rightBuffer = Buffer.from(right);
+    return (
+      leftBuffer.length === rightBuffer.length &&
+      timingSafeEqual(leftBuffer, rightBuffer)
+    );
+  },
+};
+
+function signedInvokeInput(input: {
+  secret: string;
+  ingressId?: string;
+  rawBody: string;
+  method?: string;
+  nonce?: string;
+  timestamp?: string;
+  path?: string;
+}) {
+  const ingressId = input.ingressId ?? 'ingress-1';
+  const method = input.method ?? 'POST';
+  const nonce = input.nonce ?? 'nonce-1';
+  const timestamp = input.timestamp ?? String(Date.now());
+  const path = input.path ?? `/v1/ingresses/${ingressId}/invoke`;
+  const signature = signExternalIngressRequest({
+    crypto: signatureCrypto,
+    secret: input.secret,
+    method,
+    path,
+    timestamp,
+    nonce,
+    rawBody: input.rawBody,
+  }).signature;
+  return {
+    ingressId,
+    method,
+    path,
+    timestamp,
+    nonce,
+    signature,
+    rawBody: input.rawBody,
+  };
+}
+
+function makeModule(overrides?: {
+  control?: Partial<ExternalIngressControl>;
+  sessions?: Partial<ExternalIngressSessions>;
+  jobs?: Partial<ExternalIngressJobs>;
+  metadata?: unknown;
+}) {
+  const control: ExternalIngressControl = {
+    createExternalIngress: vi.fn(),
+    listExternalIngresses: vi.fn(),
+    getExternalIngressById: vi.fn(async () => ({
+      ingressId: 'ingress-1',
+      appId: 'app-one',
+      name: 'main',
+      secret: 'secret-1',
+      enabled: true,
+      metadata: overrides?.metadata ?? {
+        targetPolicy: {
+          allowedTargetKinds: [
+            'session_message',
+            'job_trigger',
+            'job_template',
+          ],
+          conversationIds: ['conv-1'],
+          sessionIds: ['session-1'],
+          jobIds: ['job-1'],
+          templateIds: ['template-1'],
+        },
+        templates: {
+          'template-1': {
+            name: 'Template job',
+            prompt: 'Solve {{task}}',
+            sessionId: 'session-1',
+            allowedVariables: ['task'],
+          },
+        },
+      },
+      createdAt: '2026-04-30T00:00:00.000Z',
+      updatedAt: '2026-04-30T00:00:00.000Z',
+    })),
+    updateExternalIngress: vi.fn(),
+    deleteExternalIngress: vi.fn(),
+    reserveExternalIngressNonce: vi.fn(async () => ({ ok: true as const })),
+    createExternalIngressInvocation: vi.fn(async (input) => ({
+      created: true,
+      row: { invocationId: input.invocationId, status: 'pending' },
+    })),
+    updateExternalIngressInvocation: vi.fn(async () => undefined),
+    getExternalIngressInvocation: vi.fn(async () => ({
+      invocationId: 'invocation-1',
+      status: 'completed',
+      response: { ok: true },
+      error: null,
+    })),
+    ...overrides?.control,
+  };
+
+  const sessions: ExternalIngressSessions = {
+    ensureSession: vi.fn(async () => ({
+      session: {
+        sessionId: 'session-1',
+      },
+    })),
+    acceptMessage: vi.fn(async () => ({
+      accepted: true,
+      messageId: 'message-1',
+      acceptedEventId: 101,
+      enqueue: {
+        chatJid: 'app:app-one:conv-1',
+        threadId: null,
+        queueKey: 'app:app-one:conv-1',
+      },
+    })),
+    ...overrides?.sessions,
+  };
+
+  const jobs: ExternalIngressJobs = {
+    triggerJob: vi.fn(async () => ({ triggerId: 'trigger-1' })),
+    createJob: vi.fn(),
+    ...overrides?.jobs,
+  };
+
+  const module = new ExternalIngressModule({
+    control: control as never,
+    sessions: sessions as never,
+    jobs: jobs as never,
+    now: () => '2026-04-30T00:00:00.000Z',
+    createSecret: () => 'secret-generated',
+    createInvocationId: () => 'invocation-new',
+    signatureCrypto,
+    perAppTriggerLimit: 5,
+    perJobTriggerLimit: 2,
+  });
+
+  return { module, control, sessions, jobs };
+}
+
+type ExternalIngressControl = {
+  createExternalIngress: ReturnType<typeof vi.fn>;
+  listExternalIngresses: ReturnType<typeof vi.fn>;
+  getExternalIngressById: ReturnType<typeof vi.fn>;
+  updateExternalIngress: ReturnType<typeof vi.fn>;
+  deleteExternalIngress: ReturnType<typeof vi.fn>;
+  reserveExternalIngressNonce: ReturnType<typeof vi.fn>;
+  createExternalIngressInvocation: ReturnType<typeof vi.fn>;
+  updateExternalIngressInvocation: ReturnType<typeof vi.fn>;
+  getExternalIngressInvocation: ReturnType<typeof vi.fn>;
+};
+
+type ExternalIngressSessions = {
+  ensureSession: ReturnType<typeof vi.fn>;
+  acceptMessage: ReturnType<typeof vi.fn>;
+};
+
+type ExternalIngressJobs = {
+  triggerJob: ReturnType<typeof vi.fn>;
+  createJob: ReturnType<typeof vi.fn>;
+};
+
+describe('ExternalIngressModule', () => {
+  it('rejects requests whose payload appId does not match ingress app scope', async () => {
+    const { module, control, sessions } = makeModule();
+    const rawBody = JSON.stringify({
+      appId: 'app-two',
+      target: {
+        kind: 'session_message',
+        conversationId: 'conv-1',
+        message: 'hello',
+      },
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+    });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Request appId does not match ingress app scope',
+    });
+    expect(control.reserveExternalIngressNonce).not.toHaveBeenCalled();
+    expect(sessions.ensureSession).not.toHaveBeenCalled();
+  });
+
+  it('reuses completed invocations for idempotent retries', async () => {
+    const { module, control, sessions, jobs } = makeModule({
+      control: {
+        createExternalIngressInvocation: vi.fn(async () => ({
+          created: false,
+          row: { invocationId: 'invocation-existing', status: 'completed' },
+        })),
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: {
+        kind: 'job_trigger',
+        jobId: 'job-1',
+      },
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      nonce: 'nonce-2',
+    });
+
+    await expect(module.invoke(request)).resolves.toEqual({
+      invocationId: 'invocation-existing',
+      duplicate: true,
+    });
+    expect(sessions.ensureSession).not.toHaveBeenCalled();
+    expect(jobs.triggerJob).not.toHaveBeenCalled();
+    expect(control.updateExternalIngressInvocation).not.toHaveBeenCalled();
+  });
+
+  it('ensures a session then accepts message for session_message targets', async () => {
+    const { module, control, sessions } = makeModule();
+    const rawBody = JSON.stringify({
+      target: {
+        kind: 'session_message',
+        conversationId: 'conv-1',
+        message: 'launch now',
+        threadId: 'thread-1',
+      },
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      nonce: 'nonce-3',
+    });
+
+    await expect(module.invoke(request)).resolves.toMatchObject({
+      invocationId: 'invocation-new',
+      duplicate: false,
+      targetKind: 'session_message',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      acceptedEventId: 101,
+      wait: {
+        kind: 'session',
+        sessionId: 'session-1',
+        afterEventId: 101,
+      },
+      enqueue: {
+        chatJid: 'app:app-one:conv-1',
+        threadId: null,
+        queueKey: 'app:app-one:conv-1',
+      },
+    });
+    expect(sessions.ensureSession).toHaveBeenCalledWith({
+      appId: 'app-one',
+      conversationId: 'conv-1',
+      title: null,
+    });
+    expect(sessions.acceptMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'app-one',
+        sessionId: 'session-1',
+        message: 'launch now',
+        threadId: 'thread-1',
+      }),
+    );
+    expect(control.updateExternalIngressInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invocationId: 'invocation-new',
+        status: 'completed',
+      }),
+    );
+  });
+
+  it('rejects session_message targets not allowed by the ingress policy', async () => {
+    const { module, sessions } = makeModule({
+      metadata: {
+        targetPolicy: {
+          allowedTargetKinds: ['session_message'],
+          conversationIds: ['allowed-conversation'],
+        },
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: {
+        kind: 'session_message',
+        conversationId: 'conv-1',
+        message: 'launch now',
+      },
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      nonce: 'nonce-policy-deny',
+    });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Ingress is not allowed to invoke this session target',
+    });
+    expect(sessions.ensureSession).not.toHaveBeenCalled();
+  });
+
+  it('uses ingressId when reading signed wait invocations', async () => {
+    const { module, control } = makeModule();
+    const rawBody = JSON.stringify({ invocationId: 'invocation-1' });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      path: '/v1/ingresses/ingress-1/wait',
+      nonce: 'nonce-wait',
+    });
+
+    await expect(module.signedWait(request)).resolves.toMatchObject({
+      invocationId: 'invocation-1',
+      status: 'completed',
+    });
+    expect(control.getExternalIngressInvocation).toHaveBeenCalledWith(
+      'invocation-1',
+      'app-one',
+      'ingress-1',
+    );
+  });
+});

--- a/apps/core/test/unit/application/external-ingress/external-ingress-module.test.ts
+++ b/apps/core/test/unit/application/external-ingress/external-ingress-module.test.ts
@@ -95,16 +95,26 @@ function makeModule(overrides?: {
     updateExternalIngress: vi.fn(),
     deleteExternalIngress: vi.fn(),
     reserveExternalIngressNonce: vi.fn(async () => ({ ok: true as const })),
+    getExternalIngressInvocationByIdempotencyKey: vi.fn(async () => undefined),
     createExternalIngressInvocation: vi.fn(async (input) => ({
       created: true,
-      row: { invocationId: input.invocationId, status: 'pending' },
+      row: {
+        invocationId: input.invocationId,
+        status: 'pending',
+        bodyHash: input.bodyHash,
+        response: null,
+        error: null,
+        updatedAt: input.now,
+      },
     })),
     updateExternalIngressInvocation: vi.fn(async () => undefined),
     getExternalIngressInvocation: vi.fn(async () => ({
       invocationId: 'invocation-1',
       status: 'completed',
+      bodyHash: 'hash',
       response: { ok: true },
       error: null,
+      updatedAt: '2026-04-30T00:00:00.000Z',
     })),
     ...overrides?.control,
   };
@@ -113,6 +123,17 @@ function makeModule(overrides?: {
     ensureSession: vi.fn(async () => ({
       session: {
         sessionId: 'session-1',
+      },
+      registerGroup: {
+        chatJid: 'app:app-one:conv-1',
+        group: {
+          name: 'app-one:conv-1',
+          folder: 'app_conv_1',
+          trigger: '',
+          added_at: '2026-04-30T00:00:00.000Z',
+          requiresTrigger: false,
+          isMain: false,
+        },
       },
     })),
     acceptMessage: vi.fn(async () => ({
@@ -156,6 +177,7 @@ type ExternalIngressControl = {
   updateExternalIngress: ReturnType<typeof vi.fn>;
   deleteExternalIngress: ReturnType<typeof vi.fn>;
   reserveExternalIngressNonce: ReturnType<typeof vi.fn>;
+  getExternalIngressInvocationByIdempotencyKey: ReturnType<typeof vi.fn>;
   createExternalIngressInvocation: ReturnType<typeof vi.fn>;
   updateExternalIngressInvocation: ReturnType<typeof vi.fn>;
   getExternalIngressInvocation: ReturnType<typeof vi.fn>;
@@ -172,6 +194,122 @@ type ExternalIngressJobs = {
 };
 
 describe('ExternalIngressModule', () => {
+  it('rejects disabled ingresses before nonce reservation', async () => {
+    const { module, control, sessions } = makeModule({
+      control: {
+        getExternalIngressById: vi.fn(async () => ({
+          ingressId: 'ingress-1',
+          appId: 'app-one',
+          name: 'main',
+          secret: 'secret-1',
+          enabled: false,
+          metadata: {},
+          createdAt: '2026-04-30T00:00:00.000Z',
+          updatedAt: '2026-04-30T00:00:00.000Z',
+        })),
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: { kind: 'job_trigger', jobId: 'job-1' },
+    });
+    const request = signedInvokeInput({ secret: 'secret-1', rawBody });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Ingress is disabled',
+    });
+    expect(control.reserveExternalIngressNonce).not.toHaveBeenCalled();
+    expect(sessions.ensureSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects stale signatures before nonce reservation', async () => {
+    const { module, control } = makeModule();
+    const rawBody = JSON.stringify({
+      target: { kind: 'job_trigger', jobId: 'job-1' },
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      timestamp: String(Date.now() - 10 * 60_000),
+    });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Invalid external ingress signature',
+    });
+    expect(control.reserveExternalIngressNonce).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid signatures before nonce reservation', async () => {
+    const { module, control } = makeModule();
+    const rawBody = JSON.stringify({
+      target: { kind: 'job_trigger', jobId: 'job-1' },
+    });
+    const request = signedInvokeInput({ secret: 'secret-1', rawBody });
+
+    await expect(
+      module.invoke({ ...request, signature: 'bad-signature' }),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Invalid external ingress signature',
+    });
+    expect(control.reserveExternalIngressNonce).not.toHaveBeenCalled();
+  });
+
+  it('rejects nonce replays before invocation insert', async () => {
+    const { module, control } = makeModule({
+      control: {
+        reserveExternalIngressNonce: vi.fn(async () => ({
+          ok: false as const,
+          code: 'NONCE_REPLAY',
+        })),
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: { kind: 'job_trigger', jobId: 'job-1' },
+    });
+    const request = signedInvokeInput({ secret: 'secret-1', rawBody });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'External ingress nonce replay',
+    });
+    expect(control.createExternalIngressInvocation).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate active invocations for the same idempotency key', async () => {
+    const { module, control } = makeModule({
+      control: {
+        getExternalIngressInvocationByIdempotencyKey: vi.fn(async () => ({
+          invocationId: 'invocation-existing',
+          status: 'pending',
+          bodyHash: signatureCrypto.sha256(
+            JSON.stringify({
+              target: { kind: 'job_trigger', jobId: 'job-1' },
+              idempotencyKey: 'idem-active',
+            }),
+          ),
+          response: null,
+          error: null,
+          updatedAt: '2026-04-30T00:00:00.000Z',
+        })),
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: { kind: 'job_trigger', jobId: 'job-1' },
+      idempotencyKey: 'idem-active',
+    });
+    const request = signedInvokeInput({ secret: 'secret-1', rawBody });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Duplicate active external ingress invocation',
+    });
+    expect(control.reserveExternalIngressNonce).not.toHaveBeenCalled();
+    expect(control.createExternalIngressInvocation).not.toHaveBeenCalled();
+    expect(control.updateExternalIngressInvocation).not.toHaveBeenCalled();
+  });
+
   it('rejects requests whose payload appId does not match ingress app scope', async () => {
     const { module, control, sessions } = makeModule();
     const rawBody = JSON.stringify({
@@ -198,9 +336,24 @@ describe('ExternalIngressModule', () => {
   it('reuses completed invocations for idempotent retries', async () => {
     const { module, control, sessions, jobs } = makeModule({
       control: {
-        createExternalIngressInvocation: vi.fn(async () => ({
-          created: false,
-          row: { invocationId: 'invocation-existing', status: 'completed' },
+        getExternalIngressInvocationByIdempotencyKey: vi.fn(async () => ({
+          invocationId: 'invocation-existing',
+          status: 'completed',
+          bodyHash: signatureCrypto.sha256(
+            JSON.stringify({
+              target: {
+                kind: 'job_trigger',
+                jobId: 'job-1',
+              },
+            }),
+          ),
+          response: {
+            targetKind: 'job_trigger',
+            jobId: 'job-1',
+            triggerId: 'trigger-1',
+          },
+          error: null,
+          updatedAt: '2026-04-30T00:00:00.000Z',
         })),
       },
     });
@@ -219,10 +372,50 @@ describe('ExternalIngressModule', () => {
     await expect(module.invoke(request)).resolves.toEqual({
       invocationId: 'invocation-existing',
       duplicate: true,
+      status: 'completed',
+      targetKind: 'job_trigger',
+      jobId: 'job-1',
+      triggerId: 'trigger-1',
     });
+    expect(control.reserveExternalIngressNonce).not.toHaveBeenCalled();
+    expect(control.createExternalIngressInvocation).not.toHaveBeenCalled();
     expect(sessions.ensureSession).not.toHaveBeenCalled();
     expect(jobs.triggerJob).not.toHaveBeenCalled();
     expect(control.updateExternalIngressInvocation).not.toHaveBeenCalled();
+  });
+
+  it('rejects idempotency key reuse with a different body hash', async () => {
+    const { module, control, jobs } = makeModule({
+      control: {
+        getExternalIngressInvocationByIdempotencyKey: vi.fn(async () => ({
+          invocationId: 'invocation-existing',
+          status: 'completed',
+          bodyHash: 'different-body-hash',
+          response: { targetKind: 'job_trigger' },
+          error: null,
+          updatedAt: '2026-04-30T00:00:00.000Z',
+        })),
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: {
+        kind: 'job_trigger',
+        jobId: 'job-1',
+      },
+      idempotencyKey: 'idem-reused',
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      nonce: 'nonce-reused',
+    });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Idempotency key reused with different request body',
+    });
+    expect(control.reserveExternalIngressNonce).not.toHaveBeenCalled();
+    expect(jobs.triggerJob).not.toHaveBeenCalled();
   });
 
   it('ensures a session then accepts message for session_message targets', async () => {
@@ -257,6 +450,12 @@ describe('ExternalIngressModule', () => {
         chatJid: 'app:app-one:conv-1',
         threadId: null,
         queueKey: 'app:app-one:conv-1',
+      },
+      registerGroup: {
+        chatJid: 'app:app-one:conv-1',
+        group: expect.objectContaining({
+          folder: 'app_conv_1',
+        }),
       },
     });
     expect(sessions.ensureSession).toHaveBeenCalledWith({
@@ -307,6 +506,69 @@ describe('ExternalIngressModule', () => {
       message: 'Ingress is not allowed to invoke this session target',
     });
     expect(sessions.ensureSession).not.toHaveBeenCalled();
+  });
+
+  it('requires allowed sessionId when a sessionId is explicitly supplied', async () => {
+    const { module, sessions } = makeModule({
+      metadata: {
+        targetPolicy: {
+          allowedTargetKinds: ['session_message'],
+          conversationIds: ['conv-1'],
+          sessionIds: ['session-allowed'],
+        },
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: {
+        kind: 'session_message',
+        sessionId: 'session-off-policy',
+        conversationId: 'conv-1',
+        message: 'launch now',
+      },
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      nonce: 'nonce-session-policy',
+    });
+
+    await expect(module.invoke(request)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Ingress is not allowed to invoke this session target',
+    });
+    expect(sessions.acceptMessage).not.toHaveBeenCalled();
+  });
+
+  it('marks invocations failed when dispatch throws', async () => {
+    const dispatchError = new Error('dispatch failed');
+    const { module, control } = makeModule({
+      sessions: {
+        acceptMessage: vi.fn(async () => {
+          throw dispatchError;
+        }),
+      },
+    });
+    const rawBody = JSON.stringify({
+      target: {
+        kind: 'session_message',
+        sessionId: 'session-1',
+        message: 'launch now',
+      },
+    });
+    const request = signedInvokeInput({
+      secret: 'secret-1',
+      rawBody,
+      nonce: 'nonce-dispatch-fail',
+    });
+
+    await expect(module.invoke(request)).rejects.toThrow('dispatch failed');
+    expect(control.updateExternalIngressInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invocationId: 'invocation-new',
+        status: 'failed',
+        error: 'dispatch failed',
+      }),
+    );
   });
 
   it('uses ingressId when reading signed wait invocations', async () => {

--- a/apps/core/test/unit/application/external-ingress/signature.test.ts
+++ b/apps/core/test/unit/application/external-ingress/signature.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+import {
+  buildExternalIngressSignaturePayload,
+  isExternalIngressTimestampFresh,
+  signExternalIngressRequest,
+  verifyExternalIngressRequestSignature,
+} from '@core/application/external-ingress/signature.js';
+
+const cryptoPort = {
+  sha256: (input: string) => createHash('sha256').update(input).digest('hex'),
+  hmacSha256: (secret: string, payload: string) =>
+    createHmac('sha256', secret).update(payload).digest('hex'),
+  constantTimeEqual: (left: string, right: string) => {
+    const leftBuffer = Buffer.from(left);
+    const rightBuffer = Buffer.from(right);
+    return (
+      leftBuffer.length === rightBuffer.length &&
+      timingSafeEqual(leftBuffer, rightBuffer)
+    );
+  },
+};
+
+describe('external ingress signature helpers', () => {
+  it('accepts a valid signature', () => {
+    const timestamp = String(Date.now());
+    const signature = signExternalIngressRequest({
+      crypto: cryptoPort,
+      secret: 'secret',
+      method: 'post',
+      path: '/v1/external-ingress/invoke',
+      timestamp,
+      nonce: 'nonce-1',
+      rawBody: JSON.stringify({ ok: true }),
+    }).signature;
+
+    expect(
+      verifyExternalIngressRequestSignature({
+        crypto: cryptoPort,
+        secret: 'secret',
+        method: 'POST',
+        path: '/v1/external-ingress/invoke',
+        timestamp,
+        nonce: 'nonce-1',
+        rawBody: JSON.stringify({ ok: true }),
+        signature,
+        nowMs: Date.now(),
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a tampered body', () => {
+    const timestamp = String(Date.now());
+    const signature = signExternalIngressRequest({
+      crypto: cryptoPort,
+      secret: 'secret',
+      method: 'POST',
+      path: '/v1/external-ingress/invoke',
+      timestamp,
+      nonce: 'nonce-1',
+      rawBody: JSON.stringify({ ok: true }),
+    }).signature;
+
+    expect(
+      verifyExternalIngressRequestSignature({
+        crypto: cryptoPort,
+        secret: 'secret',
+        method: 'POST',
+        path: '/v1/external-ingress/invoke',
+        timestamp,
+        nonce: 'nonce-1',
+        rawBody: JSON.stringify({ ok: false }),
+        signature,
+        nowMs: Date.now(),
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects stale timestamps', () => {
+    const timestamp = String(Date.now() - 10 * 60_000);
+    const signature = signExternalIngressRequest({
+      crypto: cryptoPort,
+      secret: 'secret',
+      method: 'POST',
+      path: '/v1/external-ingress/invoke',
+      timestamp,
+      nonce: 'nonce-1',
+      rawBody: '{}',
+    }).signature;
+
+    expect(
+      verifyExternalIngressRequestSignature({
+        crypto: cryptoPort,
+        secret: 'secret',
+        method: 'POST',
+        path: '/v1/external-ingress/invoke',
+        timestamp,
+        nonce: 'nonce-1',
+        rawBody: '{}',
+        signature,
+        nowMs: Date.now(),
+      }),
+    ).toBe(false);
+  });
+
+  it('canonicalizes method casing and emits a body hash', () => {
+    const bodyHash = cryptoPort.sha256('{"ok":true}');
+    const payload = buildExternalIngressSignaturePayload({
+      method: 'post',
+      path: '/v1/external-ingress/invoke',
+      timestamp: '1700000000000',
+      nonce: 'nonce-1',
+      bodyHash,
+      rawBody: '{"ok":true}',
+    });
+
+    expect(bodyHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(payload.startsWith('POST\n')).toBe(true);
+  });
+
+  it('validates timestamp freshness windows', () => {
+    expect(
+      isExternalIngressTimestampFresh({
+        timestamp: '1700000000000',
+        nowMs: 1700000001000,
+        toleranceMs: 10_000,
+      }),
+    ).toBe(true);
+    expect(
+      isExternalIngressTimestampFresh({
+        timestamp: '1700000000000',
+        nowMs: 1700000020000,
+        toleranceMs: 10_000,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/core/test/unit/application/external-ingress/signature.test.ts
+++ b/apps/core/test/unit/application/external-ingress/signature.test.ts
@@ -104,6 +104,32 @@ describe('external ingress signature helpers', () => {
     ).toBe(false);
   });
 
+  it('rejects non-numeric timestamps', () => {
+    const signature = signExternalIngressRequest({
+      crypto: cryptoPort,
+      secret: 'secret',
+      method: 'POST',
+      path: '/v1/external-ingress/invoke',
+      timestamp: 'not-a-number',
+      nonce: 'nonce-1',
+      rawBody: '{}',
+    }).signature;
+
+    expect(
+      verifyExternalIngressRequestSignature({
+        crypto: cryptoPort,
+        secret: 'secret',
+        method: 'POST',
+        path: '/v1/external-ingress/invoke',
+        timestamp: 'not-a-number',
+        nonce: 'nonce-1',
+        rawBody: '{}',
+        signature,
+        nowMs: Date.now(),
+      }),
+    ).toBe(false);
+  });
+
   it('canonicalizes method casing and emits a body hash', () => {
     const bodyHash = cryptoPort.sha256('{"ok":true}');
     const payload = buildExternalIngressSignaturePayload({

--- a/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
+++ b/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionInteractionModule } from '@core/application/sessions/session-interaction-module.js';
+
+function makeModule() {
+  const control = {
+    ensureAppSession: vi.fn(async (input) => ({
+      sessionId: 'session-1',
+      appId: input.appId,
+      conversationId: input.conversationId,
+      chatJid: input.chatJid,
+      workspaceKey: input.folder,
+      defaultResponseMode: input.defaultResponseMode ?? 'sse',
+      defaultWebhookId: input.defaultWebhookId ?? null,
+    })),
+    getWebhookById: vi.fn(),
+  };
+  const module = new SessionInteractionModule({
+    control: control as never,
+    ops: {} as never,
+    repositories: {} as never,
+    runtimeEvents: {} as never,
+    now: () => '2026-04-30T00:00:00.000Z' as never,
+    createId: () => 'id-1',
+    stableHash: () => '123456789abc',
+  });
+  return { module, control };
+}
+
+describe('SessionInteractionModule', () => {
+  it('rejects non-canonical conversation ids before creating app chat ids', async () => {
+    const { module, control } = makeModule();
+
+    await expect(
+      module.ensureSession({
+        appId: 'app-one',
+        conversationId: 'bad:conversation',
+      }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_REQUEST',
+      message:
+        'appId and conversationId must contain only letters, numbers, dot, underscore, or dash',
+    });
+    expect(control.ensureAppSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
+++ b/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { SessionInteractionModule } from '@core/application/sessions/session-interaction-module.js';
 
-function makeModule() {
+function makeModule(overrides?: {
+  control?: Record<string, unknown>;
+  runtimeEvents?: Record<string, unknown>;
+}) {
   const control = {
     ensureAppSession: vi.fn(async (input) => ({
       sessionId: 'session-1',
@@ -14,17 +17,46 @@ function makeModule() {
       defaultWebhookId: input.defaultWebhookId ?? null,
     })),
     getWebhookById: vi.fn(),
+    getAppSessionById: vi.fn(async () => ({
+      sessionId: 'session-1',
+      appId: 'app-one',
+      conversationId: 'conv-1',
+      chatJid: 'app:app-one:conv-1',
+      workspaceKey: 'group',
+      defaultResponseMode: 'sse',
+      defaultWebhookId: null,
+    })),
+    upsertAppResponseRoute: vi.fn(async () => ({
+      responseMode: 'sse',
+      webhookId: null,
+      correlationId: null,
+    })),
+    getAppSessionByChatJid: vi.fn(),
+    getAppResponseRoute: vi.fn(),
+    ...overrides?.control,
+  };
+  const runtimeEvents = {
+    publish: vi.fn(async () => ({ eventId: 1001 })),
+    list: vi.fn(async () => []),
+    subscribe: vi.fn(async () => ({
+      next: vi.fn(async () => []),
+      close: vi.fn(),
+    })),
+    ...overrides?.runtimeEvents,
   };
   const module = new SessionInteractionModule({
     control: control as never,
-    ops: {} as never,
+    ops: {
+      storeChatMetadata: vi.fn(async () => undefined),
+      storeMessage: vi.fn(async () => undefined),
+    } as never,
     repositories: {} as never,
-    runtimeEvents: {} as never,
+    runtimeEvents: runtimeEvents as never,
     now: () => '2026-04-30T00:00:00.000Z' as never,
     createId: () => 'id-1',
     stableHash: () => '123456789abc',
   });
-  return { module, control };
+  return { module, control, runtimeEvents };
 }
 
 describe('SessionInteractionModule', () => {
@@ -42,5 +74,64 @@ describe('SessionInteractionModule', () => {
         'appId and conversationId must contain only letters, numbers, dot, underscore, or dash',
     });
     expect(control.ensureAppSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects waits for sessions outside the authenticated app', async () => {
+    const { module, runtimeEvents } = makeModule({
+      control: {
+        getAppSessionById: vi.fn(async () => ({
+          sessionId: 'session-1',
+          appId: 'app-two',
+          conversationId: 'conv-1',
+          chatJid: 'app:app-two:conv-1',
+          workspaceKey: 'group',
+          defaultResponseMode: 'sse',
+          defaultWebhookId: null,
+        })),
+      },
+    });
+
+    await expect(
+      module.waitForVisibleEvent({
+        appId: 'app-one',
+        sessionId: 'session-1',
+        timeoutMs: 0,
+      }),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'API key cannot access this session',
+    });
+    expect(runtimeEvents.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('times out session waits and closes the subscription', async () => {
+    const close = vi.fn();
+    const next = vi.fn(async () => []);
+    const { module, runtimeEvents } = makeModule({
+      runtimeEvents: {
+        subscribe: vi.fn(async () => ({ next, close })),
+      },
+    });
+
+    await expect(
+      module.waitForVisibleEvent({
+        appId: 'app-one',
+        sessionId: 'session-1',
+        afterEventId: 9,
+        timeoutMs: 0,
+      }),
+    ).rejects.toMatchObject({
+      code: 'WAIT_TIMEOUT',
+      message: 'Timed out waiting for session event',
+    });
+    expect(runtimeEvents.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'app-one',
+        sessionId: 'session-1',
+        afterEventId: 9,
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/core/test/unit/control/sdk-transport.test.ts
+++ b/apps/core/test/unit/control/sdk-transport.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   MyClawClient,
+  signIngressRequest,
+  verifyIngressSignature,
   verifyWebhookSignature,
 } from '../../../../../packages/sdk/src/index.js';
 
@@ -57,6 +59,83 @@ describe('@myclaw/sdk webhook verification', () => {
   });
 });
 
+describe('@myclaw/sdk ingress signature verification', () => {
+  it('accepts a valid ingress signature', () => {
+    const timestamp = String(Date.now());
+    const signature = signIngressRequest({
+      secret: 'secret',
+      method: 'post',
+      path: '/v1/external-ingress/invoke',
+      timestamp,
+      nonce: 'nonce-1',
+      rawBody: JSON.stringify({ ok: true }),
+    });
+
+    expect(
+      verifyIngressSignature({
+        secret: 'secret',
+        method: 'POST',
+        path: '/v1/external-ingress/invoke',
+        timestamp,
+        nonce: 'nonce-1',
+        rawBody: JSON.stringify({ ok: true }),
+        signature,
+        nowMs: Date.now(),
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects stale ingress signatures by default', () => {
+    const timestamp = String(Date.now() - 10 * 60_000);
+    const signature = signIngressRequest({
+      secret: 'secret',
+      method: 'POST',
+      path: '/v1/external-ingress/invoke',
+      timestamp,
+      nonce: 'nonce-1',
+      rawBody: '{}',
+    });
+
+    expect(
+      verifyIngressSignature({
+        secret: 'secret',
+        method: 'POST',
+        path: '/v1/external-ingress/invoke',
+        timestamp,
+        nonce: 'nonce-1',
+        rawBody: '{}',
+        signature,
+        nowMs: Date.now(),
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects tampered ingress payloads', () => {
+    const timestamp = String(Date.now());
+    const signature = signIngressRequest({
+      secret: 'secret',
+      method: 'POST',
+      path: '/v1/external-ingress/invoke',
+      timestamp,
+      nonce: 'nonce-1',
+      rawBody: JSON.stringify({ ok: true }),
+    });
+
+    expect(
+      verifyIngressSignature({
+        secret: 'secret',
+        method: 'POST',
+        path: '/v1/external-ingress/invoke',
+        timestamp,
+        nonce: 'nonce-1',
+        rawBody: JSON.stringify({ ok: false }),
+        signature,
+        nowMs: Date.now(),
+      }),
+    ).toBe(false);
+  });
+});
+
 describe('@myclaw/sdk transport', () => {
   it('does not send an undefined content-type header for GET requests', async () => {
     const port = await listen((req, res) => {
@@ -92,6 +171,82 @@ describe('@myclaw/sdk transport', () => {
         conversationId: 'conv-one',
       }),
     ).resolves.toEqual({ sessionId: 'session-1' });
+  });
+
+  it('builds ingress management requests', async () => {
+    const seen: Array<{ method?: string; url?: string; body: unknown }> = [];
+    const port = await listen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        seen.push({
+          method: req.method,
+          url: req.url,
+          body: raw ? JSON.parse(raw) : null,
+        });
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, ingresses: [] }));
+      });
+    });
+    const client = new MyClawClient({
+      apiKey: 'test-key',
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+
+    await client.ingresses.create({
+      name: 'Primary ingress',
+      enabled: true,
+      metadata: { team: 'ops' },
+    });
+    await client.ingresses.list();
+    await client.ingresses.get('ingress/1');
+    await client.ingresses.update('ingress/1', {
+      name: 'Renamed ingress',
+      enabled: false,
+    });
+    await client.ingresses.rotate('ingress/1');
+    await client.ingresses.delete('ingress/1');
+
+    expect(seen).toEqual([
+      {
+        method: 'POST',
+        url: '/v1/ingresses',
+        body: {
+          name: 'Primary ingress',
+          enabled: true,
+          metadata: { team: 'ops' },
+        },
+      },
+      {
+        method: 'GET',
+        url: '/v1/ingresses',
+        body: null,
+      },
+      {
+        method: 'GET',
+        url: '/v1/ingresses/ingress%2F1',
+        body: null,
+      },
+      {
+        method: 'PATCH',
+        url: '/v1/ingresses/ingress%2F1',
+        body: {
+          name: 'Renamed ingress',
+          enabled: false,
+        },
+      },
+      {
+        method: 'POST',
+        url: '/v1/ingresses/ingress%2F1/rotate',
+        body: null,
+      },
+      {
+        method: 'DELETE',
+        url: '/v1/ingresses/ingress%2F1',
+        body: null,
+      },
+    ]);
   });
 
   it('builds every channel onboarding and binding request', async () => {

--- a/apps/core/test/unit/control/server-auth.test.ts
+++ b/apps/core/test/unit/control/server-auth.test.ts
@@ -856,6 +856,54 @@ describe('control server runtime hardening', () => {
     }
   });
 
+  it('uses API key app scope when session ensure omits appId', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    process.env.MYCLAW_CONTROL_API_KEYS_JSON = JSON.stringify([
+      {
+        kid: 'k',
+        token: 'token-ensure-implicit-app',
+        scopes: ['sessions:write'],
+        appId: 'app-one',
+      },
+    ]);
+    const app = {
+      registerGroup: vi.fn(),
+      queue: { enqueueMessageCheck: vi.fn() },
+    };
+    const handle = startControlServer({ app: app as any });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/sessions/ensure`,
+        'token-ensure-implicit-app',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            conversationId: 'conv-implicit',
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+      expect(controlRepo.ensureAppSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'app-one',
+          conversationId: 'conv-implicit',
+          chatJid: 'app:app-one:conv-implicit',
+        }),
+      );
+      expect(app.registerGroup).toHaveBeenCalledWith(
+        'app:app-one:conv-implicit',
+        expect.objectContaining({
+          name: 'app-one:conv-implicit',
+        }),
+      );
+    } finally {
+      await handle.close();
+    }
+  });
+
   it('blocks memory access for mismatched app access', async () => {
     const port = await reservePort();
     process.env.MYCLAW_CONTROL_PORT = String(port);

--- a/apps/core/test/unit/control/server-auth.test.ts
+++ b/apps/core/test/unit/control/server-auth.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import { EventEmitter } from 'node:events';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
@@ -19,6 +21,7 @@ import {
   loadRuntimeSettings,
   saveRuntimeSettings,
 } from '@core/config/settings/runtime-settings.js';
+import { signExternalIngressRequest } from '@core/application/external-ingress/signature.js';
 
 vi.mock('@core/config/index.js', async () => {
   const runtimeHome = '/tmp/myclaw-control-test-home';
@@ -128,6 +131,54 @@ const controlRepo = {
   markWebhookDeliveryDelivered: vi.fn(async () => undefined),
   markWebhookDeliveryRetry: vi.fn(async () => undefined),
   markWebhookDeliveryDead: vi.fn(async () => undefined),
+  createExternalIngress: vi.fn(),
+  listExternalIngresses: vi.fn(async () => []),
+  getExternalIngressById: vi.fn(async () => ({
+    ingressId: 'ingress-1',
+    appId: 'app-one',
+    name: 'ingress-main',
+    secret: 'ingress-secret',
+    enabled: true,
+    metadata: {
+      targetPolicy: {
+        allowedTargetKinds: ['session_message', 'job_trigger'],
+        conversationIds: ['conv-1'],
+        sessionIds: ['session-1'],
+        jobIds: ['job-1'],
+      },
+    },
+    createdAt: '2026-04-24T00:00:00.000Z',
+    updatedAt: '2026-04-24T00:00:00.000Z',
+  })),
+  updateExternalIngress: vi.fn(),
+  deleteExternalIngress: vi.fn(async () => true),
+  reserveExternalIngressNonce: vi.fn(async () => ({ ok: true as const })),
+  getExternalIngressInvocationByIdempotencyKey: vi.fn(async () => undefined),
+  createExternalIngressInvocation: vi.fn(async (input: any) => ({
+    created: true,
+    row: {
+      invocationId: input.invocationId,
+      status: 'pending',
+      bodyHash: input.bodyHash,
+      response: null,
+      error: null,
+      updatedAt: input.now,
+    },
+  })),
+  updateExternalIngressInvocation: vi.fn(async () => undefined),
+  getExternalIngressInvocation: vi.fn(async () => ({
+    invocationId: 'invocation-1',
+    status: 'completed',
+    bodyHash: 'hash',
+    response: { ok: true },
+    error: null,
+    updatedAt: '2026-04-24T00:00:00.000Z',
+  })),
+  sweepExpiredExternalIngressState: vi.fn(async () => ({
+    noncesDeleted: 0,
+    invocationsDeleted: 0,
+    stalePendingFailed: 0,
+  })),
 };
 
 const opsRepo = {
@@ -202,6 +253,20 @@ const memoryService = {
   dreamingStatus: vi.fn(async () => []),
 };
 
+const ingressSignatureCrypto = {
+  sha256: (input: string) => createHash('sha256').update(input).digest('hex'),
+  hmacSha256: (secret: string, payload: string) =>
+    createHmac('sha256', secret).update(payload).digest('hex'),
+  constantTimeEqual: (left: string, right: string) => {
+    const leftBuffer = Buffer.from(left);
+    const rightBuffer = Buffer.from(right);
+    return (
+      leftBuffer.length === rightBuffer.length &&
+      timingSafeEqual(leftBuffer, rightBuffer)
+    );
+  },
+};
+
 vi.mock('@core/adapters/storage/postgres/runtime-store.js', () => ({
   getRuntimeControlRepository: () => controlRepo,
   getRuntimeEventExchange: () => runtimeEvents,
@@ -221,6 +286,7 @@ import {
   _testControlServer,
   startControlServer,
 } from '@core/control/server/index.js';
+import { _testSessionRoutes } from '@core/control/server/routes/sessions.js';
 
 async function reservePort(): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
@@ -295,6 +361,31 @@ async function requestWithRetry(
     : new Error('Control server did not start in time');
 }
 
+function signIngressRequest(input: {
+  ingressId: string;
+  secret?: string;
+  nonce?: string;
+  timestamp?: string;
+  path?: string;
+  rawBody: string;
+  method?: string;
+}) {
+  const method = input.method ?? 'POST';
+  const timestamp = input.timestamp ?? String(Date.now());
+  const nonce = input.nonce ?? 'nonce-1';
+  const path = input.path ?? `/v1/ingresses/${input.ingressId}/invoke`;
+  const signature = signExternalIngressRequest({
+    crypto: ingressSignatureCrypto,
+    secret: input.secret ?? 'ingress-secret',
+    method,
+    path,
+    timestamp,
+    nonce,
+    rawBody: input.rawBody,
+  }).signature;
+  return { method, timestamp, nonce, signature };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   controlRepo.listDueWebhookDeliveries.mockResolvedValue([]);
@@ -309,6 +400,55 @@ beforeEach(() => {
   controlRepo.markWebhookDeliveryDelivered.mockResolvedValue(undefined);
   controlRepo.markWebhookDeliveryRetry.mockResolvedValue(undefined);
   controlRepo.markWebhookDeliveryDead.mockResolvedValue(undefined);
+  controlRepo.listExternalIngresses.mockResolvedValue([]);
+  controlRepo.getExternalIngressById.mockResolvedValue({
+    ingressId: 'ingress-1',
+    appId: 'app-one',
+    name: 'ingress-main',
+    secret: 'ingress-secret',
+    enabled: true,
+    metadata: {
+      targetPolicy: {
+        allowedTargetKinds: ['session_message', 'job_trigger'],
+        conversationIds: ['conv-1'],
+        sessionIds: ['session-1'],
+        jobIds: ['job-1'],
+      },
+    },
+    createdAt: '2026-04-24T00:00:00.000Z',
+    updatedAt: '2026-04-24T00:00:00.000Z',
+  });
+  controlRepo.reserveExternalIngressNonce.mockResolvedValue({ ok: true });
+  controlRepo.getExternalIngressInvocationByIdempotencyKey.mockResolvedValue(
+    undefined,
+  );
+  controlRepo.createExternalIngressInvocation.mockImplementation(
+    async (input: any) => ({
+      created: true,
+      row: {
+        invocationId: input.invocationId,
+        status: 'pending',
+        bodyHash: input.bodyHash,
+        response: null,
+        error: null,
+        updatedAt: input.now,
+      },
+    }),
+  );
+  controlRepo.updateExternalIngressInvocation.mockResolvedValue(undefined);
+  controlRepo.getExternalIngressInvocation.mockResolvedValue({
+    invocationId: 'invocation-1',
+    status: 'completed',
+    bodyHash: 'hash',
+    response: { ok: true },
+    error: null,
+    updatedAt: '2026-04-24T00:00:00.000Z',
+  });
+  controlRepo.sweepExpiredExternalIngressState.mockResolvedValue({
+    noncesDeleted: 0,
+    invocationsDeleted: 0,
+    stalePendingFailed: 0,
+  });
   opsRepo.storeChatMetadata.mockResolvedValue(undefined);
   opsRepo.storeMessage.mockResolvedValue(undefined);
   opsRepo.getJobRunById.mockResolvedValue(undefined);
@@ -899,6 +1039,243 @@ describe('control server runtime hardening', () => {
           name: 'app-one:conv-implicit',
         }),
       );
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('unblocks SSE event writes when the client closes during backpressure', async () => {
+    const response = new EventEmitter() as EventEmitter & {
+      destroyed: boolean;
+      write: ReturnType<typeof vi.fn>;
+      off: EventEmitter['off'];
+      once: EventEmitter['once'];
+    };
+    response.destroyed = false;
+    response.write = vi.fn(() => false);
+    let closed = false;
+    let settled = false;
+
+    const write = _testSessionRoutes
+      .writeSseEvent(
+        response as never,
+        {
+          eventId: 1,
+          appId: 'app-one',
+          sessionId: 'session-1',
+          eventType: 'session.message',
+          payload: { ok: true },
+          createdAt: '2026-04-30T00:00:00.000Z',
+        },
+        () => closed,
+      )
+      .then(() => {
+        settled = true;
+      });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    closed = true;
+    response.destroyed = true;
+    response.emit('close');
+
+    await write;
+    expect(settled).toBe(true);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+  });
+
+  it('unblocks SSE event writes when the response errors during backpressure', async () => {
+    const response = new EventEmitter() as EventEmitter & {
+      destroyed: boolean;
+      write: ReturnType<typeof vi.fn>;
+      off: EventEmitter['off'];
+      once: EventEmitter['once'];
+    };
+    response.destroyed = false;
+    response.write = vi.fn(() => false);
+    let closed = false;
+    let settled = false;
+
+    const write = _testSessionRoutes
+      .writeSseEvent(
+        response as never,
+        {
+          eventId: 2,
+          appId: 'app-one',
+          sessionId: 'session-1',
+          eventType: 'session.message',
+          payload: { ok: true },
+          createdAt: '2026-04-30T00:00:00.000Z',
+        },
+        () => closed,
+      )
+      .then(() => {
+        settled = true;
+      });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    closed = true;
+    response.destroyed = true;
+    response.emit('error', new Error('socket reset'));
+
+    await write;
+    expect(settled).toBe(true);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+  });
+
+  it('accepts signed external ingress session messages and registers before enqueue', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    const app = {
+      registerGroup: vi.fn(async () => undefined),
+      queue: { enqueueMessageCheck: vi.fn() },
+    };
+    controlRepo.getAppSessionById.mockResolvedValue({
+      sessionId: 'session-1',
+      appId: 'app-one',
+      conversationId: 'conv-1',
+      chatJid: 'app:app-one:conv-1',
+      workspaceKey: 'app_conv_1',
+      title: null,
+      defaultResponseMode: 'sse',
+      defaultWebhookId: null,
+    });
+    const handle = startControlServer({ app: app as any });
+    const path = '/v1/ingresses/ingress-1/invoke';
+    const rawBody = JSON.stringify({
+      target: {
+        kind: 'session_message',
+        conversationId: 'conv-1',
+        message: 'solve captcha',
+      },
+      idempotencyKey: 'idem-ingress-session',
+    });
+    const signed = signIngressRequest({
+      ingressId: 'ingress-1',
+      path,
+      rawBody,
+      nonce: 'nonce-ingress-session',
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}${path}`,
+        '',
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': signed.timestamp,
+            'x-myclaw-ingress-nonce': signed.nonce,
+            'x-myclaw-ingress-signature': signed.signature,
+          },
+          body: rawBody,
+        },
+      );
+
+      expect(response.status).toBe(202);
+      await expect(response.json()).resolves.toMatchObject({
+        duplicate: false,
+        targetKind: 'session_message',
+        sessionId: 'session-1',
+      });
+      expect(app.registerGroup).toHaveBeenCalledWith(
+        'app:app-one:conv-1',
+        expect.objectContaining({
+          name: 'app-one:conv-1',
+        }),
+      );
+      expect(app.queue.enqueueMessageCheck).toHaveBeenCalledWith(
+        'app:app-one:conv-1',
+      );
+      expect(app.registerGroup.mock.invocationCallOrder[0]).toBeLessThan(
+        app.queue.enqueueMessageCheck.mock.invocationCallOrder[0],
+      );
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects missing external ingress signature headers before lookup', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    const handle = startControlServer({
+      app: {
+        registerGroup: vi.fn(),
+        queue: { enqueueMessageCheck: vi.fn() },
+      } as any,
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/ingresses/ingress-1/invoke`,
+        '',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            target: { kind: 'job_trigger', jobId: 'job-1' },
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          code: 'INVALID_REQUEST',
+        },
+      });
+      expect(controlRepo.getExternalIngressById).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects tampered external ingress signatures before nonce reservation', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    const handle = startControlServer({
+      app: {
+        registerGroup: vi.fn(),
+        queue: { enqueueMessageCheck: vi.fn() },
+      } as any,
+    });
+    const path = '/v1/ingresses/ingress-1/invoke';
+    const rawBody = JSON.stringify({
+      target: { kind: 'job_trigger', jobId: 'job-1' },
+    });
+    const signed = signIngressRequest({
+      ingressId: 'ingress-1',
+      path,
+      rawBody,
+      nonce: 'nonce-tampered',
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}${path}`,
+        '',
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': signed.timestamp,
+            'x-myclaw-ingress-nonce': signed.nonce,
+            'x-myclaw-ingress-signature': 'bad-signature',
+          },
+          body: rawBody,
+        },
+      );
+
+      expect(response.status).toBe(403);
+      expect(controlRepo.reserveExternalIngressNonce).not.toHaveBeenCalled();
     } finally {
       await handle.close();
     }
@@ -2297,6 +2674,341 @@ describe('control server runtime hardening', () => {
         expect.not.objectContaining({ eventTypes: expect.anything() }),
       );
       expect(subscription.close).toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects signed wait requests with missing required signature headers before ingress lookup', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    const handle = startControlServer({
+      app: { registerGroup: vi.fn(), queue: { enqueueMessageCheck: vi.fn() } },
+    } as any);
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/ingresses/ingress-1/wait`,
+        'token-any',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ invocationId: 'invocation-1' }),
+        },
+      );
+      expect(response.status).toBe(400);
+      expect(controlRepo.getExternalIngressById).not.toHaveBeenCalled();
+      expect(controlRepo.reserveExternalIngressNonce).not.toHaveBeenCalled();
+      expect(controlRepo.getExternalIngressInvocation).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects ingress invokes for disabled ingresses', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    controlRepo.getExternalIngressById.mockResolvedValue({
+      ingressId: 'ingress-1',
+      appId: 'app-one',
+      name: 'ingress-main',
+      secret: 'ingress-secret',
+      enabled: false,
+      metadata: {},
+      createdAt: '2026-04-24T00:00:00.000Z',
+      updatedAt: '2026-04-24T00:00:00.000Z',
+    });
+    const pathName = '/v1/ingresses/ingress-1/invoke';
+    const rawBody = JSON.stringify({
+      target: { kind: 'session_message', sessionId: 'session-1', message: 'x' },
+    });
+    const signed = signIngressRequest({
+      ingressId: 'ingress-1',
+      path: pathName,
+      rawBody,
+    });
+    const handle = startControlServer({
+      app: { registerGroup: vi.fn(), queue: { enqueueMessageCheck: vi.fn() } },
+    } as any);
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}${pathName}`,
+        'token-any',
+        {
+          method: signed.method,
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': signed.timestamp,
+            'x-myclaw-ingress-nonce': signed.nonce,
+            'x-myclaw-ingress-signature': signed.signature,
+          },
+          body: rawBody,
+        },
+      );
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: 'FORBIDDEN', message: 'Ingress is disabled' },
+      });
+      expect(controlRepo.reserveExternalIngressNonce).not.toHaveBeenCalled();
+      expect(
+        controlRepo.createExternalIngressInvocation,
+      ).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects stale or malformed ingress signatures', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    const pathName = '/v1/ingresses/ingress-1/invoke';
+    const rawBody = JSON.stringify({
+      target: { kind: 'session_message', sessionId: 'session-1', message: 'x' },
+    });
+    const stale = signIngressRequest({
+      ingressId: 'ingress-1',
+      path: pathName,
+      rawBody,
+      timestamp: String(Date.now() - 10 * 60_000),
+      nonce: 'nonce-stale',
+    });
+    const handle = startControlServer({
+      app: { registerGroup: vi.fn(), queue: { enqueueMessageCheck: vi.fn() } },
+    } as any);
+
+    try {
+      const staleResponse = await requestWithRetry(
+        `http://127.0.0.1:${port}${pathName}`,
+        'token-any',
+        {
+          method: stale.method,
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': stale.timestamp,
+            'x-myclaw-ingress-nonce': stale.nonce,
+            'x-myclaw-ingress-signature': stale.signature,
+          },
+          body: rawBody,
+        },
+      );
+      expect(staleResponse.status).toBe(403);
+      await expect(staleResponse.json()).resolves.toMatchObject({
+        error: {
+          code: 'FORBIDDEN',
+          message: 'Invalid external ingress signature',
+        },
+      });
+      expect(controlRepo.reserveExternalIngressNonce).not.toHaveBeenCalled();
+
+      const badResponse = await requestWithRetry(
+        `http://127.0.0.1:${port}${pathName}`,
+        'token-any',
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': String(Date.now()),
+            'x-myclaw-ingress-nonce': 'nonce-bad-sig',
+            'x-myclaw-ingress-signature': 'bad-signature',
+          },
+          body: rawBody,
+        },
+      );
+      expect(badResponse.status).toBe(403);
+      await expect(badResponse.json()).resolves.toMatchObject({
+        error: {
+          code: 'FORBIDDEN',
+          message: 'Invalid external ingress signature',
+        },
+      });
+      expect(controlRepo.reserveExternalIngressNonce).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns conflict for nonce replays and duplicate active invocations', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    const pathName = '/v1/ingresses/ingress-1/invoke';
+    const rawBody = JSON.stringify({
+      idempotencyKey: 'idem-conflict',
+      target: { kind: 'session_message', sessionId: 'session-1', message: 'x' },
+    });
+    const signed = signIngressRequest({
+      ingressId: 'ingress-1',
+      path: pathName,
+      rawBody,
+      nonce: 'nonce-conflict',
+    });
+    const handle = startControlServer({
+      app: { registerGroup: vi.fn(), queue: { enqueueMessageCheck: vi.fn() } },
+    } as any);
+
+    try {
+      controlRepo.reserveExternalIngressNonce.mockResolvedValueOnce({
+        ok: false,
+        code: 'NONCE_REPLAY',
+      });
+      const nonceReplayResponse = await requestWithRetry(
+        `http://127.0.0.1:${port}${pathName}`,
+        'token-any',
+        {
+          method: signed.method,
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': signed.timestamp,
+            'x-myclaw-ingress-nonce': signed.nonce,
+            'x-myclaw-ingress-signature': signed.signature,
+          },
+          body: rawBody,
+        },
+      );
+      expect(nonceReplayResponse.status).toBe(409);
+      await expect(nonceReplayResponse.json()).resolves.toMatchObject({
+        error: { code: 'CONFLICT', message: 'External ingress nonce replay' },
+      });
+      expect(
+        controlRepo.createExternalIngressInvocation,
+      ).not.toHaveBeenCalled();
+
+      controlRepo.getExternalIngressInvocationByIdempotencyKey.mockResolvedValueOnce(
+        {
+          invocationId: 'invocation-active',
+          status: 'pending',
+          bodyHash: ingressSignatureCrypto.sha256(rawBody),
+          response: null,
+          error: null,
+          updatedAt: '2026-04-24T00:00:00.000Z',
+        },
+      );
+      const duplicatePendingResponse = await requestWithRetry(
+        `http://127.0.0.1:${port}${pathName}`,
+        'token-any',
+        {
+          method: signed.method,
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': signed.timestamp,
+            'x-myclaw-ingress-nonce': 'nonce-duplicate-active',
+            'x-myclaw-ingress-signature': signIngressRequest({
+              ingressId: 'ingress-1',
+              path: pathName,
+              rawBody,
+              nonce: 'nonce-duplicate-active',
+              timestamp: signed.timestamp,
+            }).signature,
+          },
+          body: rawBody,
+        },
+      );
+      expect(duplicatePendingResponse.status).toBe(409);
+      await expect(duplicatePendingResponse.json()).resolves.toMatchObject({
+        error: {
+          code: 'CONFLICT',
+          message: 'Duplicate active external ingress invocation',
+        },
+      });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('reuses prior invocation for exact retries with same nonce and idempotency key', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    const app = {
+      registerGroup: vi.fn(),
+      queue: { enqueueMessageCheck: vi.fn() },
+    };
+    controlRepo.getAppSessionById.mockResolvedValue({
+      sessionId: 'session-1',
+      appId: 'app-one',
+      conversationId: 'conv-1',
+      chatJid: 'app:app-one:conv-1',
+      groupFolder: 'app_app_one_conv_1',
+      title: null,
+      defaultResponseMode: 'sse',
+      defaultWebhookId: null,
+    });
+    const pathName = '/v1/ingresses/ingress-1/invoke';
+    const rawBody = JSON.stringify({
+      idempotencyKey: 'idem-exact-retry',
+      target: { kind: 'session_message', sessionId: 'session-1', message: 'x' },
+    });
+    const signed = signIngressRequest({
+      ingressId: 'ingress-1',
+      path: pathName,
+      rawBody,
+      nonce: 'nonce-exact-retry',
+    });
+    controlRepo.reserveExternalIngressNonce
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, code: 'NONCE_REPLAY' });
+    controlRepo.getExternalIngressInvocationByIdempotencyKey
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        invocationId: 'invocation-first',
+        status: 'completed',
+        bodyHash: ingressSignatureCrypto.sha256(rawBody),
+        response: {
+          targetKind: 'session_message',
+          sessionId: 'session-1',
+        },
+        error: null,
+        updatedAt: '2026-04-24T00:00:01.000Z',
+      });
+    controlRepo.createExternalIngressInvocation.mockResolvedValueOnce({
+      created: true,
+      row: {
+        invocationId: 'invocation-first',
+        status: 'pending',
+        bodyHash: ingressSignatureCrypto.sha256(rawBody),
+        response: null,
+        error: null,
+        updatedAt: '2026-04-24T00:00:00.000Z',
+      },
+    });
+    const handle = startControlServer({ app: app as any });
+
+    try {
+      const first = await requestWithRetry(
+        `http://127.0.0.1:${port}${pathName}`,
+        'token-any',
+        {
+          method: signed.method,
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': signed.timestamp,
+            'x-myclaw-ingress-nonce': signed.nonce,
+            'x-myclaw-ingress-signature': signed.signature,
+          },
+          body: rawBody,
+        },
+      );
+      expect(first.status).toBe(202);
+
+      const second = await requestWithRetry(
+        `http://127.0.0.1:${port}${pathName}`,
+        'token-any',
+        {
+          method: signed.method,
+          headers: {
+            'content-type': 'application/json',
+            'x-myclaw-ingress-timestamp': signed.timestamp,
+            'x-myclaw-ingress-nonce': signed.nonce,
+            'x-myclaw-ingress-signature': signed.signature,
+          },
+          body: rawBody,
+        },
+      );
+      expect(second.status).toBe(202);
+      await expect(second.json()).resolves.toMatchObject({
+        invocationId: 'invocation-first',
+        duplicate: true,
+      });
+      expect(app.queue.enqueueMessageCheck).toHaveBeenCalledTimes(1);
     } finally {
       await handle.close();
     }

--- a/apps/core/test/unit/control/session-control-port.test.ts
+++ b/apps/core/test/unit/control/session-control-port.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { adaptSessionControlPort } from '@core/control/server/session-control-port.js';
+
+describe('adaptSessionControlPort', () => {
+  it('maps ensureAppSession.folder into repository groupFolder', async () => {
+    const ensureAppSession = vi.fn(async (input: unknown) => input);
+    const control = {
+      ensureAppSession,
+      getAppSessionById: vi.fn(),
+      getAppSessionByChatJid: vi.fn(),
+      getWebhookById: vi.fn(),
+      upsertAppResponseRoute: vi.fn(),
+      getAppResponseRoute: vi.fn(),
+    };
+    const port = adaptSessionControlPort(control as never);
+
+    await port.ensureAppSession({
+      appId: 'app-one',
+      conversationId: 'conv-one',
+      chatJid: 'app:app-one:conv-one',
+      folder: 'app_scope_folder',
+      title: 'Conversation One',
+      defaultResponseMode: 'sse',
+      defaultWebhookId: 'webhook-1',
+    });
+
+    expect(ensureAppSession).toHaveBeenCalledTimes(1);
+    const [input] = ensureAppSession.mock.calls[0]!;
+    expect(input).toMatchObject({
+      appId: 'app-one',
+      conversationId: 'conv-one',
+      chatJid: 'app:app-one:conv-one',
+      groupFolder: 'app_scope_folder',
+      title: 'Conversation One',
+      defaultResponseMode: 'sse',
+      defaultWebhookId: 'webhook-1',
+    });
+    expect(input).not.toHaveProperty('folder');
+  });
+});

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -12,3 +12,4 @@
 - Remove template, fork, or upstream framing from active docs unless a historical note is explicitly required.
 - Prefer repo-relative paths and current commands such as `apps/core/...`, `packages/agent-runner/...`, and `ops/...` when describing the codebase.
 - When docs change operational commands, verify the command still exists in this repo before publishing it.
+- Treat `/v1/webhooks` as outbound callback delivery only. Signed inbound sidecar systems use external ingress records under `/v1/ingresses`; do not describe webhooks as ingress authority.

--- a/docs/architecture/canonical-domain-model.md
+++ b/docs/architecture/canonical-domain-model.md
@@ -68,7 +68,8 @@ Identity rules:
 | `AgentSession`        | Domain                   | Canonical continuity state for an agent in an app, conversation, thread, job, or run context. It survives provider swaps.                                                          |
 | `ProviderSession`     | Adapter                  | A provider-specific resume token or transcript pointer, such as a Claude session id. It is attached to an `AgentSession`.                                                          |
 | `AgentRun`            | Domain/application       | One execution attempt by an agent for a message, job, control request, or manual trigger.                                                                                          |
-| `RuntimeEvent`        | Application/storage      | The durable observable runtime stream for run, job, session, SSE/wait, SDK listing, and webhook delivery events. Audit records remain in their owning modules.                     |
+| `RuntimeEvent`        | Application/storage      | The durable observable runtime stream for run, job, session, SSE/wait, SDK listing, and outbound webhook delivery events. Audit records remain in their owning modules.            |
+| `ExternalIngress`     | Application/storage      | A signed inbound authority record for external systems. It derives app scope, protects nonce replay, records invocations, and dispatches only to approved session/job/template targets. |
 | `MemorySubject`       | Domain                   | A memory boundary for app, agent, user, group/team, conversation, thread, or common shared memory.                                                                                 |
 | `Job`                 | Domain/application       | Scheduled, recurring, or manual work that creates agent runs under explicit app, agent, session, and permission context.                                                           |
 | `ToolCatalogItem`     | Domain catalog           | A tool capability exposed to agents with name, input contract, risk classification, permission requirements, and adapter binding.                                                  |
@@ -171,10 +172,14 @@ session, conversation/thread context, permission context, sandbox lease,
 workspace snapshot, provider profile, status, timestamps, and result summary.
 
 `RuntimeEvent` is the observable runtime delivery stream for SDK event listing,
-SSE/wait, webhook projection, run events, job events, and app-channel
+SSE/wait, outbound webhook projection, run events, job events, and app-channel
 session/control output. Run-event responses are projections filtered from
 runtime events instead of a separately owned `AgentRunEvent` stream. Audit
 histories remain in their owned modules.
+
+`ExternalIngress` is inbound. It is not a webhook callback destination. It
+derives app scope from its record and can only invoke configured target kinds:
+session messages, existing job triggers, or constrained one-time job templates.
 
 ### Memory And Jobs
 

--- a/docs/architecture/local-state-inventory.md
+++ b/docs/architecture/local-state-inventory.md
@@ -11,6 +11,9 @@ This inventory classifies local filesystem state by durability.
   using the local artifact backend. Postgres stores the skill row, lifecycle
   state, content hash, and binding; this folder stores the referenced bytes.
 - Local credential files managed by their owning credential adapters.
+- Postgres, not runtime-home files, stores external ingress records,
+  invocations, nonces, jobs, sessions, messages, runtime events, outbound
+  webhook delivery state, memory, and canonical app scope.
 
 ## Temporary Local State
 
@@ -39,3 +42,14 @@ Runtime-home Claude settings and skills are also unsupported as MyClaw
 configuration or skill truth.
 
 No automatic migration is provided for unsupported local Claude files.
+
+## Safe Cleanup
+
+After building and restarting from the current checkout, confirm `myclaw status`
+before inspecting `~/myclaw`. Stale generated logs, obsolete scratch session/job
+snapshots, old provider transcript artifacts outside the provider artifact
+store, and unused local hook/webhook scratch files may be archived under
+`~/myclaw/cleanup-archive/<timestamp>/`.
+
+Do not move or delete secrets, `settings.yaml`, Postgres data, OneCLI data,
+`artifacts/`, or active agent folders unless a reset was explicitly requested.

--- a/docs/architecture/runtime-components.md
+++ b/docs/architecture/runtime-components.md
@@ -84,12 +84,13 @@ sequenceDiagram
 ```
 
 1. Channel inbound path: Slack and Telegram adapters send normalized inbound messages through channel wiring. The persistence handlers enforce sender policy, store chat metadata, and insert a durable message.
-2. SDK app inbound path: `sessions.sendMessage()` in the control server maps the SDK session to an `app:` group, inserts the inbound message, publishes a `session.message.inbound` runtime event, stores response routing, and enqueues normal processing.
-3. Durable storage: Postgres is the source of truth for messages, cursors, canonical `AgentSession` records, provider diagnostics, runs, memory, jobs, webhooks, runtime events, and audit data.
-4. Polling and recovery: the message loop polls for new messages during normal operation and calls recovery on startup so pending threads are not lost after a restart.
-5. Queueing: `GroupQueue` deduplicates checks per group/thread, limits concurrent containers, retries failed processing, and routes follow-up messages into an active child run when possible.
-6. Agent execution: the group processor resolves or creates the canonical session, hydrates scoped durable memory, then starts a live streaming child runner. Follow-up messages are piped into that runner until it is stopped or idles out.
-7. Streaming and final response: the processor forwards partial output, progress, typing, and final replies through channel wiring. Slack and Telegram send network responses; the app channel records durable runtime events for `wait()`, `stream()`, webhooks, and replay.
+2. SDK app inbound path: `sessions.sendMessage()` derives `appId` from the API key, enters `SessionInteractionModule`, maps the SDK session to an `app:` group, inserts the inbound message, publishes a `session.message.inbound` runtime event, stores response routing, and returns a queue intent for normal processing.
+3. Signed external ingress path: `/v1/ingresses/:id/invoke` derives `appId` from the ingress record, verifies HMAC timestamp and nonce, enforces the ingress record's target policy, records the invocation, and dispatches to session message, job trigger, or job template targets through application modules.
+4. Durable storage: Postgres is the source of truth for messages, cursors, canonical `AgentSession` records, provider diagnostics, runs, memory, jobs, external ingress records, outbound webhooks, runtime events, and audit data.
+5. Polling and recovery: the message loop polls for new messages during normal operation and calls recovery on startup so pending threads are not lost after a restart.
+6. Queueing: `GroupQueue` deduplicates checks per group/thread, limits concurrent containers, retries failed processing, and routes follow-up messages into an active child run when possible.
+7. Agent execution: the group processor resolves or creates the canonical session, hydrates scoped durable memory, then starts a live streaming child runner. Follow-up messages are piped into that runner until it is stopped or idles out.
+8. Streaming and final response: the processor forwards partial output, progress, typing, and final replies through channel wiring. Slack and Telegram send network responses; the app channel records durable runtime events for `wait()`, `stream()`, webhooks, and replay.
 
 ## Agent Runtime Deep Dive
 

--- a/docs/decisions/2026-04-30-external-ingress-vs-outbound-webhooks.md
+++ b/docs/decisions/2026-04-30-external-ingress-vs-outbound-webhooks.md
@@ -1,0 +1,33 @@
+# 2026-04-30 - External Ingress vs Outbound Webhooks
+
+## Context
+
+Sidecar systems need to push work into MyClaw without holding a control API key.
+The existing `/v1/webhooks` surface already means host-owned outbound callback
+delivery for runtime events.
+
+## Decision
+
+1. External ingress is a separate inbound authority surface under
+   `/v1/ingresses`.
+2. Signed ingress requests derive `appId` from the ingress record.
+3. Request-body `appId` is optional and only an assertion; mismatches fail.
+4. Ingress HMAC-SHA256 covers method, path, timestamp, nonce, body hash, and raw
+   body.
+5. Nonces and invocations are durable Postgres records so replay and duplicate
+   active invocation checks survive restart.
+6. Ingress records are scoped capabilities. Their target policy is default-deny
+   and must explicitly allow target kinds plus concrete sessions,
+   conversations, jobs, or templates.
+7. `/v1/webhooks` remains outbound callback registration, retry, dead-letter,
+   replay, and purge only.
+8. Job-template ingress uses MyClaw-owned templates. Callers supply variables and
+   metadata, not arbitrary prompt, model, or schedule.
+
+## Consequences
+
+- Sidecar examples omit `appId`; API keys and ingress records own scope.
+- External ingress and outbound webhooks can use similar HMAC mechanics without
+  sharing authority or route names.
+- Cleanup searches should treat old webhook-as-ingress wording as stale active
+  guidance unless it appears in this decision as historical context.

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -118,8 +118,8 @@ supports it end to end.
 
 ```ts
 client.sessions.ensure({
-  appId,
   conversationId,
+  appId?, // optional assertion; defaults to API key app scope
   title?,
   responseMode?, // sse | webhook | both | none
   webhookId?,
@@ -152,6 +152,65 @@ GET /v1/sessions/:sessionId/runs?limit=100
 
 Responses are scoped by the API key's app access. Session history is backed by
 Postgres `AgentSession`, `Message`, `AgentRun`, and `ProviderSession` records.
+
+## External Ingress
+
+```ts
+const ingress = await client.ingresses.create({
+  name: 'scraper',
+  metadata: {
+    targetPolicy: {
+      allowedTargetKinds: ['session_message', 'job_template'],
+      conversationIds: ['scraper-task-42'],
+      templateIds: ['captcha_resolution'],
+    },
+    templates: {
+      captcha_resolution: {
+        name: 'Resolve captcha',
+        sessionId,
+        prompt: 'Resolve task {{taskId}} at {{url}}',
+        allowedVariables: ['taskId', 'url'],
+      },
+    },
+  },
+});
+
+client.ingresses.list();
+client.ingresses.get(ingress.ingressId);
+client.ingresses.update(ingress.ingressId, { enabled: false });
+client.ingresses.rotate(ingress.ingressId);
+client.ingresses.delete(ingress.ingressId);
+```
+
+Runtime calls sign the exact HTTP method, path, timestamp, nonce, body hash, and
+raw body using the ingress secret.
+
+Ingress records are scoped capabilities. A signed caller can only invoke target
+kinds and concrete sessions, conversations, jobs, or templates listed in
+`metadata.targetPolicy`; omitted policy fields deny access by default.
+
+```ts
+import { signIngressRequest } from '@myclaw/sdk';
+
+const path = `/v1/ingresses/${ingressId}/invoke`;
+const rawBody = JSON.stringify({
+  target: {
+    kind: 'session_message',
+    conversationId: 'scraper-task-42',
+    message: 'Captcha solved: 1234',
+  },
+});
+const timestamp = String(Date.now());
+const nonce = crypto.randomUUID();
+const signature = signIngressRequest({
+  secret,
+  method: 'POST',
+  path,
+  timestamp,
+  nonce,
+  rawBody,
+});
+```
 
 ## Jobs
 

--- a/docs/sdk/overview.md
+++ b/docs/sdk/overview.md
@@ -30,7 +30,8 @@ Authentication is bearer-token based and scoped. The runtime reads keys from:
 
 Production apps should use the narrowest key needed. A typical chat backend
 uses `sessions:read` and `sessions:write`; job dashboards add `jobs:read` and
-`jobs:write`; webhook administration uses `webhooks:read` and
+`jobs:write`; external ingress administration uses `ingresses:read` and
+`ingresses:write`; outbound webhook administration uses `webhooks:read` and
 `webhooks:write`.
 
 ## Core flow
@@ -41,7 +42,11 @@ uses `sessions:read` and `sessions:write`; job dashboards add `jobs:read` and
 4. The message enters the normal group queue.
 5. The agent runs through the normal host runtime.
 6. Outbound replies/progress/streaming are emitted as durable `RuntimeEvent` records in `runtime_events`.
-7. The app consumes those events through `sessions.wait()`, `sessions.stream()`, or signed webhooks.
+7. The app consumes those events through `sessions.wait()`, `sessions.stream()`, or signed outbound webhooks.
+
+`appId` is derived from the API key for normal sidecar calls. SDK examples omit
+it. Advanced multi-app callers may pass `appId` as an assertion, but MyClaw
+rejects it when it does not match the resolved app scope.
 
 ```mermaid
 sequenceDiagram
@@ -67,11 +72,32 @@ sequenceDiagram
 - `sessions`
 - `jobs`
 - `runs`
+- `ingresses`
 - `webhooks`
 - `health`
 - `doctor`
 
-For the runtime boundary, message lifecycle, job lifecycle, and webhook delivery internals, see [Agent Internals For SDK Consumers](./agent-internals.md).
+For the runtime boundary, message lifecycle, job lifecycle, and outbound webhook delivery internals, see [Agent Internals For SDK Consumers](./agent-internals.md).
+
+## External Ingress
+
+External ingress is for signed systems that cannot hold a control API key, such
+as a scraper worker or task resolver. Ingress callers sign `method`, `path`,
+`timestamp`, `nonce`, body hash, and raw body with the ingress secret.
+
+Supported target kinds:
+
+- `session_message`: accept a normal user message into a configured or derived session.
+- `job_trigger`: trigger an existing manual, once, or recurring job.
+- `job_template`: invoke a MyClaw-owned one-time job template with variables and metadata only.
+
+Each ingress record is a scoped capability. Management callers configure
+`metadata.targetPolicy.allowedTargetKinds` and the allowed `sessionIds`,
+`conversationIds`, `jobIds`, or `templateIds`; omitted policy fields deny
+access by default.
+
+External ingress is inbound authority. `/v1/webhooks` is outbound callback
+delivery and is not used for inbound requests.
 
 ## Event model
 

--- a/docs/sdk/quickstart-nestjs.md
+++ b/docs/sdk/quickstart-nestjs.md
@@ -25,7 +25,6 @@ export class AgentService {
 
   async ask(conversationId: string, message: string) {
     const session = await this.myclaw.client.sessions.ensure({
-      appId: 'nestjs-app',
       conversationId,
       responseMode: 'sse',
     });
@@ -59,3 +58,6 @@ export class AgentService {
   }
 }
 ```
+
+Normal sidecar calls derive `appId` from the API key. Pass `appId` only as an
+advanced assertion when the caller intentionally verifies a known app scope.

--- a/docs/sdk/quickstart-nextjs.md
+++ b/docs/sdk/quickstart-nextjs.md
@@ -19,7 +19,6 @@ export async function POST(req: Request) {
   const webhookId = await resolveUserWebhookId(user.id);
 
   const session = await client.sessions.ensure({
-    appId: 'nextjs-app',
     conversationId,
     title: body.title,
     responseMode: 'both',
@@ -45,6 +44,9 @@ export async function POST(req: Request) {
   });
 }
 ```
+
+Normal sidecar calls derive `appId` from the API key. Pass `appId` only as an
+advanced assertion when the caller intentionally verifies a known app scope.
 
 ## Streaming in a route handler
 

--- a/docs/sdk/webhooks.md
+++ b/docs/sdk/webhooks.md
@@ -1,6 +1,11 @@
-# Webhooks
+# Outbound Webhooks
 
-MyClaw webhooks are host-owned callback destinations. Agents do not choose webhook URLs.
+MyClaw outbound webhooks are host-owned callback destinations. Agents do not
+choose webhook URLs. They deliver durable runtime events to an application after
+MyClaw has accepted work.
+
+Do not use `/v1/webhooks` for inbound authority. Signed inbound systems use
+external ingress records under `/v1/ingresses`.
 
 ## Delivery behavior
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test": "npm run build:contracts && npm run test:unit && npm run test:integration",
     "test:unit": "npm run build:contracts && vitest run -c vitest.unit.config.ts",
     "test:integration": "npm run build:contracts && vitest run -c vitest.integration.config.ts",
-    "test:integration:postgres": "node .codex/scripts/require-postgres-integration-env.mjs && npm run test:integration -- apps/core/test/integration/session-continuity-postgres.integration.test.ts apps/core/test/integration/application-services-postgres.integration.test.ts apps/core/test/integration/durable-message-delivery.integration.test.ts apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts apps/core/test/integration/mcp-server-postgres.integration.test.ts",
+    "test:integration:postgres": "node .codex/scripts/require-postgres-integration-env.mjs && npm run test:integration -- apps/core/test/integration/session-continuity-postgres.integration.test.ts apps/core/test/integration/application-services-postgres.integration.test.ts apps/core/test/integration/durable-message-delivery.integration.test.ts apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts apps/core/test/integration/mcp-server-postgres.integration.test.ts apps/core/test/integration/control-plane-repository.postgres.integration.test.ts",
     "test:e2e": "npm run build:contracts && vitest run -c vitest.e2e.config.ts",
     "test:watch": "npm run build:contracts && vitest -c vitest.config.ts"
   },

--- a/packages/contracts/src/sessions/index.ts
+++ b/packages/contracts/src/sessions/index.ts
@@ -13,7 +13,7 @@ export const ResponseModeSchema = z.enum(['sse', 'webhook', 'both', 'none']);
 export type ResponseMode = z.infer<typeof ResponseModeSchema>;
 
 export const CreateSessionRequestSchema = z.object({
-  appId: z.string(),
+  appId: z.string().optional(),
   agentId: z.string().optional(),
   conversationId: z.string().optional(),
   threadId: z.string().optional(),

--- a/packages/contracts/test/unit/index.test.ts
+++ b/packages/contracts/test/unit/index.test.ts
@@ -18,6 +18,7 @@ import {
   ConversationThreadResponseSchema,
   CreateAgentRequestSchema,
   CreateJobRequestSchema,
+  CreateSessionRequestSchema,
   ExternalReferenceSchema,
   IsoDateTimeSchema,
   JobScheduleSchema,
@@ -123,6 +124,12 @@ describe('contracts package', () => {
   });
 
   it('validates representative canonical DTOs and rejects constrained invalid input', () => {
+    expect(
+      CreateSessionRequestSchema.parse({
+        conversationId: 'conversation-1',
+      }),
+    ).toMatchObject({ conversationId: 'conversation-1' });
+
     expect(
       AgentResponseSchema.parse({
         id: 'agent-1',

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,7 @@ import type {
   RequestOptions,
   SseEvent,
 } from './types.js';
+import { createIngressesClient } from './ingresses.js';
 export type {
   RuntimeSettingsResponse,
   UpdateRuntimeSettingsRequest,
@@ -262,9 +263,11 @@ export class MyClawClient {
   private readonly transport: Transport;
   private readonly request = <T>(options: RequestOptions) =>
     this.transport.request<T>(options);
+  readonly ingresses: ReturnType<typeof createIngressesClient>;
 
   constructor(options: ClientOptions) {
     this.transport = new Transport(options);
+    this.ingresses = createIngressesClient(this.transport);
   }
 
   health() {
@@ -285,7 +288,7 @@ export class MyClawClient {
 
   readonly sessions = {
     ensure: (input: {
-      appId: string;
+      appId?: string;
       conversationId: string;
       title?: string;
       responseMode?: ResponseMode;
@@ -678,4 +681,10 @@ export class MyClawClient {
 }
 export const createClient = (options: ClientOptions) =>
   new MyClawClient(options);
+export {
+  buildIngressSignaturePayload,
+  signIngressRequest,
+  signIngressSignaturePayload,
+  verifyIngressSignature,
+} from './ingress-signature.js';
 export { verifyWebhookSignature } from './webhook-signature.js';

--- a/packages/sdk/src/ingress-signature.ts
+++ b/packages/sdk/src/ingress-signature.ts
@@ -1,0 +1,84 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+export interface IngressSignaturePayloadInput {
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  rawBody: string;
+}
+
+export function buildIngressSignaturePayload(
+  input: IngressSignaturePayloadInput,
+): {
+  canonicalPayload: string;
+  bodyHash: string;
+} {
+  const method = input.method.trim().toUpperCase();
+  const path = input.path.trim();
+  const timestamp = input.timestamp.trim();
+  const nonce = input.nonce.trim();
+  const body = input.rawBody;
+  const bodyHash = createHash('sha256').update(body).digest('hex');
+  return {
+    canonicalPayload: [method, path, timestamp, nonce, bodyHash, body].join(
+      '\n',
+    ),
+    bodyHash,
+  };
+}
+
+export function signIngressSignaturePayload(input: {
+  secret: string;
+  payload: string;
+}): string {
+  return createHmac('sha256', input.secret).update(input.payload).digest('hex');
+}
+
+export function signIngressRequest(input: {
+  secret: string;
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  rawBody: string;
+}): string {
+  return signIngressSignaturePayload({
+    secret: input.secret,
+    payload: buildIngressSignaturePayload(input).canonicalPayload,
+  });
+}
+
+export function verifyIngressSignature(input: {
+  secret: string;
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  rawBody: string;
+  signature: string;
+  toleranceMs?: number;
+  nowMs?: number;
+}): boolean {
+  const timestampMs = Number(input.timestamp);
+  const toleranceMs = input.toleranceMs ?? 5 * 60_000;
+  if (
+    !Number.isFinite(timestampMs) ||
+    (toleranceMs >= 0 &&
+      Math.abs((input.nowMs ?? Date.now()) - timestampMs) > toleranceMs)
+  ) {
+    return false;
+  }
+
+  const expected = signIngressRequest({
+    secret: input.secret,
+    method: input.method,
+    path: input.path,
+    timestamp: input.timestamp,
+    nonce: input.nonce,
+    rawBody: input.rawBody,
+  });
+  const left = Buffer.from(expected);
+  const right = Buffer.from(input.signature);
+  return left.length === right.length && timingSafeEqual(left, right);
+}

--- a/packages/sdk/src/ingresses.ts
+++ b/packages/sdk/src/ingresses.ts
@@ -1,0 +1,45 @@
+import type { RequestOptions } from './types.js';
+
+type TransportLike = {
+  request<T>(options: RequestOptions): Promise<T>;
+};
+
+export function createIngressesClient(transport: TransportLike) {
+  return {
+    create: (input: { name: string; enabled?: boolean; metadata?: unknown }) =>
+      transport.request<Record<string, unknown>>({
+        method: 'POST',
+        path: '/v1/ingresses',
+        body: input,
+      }),
+    list: () =>
+      transport.request<{ ingresses: unknown[] }>({
+        method: 'GET',
+        path: '/v1/ingresses',
+      }),
+    get: (ingressId: string) =>
+      transport.request<Record<string, unknown>>({
+        method: 'GET',
+        path: `/v1/ingresses/${encodeURIComponent(ingressId)}`,
+      }),
+    update: (
+      ingressId: string,
+      patch: { name?: string; enabled?: boolean; metadata?: unknown },
+    ) =>
+      transport.request<Record<string, unknown>>({
+        method: 'PATCH',
+        path: `/v1/ingresses/${encodeURIComponent(ingressId)}`,
+        body: patch,
+      }),
+    delete: (ingressId: string) =>
+      transport.request<{ deleted: true }>({
+        method: 'DELETE',
+        path: `/v1/ingresses/${encodeURIComponent(ingressId)}`,
+      }),
+    rotate: (ingressId: string) =>
+      transport.request<Record<string, unknown>>({
+        method: 'POST',
+        path: `/v1/ingresses/${encodeURIComponent(ingressId)}/rotate`,
+      }),
+  };
+}


### PR DESCRIPTION
## Summary
- add app-scoped session interaction and external ingress application modules
- add signed HMAC external ingress management/runtime APIs, SDK helpers, and Postgres persistence
- move session route behavior behind application-owned interfaces and keep outbound webhooks callback-only
- update docs, ADR, quickstarts, runtime-state cleanup guidance, and tests

## Validation
- npm run typecheck
- npm run format:check
- npm run test:unit -- apps/core/test/unit/control/server-auth.test.ts apps/core/test/unit/application/app-scope/resolve-app-scope.test.ts apps/core/test/unit/application/external-ingress/external-ingress-module.test.ts apps/core/test/unit/application/sessions/session-interaction-module.test.ts apps/core/test/unit/control/sdk-transport.test.ts apps/core/test/unit/control/session-control-port.test.ts apps/core/test/unit/channels/app.test.ts packages/contracts/test/unit/index.test.ts
- npm run test:integration:postgres
- python3 .codex/scripts/verify.py
- python3 .codex/scripts/validate_artifacts.py --allow-missing-run
- python3 .codex/scripts/validate_work.py

## Runtime cleanup
- reset the configured local MyClaw Postgres schema after the final build
- restarted the launchd service from this checkout
- verified `node dist/cli/index.js status` is healthy with Postgres ready and zero groups after reset
- deleted archived group-tied skill artifacts under `~/myclaw/cleanup-archive`
