### PR TITLE
[codex] Add autonomous scheduler job visibility

### DIFF
--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -27,6 +27,7 @@
 - MCP runner handoff files contain resolved credentials. Write them only after spawn preconditions pass and remove them in host cleanup paths; `npx-package` stdio templates may accept only one safe npm package argument.
 - Resolved third-party MCP credentials must not be serialized into long-lived process env; use a private per-run handoff and keep SDK tool env sanitized.
 - Broker model proxy and CA values belong only in the model SDK credential lane. Keep general runner, script, browser, and MCP env tool-agnostic; `NO_PROXY` is compatibility only, not a safety boundary.
+- Autonomous scheduler jobs must never use chat permission IPC during execution. Resolve target-agent tools at run time, merge only approved job-scoped extras from `targetJson.capabilityPolicy.allowedTools`, and fail fast with `tool not on autonomous job allowlist` when a scheduled run requests anything outside that effective set.
 - Host runner sync code must work with npm workspace hoisting and installed package layouts; do not assume `packages/agent-runner/node_modules` exists.
 - Files under `apps/core/src/app/bootstrap/` own composition and wiring only; runtime behavior must live in `runtime/`, `jobs/`, `session/`, `platform/`, `messaging/`, `memory/`, or infrastructure modules.
 - Channel provider catalog flags must match executable behavior: do not advertise `install` or `discover` unless the CLI/control path can actually perform setup or discovery, and document any remaining runtime adapter seam explicitly.

--- a/apps/core/src/adapters/storage/postgres/job-tool-repository-runtime.ts
+++ b/apps/core/src/adapters/storage/postgres/job-tool-repository-runtime.ts
@@ -1,0 +1,12 @@
+import type { ToolCatalogRepository } from '../../../domain/ports/repositories.js';
+import { getRuntimeStorage } from './runtime-store.js';
+
+export function getRuntimeToolRepositoryIfReady():
+  | ToolCatalogRepository
+  | undefined {
+  try {
+    return getRuntimeStorage().repositories.tools;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-job-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-job-repository.postgres.ts
@@ -88,6 +88,7 @@ const CANONICAL_JOB_EVENT_TYPES = [
   RUNTIME_EVENT_TYPES.JOB_RUN_STARTED,
   RUNTIME_EVENT_TYPES.JOB_STARTED,
   RUNTIME_EVENT_TYPES.JOB_STREAMING,
+  RUNTIME_EVENT_TYPES.JOB_TOOL_DENIED,
   RUNTIME_EVENT_TYPES.RUN_COMPLETED,
   RUNTIME_EVENT_TYPES.RUN_FAILED,
   RUNTIME_EVENT_TYPES.RUN_TIMEOUT,
@@ -97,6 +98,39 @@ const CANONICAL_JOB_EVENT_TYPES = [
   RUNTIME_EVENT_TYPES.JOB_RUN_COMPLETED,
   RUNTIME_EVENT_TYPES.JOB_RUN_FAILED,
 ] as const;
+
+function canonicalAgentId(agentId: string): string {
+  const trimmed = agentId.trim();
+  return trimmed.startsWith('agent:') ? trimmed : `agent:${trimmed}`;
+}
+
+function kindClause(
+  kind: NonNullable<JobListFilters['kind']>,
+  scheduleJson: unknown,
+) {
+  if (kind === 'manual') {
+    return sql`${scheduleJson}::jsonb ->> 'type' = 'manual'`;
+  }
+  if (kind === 'once') {
+    return sql`${scheduleJson}::jsonb ->> 'type' = 'once'`;
+  }
+  return sql`${scheduleJson}::jsonb ->> 'type' in ('cron', 'interval')`;
+}
+
+function linkedSessionsAllowedClause(targetJson: unknown, jids: string[]) {
+  if (jids.length === 0) {
+    return sql`jsonb_array_length(coalesce(${targetJson}::jsonb -> 'linkedSessions', '[]'::jsonb)) = 0`;
+  }
+  const allowed = sql.join(
+    jids.map((jid) => sql`${jid}`),
+    sql`, `,
+  );
+  return sql`not exists (
+    select 1
+    from jsonb_array_elements_text(coalesce(${targetJson}::jsonb -> 'linkedSessions', '[]'::jsonb)) as linked_session(value)
+    where linked_session.value not in (${allowed})
+  )`;
+}
 
 export class PostgresCanonicalJobRepository {
   private readonly graph: PostgresCanonicalGraphRepository;
@@ -138,12 +172,36 @@ export class PostgresCanonicalJobRepository {
           ? sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb ->> 'threadId' = ${filters.threadId}`
           : sql`coalesce(${pgSchema.canonicalJobsPostgres.targetJson}::jsonb ->> 'threadId', '') = ''`
         : undefined,
+      filters?.agentId
+        ? sql`(
+            ${pgSchema.canonicalJobsPostgres.agentId} = ${canonicalAgentId(filters.agentId)}
+            or ${pgSchema.canonicalJobsPostgres.targetJson}::jsonb ->> 'groupScope' = ${filters.agentId}
+            or ${pgSchema.canonicalJobsPostgres.targetJson}::jsonb ->> 'groupScope' = ${canonicalAgentId(filters.agentId)}
+          )`
+        : undefined,
+      filters?.kind
+        ? kindClause(filters.kind, pgSchema.canonicalJobsPostgres.scheduleJson)
+        : undefined,
+      filters?.conversationJid
+        ? sql`exists (
+            select 1
+            from jsonb_array_elements_text(coalesce(${pgSchema.canonicalJobsPostgres.targetJson}::jsonb -> 'linkedSessions', '[]'::jsonb)) as linked_session(value)
+            where linked_session.value = ${filters.conversationJid}
+          )`
+        : undefined,
+      filters?.allowedConversationJids
+        ? linkedSessionsAllowedClause(
+            pgSchema.canonicalJobsPostgres.targetJson,
+            filters.allowedConversationJids,
+          )
+        : undefined,
     ].filter(Boolean);
     const filtered = clauses.length > 0 ? query.where(and(...clauses)) : query;
-    return filtered.orderBy(
+    const ordered = filtered.orderBy(
       desc(pgSchema.canonicalJobsPostgres.updatedAt),
       desc(pgSchema.canonicalJobsPostgres.createdAt),
     );
+    return filters?.limit ? ordered.limit(filters.limit) : ordered;
   }
 
   async upsertJob(record: JobRecordInput): Promise<void> {

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0026_agent_runs_job_started_index.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0026_agent_runs_job_started_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_agent_runs_job_started
+  ON agent_runs(job_id, started_at DESC NULLS LAST, created_at DESC);

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1777075800000,
       "tag": "0025_memory_items_search_index",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1777079400000,
+      "tag": "0026_agent_runs_job_started_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/adapters/storage/postgres/schema/runs.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/runs.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 import {
   agentConfigVersionsPostgres,
@@ -13,42 +13,54 @@ import {
 import { messagesPostgres } from './messages.js';
 import { agentSessionsPostgres } from './sessions.js';
 
-export const agentRunsPostgres = pgTable('agent_runs', {
-  id: text('id').primaryKey(),
-  appId: text('app_id')
-    .notNull()
-    .references(() => appsPostgres.id, { onDelete: 'cascade' }),
-  agentId: text('agent_id')
-    .notNull()
-    .references(() => agentsPostgres.id, { onDelete: 'cascade' }),
-  configVersionId: text('config_version_id')
-    .notNull()
-    .references(() => agentConfigVersionsPostgres.id),
-  sessionId: text('session_id').references(() => agentSessionsPostgres.id, {
-    onDelete: 'set null',
+export const agentRunsPostgres = pgTable(
+  'agent_runs',
+  {
+    id: text('id').primaryKey(),
+    appId: text('app_id')
+      .notNull()
+      .references(() => appsPostgres.id, { onDelete: 'cascade' }),
+    agentId: text('agent_id')
+      .notNull()
+      .references(() => agentsPostgres.id, { onDelete: 'cascade' }),
+    configVersionId: text('config_version_id')
+      .notNull()
+      .references(() => agentConfigVersionsPostgres.id),
+    sessionId: text('session_id').references(() => agentSessionsPostgres.id, {
+      onDelete: 'set null',
+    }),
+    conversationId: text('conversation_id').references(
+      () => conversationsPostgres.id,
+    ),
+    threadId: text('thread_id').references(
+      () => conversationThreadsPostgres.id,
+    ),
+    messageId: text('message_id').references(() => messagesPostgres.id),
+    jobId: text('job_id'),
+    llmProfileId: text('llm_profile_id')
+      .notNull()
+      .references(() => llmProfilesPostgres.id),
+    permissionDecisionIdsJson: text('permission_decision_ids_json')
+      .notNull()
+      .default('[]'),
+    sandboxLeaseId: text('sandbox_lease_id'),
+    workspaceSnapshotId: text('workspace_snapshot_id'),
+    cause: text('cause').notNull(),
+    status: text('status').notNull(),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'string',
+    }).notNull(),
+    startedAt: timestamp('started_at', { withTimezone: true, mode: 'string' }),
+    endedAt: timestamp('ended_at', { withTimezone: true, mode: 'string' }),
+    resultSummary: text('result_summary'),
+    errorSummary: text('error_summary'),
+  },
+  (table) => ({
+    jobStartedIdx: index('idx_agent_runs_job_started').on(
+      table.jobId,
+      table.startedAt,
+      table.createdAt,
+    ),
   }),
-  conversationId: text('conversation_id').references(
-    () => conversationsPostgres.id,
-  ),
-  threadId: text('thread_id').references(() => conversationThreadsPostgres.id),
-  messageId: text('message_id').references(() => messagesPostgres.id),
-  jobId: text('job_id'),
-  llmProfileId: text('llm_profile_id')
-    .notNull()
-    .references(() => llmProfilesPostgres.id),
-  permissionDecisionIdsJson: text('permission_decision_ids_json')
-    .notNull()
-    .default('[]'),
-  sandboxLeaseId: text('sandbox_lease_id'),
-  workspaceSnapshotId: text('workspace_snapshot_id'),
-  cause: text('cause').notNull(),
-  status: text('status').notNull(),
-  createdAt: timestamp('created_at', {
-    withTimezone: true,
-    mode: 'string',
-  }).notNull(),
-  startedAt: timestamp('started_at', { withTimezone: true, mode: 'string' }),
-  endedAt: timestamp('ended_at', { withTimezone: true, mode: 'string' }),
-  resultSummary: text('result_summary'),
-  errorSummary: text('error_summary'),
-});
+);

--- a/apps/core/src/adapters/storage/postgres/services/canonical-job-ops-service.ts
+++ b/apps/core/src/adapters/storage/postgres/services/canonical-job-ops-service.ts
@@ -76,6 +76,7 @@ export class CanonicalJobOpsService {
         last_run: job.last_run,
         silent: job.silent,
         pause_reason: job.pause_reason,
+        capability_policy: job.capability_policy,
         created_at: job.created_at || now,
         updated_at: job.updated_at || now,
       }),
@@ -264,6 +265,7 @@ export class CanonicalJobOpsService {
       {},
     );
     const target = parseJson<Record<string, unknown>>(row.targetJson, {});
+    const capabilityPolicy = parseCapabilityPolicy(target.capabilityPolicy);
     return {
       id: row.id,
       name: row.name,
@@ -296,6 +298,7 @@ export class CanonicalJobOpsService {
       lease_run_id: row.leaseRunId,
       lease_expires_at: row.leaseExpiresAt,
       pause_reason: (target.pauseReason as string | null | undefined) ?? null,
+      capability_policy: capabilityPolicy,
     };
   }
 
@@ -328,6 +331,11 @@ export class CanonicalJobOpsService {
         maxConsecutiveFailures: job.max_consecutive_failures ?? 5,
         consecutiveFailures: job.consecutive_failures ?? 0,
         pauseReason: job.pause_reason ?? null,
+        capabilityPolicy: {
+          allowedTools: normalizeAllowedTools(
+            job.capability_policy?.allowed_tools,
+          ),
+        },
       }),
       silent: Boolean(job.silent),
       timeoutMs: job.timeout_ms ?? 300000,
@@ -372,4 +380,23 @@ export class CanonicalJobOpsService {
       created_at: row.createdAt,
     };
   }
+}
+
+function normalizeAllowedTools(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of input) {
+    const value = typeof item === 'string' ? item.trim() : '';
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function parseCapabilityPolicy(input: unknown): Job['capability_policy'] {
+  if (!input || typeof input !== 'object') return { allowed_tools: [] };
+  const allowedTools = (input as { allowedTools?: unknown }).allowedTools;
+  return { allowed_tools: normalizeAllowedTools(allowedTools) };
 }

--- a/apps/core/src/app/bootstrap/runtime-services.ts
+++ b/apps/core/src/app/bootstrap/runtime-services.ts
@@ -18,7 +18,10 @@ import {
 } from '../../jobs/scheduler.js';
 import { makeThreadQueueKey } from '../../runtime/thread-queue-key.js';
 import type { OpsRepository } from '../../domain/repositories/ops-repo.js';
-import { getRuntimeOpsRepository } from '../../adapters/storage/postgres/runtime-store.js';
+import {
+  getRuntimeOpsRepository,
+  getRuntimeStorage,
+} from '../../adapters/storage/postgres/runtime-store.js';
 import type { SessionMemoryCollector } from '../../domain/ports/session-memory-collector.js';
 import { ChannelWiring } from './channel-wiring.js';
 import { RuntimeApp } from './runtime-app.js';
@@ -146,6 +149,7 @@ export async function startRuntimeServices(
     onSchedulerChanged,
     opsRepository: resolved.opsRepository,
     collectSessionMemory: resolved.collectSessionMemory,
+    getToolRepository: () => getRuntimeStorage().repositories.tools,
   });
 
   resolved.startIpcWatcher({
@@ -171,6 +175,7 @@ export async function startRuntimeServices(
       ),
     onSchedulerChanged,
     opsRepository: resolved.opsRepository,
+    getToolRepository: () => getRuntimeStorage().repositories.tools,
     requestPermissionApproval: channelWiring.requestPermissionApproval,
     requestUserAnswer: channelWiring.requestUserAnswer,
     mcpHostnameLookup: resolved.mcpHostnameLookup,

--- a/apps/core/src/application/jobs/job-extra-tool-approval.ts
+++ b/apps/core/src/application/jobs/job-extra-tool-approval.ts
@@ -1,0 +1,61 @@
+import { ApplicationError } from '../common/application-error.js';
+import type { JobExtraToolApprovalRequest } from './job-management-types.js';
+import {
+  agentIdForJobGroupScope,
+  jobToolRulesBeyondInherited,
+  resolveAgentToolBindings,
+} from './job-tool-policy.js';
+import type { JobManagementServiceDeps } from './job-management-types.js';
+
+export async function requireJobExtraToolApproval(input: {
+  deps: Pick<
+    JobManagementServiceDeps,
+    'toolRepository' | 'approveJobExtraTools'
+  >;
+  jobId: string;
+  jobName: string;
+  appId: string;
+  groupScope: string;
+  allowedTools: string[];
+  existingJobExtraTools: string[];
+  isMain: boolean;
+  operation: JobExtraToolApprovalRequest['operation'];
+}): Promise<void> {
+  if (input.allowedTools.length === 0) return;
+  const agentId = agentIdForJobGroupScope(input.groupScope);
+  const inheritedTools = await resolveAgentToolBindings({
+    repository: input.deps.toolRepository,
+    appId: input.appId,
+    agentId,
+  });
+  const extrasBeyondInherited = jobToolRulesBeyondInherited({
+    requestedRules: input.allowedTools,
+    inheritedTools: [...inheritedTools, ...input.existingJobExtraTools],
+  });
+  if (extrasBeyondInherited.length === 0) return;
+  if (!input.deps.approveJobExtraTools) {
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'Job-scoped extra tools require approval before they can be stored.',
+    );
+  }
+  const decision = await input.deps.approveJobExtraTools({
+    jobId: input.jobId,
+    jobName: input.jobName,
+    target: {
+      appId: input.appId,
+      agentId,
+      groupScope: input.groupScope,
+    },
+    inheritedTools,
+    requestedJobExtraTools: input.allowedTools,
+    extrasBeyondInherited,
+    existingJobExtraTools: input.existingJobExtraTools,
+    operation: input.operation,
+  });
+  if (decision.approved) return;
+  throw new ApplicationError(
+    'FORBIDDEN',
+    `Job-scoped tool approval denied: ${decision.reason || 'not approved'}.`,
+  );
+}

--- a/apps/core/src/application/jobs/job-list-filters.ts
+++ b/apps/core/src/application/jobs/job-list-filters.ts
@@ -1,0 +1,37 @@
+import type { Job } from '../../domain/types.js';
+import { jobBelongsToApp } from './job-access.js';
+import { agentIdForJobGroupScope } from './job-tool-policy.js';
+import { canAccessSchedulerJob } from './job-management-access.js';
+import type { JobKind, SchedulerJobAccess } from './job-management-types.js';
+
+export interface JobVisibilityFilter {
+  appId?: string;
+  access?: SchedulerJobAccess;
+  agentId?: string;
+  kind?: JobKind;
+  conversationJid?: string;
+}
+
+export function isVisibleJob(job: Job, input: JobVisibilityFilter): boolean {
+  if (input.appId && !jobBelongsToApp(job, input.appId)) return false;
+  if (input.access && !canAccessSchedulerJob(job, input.access)) return false;
+  if (
+    input.agentId &&
+    agentIdForJobGroupScope(job.group_scope) !== input.agentId
+  )
+    return false;
+  if (input.kind && jobKindFor(job) !== input.kind) return false;
+  if (
+    input.conversationJid &&
+    !job.linked_sessions.includes(input.conversationJid)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function jobKindFor(job: Job): JobKind {
+  if (job.schedule_type === 'manual') return 'manual';
+  if (job.schedule_type === 'once') return 'once';
+  return 'recurring';
+}

--- a/apps/core/src/application/jobs/job-management-create.ts
+++ b/apps/core/src/application/jobs/job-management-create.ts
@@ -1,0 +1,94 @@
+import { ApplicationError } from '../common/application-error.js';
+import type {
+  CreateManagedJobInput,
+  JobManagementServiceDeps,
+} from './job-management-types.js';
+import { resolveRequestedJobModel } from './job-model-selection.js';
+import { requireJobExtraToolApproval } from './job-extra-tool-approval.js';
+import {
+  assertJobExtraToolsAllowedForTarget,
+  normalizeJobExtraTools,
+} from './job-tool-policy.js';
+
+export async function createManagedJob(
+  deps: JobManagementServiceDeps,
+  input: CreateManagedJobInput,
+) {
+  if (!deps.control) {
+    throw new ApplicationError(
+      'UNAVAILABLE',
+      'Job control repository unavailable',
+    );
+  }
+  const session = await deps.control.getAppSessionById(input.sessionId);
+  if (!input.name.trim() || !input.prompt.trim() || !session) {
+    throw new ApplicationError(
+      'INVALID_REQUEST',
+      'name, prompt, and sessionId are required',
+    );
+  }
+  if (session.appId !== input.appId) {
+    throw new ApplicationError(
+      'FORBIDDEN',
+      'API key cannot access this session',
+    );
+  }
+
+  const kind = input.kind ?? 'manual';
+  const schedule = deps.schedulePlanner.planAppSchedule({
+    kind,
+    runAt: input.runAt,
+    schedule: input.schedule,
+  });
+  const modelAlias = resolveRequestedJobModel(
+    input.modelAlias,
+    input.modelProfileId,
+  );
+  const jobId = deps.schedulePlanner.createManualJobId();
+  const runtimeContext = {
+    sessionId: session.sessionId,
+    chatJid: session.chatJid,
+    groupScope: session.workspaceKey,
+    threadId: typeof input.threadId === 'string' ? input.threadId : null,
+  };
+  const allowedTools = normalizeJobExtraTools(input.allowedTools);
+  assertJobExtraToolsAllowedForTarget({
+    rules: allowedTools,
+    isMain: false,
+  });
+  if (input.dryRun === true) {
+    return { jobId, created: false, modelAlias, runtimeContext };
+  }
+  await requireJobExtraToolApproval({
+    deps,
+    jobId,
+    jobName: input.name.trim(),
+    appId: input.appId,
+    groupScope: session.workspaceKey,
+    allowedTools,
+    existingJobExtraTools: [],
+    isMain: false,
+    operation: 'create',
+  });
+  const result = await deps.ops.upsertJob({
+    id: jobId,
+    name: input.name.trim(),
+    prompt: input.prompt.trim(),
+    model: modelAlias ?? null,
+    script: null,
+    schedule_type: schedule.scheduleType,
+    schedule_value: schedule.scheduleValue,
+    status: 'active',
+    linked_sessions: [session.chatJid],
+    session_id: null,
+    thread_id: typeof input.threadId === 'string' ? input.threadId : null,
+    group_scope: session.workspaceKey,
+    created_by: 'human',
+    next_run: schedule.nextRun,
+    execution_mode:
+      input.executionMode === 'serialized' ? 'serialized' : 'parallel',
+    capability_policy: { allowed_tools: allowedTools },
+  });
+  deps.scheduler.requestSchedulerSync(jobId);
+  return { jobId, created: result.created, modelAlias, runtimeContext };
+}

--- a/apps/core/src/application/jobs/job-management-helpers.ts
+++ b/apps/core/src/application/jobs/job-management-helpers.ts
@@ -79,6 +79,9 @@ export function buildJobUpdates(
   if (patch.maxConsecutiveFailures !== undefined) {
     updates.max_consecutive_failures = patch.maxConsecutiveFailures;
   }
+  if (patch.allowedTools !== undefined) {
+    updates.capability_policy = { allowed_tools: patch.allowedTools };
+  }
   if (patch.scheduleType !== undefined)
     updates.schedule_type = patch.scheduleType;
   if (patch.scheduleValue !== undefined)

--- a/apps/core/src/application/jobs/job-management-service.ts
+++ b/apps/core/src/application/jobs/job-management-service.ts
@@ -1,14 +1,16 @@
 import { RUNTIME_EVENT_TYPES } from '../../domain/events/runtime-event-types.js';
 import { ApplicationError } from '../common/application-error.js';
 import type { Clock } from '../common/clock.js';
-import { assertJobBelongsToApp, jobBelongsToApp } from './job-access.js';
+import { assertJobBelongsToApp, resolveJobRuntimeAppId } from './job-access.js';
+import { isVisibleJob } from './job-list-filters.js';
 import {
   assertSchedulerJobAccess,
-  canAccessSchedulerJob,
   normalizeOptional,
   resolveLinkedSessions,
   validateSchedulerUpdate,
 } from './job-management-access.js';
+import { createManagedJob } from './job-management-create.js';
+import { requireJobExtraToolApproval } from './job-extra-tool-approval.js';
 import {
   buildJobUpdates,
   encodeTriggerRequester,
@@ -29,13 +31,21 @@ import type {
   RuntimeEventPublisherPort,
   SchedulerJobAccess,
   JobUpdatePatch,
+  CreateManagedJobInput,
+  UpsertJobFromIpcInput,
 } from './job-management-types.js';
 import {
   resolveOptionalJobModel,
   resolveRequestedJobModel,
 } from './job-model-selection.js';
+import {
+  assertJobExtraToolsAllowedForTarget,
+  normalizeJobExtraTools,
+} from './job-tool-policy.js';
 
 const DEFAULT_RUN_LIMIT = 50;
+const DEFAULT_JOB_LIST_LIMIT = 100;
+const MAX_JOB_LIST_LIMIT = 500;
 const DEFAULT_EVENT_LIMIT = 200;
 const DEFAULT_DEAD_LETTER_LIMIT = 50;
 const TRIGGER_POLL_INTERVAL_MS = 2_000;
@@ -43,100 +53,13 @@ const TRIGGER_POLL_INTERVAL_MS = 2_000;
 export class JobManagementService {
   constructor(private readonly deps: JobManagementServiceDeps) {}
 
-  async createJob(input: {
-    appId: string;
-    name: string;
-    prompt: string;
-    sessionId: string;
-    kind?: JobKind;
-    runAt?: string;
-    schedule?: { type?: unknown; value?: unknown };
-    executionMode?: unknown;
-    threadId?: unknown;
-    modelAlias?: unknown;
-    modelProfileId?: unknown;
-    dryRun?: unknown;
-  }) {
-    const control = this.requireControl();
-    const session = await control.getAppSessionById(input.sessionId);
-    if (!input.name.trim() || !input.prompt.trim() || !session) {
-      throw new ApplicationError(
-        'INVALID_REQUEST',
-        'name, prompt, and sessionId are required',
-      );
-    }
-    if (session.appId !== input.appId) {
-      throw new ApplicationError(
-        'FORBIDDEN',
-        'API key cannot access this session',
-      );
-    }
-
-    const kind = input.kind ?? 'manual';
-    const schedule = this.deps.schedulePlanner.planAppSchedule({
-      kind,
-      runAt: input.runAt,
-      schedule: input.schedule,
-    });
-    const modelAlias = resolveRequestedJobModel(
-      input.modelAlias,
-      input.modelProfileId,
-    );
-    const jobId = this.deps.schedulePlanner.createManualJobId();
-    const runtimeContext = {
-      sessionId: session.sessionId,
-      chatJid: session.chatJid,
-      groupScope: session.workspaceKey,
-      threadId: typeof input.threadId === 'string' ? input.threadId : null,
-    };
-    if (input.dryRun === true) {
-      return { jobId, created: false, modelAlias, runtimeContext };
-    }
-    const result = await this.deps.ops.upsertJob({
-      id: jobId,
-      name: input.name.trim(),
-      prompt: input.prompt.trim(),
-      model: modelAlias ?? null,
-      script: null,
-      schedule_type: schedule.scheduleType,
-      schedule_value: schedule.scheduleValue,
-      status: 'active',
-      linked_sessions: [session.chatJid],
-      session_id: null,
-      thread_id: typeof input.threadId === 'string' ? input.threadId : null,
-      group_scope: session.workspaceKey,
-      created_by: 'human',
-      next_run: schedule.nextRun,
-      execution_mode:
-        input.executionMode === 'serialized' ? 'serialized' : 'parallel',
-    });
-    this.deps.scheduler.requestSchedulerSync(jobId);
-    return { jobId, created: result.created, modelAlias, runtimeContext };
+  async createJob(input: CreateManagedJobInput) {
+    return createManagedJob(this.deps, input);
   }
 
-  async upsertJobFromIpc(input: {
-    access: SchedulerJobAccess;
-    jobId?: string;
-    name: string;
-    prompt: string;
-    modelAlias?: string | null;
-    modelProfileId?: string | null;
-    scheduleType: unknown;
-    scheduleValue: string;
-    linkedSessions?: string[];
-    deliverTo?: string[];
-    threadId?: string;
-    silent?: boolean;
-    cleanupAfterMs?: number;
-    timeoutMs?: number;
-    maxRetries?: number;
-    retryBackoffMs?: number;
-    maxConsecutiveFailures?: number;
-    executionMode?: unknown;
-    serialize?: unknown;
-    groupScope?: string;
-    createdBy?: 'agent' | 'human';
-  }): Promise<{ jobId: string; created: boolean; modelAlias?: string }> {
+  async upsertJobFromIpc(
+    input: UpsertJobFromIpcInput,
+  ): Promise<{ jobId: string; created: boolean; modelAlias?: string }> {
     const access = input.access;
     const name = input.name.trim();
     const prompt = input.prompt.trim();
@@ -201,6 +124,26 @@ export class JobManagementService {
     }
     existingJob ??= await this.deps.ops.getJobById(id);
     if (existingJob) assertSchedulerJobAccess(existingJob, access);
+    const allowedTools =
+      input.allowedTools === undefined
+        ? (existingJob?.capability_policy?.allowed_tools ?? [])
+        : normalizeJobExtraTools(input.allowedTools);
+    assertJobExtraToolsAllowedForTarget({
+      rules: allowedTools,
+      isMain: access.isMain,
+    });
+    await requireJobExtraToolApproval({
+      deps: this.deps,
+      jobId: id,
+      jobName: name,
+      appId: 'default',
+      groupScope,
+      allowedTools,
+      existingJobExtraTools:
+        existingJob?.capability_policy?.allowed_tools ?? [],
+      isMain: access.isMain,
+      operation: existingJob ? 'update' : 'create',
+    });
 
     const job: JobUpsertInput = {
       id,
@@ -227,6 +170,7 @@ export class JobManagementService {
         input.executionMode,
         input.serialize,
       ),
+      capability_policy: { allowed_tools: allowedTools },
     };
     const result = await this.deps.ops.upsertJob(job);
     this.deps.scheduler.requestSchedulerSync(id);
@@ -238,6 +182,10 @@ export class JobManagementService {
     access?: SchedulerJobAccess;
     statuses?: string[];
     groupScope?: string;
+    agentId?: string;
+    kind?: JobKind;
+    conversationJid?: string;
+    limit?: number;
   }): Promise<{ jobs: Job[] }> {
     const queryGroupScope = input.access
       ? input.access.isMain
@@ -251,14 +199,20 @@ export class JobManagementService {
       threadId: input.access
         ? (normalizeOptional(input.access.authThreadId) ?? null)
         : undefined,
+      agentId: input.agentId,
+      kind: input.kind,
+      conversationJid: input.conversationJid,
+      allowedConversationJids:
+        input.access && !input.access.isMain
+          ? input.access.sourceGroupJids
+          : undefined,
+      limit: Math.min(
+        resolveLimit(input.limit, DEFAULT_JOB_LIST_LIMIT),
+        MAX_JOB_LIST_LIMIT,
+      ),
     });
     return {
-      jobs: jobs.filter((job) => {
-        if (input.appId && !jobBelongsToApp(job, input.appId)) return false;
-        if (input.access && !canAccessSchedulerJob(job, input.access))
-          return false;
-        return true;
-      }),
+      jobs: jobs.filter((job) => isVisibleJob(job, input)),
     };
   }
 
@@ -286,9 +240,34 @@ export class JobManagementService {
     if (typeof patch.model === 'string') {
       patch.model = resolveOptionalJobModel(patch.model);
     }
+    const allowedTools =
+      patch.allowedTools === undefined
+        ? undefined
+        : normalizeJobExtraTools(patch.allowedTools);
+    if (allowedTools) {
+      assertJobExtraToolsAllowedForTarget({
+        rules: allowedTools,
+        isMain: input.access?.isMain ?? true,
+      });
+      const targetGroupScope = patch.groupScope ?? job.group_scope;
+      await requireJobExtraToolApproval({
+        deps: this.deps,
+        jobId: job.id,
+        jobName: patch.name ?? job.name,
+        appId: resolveJobRuntimeAppId(job),
+        groupScope: targetGroupScope,
+        allowedTools,
+        existingJobExtraTools: job.capability_policy?.allowed_tools ?? [],
+        isMain: input.access?.isMain ?? true,
+        operation: 'update',
+      });
+    }
     const updates = buildJobUpdates(
       job,
-      patch,
+      {
+        ...patch,
+        ...(allowedTools ? { allowedTools } : {}),
+      },
       this.deps.schedulePlanner,
       this.clock(),
     );

--- a/apps/core/src/application/jobs/job-management-types.ts
+++ b/apps/core/src/application/jobs/job-management-types.ts
@@ -13,6 +13,7 @@ import type {
   JobUpsertInput,
   OpsRepository,
 } from '../../domain/repositories/ops-repo.js';
+import type { ToolCatalogRepository } from '../../domain/ports/repositories.js';
 import type { Clock } from '../common/clock.js';
 import type { SchedulerCoordinationPort } from './scheduler-coordination-port.js';
 
@@ -98,9 +99,70 @@ export interface JobManagementServiceDeps {
   scheduler: SchedulerCoordinationPort;
   schedulePlanner: JobSchedulePlanner;
   clock?: Clock;
+  toolRepository?: ToolCatalogRepository;
+  approveJobExtraTools?: (input: JobExtraToolApprovalRequest) => Promise<{
+    approved: boolean;
+    reason?: string;
+  }>;
   control?: JobControlPort;
   runtimeEvents?: RuntimeEventPublisherPort;
   triggerQueue?: JobTriggerQueuePort;
+}
+
+export interface JobExtraToolApprovalRequest {
+  jobId: string;
+  jobName: string;
+  target: {
+    appId: string;
+    agentId: string;
+    groupScope: string;
+  };
+  inheritedTools: string[];
+  requestedJobExtraTools: string[];
+  extrasBeyondInherited: string[];
+  existingJobExtraTools: string[];
+  operation: 'create' | 'update';
+}
+
+export interface CreateManagedJobInput {
+  appId: string;
+  name: string;
+  prompt: string;
+  sessionId: string;
+  kind?: JobKind;
+  runAt?: string;
+  schedule?: { type?: unknown; value?: unknown };
+  executionMode?: unknown;
+  threadId?: unknown;
+  modelAlias?: unknown;
+  modelProfileId?: unknown;
+  allowedTools?: unknown;
+  dryRun?: unknown;
+}
+
+export interface UpsertJobFromIpcInput {
+  access: SchedulerJobAccess;
+  jobId?: string;
+  name: string;
+  prompt: string;
+  modelAlias?: string | null;
+  modelProfileId?: string | null;
+  scheduleType: unknown;
+  scheduleValue: string;
+  linkedSessions?: string[];
+  deliverTo?: string[];
+  threadId?: string;
+  silent?: boolean;
+  cleanupAfterMs?: number;
+  timeoutMs?: number;
+  maxRetries?: number;
+  retryBackoffMs?: number;
+  maxConsecutiveFailures?: number;
+  executionMode?: unknown;
+  serialize?: unknown;
+  groupScope?: string;
+  createdBy?: 'agent' | 'human';
+  allowedTools?: unknown;
 }
 
 export interface ConversationBinding {
@@ -132,6 +194,7 @@ export type JobUpdatePatch = Partial<{
   maxConsecutiveFailures: number;
   executionMode: JobExecutionMode;
   status: Extract<Job['status'], 'active' | 'paused'>;
+  allowedTools: string[];
 }>;
 
 export interface JobListInput {
@@ -139,6 +202,9 @@ export interface JobListInput {
   access?: SchedulerJobAccess;
   statuses?: string[];
   groupScope?: string;
+  agentId?: string;
+  kind?: JobKind;
+  conversationJid?: string;
 }
 
 export interface JobLookupInput {

--- a/apps/core/src/application/jobs/job-tool-policy.ts
+++ b/apps/core/src/application/jobs/job-tool-policy.ts
@@ -1,0 +1,122 @@
+import type { Job } from '../../domain/types.js';
+import type { ToolCatalogRepository } from '../../domain/ports/repositories.js';
+import { ApplicationError } from '../common/application-error.js';
+import {
+  anyToolRuleMatches,
+  normalizeToolRules,
+  validateAutonomousToolRules,
+} from '../../shared/tool-rule-matcher.js';
+
+const NON_MAIN_ADMIN_TOOLS = new Set([
+  'mcp__myclaw__settings_desired_state',
+  'mcp__myclaw__request_settings_update',
+  'mcp__myclaw__service_restart',
+  'mcp__myclaw__register_agent',
+]);
+
+export interface JobToolPolicyResolution {
+  inheritedTools: string[];
+  jobExtraTools: string[];
+  effectiveAllowedTools: string[];
+}
+
+export function normalizeJobExtraTools(input: unknown): string[] {
+  const rules = normalizeToolRules(Array.isArray(input) ? input : undefined);
+  const validation = validateAutonomousToolRules(rules);
+  if (!validation.ok) {
+    throw new ApplicationError(
+      'INVALID_REQUEST',
+      validation.reason || 'Invalid job tool rule.',
+    );
+  }
+  return rules;
+}
+
+export function assertJobExtraToolsAllowedForTarget(input: {
+  rules: readonly string[];
+  isMain: boolean;
+}): void {
+  if (input.isMain) return;
+  const forbidden = input.rules.find(
+    (rule) => NON_MAIN_ADMIN_TOOLS.has(rule) || rule === 'mcp__myclaw__*',
+  );
+  if (forbidden) {
+    throw new ApplicationError(
+      'FORBIDDEN',
+      `Tool ${forbidden} is only available to main/admin jobs.`,
+    );
+  }
+}
+
+export function agentIdForJobGroupScope(groupScope: string): string {
+  const trimmed = groupScope.trim();
+  return trimmed.startsWith('agent:') ? trimmed : `agent:${trimmed}`;
+}
+
+export function jobToolRulesBeyondInherited(input: {
+  requestedRules: readonly string[];
+  inheritedTools: readonly string[];
+}): string[] {
+  return input.requestedRules.filter(
+    (rule) => !anyToolRuleMatches(input.inheritedTools, rule),
+  );
+}
+
+export async function resolveJobToolPolicy(input: {
+  job: Job;
+  appId?: string;
+  agentId?: string;
+  isMain: boolean;
+  toolRepository?: ToolCatalogRepository;
+}): Promise<JobToolPolicyResolution> {
+  const inheritedTools =
+    input.appId && input.agentId
+      ? await resolveAgentToolBindings({
+          repository: input.toolRepository,
+          appId: input.appId,
+          agentId: input.agentId,
+        })
+      : [];
+  const jobExtraTools = normalizeJobExtraTools(
+    input.job.capability_policy?.allowed_tools,
+  );
+  assertJobExtraToolsAllowedForTarget({
+    rules: jobExtraTools,
+    isMain: input.isMain,
+  });
+  return {
+    inheritedTools,
+    jobExtraTools,
+    effectiveAllowedTools: mergeUnique(inheritedTools, jobExtraTools),
+  };
+}
+
+export async function resolveAgentToolBindings(input: {
+  repository?: ToolCatalogRepository;
+  appId: string;
+  agentId: string;
+}): Promise<string[]> {
+  if (!input.repository) return [];
+  const bindings = await input.repository.listAgentToolBindings({
+    appId: input.appId as never,
+    agentId: input.agentId as never,
+  });
+  return bindings
+    .filter((binding) => binding.status === 'active')
+    .map((binding) => {
+      const value = String(binding.toolId);
+      return value.startsWith('tool:') ? value.slice('tool:'.length) : value;
+    });
+}
+
+function mergeUnique(
+  base: readonly string[],
+  next: readonly string[],
+): string[] {
+  const out = new Set<string>();
+  for (const item of [...base, ...next]) {
+    const value = item.trim();
+    if (value) out.add(value);
+  }
+  return [...out];
+}

--- a/apps/core/src/application/jobs/job-visibility-metadata.ts
+++ b/apps/core/src/application/jobs/job-visibility-metadata.ts
@@ -1,0 +1,166 @@
+import type { OpsRepository } from '../../domain/repositories/ops-repo.js';
+import type { Job } from '../../domain/types.js';
+import type { ToolCatalogRepository } from '../../domain/ports/repositories.js';
+import { resolveJobRuntimeAppId } from './job-access.js';
+import {
+  agentIdForJobGroupScope,
+  normalizeJobExtraTools,
+  resolveAgentToolBindings,
+  resolveJobToolPolicy,
+} from './job-tool-policy.js';
+
+export interface JobVisibilityMetadata {
+  target: {
+    appId: string;
+    agentId: string;
+    groupScope: string;
+    conversationJids: string[];
+    threadId: string | null;
+  };
+  promptPreview: string;
+  fullPrompt?: string;
+  notificationTarget: {
+    linkedSessions: string[];
+    threadId: string | null;
+    silent: boolean;
+  };
+  inheritedTools: string[];
+  jobExtraTools: string[];
+  effectiveAllowedTools: string[];
+  inheritedToolCount?: number;
+  jobExtraToolCount?: number;
+  effectiveAllowedToolCount?: number;
+  recentRunErrors: Array<{
+    runId: string;
+    status: string;
+    errorSummary: string;
+    endedAt: string | null;
+  }>;
+}
+
+export async function buildJobVisibilityMetadata(input: {
+  job: Job;
+  ops: OpsRepository;
+  toolRepository?: ToolCatalogRepository;
+  isMain?: boolean;
+  recentRunLimit?: number;
+}): Promise<JobVisibilityMetadata> {
+  const appId = resolveJobRuntimeAppId(input.job);
+  const agentId = agentIdForJobGroupScope(input.job.group_scope);
+  const policy = await resolveJobToolPolicy({
+    job: input.job,
+    appId,
+    agentId,
+    isMain: input.isMain ?? input.job.group_scope === 'main_agent',
+    toolRepository: input.toolRepository,
+  });
+  const runs =
+    typeof input.ops.listJobRuns === 'function'
+      ? await input.ops.listJobRuns(input.job.id, input.recentRunLimit ?? 5)
+      : [];
+  return {
+    target: {
+      appId,
+      agentId,
+      groupScope: input.job.group_scope,
+      conversationJids: input.job.linked_sessions,
+      threadId: input.job.thread_id,
+    },
+    promptPreview: promptPreview(input.job.prompt),
+    fullPrompt: input.job.prompt,
+    notificationTarget: {
+      linkedSessions: input.job.linked_sessions,
+      threadId: input.job.thread_id,
+      silent: input.job.silent,
+    },
+    inheritedTools: policy.inheritedTools,
+    jobExtraTools: policy.jobExtraTools,
+    effectiveAllowedTools: policy.effectiveAllowedTools,
+    recentRunErrors: runs
+      .filter((run) => Boolean(run.error_summary))
+      .map((run) => ({
+        runId: run.run_id,
+        status: run.status,
+        errorSummary: run.error_summary ?? '',
+        endedAt: run.ended_at,
+      })),
+  };
+}
+
+export async function buildJobListVisibilityMetadata(input: {
+  jobs: Job[];
+  toolRepository?: ToolCatalogRepository;
+  isMain?: boolean;
+}): Promise<Map<string, JobVisibilityMetadata>> {
+  const inheritedToolsByTarget = new Map<string, Promise<string[]>>();
+  const loadInheritedTools = (appId: string, agentId: string) => {
+    const key = `${appId}\0${agentId}`;
+    let promise = inheritedToolsByTarget.get(key);
+    if (!promise) {
+      promise = resolveAgentToolBindings({
+        repository: input.toolRepository,
+        appId,
+        agentId,
+      });
+      inheritedToolsByTarget.set(key, promise);
+    }
+    return promise;
+  };
+
+  return new Map(
+    await Promise.all(
+      input.jobs.map(async (job) => {
+        const appId = resolveJobRuntimeAppId(job);
+        const agentId = agentIdForJobGroupScope(job.group_scope);
+        const inheritedTools = await loadInheritedTools(appId, agentId);
+        const jobExtraTools = normalizeJobExtraTools(
+          job.capability_policy?.allowed_tools,
+        );
+        const effectiveAllowedTools = mergeUnique(
+          inheritedTools,
+          jobExtraTools,
+        );
+        const metadata: JobVisibilityMetadata = {
+          target: {
+            appId,
+            agentId,
+            groupScope: job.group_scope,
+            conversationJids: job.linked_sessions,
+            threadId: job.thread_id,
+          },
+          promptPreview: promptPreview(job.prompt),
+          notificationTarget: {
+            linkedSessions: job.linked_sessions,
+            threadId: job.thread_id,
+            silent: job.silent,
+          },
+          inheritedTools: [],
+          jobExtraTools: [],
+          effectiveAllowedTools: [],
+          inheritedToolCount: inheritedTools.length,
+          jobExtraToolCount: jobExtraTools.length,
+          effectiveAllowedToolCount: effectiveAllowedTools.length,
+          recentRunErrors: [],
+        };
+        return [job.id, metadata] as const;
+      }),
+    ),
+  );
+}
+
+function promptPreview(prompt: string): string {
+  const compact = prompt.replace(/\s+/g, ' ').trim();
+  return compact.length > 160 ? `${compact.slice(0, 157)}...` : compact;
+}
+
+function mergeUnique(
+  base: readonly string[],
+  next: readonly string[],
+): string[] {
+  const out = new Set<string>();
+  for (const item of [...base, ...next]) {
+    const value = item.trim();
+    if (value) out.add(value);
+  }
+  return [...out];
+}

--- a/apps/core/src/cli/index.ts
+++ b/apps/core/src/cli/index.ts
@@ -55,6 +55,7 @@ function usage(): string {
     '  myclaw conversation info|approvers',
     '  myclaw agent list|info|add|remove|trigger|dm-access|policy',
     '  myclaw browser profiles|status',
+    '  myclaw jobs list|show',
     '  myclaw model list|set-default|doctor',
     '  myclaw settings export-current|drift',
     '  myclaw service install|start|stop|restart',
@@ -446,6 +447,11 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (command === 'model') {
     const { runModelCommand } = await import('./model.js');
     return runModelCommand(runtimeHome, rest);
+  }
+
+  if (command === 'jobs') {
+    const { runJobsCommand } = await import('./jobs.js');
+    return runJobsCommand(runtimeHome, rest);
   }
 
   if (command === 'settings') {

--- a/apps/core/src/cli/jobs.ts
+++ b/apps/core/src/cli/jobs.ts
@@ -1,0 +1,107 @@
+import * as p from '@clack/prompts';
+
+import { controlApiRequest } from './control-api.js';
+
+interface JobRecord {
+  jobId: string;
+  name: string;
+  kind: string;
+  status: string;
+  groupScope: string;
+  threadId: string | null;
+  nextRun: string | null;
+  lastRun: string | null;
+  modelAlias: string | null;
+  prompt: string;
+}
+
+export async function runJobsCommand(
+  runtimeHome: string,
+  args: string[],
+): Promise<number> {
+  const [action, maybeJobId, ...rest] = args;
+  if (action === 'list') return listJobs(runtimeHome, [maybeJobId, ...rest]);
+  if (action === 'show' && maybeJobId) return showJob(runtimeHome, maybeJobId);
+  p.log.error('Usage: myclaw jobs list|show <job_id>');
+  return 1;
+}
+
+async function listJobs(runtimeHome: string, args: string[]): Promise<number> {
+  const params = new URLSearchParams();
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg) continue;
+    const next = args[index + 1];
+    if (arg === '--agent' && next) {
+      params.set('agentId', next);
+      index += 1;
+    } else if (arg === '--group' && next) {
+      params.set('groupScope', next);
+      index += 1;
+    } else if (arg === '--conversation' && next) {
+      params.set('conversationJid', next);
+      index += 1;
+    } else if (arg === '--kind' && next) {
+      params.set('kind', next);
+      index += 1;
+    } else if (arg === '--status' && next) {
+      params.append('status', next);
+      index += 1;
+    } else if (arg === '--limit' && next) {
+      params.set('limit', next);
+      index += 1;
+    }
+  }
+  const response = (await controlApiRequest(runtimeHome, {
+    method: 'GET',
+    path: `/v1/jobs${params.toString() ? `?${params}` : ''}`,
+  })) as { jobs?: JobRecord[] };
+  const jobs = response.jobs ?? [];
+  if (jobs.length === 0) {
+    p.note('No jobs found.', 'Jobs');
+    return 0;
+  }
+  p.note(formatJobTable(jobs), 'Jobs');
+  return 0;
+}
+
+async function showJob(runtimeHome: string, jobId: string): Promise<number> {
+  const job = (await controlApiRequest(runtimeHome, {
+    method: 'GET',
+    path: `/v1/jobs/${encodeURIComponent(jobId)}`,
+  })) as Record<string, unknown>;
+  p.note(JSON.stringify(job, null, 2), `Job ${jobId}`);
+  return 0;
+}
+
+function formatJobTable(jobs: JobRecord[]): string {
+  const rows = jobs.map((job) => [
+    job.jobId,
+    job.kind,
+    job.status,
+    job.groupScope,
+    job.threadId ?? '',
+    job.nextRun ?? '',
+    job.name,
+  ]);
+  const headers = [
+    'ID',
+    'Kind',
+    'Status',
+    'Group',
+    'Thread',
+    'Next run',
+    'Name',
+  ];
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index].length)),
+  );
+  return [headers, ...rows]
+    .map((row) =>
+      row
+        .map((cell, index) => cell.padEnd(widths[index]))
+        .join('  ')
+        .trimEnd(),
+    )
+    .join('\n');
+}

--- a/apps/core/src/control/server/app-identity.ts
+++ b/apps/core/src/control/server/app-identity.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import type { Job, RegisteredGroup } from '../../domain/types.js';
+import type { JobVisibilityMetadata } from '../../application/jobs/job-visibility-metadata.js';
 import type { getRuntimeControlRepository } from '../../adapters/storage/postgres/runtime-store.js';
 import { nowIso as runtimeNowIso } from '../../infrastructure/time/datetime.js';
 import { resolveAppScopeAppId as applicationResolveAppScopeAppId } from '../../application/app-scope/resolve-app-scope.js';
@@ -120,13 +121,20 @@ export async function resolveOwnedWebhookId(
   return webhook.webhookId;
 }
 
-export function mapManualJobToStored(job: Job): Record<string, unknown> {
+export function mapManualJobToStored(
+  job: Job,
+  metadata?: JobVisibilityMetadata,
+  options: { detail?: boolean } = { detail: true },
+): Record<string, unknown> {
   const isManual = job.schedule_type === 'manual';
   const resolvedModel = resolveModelSelection(job.model);
+  const detail = options.detail !== false;
   return {
     jobId: job.id,
     name: job.name,
-    prompt: job.prompt,
+    ...(detail ? { prompt: job.prompt } : {}),
+    promptPreview: metadata?.promptPreview ?? previewPrompt(job.prompt),
+    ...(detail ? { fullPrompt: metadata?.fullPrompt ?? job.prompt } : {}),
     kind: isManual
       ? 'manual'
       : job.schedule_type === 'once'
@@ -160,5 +168,48 @@ export function mapManualJobToStored(job: Job): Record<string, unknown> {
     threadId: job.thread_id,
     groupScope: job.group_scope,
     sessionId: job.session_id,
+    target: metadata?.target ?? {
+      appId: resolveJobRuntimeAppId(job),
+      agentId: job.group_scope.startsWith('agent:')
+        ? job.group_scope
+        : `agent:${job.group_scope}`,
+      groupScope: job.group_scope,
+      conversationJids: job.linked_sessions,
+      threadId: job.thread_id,
+    },
+    notificationTarget: metadata?.notificationTarget ?? {
+      linkedSessions: job.linked_sessions,
+      threadId: job.thread_id,
+      silent: job.silent,
+    },
+    ...(detail
+      ? {
+          inheritedTools: metadata?.inheritedTools ?? [],
+          jobExtraTools:
+            metadata?.jobExtraTools ??
+            job.capability_policy?.allowed_tools ??
+            [],
+          effectiveAllowedTools:
+            metadata?.effectiveAllowedTools ??
+            job.capability_policy?.allowed_tools ??
+            [],
+          recentRunErrors: metadata?.recentRunErrors ?? [],
+        }
+      : {
+          inheritedToolCount: metadata?.inheritedToolCount ?? 0,
+          jobExtraToolCount:
+            metadata?.jobExtraToolCount ??
+            job.capability_policy?.allowed_tools?.length ??
+            0,
+          effectiveAllowedToolCount:
+            metadata?.effectiveAllowedToolCount ??
+            job.capability_policy?.allowed_tools?.length ??
+            0,
+        }),
   };
+}
+
+function previewPrompt(prompt: string): string {
+  const compact = prompt.replace(/\s+/g, ' ').trim();
+  return compact.length > 160 ? `${compact.slice(0, 157)}...` : compact;
 }

--- a/apps/core/src/control/server/routes/jobs.ts
+++ b/apps/core/src/control/server/routes/jobs.ts
@@ -9,6 +9,11 @@ import type { ZodIssue } from 'zod';
 
 import { ApplicationError } from '../../../application/common/application-error.js';
 import { JobManagementService } from '../../../application/jobs/job-management-service.js';
+import {
+  buildJobListVisibilityMetadata,
+  buildJobVisibilityMetadata,
+} from '../../../application/jobs/job-visibility-metadata.js';
+import { getRuntimeToolRepositoryIfReady } from '../../../adapters/storage/postgres/job-tool-repository-runtime.js';
 import type {
   AppSessionRecord,
   JobControlPort,
@@ -131,6 +136,7 @@ export function createJobManagementService() {
     ops: getRuntimeOpsRepository(),
     control: adaptJobControl(control),
     runtimeEvents: getRuntimeEventExchange(),
+    toolRepository: getRuntimeToolRepositoryIfReady(),
     scheduler: { requestSchedulerSync },
     schedulePlanner: runtimeJobSchedulePlanner,
     clock: { now: nowIso },
@@ -270,6 +276,20 @@ function resolveCreateJobModel(input: {
   };
 }
 
+function parseJobKind(
+  value: string | null,
+): 'manual' | 'once' | 'recurring' | undefined {
+  return value === 'manual' || value === 'once' || value === 'recurring'
+    ? value
+    : undefined;
+}
+
+function parsePositiveInt(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
 export async function handleJobRoutes(
   req: IncomingMessage,
   res: ServerResponse,
@@ -306,6 +326,7 @@ export async function handleJobRoutes(
         modelAlias: resolvedModel.explicit
           ? resolvedModel.modelAlias
           : undefined,
+        allowedTools: body.allowedTools,
         dryRun: body.dryRun,
       });
       sendJson(res, body.dryRun === true ? 200 : 201, {
@@ -334,11 +355,24 @@ export async function handleJobRoutes(
   if (pathname === '/v1/jobs' && req.method === 'GET') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['jobs:read']);
     if (!auth) return true;
-    const { jobs: visibleJobs } = await createJobManagementService().listJobs({
+    const service = createJobManagementService();
+    const { jobs: visibleJobs } = await service.listJobs({
       appId: auth.appId,
+      statuses: url.searchParams.getAll('status'),
+      groupScope: url.searchParams.get('groupScope') || undefined,
+      agentId: url.searchParams.get('agentId') || undefined,
+      kind: parseJobKind(url.searchParams.get('kind')),
+      conversationJid: url.searchParams.get('conversationJid') || undefined,
+      limit: parsePositiveInt(url.searchParams.get('limit')),
+    });
+    const metadata = await buildJobListVisibilityMetadata({
+      jobs: visibleJobs,
+      toolRepository: getRuntimeToolRepositoryIfReady(),
     });
     sendJson(res, 200, {
-      jobs: visibleJobs.map((job) => mapManualJobToStored(job)),
+      jobs: visibleJobs.map((job) =>
+        mapManualJobToStored(job, metadata.get(job.id), { detail: false }),
+      ),
     });
     return true;
   }
@@ -348,7 +382,8 @@ export async function handleJobRoutes(
     const auth = authorizeControlRequest(req, res, ctx.keys, ['jobs:read']);
     if (!auth) return true;
     try {
-      const { job } = await createJobManagementService().getJob({
+      const service = createJobManagementService();
+      const { job } = await service.getJob({
         appId: auth.appId,
         jobId: jobRoute.jobId,
       });
@@ -356,7 +391,18 @@ export async function handleJobRoutes(
         sendError(res, 404, 'JOB_NOT_FOUND', 'Job not found');
         return true;
       }
-      sendJson(res, 200, mapManualJobToStored(job));
+      sendJson(
+        res,
+        200,
+        mapManualJobToStored(
+          job,
+          await buildJobVisibilityMetadata({
+            job,
+            ops: getRuntimeOpsRepository(),
+            toolRepository: getRuntimeToolRepositoryIfReady(),
+          }),
+        ),
+      );
     } catch (error) {
       if (!sendApplicationError(res, error)) throw error;
     }
@@ -389,7 +435,8 @@ export async function handleJobRoutes(
         body.modelAlias,
         body.modelProfileId,
       );
-      const { job: updated } = await createJobManagementService().updateJob({
+      const service = createJobManagementService();
+      const { job: updated } = await service.updateJob({
         appId: auth.appId,
         jobId: jobRoute.jobId,
         patch: {
@@ -403,12 +450,26 @@ export async function handleJobRoutes(
             ? { threadId: body.threadId }
             : {}),
           ...(requestedModel.specified ? { model: requestedModel.model } : {}),
+          ...(Array.isArray(body.allowedTools)
+            ? { allowedTools: body.allowedTools }
+            : {}),
           ...(body.status === 'active' || body.status === 'paused'
             ? { status: body.status }
             : {}),
         },
       });
-      sendJson(res, 200, mapManualJobToStored(updated));
+      sendJson(
+        res,
+        200,
+        mapManualJobToStored(
+          updated,
+          await buildJobVisibilityMetadata({
+            job: updated,
+            ops: getRuntimeOpsRepository(),
+            toolRepository: getRuntimeToolRepositoryIfReady(),
+          }),
+        ),
+      );
     } catch (error) {
       if (!sendApplicationError(res, error)) throw error;
     }

--- a/apps/core/src/domain/events/runtime-event-types.ts
+++ b/apps/core/src/domain/events/runtime-event-types.ts
@@ -9,6 +9,7 @@ export const RUNTIME_EVENT_TYPES = {
   JOB_RUN_STARTED: 'job.run.started',
   JOB_STARTED: 'job.started',
   JOB_STREAMING: 'job.streaming',
+  JOB_TOOL_DENIED: 'job.tool_denied',
   JOB_COMPLETED: 'job.completed',
   JOB_FAILED: 'job.failed',
   JOB_RUN_COMPLETED: 'job.run.completed',

--- a/apps/core/src/domain/repositories/ops-repo.ts
+++ b/apps/core/src/domain/repositories/ops-repo.ts
@@ -36,6 +36,7 @@ export interface JobUpsertInput {
   lease_run_id?: string | null;
   lease_expires_at?: string | null;
   pause_reason?: string | null;
+  capability_policy?: Job['capability_policy'];
 }
 
 export interface JobListFilters {
@@ -43,6 +44,11 @@ export interface JobListFilters {
   statuses?: string[];
   groupScope?: string;
   threadId?: string | null;
+  agentId?: string;
+  kind?: 'manual' | 'once' | 'recurring';
+  conversationJid?: string;
+  allowedConversationJids?: string[];
+  limit?: number;
 }
 
 export interface JobRunListFilters {

--- a/apps/core/src/domain/types.ts
+++ b/apps/core/src/domain/types.ts
@@ -124,6 +124,9 @@ export interface Job {
   lease_run_id: string | null;
   lease_expires_at: string | null;
   pause_reason: string | null;
+  capability_policy?: {
+    allowed_tools: string[];
+  };
 }
 
 export type JobRunStatus =

--- a/apps/core/src/jobs/execution-notifications.ts
+++ b/apps/core/src/jobs/execution-notifications.ts
@@ -1,0 +1,60 @@
+import type { Job, JobRunStatus } from '../domain/types.js';
+import type { SchedulerSendMessage } from './delivery.js';
+import { notifyLinkedSessions } from './delivery.js';
+import { formatRunStatusMessage } from './status-formatting.js';
+import { MEMORY_DREAM_SYSTEM_PROMPT } from './system-jobs.js';
+
+export function logMemoryDreamJobFailure(input: {
+  job: Job;
+  runId: string;
+  error: string | null;
+  logger: {
+    error(payload: Record<string, unknown>, message: string): void;
+  };
+}): void {
+  if (!input.error || input.job.prompt !== MEMORY_DREAM_SYSTEM_PROMPT) return;
+  input.logger.error(
+    {
+      jobId: input.job.id,
+      groupScope: input.job.group_scope,
+      runId: input.runId,
+      error: input.error,
+    },
+    'Memory dreaming system job failed',
+  );
+}
+
+export async function notifySchedulerRunFailure(input: {
+  job: Job;
+  runId: string;
+  runStatus: Extract<JobRunStatus, 'failed' | 'timeout' | 'dead_lettered'>;
+  summary: string;
+  nextRun: string | null;
+  retryCount: number;
+  pauseReason: string | null;
+  sendMessage: SchedulerSendMessage;
+  deliverMessage: (text: string) => Promise<boolean>;
+  error: string | null;
+}): Promise<boolean> {
+  let notified = false;
+  if (input.error && !input.job.silent) {
+    notified =
+      (await input.deliverMessage(
+        `⚠️ Scheduled task failed: ${input.summary}`,
+      )) || notified;
+  }
+  if (input.job.silent) return notified;
+  const message = formatRunStatusMessage({
+    job: input.job,
+    runId: input.runId,
+    runStatus: input.runStatus,
+    summary: input.summary,
+    nextRun: input.nextRun,
+    retryCount: input.retryCount,
+    pauseReason: input.pauseReason,
+  });
+  return (
+    (await notifyLinkedSessions(input.job, message, input.sendMessage)) ||
+    notified
+  );
+}

--- a/apps/core/src/jobs/execution-tool-policy.ts
+++ b/apps/core/src/jobs/execution-tool-policy.ts
@@ -1,0 +1,14 @@
+import type { Job } from '../domain/types.js';
+import type { ToolCatalogRepository } from '../domain/ports/repositories.js';
+import { resolveJobToolPolicy } from '../application/jobs/job-tool-policy.js';
+
+export async function resolveExecutionAllowedTools(input: {
+  job: Job;
+  appId?: string;
+  agentId?: string;
+  isMain: boolean;
+  toolRepository?: ToolCatalogRepository;
+}): Promise<string[]> {
+  const policy = await resolveJobToolPolicy(input);
+  return policy.effectiveAllowedTools;
+}

--- a/apps/core/src/jobs/execution.ts
+++ b/apps/core/src/jobs/execution.ts
@@ -8,6 +8,7 @@ import {
   getRuntimeEventExchange,
 } from '../adapters/storage/postgres/runtime-store.js';
 import { resolveJobRuntimeAppId } from '../application/jobs/job-access.js';
+import { agentIdForJobGroupScope } from '../application/jobs/job-tool-policy.js';
 import {
   RUNTIME_EVENT_TYPES,
   type RuntimeEventType,
@@ -27,14 +28,16 @@ import {
   collectCompactBoundaryMemory,
   collectJobCompletionMemory,
 } from './compact-memory.js';
-import { notifyLinkedSessions } from './delivery.js';
 import { normalizeCleanupAfterMs } from './cleanup.js';
 import {
   resolveExecutionContext,
   resolveExecutionMemoryContext,
 } from './execution-context.js';
 import { computeNextJobRun } from './schedule-math.js';
-import { formatRunStatusMessage } from './status-formatting.js';
+import {
+  logMemoryDreamJobFailure,
+  notifySchedulerRunFailure,
+} from './execution-notifications.js';
 import { handleSystemJob, MEMORY_DREAM_SYSTEM_PROMPT } from './system-jobs.js';
 import {
   buildJobStreamingOptions,
@@ -49,6 +52,7 @@ import {
   resolveJobModel,
   type NormalizedModelUsage,
 } from './model-resolution.js';
+import { resolveExecutionAllowedTools } from './execution-tool-policy.js';
 import {
   resolveAppSessionForJob,
   resolveAppSessionForTrigger,
@@ -375,6 +379,15 @@ export async function runJob(
           chatJid: execution.executionJid,
           threadId: currentJob.thread_id ?? null,
         });
+        const effectiveAllowedTools = await resolveExecutionAllowedTools({
+          job: currentJob,
+          appId: turnContext?.appId ?? runtimeAppId,
+          agentId:
+            turnContext?.agentId ??
+            agentIdForJobGroupScope(execution.group.folder),
+          isMain,
+          toolRepository: deps.getToolRepository?.(),
+        });
         agentRunId = turnContext?.agentSessionId
           ? await deps.opsRepository.createSessionAgentRun?.({
               agentSessionId: turnContext.agentSessionId,
@@ -398,6 +411,7 @@ export async function runJob(
             assistantName: ASSISTANT_NAME,
             script: currentJob.script || undefined,
             memoryContextBlock: turnContext?.memoryContextBlock,
+            allowedTools: effectiveAllowedTools,
           },
           (proc, runHandle) =>
             deps.onProcess(
@@ -593,47 +607,32 @@ export async function runJob(
     retry_count: retryCount,
     pause_reason: pauseReason,
   });
+  if (error?.includes('tool not on autonomous job allowlist'))
+    await emitJobEvent(RUNTIME_EVENT_TYPES.JOB_TOOL_DENIED, {
+      error_summary: error.slice(0, 500),
+    });
 
   const summary = error
     ? error.slice(0, 240)
     : resultSummary
       ? resultSummary.slice(0, 4000)
       : 'Completed';
-  if (error && currentJob.prompt === MEMORY_DREAM_SYSTEM_PROMPT) {
-    logger.error(
-      {
-        jobId: currentJob.id,
-        groupScope: currentJob.group_scope,
-        runId,
-        error,
-      },
-      'Memory dreaming system job failed',
-    );
-  }
-  let notified = false;
-  if (error && !currentJob.silent) {
-    const delivered = await deliverMessage(
-      `⚠️ Scheduled task failed: ${summary}`,
-    );
-    notified = notified || delivered;
-  }
-  if (runStatus !== 'completed' && !currentJob.silent) {
-    const message = formatRunStatusMessage({
-      job: currentJob,
-      runId,
-      runStatus,
-      summary,
-      nextRun,
-      retryCount,
-      pauseReason,
-    });
-    const delivered = await notifyLinkedSessions(
-      currentJob,
-      message,
-      deps.sendMessage,
-    );
-    notified = notified || delivered;
-  }
+  logMemoryDreamJobFailure({ job: currentJob, runId, error, logger });
+  const notified =
+    runStatus === 'completed'
+      ? false
+      : await notifySchedulerRunFailure({
+          job: currentJob,
+          runId,
+          runStatus,
+          summary,
+          nextRun,
+          retryCount,
+          pauseReason,
+          sendMessage: deps.sendMessage,
+          deliverMessage,
+          error,
+        });
   if (notified) {
     await deps.opsRepository.markJobRunNotified(runId);
   }

--- a/apps/core/src/jobs/ipc-handler.ts
+++ b/apps/core/src/jobs/ipc-handler.ts
@@ -6,7 +6,10 @@ import { schedulerMutateTaskHandlers } from './ipc-scheduler-mutate-handlers.js'
 import { schedulerQueryTaskHandlers } from './ipc-scheduler-query-handlers.js';
 import { TaskHandler, TaskIpcData } from './ipc-types.js';
 import { writeTaskIpcResponse } from './ipc-shared.js';
-import { getRuntimeOpsRepository } from '../adapters/storage/postgres/runtime-store.js';
+import {
+  getRuntimeOpsRepository,
+  getRuntimeStorage,
+} from '../adapters/storage/postgres/runtime-store.js';
 
 const taskHandlers: Record<string, TaskHandler> = {
   ...schedulerCreateTaskHandlers,
@@ -47,6 +50,15 @@ export async function processTaskIpc(
   const resolvedDeps = {
     ...deps,
     opsRepository: deps.opsRepository ?? getRuntimeOpsRepository(),
+    getToolRepository:
+      deps.getToolRepository ??
+      (() => {
+        try {
+          return getRuntimeStorage().repositories.tools;
+        } catch {
+          return undefined;
+        }
+      }),
   };
 
   try {

--- a/apps/core/src/jobs/ipc-scheduler-approval-target.ts
+++ b/apps/core/src/jobs/ipc-scheduler-approval-target.ts
@@ -1,0 +1,35 @@
+import type { TaskContext } from './ipc-types.js';
+import { toTrimmedString } from './ipc-shared.js';
+
+export function resolveSchedulerApprovalTarget(
+  context: TaskContext,
+): { ok: true; targetJid: string } | { ok: false; reason: string } {
+  const requestedTargetJid = toTrimmedString(context.data.chatJid, {
+    maxLen: 512,
+  });
+  const targetOverride = toTrimmedString(
+    context.data.targetJid || context.data.jid,
+    { maxLen: 512 },
+  );
+
+  if (targetOverride && targetOverride !== requestedTargetJid) {
+    return {
+      ok: false,
+      reason:
+        'scheduler job tool approval must use the originating chat as the approval target',
+    };
+  }
+
+  if (
+    !requestedTargetJid ||
+    !context.sourceGroupJids.includes(requestedTargetJid)
+  ) {
+    return {
+      ok: false,
+      reason:
+        'scheduler job tool approval requires an originating chat for this agent',
+    };
+  }
+
+  return { ok: true, targetJid: requestedTargetJid };
+}

--- a/apps/core/src/jobs/ipc-scheduler-create-handlers.ts
+++ b/apps/core/src/jobs/ipc-scheduler-create-handlers.ts
@@ -1,4 +1,7 @@
+import { randomUUID } from 'node:crypto';
+
 import { JobManagementService } from '../application/jobs/job-management-service.js';
+import type { JobExtraToolApprovalRequest } from '../application/jobs/job-management-types.js';
 import type { JobScheduleType } from '../domain/types.js';
 import { logger } from '../infrastructure/logging/logger.js';
 import { TaskHandler, TaskContext } from './ipc-types.js';
@@ -12,13 +15,51 @@ import {
   resolveModelSelection,
 } from '../shared/model-catalog.js';
 import { formatBrowserProfileLabel } from '../shared/browser-profile-scope.js';
+import { resolveSchedulerApprovalTarget } from './ipc-scheduler-approval-target.js';
 
 function makeJobService(context: TaskContext): JobManagementService {
   return new JobManagementService({
     ops: context.deps.opsRepository,
     scheduler: { requestSchedulerSync: context.deps.onSchedulerChanged },
     schedulePlanner: runtimeJobSchedulePlanner,
+    toolRepository: context.deps.getToolRepository?.(),
+    approveJobExtraTools: (request) =>
+      requestJobExtraToolApproval(context, request),
   });
+}
+
+async function requestJobExtraToolApproval(
+  context: TaskContext,
+  request: JobExtraToolApprovalRequest,
+): Promise<{ approved: boolean; reason?: string }> {
+  const approvalTarget = resolveSchedulerApprovalTarget(context);
+  if (!approvalTarget.ok) {
+    return { approved: false, reason: approvalTarget.reason };
+  }
+  const decision = await context.deps.requestPermissionApproval({
+    requestId: `job-tools-${randomUUID()}`,
+    sourceGroup: context.sourceGroup,
+    targetJid: approvalTarget.targetJid,
+    threadId: context.data.authThreadId,
+    decisionPolicy: 'same_channel',
+    toolName: 'scheduler_job_tools',
+    displayName: 'Autonomous job tools',
+    title: 'Approve job-scoped autonomous tools',
+    description:
+      'Approving stores these extra tool rules on this scheduler job only. Future runs still inherit the target agent tools dynamically.',
+    decisionReason: `${request.operation === 'create' ? 'Create' : 'Update'} scheduler job ${request.jobName} with job-scoped extra tools.`,
+    toolInput: {
+      jobId: request.jobId,
+      target: request.target,
+      inheritedTools: request.inheritedTools,
+      existingJobExtraTools: request.existingJobExtraTools,
+      requestedJobExtraTools: request.requestedJobExtraTools,
+      extrasBeyondInherited: request.extrasBeyondInherited,
+      persistence: 'target_json.capabilityPolicy.allowedTools',
+    },
+    decisionOptions: ['allow_once', 'cancel'],
+  });
+  return { approved: decision.approved, reason: decision.reason };
 }
 
 function scheduleType(raw: unknown): JobScheduleType | undefined {
@@ -91,6 +132,7 @@ const schedulerUpsertJobHandler: TaskHandler = async (context) => {
       serialize: data.serialize,
       groupScope: data.groupScope,
       createdBy: data.createdBy,
+      allowedTools: data.allowedTools,
     });
 
     logger.info(

--- a/apps/core/src/jobs/ipc-scheduler-mutate-handlers.ts
+++ b/apps/core/src/jobs/ipc-scheduler-mutate-handlers.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from 'node:crypto';
+
 import { ApplicationError } from '../application/common/application-error.js';
 import { JobManagementService } from '../application/jobs/job-management-service.js';
+import type { JobExtraToolApprovalRequest } from '../application/jobs/job-management-types.js';
 import type { JobExecutionMode, JobScheduleType } from '../domain/types.js';
 import { logger } from '../infrastructure/logging/logger.js';
 import { TaskContext, TaskHandler } from './ipc-types.js';
@@ -12,13 +15,51 @@ import { mapApplicationError } from './ipc-application-error.js';
 import { runtimeJobSchedulePlanner } from './job-schedule-planner.js';
 import { invalidateSystemJobRegistrationSignature } from './system-registration-cache.js';
 import { resolveRequestedJobModelPatch } from '../application/jobs/job-model-selection.js';
+import { resolveSchedulerApprovalTarget } from './ipc-scheduler-approval-target.js';
 
 function makeJobService(context: TaskContext): JobManagementService {
   return new JobManagementService({
     ops: context.deps.opsRepository,
     scheduler: { requestSchedulerSync: context.deps.onSchedulerChanged },
     schedulePlanner: runtimeJobSchedulePlanner,
+    toolRepository: context.deps.getToolRepository?.(),
+    approveJobExtraTools: (request) =>
+      requestJobExtraToolApproval(context, request),
   });
+}
+
+async function requestJobExtraToolApproval(
+  context: TaskContext,
+  request: JobExtraToolApprovalRequest,
+): Promise<{ approved: boolean; reason?: string }> {
+  const approvalTarget = resolveSchedulerApprovalTarget(context);
+  if (!approvalTarget.ok) {
+    return { approved: false, reason: approvalTarget.reason };
+  }
+  const decision = await context.deps.requestPermissionApproval({
+    requestId: `job-tools-${randomUUID()}`,
+    sourceGroup: context.sourceGroup,
+    targetJid: approvalTarget.targetJid,
+    threadId: context.data.authThreadId,
+    decisionPolicy: 'same_channel',
+    toolName: 'scheduler_job_tools',
+    displayName: 'Autonomous job tools',
+    title: 'Approve job-scoped autonomous tools',
+    description:
+      'Approving stores these extra tool rules on this scheduler job only. Future runs still inherit the target agent tools dynamically.',
+    decisionReason: `Update scheduler job ${request.jobName} with job-scoped extra tools.`,
+    toolInput: {
+      jobId: request.jobId,
+      target: request.target,
+      inheritedTools: request.inheritedTools,
+      existingJobExtraTools: request.existingJobExtraTools,
+      requestedJobExtraTools: request.requestedJobExtraTools,
+      extrasBeyondInherited: request.extrasBeyondInherited,
+      persistence: 'target_json.capabilityPolicy.allowedTools',
+    },
+    decisionOptions: ['allow_once', 'cancel'],
+  });
+  return { approved: decision.approved, reason: decision.reason };
 }
 
 function accessFromContext(context: TaskContext) {
@@ -145,6 +186,9 @@ const schedulerUpdateJobHandler: TaskHandler = async (context) => {
           ? data.deliverTo
           : data.linkedSessions || []
       ).map((item) => String(item));
+    }
+    if (Array.isArray(data.allowedTools)) {
+      patch.allowedTools = data.allowedTools.map((item) => String(item));
     }
 
     await makeJobService(context).updateJob({

--- a/apps/core/src/jobs/ipc-scheduler-query-handlers.ts
+++ b/apps/core/src/jobs/ipc-scheduler-query-handlers.ts
@@ -1,4 +1,8 @@
 import { JobManagementService } from '../application/jobs/job-management-service.js';
+import {
+  buildJobListVisibilityMetadata,
+  buildJobVisibilityMetadata,
+} from '../application/jobs/job-visibility-metadata.js';
 import { logger } from '../infrastructure/logging/logger.js';
 import { TaskContext, TaskHandler } from './ipc-types.js';
 import { mapApplicationError } from './ipc-application-error.js';
@@ -10,6 +14,7 @@ function makeJobService(context: TaskContext): JobManagementService {
     ops: context.deps.opsRepository,
     scheduler: { requestSchedulerSync: context.deps.onSchedulerChanged },
     schedulePlanner: runtimeJobSchedulePlanner,
+    toolRepository: context.deps.getToolRepository?.(),
   });
 }
 
@@ -36,13 +41,27 @@ const schedulerGetJobHandler: TaskHandler = async (context) => {
     return;
   }
   try {
-    const result = await makeJobService(context).getJob({
+    const service = makeJobService(context);
+    const result = await service.getJob({
       jobId,
       access: accessFromContext(context),
     });
+    const data = result.job
+      ? {
+          job: {
+            ...result.job,
+            visibility: await buildJobVisibilityMetadata({
+              job: result.job,
+              ops: context.deps.opsRepository,
+              toolRepository: context.deps.getToolRepository?.(),
+              isMain: context.isMain,
+            }),
+          },
+        }
+      : result;
     acceptData(
       result.job ? `Loaded scheduler job (${jobId}).` : 'Job not found.',
-      result,
+      data,
     );
   } catch (err) {
     const mapped = mapApplicationError(err, 'Failed to query scheduler jobs.');
@@ -59,13 +78,34 @@ const schedulerListJobsHandler: TaskHandler = async (context) => {
     data.authThreadId,
   );
   try {
-    const result = await makeJobService(context).listJobs({
+    const service = makeJobService(context);
+    const result = await service.listJobs({
       access: accessFromContext(context),
       statuses: Array.isArray(data.statuses) ? data.statuses : undefined,
       groupScope:
         toTrimmedString(data.groupScope, { maxLen: 128 }) || undefined,
+      kind:
+        data.kind === 'manual' ||
+        data.kind === 'once' ||
+        data.kind === 'recurring'
+          ? data.kind
+          : undefined,
+      conversationJid:
+        toTrimmedString(data.conversationJid, { maxLen: 256 }) || undefined,
+      limit: data.limit,
     });
-    acceptData(`Listed ${result.jobs.length} scheduler job(s).`, result);
+    const metadata = await buildJobListVisibilityMetadata({
+      jobs: result.jobs,
+      toolRepository: context.deps.getToolRepository?.(),
+      isMain: context.isMain,
+    });
+    acceptData(`Listed ${result.jobs.length} scheduler job(s).`, {
+      jobs: result.jobs.map(({ prompt: _prompt, ...job }) => ({
+        ...job,
+        prompt_preview: metadata.get(job.id)?.promptPreview,
+        visibility: metadata.get(job.id),
+      })),
+    });
   } catch (err) {
     const mapped = mapApplicationError(err, 'Failed to query scheduler jobs.');
     logger.error({ err, sourceGroup }, 'scheduler_list_jobs failed');

--- a/apps/core/src/jobs/ipc-types.ts
+++ b/apps/core/src/jobs/ipc-types.ts
@@ -27,7 +27,10 @@ export interface TaskIpcData {
   maxConsecutiveFailures?: number;
   executionMode?: string;
   serialize?: boolean;
+  allowedTools?: string[];
   statuses?: string[];
+  kind?: 'manual' | 'once' | 'recurring';
+  conversationJid?: string;
   runId?: string;
   eventType?: string;
   sinceId?: number;

--- a/apps/core/src/jobs/types.ts
+++ b/apps/core/src/jobs/types.ts
@@ -9,6 +9,7 @@ import type { GroupQueue } from '../runtime/group-queue.js';
 import type { spawnAgent } from '../runtime/agent-spawn.js';
 import type { SchedulerSendMessage } from './delivery.js';
 import type { SessionMemoryCollector } from '../domain/ports/session-memory-collector.js';
+import type { ToolCatalogRepository } from '../domain/ports/repositories.js';
 
 export interface SchedulerDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
@@ -31,6 +32,7 @@ export interface SchedulerDependencies {
   runAgent?: typeof spawnAgent;
   collectSessionMemory?: SessionMemoryCollector;
   opsRepository: OpsRepository;
+  getToolRepository?: () => ToolCatalogRepository | undefined;
 }
 
 export type JobTurnContext = Awaited<

--- a/apps/core/src/runner/claude/query-loop.ts
+++ b/apps/core/src/runner/claude/query-loop.ts
@@ -40,6 +40,7 @@ import {
 } from '../../shared/model-catalog.js';
 import { validateAgentToolInput } from './agent-model-selection.js';
 import { usageEventIdForMessage } from './query-usage-event-id.js';
+import { anyToolRuleMatches } from '../../shared/tool-rule-matcher.js';
 
 export async function runQuery(
   prompt: string,
@@ -191,10 +192,6 @@ export async function runQuery(
           };
         }
 
-        if (capabilities.alwaysAllowedTools.includes(toolName)) {
-          return { behavior: 'allow' as const, updatedInput: input };
-        }
-
         const memoryGuardDenial = denyMemoryBoundaryToolUse(
           toolName,
           input,
@@ -210,6 +207,24 @@ export async function runQuery(
             message: memoryGuardDenial,
             interrupt: false,
           };
+        }
+
+        if (agentInput.isScheduledJob) {
+          if (anyToolRuleMatches(agentInput.allowedTools ?? [], toolName)) {
+            log(`Autonomous job allowed tool ${toolName}`);
+            return { behavior: 'allow' as const, updatedInput: input };
+          }
+          const message = `tool not on autonomous job allowlist: ${toolName}`;
+          log(`Autonomous job denied tool ${toolName}`);
+          return {
+            behavior: 'deny' as const,
+            message,
+            interrupt: true,
+          };
+        }
+
+        if (capabilities.alwaysAllowedTools.includes(toolName)) {
+          return { behavior: 'allow' as const, updatedInput: input };
         }
 
         if (permissionOpts.signal.aborted) {

--- a/apps/core/src/runner/mcp/tools/scheduler-formatters.ts
+++ b/apps/core/src/runner/mcp/tools/scheduler-formatters.ts
@@ -1,0 +1,51 @@
+export function schedulerJobSummary(job: unknown): string {
+  const record =
+    typeof job === 'object' && job !== null ? (job as Record<string, any>) : {};
+  const visibility =
+    typeof record.visibility === 'object' && record.visibility !== null
+      ? (record.visibility as Record<string, any>)
+      : {};
+  const target =
+    typeof visibility.target === 'object' && visibility.target !== null
+      ? (visibility.target as Record<string, any>)
+      : {};
+  const recentErrors = Array.isArray(visibility.recentRunErrors)
+    ? visibility.recentRunErrors.length
+    : 0;
+  return [
+    `Job: ${String(record.name ?? record.id ?? 'unknown')}`,
+    `Target: ${String(target.agentId ?? record.group_scope ?? 'unknown')} in ${String(target.conversationJids?.[0] ?? 'no conversation')}`,
+    `Kind/status: ${String(record.schedule_type ?? 'unknown')} / ${String(record.status ?? 'unknown')}`,
+    `Next/last run: ${String(record.next_run ?? 'none')} / ${String(record.last_run ?? 'none')}`,
+    `Tools: inherited ${Array.isArray(visibility.inheritedTools) ? visibility.inheritedTools.length : 0}, job extra ${Array.isArray(visibility.jobExtraTools) ? visibility.jobExtraTools.length : 0}, effective ${Array.isArray(visibility.effectiveAllowedTools) ? visibility.effectiveAllowedTools.length : 0}`,
+    `Recent run errors: ${recentErrors}`,
+    '',
+    'Structured JSON:',
+    JSON.stringify(record, null, 2),
+  ].join('\n');
+}
+
+export function schedulerJobsSummary(jobs: unknown[]): string {
+  const lines = jobs.map((job) => {
+    const record =
+      typeof job === 'object' && job !== null
+        ? (job as Record<string, any>)
+        : {};
+    const visibility =
+      typeof record.visibility === 'object' && record.visibility !== null
+        ? (record.visibility as Record<string, any>)
+        : {};
+    const target =
+      typeof visibility.target === 'object' && visibility.target !== null
+        ? (visibility.target as Record<string, any>)
+        : {};
+    return `- ${String(record.id ?? 'unknown')} | ${String(record.name ?? '')} | ${String(record.schedule_type ?? '')} | ${String(record.status ?? '')} | ${String(target.agentId ?? record.group_scope ?? '')}`;
+  });
+  return [
+    `Scheduler jobs (${jobs.length})`,
+    ...lines,
+    '',
+    'Structured JSON:',
+    JSON.stringify(jobs, null, 2),
+  ].join('\n');
+}

--- a/apps/core/src/runner/mcp/tools/scheduler.ts
+++ b/apps/core/src/runner/mcp/tools/scheduler.ts
@@ -19,6 +19,11 @@ import {
   resolveSchedulerThreadArg,
 } from '../scheduler-utils.js';
 import { formatModelCatalog } from '../../../shared/model-catalog.js';
+import { chatJid, threadId } from '../context.js';
+import {
+  schedulerJobSummary,
+  schedulerJobsSummary,
+} from './scheduler-formatters.js';
 
 async function requestSchedulerData(
   type: string,
@@ -99,6 +104,7 @@ export function registerSchedulerTools(server: McpServer): void {
       max_consecutive_failures: z.number().optional(),
       execution_mode: z.enum(['parallel', 'serialized']).optional(),
       serialize: z.boolean().optional(),
+      allowed_tools: z.array(z.string()).optional(),
     },
     async (args) => {
       if (args.schedule_type === 'cron') {
@@ -173,6 +179,10 @@ export function registerSchedulerTools(server: McpServer): void {
           args.serialize,
         ),
         serialize: args.serialize,
+        allowedTools: args.allowed_tools,
+        targetJid: chatJid,
+        chatJid,
+        authThreadId: threadId,
         createdBy: 'agent',
         timestamp: nowIso(),
       };
@@ -213,7 +223,6 @@ export function registerSchedulerTools(server: McpServer): void {
       };
     },
   );
-
   server.tool(
     'scheduler_get_job',
     'Get one scheduler job by ID from the host scheduler.',
@@ -229,7 +238,7 @@ export function registerSchedulerTools(server: McpServer): void {
         content: [
           {
             type: 'text' as const,
-            text: job ? JSON.stringify(job, null, 2) : 'Job not found.',
+            text: job ? schedulerJobSummary(job) : 'Job not found.',
           },
         ],
       };
@@ -242,11 +251,17 @@ export function registerSchedulerTools(server: McpServer): void {
     {
       statuses: z.array(z.string()).optional(),
       group_scope: z.string().optional(),
+      kind: z.enum(['manual', 'once', 'recurring']).optional(),
+      conversation_jid: z.string().optional(),
+      limit: z.number().optional(),
     },
     async (args) => {
       const response = await requestSchedulerData('scheduler_list_jobs', {
         statuses: args.statuses,
         groupScope: args.group_scope,
+        kind: args.kind,
+        conversationJid: args.conversation_jid,
+        limit: args.limit,
       });
       const error = taskError(response, 'Scheduler list jobs failed.');
       if (error) return error;
@@ -254,7 +269,7 @@ export function registerSchedulerTools(server: McpServer): void {
       const result = Array.isArray(jobs) ? jobs : [];
       return {
         content: [
-          { type: 'text' as const, text: JSON.stringify(result, null, 2) },
+          { type: 'text' as const, text: schedulerJobsSummary(result) },
         ],
       };
     },
@@ -283,6 +298,7 @@ export function registerSchedulerTools(server: McpServer): void {
       max_consecutive_failures: z.number().optional(),
       execution_mode: z.enum(['parallel', 'serialized']).optional(),
       serialize: z.boolean().optional(),
+      allowed_tools: z.array(z.string()).optional(),
     },
     async (args) => {
       const executionMode =
@@ -321,6 +337,10 @@ export function registerSchedulerTools(server: McpServer): void {
         maxConsecutiveFailures: args.max_consecutive_failures,
         executionMode,
         serialize: args.serialize,
+        allowedTools: args.allowed_tools,
+        targetJid: chatJid,
+        chatJid,
+        authThreadId: threadId,
         timestamp: nowIso(),
       });
       const response = await waitForTaskResponse(taskId, 20_000);

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -343,6 +343,21 @@ export async function spawnAgent(
       ...allMcpCapabilities,
       ...browserProjection.mcpCapabilities,
     ];
+    if (
+      input.isScheduledJob &&
+      jobAllowsBrowserActions(input.allowedTools) &&
+      !allMcpCapabilities.some(
+        (capability) => capability.name === BROWSER_ACTION_MCP_SERVER_NAME,
+      )
+    ) {
+      claudeRuntimeMaterialization.cleanup();
+      return {
+        status: 'error',
+        result: null,
+        error:
+          'Browser tools are on the autonomous job allowlist, but the conversation browser is unavailable. Launch the browser for this agent conversation before running the job.',
+      };
+    }
   } catch (err) {
     claudeRuntimeMaterialization.cleanup();
     return {
@@ -425,6 +440,16 @@ export async function spawnAgent(
     cleanupRunnerMcpConfigFile(mcpConfigPath);
     claudeRuntimeMaterialization.cleanup();
   }
+}
+
+function jobAllowsBrowserActions(
+  allowedTools: readonly string[] | undefined,
+): boolean {
+  return (allowedTools ?? []).some(
+    (tool) =>
+      tool === `mcp__${BROWSER_ACTION_MCP_SERVER_NAME}__*` ||
+      tool.startsWith(`mcp__${BROWSER_ACTION_MCP_SERVER_NAME}__`),
+  );
 }
 
 function isOpenRouterBaseUrl(value?: string): boolean {

--- a/apps/core/src/runtime/group-processing-flow.ts
+++ b/apps/core/src/runtime/group-processing-flow.ts
@@ -1,0 +1,47 @@
+export async function handleFailure(input: {
+  outputSentToUser: boolean;
+  groupName: string;
+  queueJid: string;
+  previousCursor: string;
+  deps: {
+    setCursor: (chatJid: string, timestamp: string) => void;
+    saveState: () => Promise<void> | void;
+  };
+  logger: {
+    warn(payload: Record<string, unknown>, message: string): void;
+  };
+}): Promise<boolean> {
+  if (input.outputSentToUser) {
+    input.logger.warn(
+      { group: input.groupName },
+      'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
+    );
+    return true;
+  }
+  input.deps.setCursor(input.queueJid, input.previousCursor);
+  await input.deps.saveState();
+  input.logger.warn(
+    { group: input.groupName },
+    'Agent error, rolled back message cursor for retry',
+  );
+  return false;
+}
+
+export async function waitOutput(input: {
+  wait: () => Promise<void>;
+  getError: () => unknown;
+  hadError: boolean;
+  groupName: string;
+  logger: {
+    error(payload: Record<string, unknown>, message: string): void;
+  };
+}): Promise<boolean> {
+  await input.wait();
+  const err = input.getError();
+  if (!err) return input.hadError;
+  input.logger.error(
+    { group: input.groupName, err },
+    'Agent output callback failed',
+  );
+  return true;
+}

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -59,6 +59,7 @@ import {
   resolveTurnAllowedTools,
 } from './group-run-context.js';
 import { getGroupBrowserStatus } from './group-browser-status.js';
+import { handleFailure, waitOutput } from './group-processing-flow.js';
 import {
   createAdvanceCursorHandler,
   createArchiveCurrentSessionHandler,
@@ -675,15 +676,6 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         outputCallbackError ??= err;
       },
     });
-    const waitForAgentOutputCallbacks = async () => {
-      await outputCallbacks.wait();
-      if (!outputCallbackError) return;
-      hadError = true;
-      logger.error(
-        { group: group.name, err: outputCallbackError },
-        'Agent output callback failed',
-      );
-    };
     try {
       output = await runAgent(
         group,
@@ -700,7 +692,13 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         },
       );
     } finally {
-      await waitForAgentOutputCallbacks();
+      hadError = await waitOutput({
+        wait: outputCallbacks.wait,
+        getError: () => outputCallbackError,
+        hadError,
+        groupName: group.name,
+        logger,
+      });
       await finalizeStreamingOutput('turn-complete');
       if (output === 'success' && pendingIdleBoundary) {
         notifyTurnIdle();
@@ -713,20 +711,14 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
     }
 
     if (output === 'error' || hadError) {
-      if (outputSentToUser) {
-        logger.warn(
-          { group: group.name },
-          'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
-        );
-        return true;
-      }
-      deps.setCursor(queueJid, previousCursor);
-      await deps.saveState();
-      logger.warn(
-        { group: group.name },
-        'Agent error, rolled back message cursor for retry',
-      );
-      return false;
+      return handleFailure({
+        outputSentToUser,
+        groupName: group.name,
+        queueJid,
+        previousCursor,
+        deps,
+        logger,
+      });
     }
 
     outputSentToUser = await finalizeGroupAgentUserVisibleOutput({

--- a/apps/core/src/runtime/ipc-domain-types.ts
+++ b/apps/core/src/runtime/ipc-domain-types.ts
@@ -8,6 +8,7 @@ import {
 } from '../domain/types.js';
 import type { OpsRepository } from '../domain/repositories/ops-repo.js';
 import type { HostnameLookup } from '../domain/network/public-address-policy.js';
+import type { ToolCatalogRepository } from '../domain/ports/repositories.js';
 
 export interface IpcDeps {
   sendMessage: (
@@ -34,6 +35,7 @@ export interface IpcDeps {
   ) => Promise<UserQuestionResponse>;
   mcpHostnameLookup?: HostnameLookup;
   opsRepository: OpsRepository;
+  getToolRepository?: () => ToolCatalogRepository | undefined;
 }
 
 export interface IpcDomainContext {

--- a/apps/core/src/runtime/ipc-task-parsing.ts
+++ b/apps/core/src/runtime/ipc-task-parsing.ts
@@ -152,6 +152,7 @@ export function parseTaskIpcData(
   });
   const jobId = toTrimmedString(raw.jobId, { maxLen: 128 });
   const linkedSessions = toOptionalStringArray(raw.linkedSessions, 200, 255);
+  const allowedTools = toOptionalStringArray(raw.allowedTools, 200, 255);
   const deliverToArray = toOptionalStringArray(raw.deliverTo, 200, 255);
   const deliverToSingle = toTrimmedString(raw.deliverTo, { maxLen: 255 });
   const deliverTo =
@@ -212,6 +213,7 @@ export function parseTaskIpcData(
   if (script !== undefined) parsed.script = script;
   if (jobId) parsed.jobId = jobId;
   if (linkedSessions !== undefined) parsed.linkedSessions = linkedSessions;
+  if (allowedTools !== undefined) parsed.allowedTools = allowedTools;
   if (deliverTo !== undefined) parsed.deliverTo = deliverTo;
   if (groupScope) parsed.groupScope = groupScope;
   if (threadBinding.authThreadId) {

--- a/apps/core/src/shared/tool-rule-matcher.ts
+++ b/apps/core/src/shared/tool-rule-matcher.ts
@@ -1,0 +1,64 @@
+const MCP_WILDCARD_RE = /^mcp__([A-Za-z0-9_-]+)__\*$/;
+
+export interface ToolRuleValidationResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export function normalizeToolRules(
+  rules: readonly unknown[] | undefined,
+): string[] {
+  if (!Array.isArray(rules)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of rules) {
+    const rule = typeof raw === 'string' ? raw.trim() : '';
+    if (!rule || seen.has(rule)) continue;
+    seen.add(rule);
+    out.push(rule);
+  }
+  return out;
+}
+
+export function validateAutonomousToolRule(
+  rule: string,
+): ToolRuleValidationResult {
+  const value = rule.trim();
+  if (!value) return { ok: false, reason: 'Tool rule cannot be empty.' };
+  if (value === '*') {
+    return { ok: false, reason: 'Global wildcard tool rule is not allowed.' };
+  }
+  if (value.includes('*')) {
+    if (MCP_WILDCARD_RE.test(value)) return { ok: true };
+    return {
+      ok: false,
+      reason: 'Wildcard tool rules must use mcp__server__* form.',
+    };
+  }
+  return { ok: true };
+}
+
+export function validateAutonomousToolRules(
+  rules: readonly string[],
+): ToolRuleValidationResult {
+  for (const rule of rules) {
+    const result = validateAutonomousToolRule(rule);
+    if (!result.ok) return result;
+  }
+  return { ok: true };
+}
+
+export function toolRuleMatches(rule: string, toolName: string): boolean {
+  const normalizedRule = rule.trim();
+  if (!normalizedRule) return false;
+  const wildcard = MCP_WILDCARD_RE.exec(normalizedRule);
+  if (wildcard) return toolName.startsWith(`mcp__${wildcard[1]}__`);
+  return normalizedRule === toolName;
+}
+
+export function anyToolRuleMatches(
+  rules: readonly string[],
+  toolName: string,
+): boolean {
+  return rules.some((rule) => toolRuleMatches(rule, toolName));
+}

--- a/apps/core/test/unit/adapters/storage/postgres/canonical-job-ops-service.test.ts
+++ b/apps/core/test/unit/adapters/storage/postgres/canonical-job-ops-service.test.ts
@@ -4,6 +4,68 @@ import { CanonicalJobOpsService } from '@core/adapters/storage/postgres/services
 import type { PostgresCanonicalJobRepository } from '@core/adapters/storage/postgres/repositories/canonical-job-repository.postgres.js';
 
 describe('CanonicalJobOpsService', () => {
+  it('persists job-scoped allowed tools under target capability policy', async () => {
+    const repository = {
+      findJobById: vi.fn(async () => null),
+      upsertJob: vi.fn(async () => undefined),
+    } as unknown as PostgresCanonicalJobRepository;
+    const service = new CanonicalJobOpsService(repository);
+
+    await service.upsertJob({
+      id: 'job-1',
+      name: 'Job',
+      prompt: 'Run',
+      schedule_type: 'interval',
+      schedule_value: '60000',
+      linked_sessions: ['tg:1'],
+      group_scope: 'agent_one',
+      capability_policy: {
+        allowed_tools: ['Read', 'mcp__agent_browser__*'],
+      },
+    });
+
+    const stored = vi.mocked(repository.upsertJob).mock.calls[0]?.[0] as {
+      targetJson: string;
+    };
+    expect(JSON.parse(stored.targetJson).capabilityPolicy).toEqual({
+      allowedTools: ['Read', 'mcp__agent_browser__*'],
+    });
+  });
+
+  it('defaults missing capability policy to an empty allowed-tools list', async () => {
+    const repository = {
+      findJobById: vi.fn(async () => ({
+        id: 'job-1',
+        agentId: 'agent:agent_one',
+        name: 'Job',
+        prompt: 'Run',
+        model: null,
+        scheduleJson: JSON.stringify({ type: 'interval', value: '60000' }),
+        status: 'active',
+        executionMode: 'parallel',
+        targetJson: JSON.stringify({
+          linkedSessions: ['tg:1'],
+          groupScope: 'agent_one',
+        }),
+        silent: false,
+        timeoutMs: 300000,
+        maxRetries: 3,
+        retryBackoffMs: 5000,
+        nextRunAt: null,
+        lastRunAt: null,
+        leaseRunId: null,
+        leaseExpiresAt: null,
+        createdAt: '2026-04-24T00:00:00.000Z',
+        updatedAt: '2026-04-24T00:00:00.000Z',
+      })),
+    } as unknown as PostgresCanonicalJobRepository;
+    const service = new CanonicalJobOpsService(repository);
+
+    await expect(service.getJobById('job-1')).resolves.toMatchObject({
+      capability_policy: { allowed_tools: [] },
+    });
+  });
+
   it('uses the runtime event app id for run-scoped event queries', async () => {
     const repository = {
       findRuntimeEventAppIdForRun: vi.fn(async () => 'app-two'),

--- a/apps/core/test/unit/application/jobs-use-cases.test.ts
+++ b/apps/core/test/unit/application/jobs-use-cases.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { JobManagementService } from '@core/application/jobs/job-management-service.js';
 import { jobBelongsToApp } from '@core/application/jobs/job-access.js';
+import { isVisibleJob } from '@core/application/jobs/job-list-filters.js';
 import {
   assertSchedulerJobAccess,
   canAccessSchedulerJob,
@@ -467,6 +468,89 @@ describe('job application use cases', () => {
     ).not.toThrow();
   });
 
+  it('filters jobs by normalized agent id for plain and canonical group scopes', () => {
+    expect(
+      isVisibleJob(makeJob({ group_scope: 'one' }), {
+        agentId: 'agent:one',
+      }),
+    ).toBe(true);
+    expect(
+      isVisibleJob(makeJob({ group_scope: 'agent:one' }), {
+        agentId: 'agent:one',
+      }),
+    ).toBe(true);
+    expect(
+      isVisibleJob(makeJob({ group_scope: 'agent:two' }), {
+        agentId: 'agent:one',
+      }),
+    ).toBe(false);
+  });
+
+  it('pushes job list filters and bounded limits into the repository query', async () => {
+    const ops = {
+      listJobs: vi.fn(async () => [makeJob({ id: 'job-1' })]),
+    };
+    const service = new JobManagementService({
+      ops: ops as unknown as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+    });
+
+    await expect(
+      service.listJobs({
+        appId: 'app-one',
+        agentId: 'agent:one',
+        kind: 'recurring',
+        conversationJid: 'tg:team',
+        statuses: ['active'],
+        limit: 900,
+      }),
+    ).resolves.toEqual({ jobs: [] });
+
+    expect(ops.listJobs).toHaveBeenCalledWith({
+      appId: 'app-one',
+      statuses: ['active'],
+      groupScope: undefined,
+      threadId: undefined,
+      agentId: 'agent:one',
+      kind: 'recurring',
+      conversationJid: 'tg:team',
+      allowedConversationJids: undefined,
+      limit: 500,
+    });
+  });
+
+  it('pushes non-main linked-session access into the bounded repository query', async () => {
+    const ops = {
+      listJobs: vi.fn(async () => []),
+    };
+    const service = new JobManagementService({
+      ops: ops as unknown as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+    });
+
+    await service.listJobs({
+      access: {
+        sourceGroup: 'team',
+        isMain: false,
+        conversationBindings: {
+          'tg:team': { folder: 'team' },
+          'tg:other': { folder: 'other' },
+        },
+        sourceGroupJids: ['tg:team'],
+      },
+    });
+
+    expect(ops.listJobs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groupScope: 'team',
+        allowedConversationJids: ['tg:team'],
+        limit: 100,
+      }),
+    );
+  });
+
   it('maps IPC scheduler schedule validation to invalid_schedule', async () => {
     const ops = {
       getJobById: vi.fn(),
@@ -796,5 +880,158 @@ describe('job application use cases', () => {
     });
     expect(subscription.next).toHaveBeenCalled();
     expect(subscription.close).toHaveBeenCalled();
+  });
+
+  it('does not request approval when job extras are already inherited by the target agent', async () => {
+    const ops = makeOps(makeJob());
+    const approveJobExtraTools = vi.fn(async () => ({ approved: true }));
+    const service = new JobManagementService({
+      ops: ops as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+      toolRepository: {
+        listAgentToolBindings: vi.fn(async () => [
+          {
+            toolId: 'tool:Read',
+            status: 'active',
+          },
+        ]),
+      } as never,
+      approveJobExtraTools,
+    });
+
+    await service.updateJob({
+      appId: 'app-one',
+      jobId: 'job-1',
+      patch: { allowedTools: ['Read'] },
+    });
+
+    expect(approveJobExtraTools).not.toHaveBeenCalled();
+    expect(ops.updateJob).toHaveBeenCalledWith('job-1', {
+      capability_policy: { allowed_tools: ['Read'] },
+    });
+  });
+
+  it('does not request approval when an IPC upsert preserves already approved job extras', async () => {
+    const ops = {
+      getJobById: vi.fn(async () =>
+        makeJob({ capability_policy: { allowed_tools: ['Bash'] } }),
+      ),
+      upsertJob: vi.fn(async () => ({ created: false })),
+    };
+    const approveJobExtraTools = vi.fn(async () => ({ approved: true }));
+    const service = new JobManagementService({
+      ops: ops as unknown as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+      toolRepository: {
+        listAgentToolBindings: vi.fn(async () => []),
+      } as never,
+      approveJobExtraTools,
+    });
+
+    await service.upsertJobFromIpc({
+      access: {
+        sourceGroup: 'app-folder',
+        isMain: true,
+        conversationBindings: {},
+        sourceGroupJids: ['app:app-one:conv-1'],
+      },
+      jobId: 'job-1',
+      name: 'Job',
+      prompt: 'Run',
+      scheduleType: 'interval',
+      scheduleValue: '60000',
+      groupScope: 'app-folder',
+    });
+
+    expect(approveJobExtraTools).not.toHaveBeenCalled();
+    expect(ops.upsertJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capability_policy: { allowed_tools: ['Bash'] },
+      }),
+    );
+  });
+
+  it('denies job extra tool updates before mutating the existing job', async () => {
+    const ops = makeOps(makeJob({ capability_policy: { allowed_tools: [] } }));
+    const approveJobExtraTools = vi.fn(async () => ({
+      approved: false,
+      reason: 'no',
+    }));
+    const service = new JobManagementService({
+      ops: ops as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+      toolRepository: {
+        listAgentToolBindings: vi.fn(async () => [
+          {
+            toolId: 'tool:Read',
+            status: 'active',
+          },
+        ]),
+      } as never,
+      approveJobExtraTools,
+    });
+
+    await expect(
+      service.updateJob({
+        appId: 'app-one',
+        jobId: 'job-1',
+        patch: { allowedTools: ['Bash'] },
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect(approveJobExtraTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extrasBeyondInherited: ['Bash'],
+        existingJobExtraTools: [],
+      }),
+    );
+    expect(ops.updateJob).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when extra tools need approval but no approval port is configured', async () => {
+    const ops = makeOps(makeJob({ capability_policy: { allowed_tools: [] } }));
+    const service = new JobManagementService({
+      ops: ops as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+      toolRepository: {
+        listAgentToolBindings: vi.fn(async () => []),
+      } as never,
+    });
+
+    await expect(
+      service.updateJob({
+        appId: 'app-one',
+        jobId: 'job-1',
+        patch: { allowedTools: ['Bash'] },
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect(ops.updateJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects broad MyClaw MCP wildcards for non-main job extras', async () => {
+    const ops = makeOps(makeJob({ capability_policy: { allowed_tools: [] } }));
+    const service = new JobManagementService({
+      ops: ops as OpsRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+    });
+
+    await expect(
+      service.updateJob({
+        access: {
+          sourceGroup: 'app-folder',
+          isMain: false,
+          conversationBindings: { 'tg:team': { folder: 'app-folder' } },
+          sourceGroupJids: ['tg:team'],
+        },
+        jobId: 'job-1',
+        patch: { allowedTools: ['mcp__myclaw__*'] },
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 });

--- a/apps/core/test/unit/control/job-trigger.test.ts
+++ b/apps/core/test/unit/control/job-trigger.test.ts
@@ -1038,7 +1038,11 @@ describe('control job trigger', () => {
       },
     ]);
     opsRepo.listJobs.mockResolvedValue([
-      makeJob({ id: 'visible', linked_sessions: ['app:app-one:conv-1'] }),
+      makeJob({
+        id: 'visible',
+        linked_sessions: ['app:app-one:conv-1'],
+        capability_policy: { allowed_tools: ['Read'] },
+      }),
       makeJob({
         id: 'mixed',
         linked_sessions: ['app:app-one:conv-1', 'app:app-two:conv-2'],
@@ -1055,9 +1059,62 @@ describe('control job trigger', () => {
       );
 
       expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        jobs: [expect.objectContaining({ jobId: 'visible' })],
+      const body = await response.json();
+      expect(body).toMatchObject({
+        jobs: [
+          expect.objectContaining({
+            jobId: 'visible',
+            promptPreview: 'Run',
+            inheritedToolCount: 0,
+            jobExtraToolCount: 1,
+            effectiveAllowedToolCount: 1,
+          }),
+        ],
       });
+      expect(body.jobs[0]).not.toHaveProperty('prompt');
+      expect(body.jobs[0]).not.toHaveProperty('fullPrompt');
+      expect(body.jobs[0]).not.toHaveProperty('inheritedTools');
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns full job visibility metadata on detail', async () => {
+    const port = await reservePort();
+    process.env.MYCLAW_CONTROL_PORT = String(port);
+    process.env.MYCLAW_CONTROL_API_KEYS_JSON = JSON.stringify([
+      {
+        kid: 'k',
+        token: 'token-jobs',
+        scopes: ['jobs:read'],
+        appId: 'app-one',
+      },
+    ]);
+    opsRepo.getJobById.mockResolvedValue(
+      makeJob({ capability_policy: { allowed_tools: ['Read'] } }),
+    );
+    const handle = startControlServer({
+      app: { queue: { enqueueMessageCheck: vi.fn() } } as never,
+    });
+
+    try {
+      const response = await requestWithRetry(
+        `http://127.0.0.1:${port}/v1/jobs/job-1`,
+        'token-jobs',
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toMatchObject({
+        jobId: 'job-1',
+        prompt: 'Run',
+        fullPrompt: 'Run',
+        inheritedTools: [],
+        jobExtraTools: ['Read'],
+        effectiveAllowedTools: ['Read'],
+        recentRunErrors: [],
+      });
+      expect(body).not.toHaveProperty('inheritedToolCount');
     } finally {
       await handle.close();
     }

--- a/apps/core/test/unit/jobs/ipc-scheduler-adapter-contract.test.ts
+++ b/apps/core/test/unit/jobs/ipc-scheduler-adapter-contract.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
     updateJob: vi.fn(),
     resumeJob: vi.fn(),
   },
+  jobServiceDeps: [] as unknown[],
 }));
 
 vi.mock('@core/jobs/ipc-shared.js', async () => {
@@ -26,7 +27,8 @@ vi.mock('@core/jobs/ipc-shared.js', async () => {
 });
 
 vi.mock('@core/application/jobs/job-management-service.js', () => ({
-  JobManagementService: vi.fn(function JobManagementService() {
+  JobManagementService: vi.fn(function JobManagementService(deps: unknown) {
+    mocks.jobServiceDeps.push(deps);
     return mocks.jobService;
   }),
 }));
@@ -50,6 +52,9 @@ function makeContext(data: TaskIpcData): TaskContext {
         getJobById: vi.fn(),
       },
       onSchedulerChanged: vi.fn(),
+      requestPermissionApproval: vi.fn(async () => ({
+        approved: true,
+      })),
     },
   } as unknown as TaskContext;
 }
@@ -57,6 +62,7 @@ function makeContext(data: TaskIpcData): TaskContext {
 describe('scheduler IPC adapter contracts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.jobServiceDeps.length = 0;
   });
 
   it('keeps missing upsert scheduleType as invalid_request', async () => {
@@ -118,6 +124,116 @@ describe('scheduler IPC adapter contracts', () => {
     expect(message).toContain('team conversation browser');
   });
 
+  it('passes scheduler upsert allowedTools through to the job service', async () => {
+    mocks.jobService.upsertJobFromIpc.mockResolvedValueOnce({
+      jobId: 'job-1',
+      created: true,
+      modelAlias: null,
+    });
+
+    await schedulerCreateTaskHandlers.scheduler_upsert_job(
+      makeContext({
+        type: 'scheduler_upsert_job',
+        name: 'Daily review',
+        prompt: 'Review memory',
+        scheduleType: 'once',
+        scheduleValue: '2026-05-04T00:00:00.000Z',
+        allowedTools: ['Read'],
+      }),
+    );
+
+    expect(mocks.jobService.upsertJobFromIpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedTools: ['Read'],
+      }),
+    );
+  });
+
+  it('routes scheduler create job tool approvals to the originating conversation', async () => {
+    mocks.jobService.upsertJobFromIpc.mockResolvedValueOnce({
+      jobId: 'job-1',
+      created: true,
+      modelAlias: null,
+    });
+    const context = makeContext({
+      type: 'scheduler_upsert_job',
+      name: 'Daily review',
+      prompt: 'Review memory',
+      scheduleType: 'once',
+      scheduleValue: '2026-05-04T00:00:00.000Z',
+      allowedTools: ['Read'],
+      chatJid: 'tg:team-b',
+      targetJid: 'tg:team-b',
+    });
+    context.sourceGroupJids = ['tg:team-a', 'tg:team-b'];
+
+    await schedulerCreateTaskHandlers.scheduler_upsert_job(context);
+
+    const deps = mocks.jobServiceDeps.at(-1) as {
+      approveJobExtraTools: (request: unknown) => Promise<{
+        approved: boolean;
+        reason?: string;
+      }>;
+    };
+    await deps.approveJobExtraTools({
+      operation: 'create',
+      jobName: 'Daily review',
+      target: { agentId: 'team' },
+      inheritedTools: [],
+      existingJobExtraTools: [],
+      requestedJobExtraTools: ['Read'],
+      extrasBeyondInherited: ['Read'],
+    });
+
+    expect(context.deps.requestPermissionApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetJid: 'tg:team-b',
+      }),
+    );
+  });
+
+  it('fails closed for scheduler create job tool approval without an originating conversation', async () => {
+    mocks.jobService.upsertJobFromIpc.mockResolvedValueOnce({
+      jobId: 'job-1',
+      created: true,
+      modelAlias: null,
+    });
+    const context = makeContext({
+      type: 'scheduler_upsert_job',
+      name: 'Daily review',
+      prompt: 'Review memory',
+      scheduleType: 'once',
+      scheduleValue: '2026-05-04T00:00:00.000Z',
+      allowedTools: ['Read'],
+    });
+    context.sourceGroupJids = ['tg:team-a', 'tg:team-b'];
+
+    await schedulerCreateTaskHandlers.scheduler_upsert_job(context);
+
+    const deps = mocks.jobServiceDeps.at(-1) as {
+      approveJobExtraTools: (request: unknown) => Promise<{
+        approved: boolean;
+        reason?: string;
+      }>;
+    };
+    const decision = await deps.approveJobExtraTools({
+      operation: 'create',
+      jobName: 'Daily review',
+      target: { agentId: 'team' },
+      inheritedTools: [],
+      existingJobExtraTools: [],
+      requestedJobExtraTools: ['Read'],
+      extrasBeyondInherited: ['Read'],
+    });
+
+    expect(decision).toEqual({
+      approved: false,
+      reason:
+        'scheduler job tool approval requires an originating chat for this agent',
+    });
+    expect(context.deps.requestPermissionApproval).not.toHaveBeenCalled();
+  });
+
   it('resolves scheduler update models through catalog aliases', async () => {
     await schedulerMutateTaskHandlers.scheduler_update_job(
       makeContext({
@@ -154,6 +270,110 @@ describe('scheduler IPC adapter contracts', () => {
     expect(mocks.responder.accept).toHaveBeenCalledWith(
       'Scheduler job updated (job-1).',
     );
+  });
+
+  it('passes scheduler update allowedTools replacements and clears through to the job service', async () => {
+    await schedulerMutateTaskHandlers.scheduler_update_job(
+      makeContext({
+        type: 'scheduler_update_job',
+        jobId: 'job-1',
+        allowedTools: [],
+      }),
+    );
+
+    expect(mocks.jobService.updateJob).toHaveBeenCalledWith({
+      jobId: 'job-1',
+      access: expect.any(Object),
+      patch: { allowedTools: [] },
+    });
+
+    vi.clearAllMocks();
+    await schedulerMutateTaskHandlers.scheduler_update_job(
+      makeContext({
+        type: 'scheduler_update_job',
+        jobId: 'job-1',
+        allowedTools: ['Read'],
+      }),
+    );
+
+    expect(mocks.jobService.updateJob).toHaveBeenCalledWith({
+      jobId: 'job-1',
+      access: expect.any(Object),
+      patch: { allowedTools: ['Read'] },
+    });
+  });
+
+  it('routes scheduler update job tool approvals to the originating conversation', async () => {
+    const context = makeContext({
+      type: 'scheduler_update_job',
+      jobId: 'job-1',
+      allowedTools: ['Read'],
+      chatJid: 'tg:team-b',
+      targetJid: 'tg:team-b',
+    });
+    context.sourceGroupJids = ['tg:team-a', 'tg:team-b'];
+
+    await schedulerMutateTaskHandlers.scheduler_update_job(context);
+
+    const deps = mocks.jobServiceDeps.at(-1) as {
+      approveJobExtraTools: (request: unknown) => Promise<{
+        approved: boolean;
+        reason?: string;
+      }>;
+    };
+    await deps.approveJobExtraTools({
+      operation: 'update',
+      jobId: 'job-1',
+      jobName: 'Daily review',
+      target: { agentId: 'team' },
+      inheritedTools: [],
+      existingJobExtraTools: [],
+      requestedJobExtraTools: ['Read'],
+      extrasBeyondInherited: ['Read'],
+    });
+
+    expect(context.deps.requestPermissionApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetJid: 'tg:team-b',
+      }),
+    );
+  });
+
+  it('fails closed for scheduler update job tool approval target overrides', async () => {
+    const context = makeContext({
+      type: 'scheduler_update_job',
+      jobId: 'job-1',
+      allowedTools: ['Read'],
+      chatJid: 'tg:team-b',
+      targetJid: 'tg:team-a',
+    });
+    context.sourceGroupJids = ['tg:team-a', 'tg:team-b'];
+
+    await schedulerMutateTaskHandlers.scheduler_update_job(context);
+
+    const deps = mocks.jobServiceDeps.at(-1) as {
+      approveJobExtraTools: (request: unknown) => Promise<{
+        approved: boolean;
+        reason?: string;
+      }>;
+    };
+    const decision = await deps.approveJobExtraTools({
+      operation: 'update',
+      jobId: 'job-1',
+      jobName: 'Daily review',
+      target: { agentId: 'team' },
+      inheritedTools: [],
+      existingJobExtraTools: [],
+      requestedJobExtraTools: ['Read'],
+      extrasBeyondInherited: ['Read'],
+    });
+
+    expect(decision).toEqual({
+      approved: false,
+      reason:
+        'scheduler job tool approval must use the originating chat as the approval target',
+    });
+    expect(context.deps.requestPermissionApproval).not.toHaveBeenCalled();
   });
 
   it('rejects raw provider IDs for scheduler update models', async () => {

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -137,6 +137,10 @@ function createRunnerFixture(): {
     path.resolve('apps/core/src/shared/agent-persona.ts'),
     path.join(sharedDir, 'agent-persona.ts'),
   );
+  fs.copyFileSync(
+    path.resolve('apps/core/src/shared/tool-rule-matcher.ts'),
+    path.join(sharedDir, 'tool-rule-matcher.ts'),
+  );
   symlinkPackage(root, 'dayjs', 'node_modules/dayjs');
   fs.writeFileSync(
     path.join(sdkDir, 'package.json'),
@@ -267,6 +271,21 @@ export async function* query({ prompt, options }) {
     );
     call.permissionRequest = request;
     call.permissionDecision = await decisionPromise;
+  }
+
+  if (process.env.TEST_TOOL_USE_ONLY) {
+    call.permissionDecision = await options.canUseTool(
+      process.env.TEST_TOOL_USE_ONLY,
+      { cmd: 'npm test' },
+      {
+        signal: new AbortController().signal,
+        title: 'Run command',
+        displayName: process.env.TEST_TOOL_USE_ONLY,
+        description: 'Needs tool access',
+        decisionReason: 'Agent wants to use a tool',
+        blockedPath: process.env.MYCLAW_WORKSPACE_GROUP_DIR,
+      },
+    );
   }
 
   if (typeof prompt === 'string') {
@@ -980,6 +999,75 @@ describe('agent-runner IPC lifecycle', () => {
       );
       expect(String(call?.permissionDecision?.message)).toContain(
         'memory boundary',
+      );
+      expect(
+        fs.existsSync(path.join(fixture.ipcDir, 'permission-requests')),
+      ).toBe(false);
+    },
+    RUNNER_IPC_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'scheduled jobs deny missing tools without writing permission IPC',
+    async () => {
+      const fixture = createRunnerFixture();
+
+      const result = await runRunner(
+        fixture,
+        baseInput({
+          isScheduledJob: true,
+          allowedTools: ['Read'],
+        }),
+        {
+          TEST_TOOL_USE_ONLY: 'Bash',
+          TEST_EXIT_AFTER_QUERY: '1',
+        },
+      );
+
+      expect(result.exitCode).toBe(1);
+      const call = readRecord(fixture.recordPath).calls[0];
+      expect(call?.permissionDecision).toEqual(
+        expect.objectContaining({
+          behavior: 'deny',
+          interrupt: true,
+          message: 'tool not on autonomous job allowlist: Bash',
+        }),
+      );
+      expect(
+        fs.existsSync(path.join(fixture.ipcDir, 'permission-requests')),
+      ).toBe(false);
+      expect(result.stdout).not.toContain(
+        '"interactionBoundary":"user_interaction"',
+      );
+    },
+    RUNNER_IPC_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'scheduled jobs do not inherit default interactive tools',
+    async () => {
+      const fixture = createRunnerFixture();
+
+      const result = await runRunner(
+        fixture,
+        baseInput({
+          isScheduledJob: true,
+          allowedTools: [],
+        }),
+        {
+          TEST_TOOL_USE_ONLY: 'WebSearch',
+          TEST_EXIT_AFTER_QUERY: '1',
+        },
+      );
+
+      expect(result.exitCode).toBe(1);
+      const call = readRecord(fixture.recordPath).calls[0];
+      expect(call?.permissionDecision).toEqual(
+        expect.objectContaining({
+          behavior: 'deny',
+          interrupt: true,
+          message: 'tool not on autonomous job allowlist: WebSearch',
+        }),
       );
       expect(
         fs.existsSync(path.join(fixture.ipcDir, 'permission-requests')),

--- a/apps/core/test/unit/runtime/ipc-auth-boundary.test.ts
+++ b/apps/core/test/unit/runtime/ipc-auth-boundary.test.ts
@@ -126,6 +126,51 @@ describe('validateIpcAuthRequest', () => {
     });
   });
 
+  it('preserves scheduler job allowedTools creates, replaces, and clears', () => {
+    const createPayload = signedPayload({
+      requestId: 'task-allowed-tools-create',
+      nonce: randomUUID(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      type: 'scheduler_upsert_job',
+      name: 'Job',
+      prompt: 'Run',
+      scheduleType: 'interval',
+      scheduleValue: '60000',
+      allowedTools: ['Read'],
+    });
+    const replacePayload = signedPayload({
+      requestId: 'task-allowed-tools-replace',
+      nonce: randomUUID(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      type: 'scheduler_update_job',
+      jobId: 'job-1',
+      allowedTools: ['Read', 'mcp__agent_browser__*'],
+    });
+    const clearPayload = signedPayload({
+      requestId: 'task-allowed-tools-clear',
+      nonce: randomUUID(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      type: 'scheduler_update_job',
+      jobId: 'job-1',
+      allowedTools: [],
+    });
+
+    expect(parseTaskIpcData(createPayload, 'team')).toMatchObject({
+      type: 'scheduler_upsert_job',
+      allowedTools: ['Read'],
+    });
+    expect(parseTaskIpcData(replacePayload, 'team')).toMatchObject({
+      type: 'scheduler_update_job',
+      jobId: 'job-1',
+      allowedTools: ['Read', 'mcp__agent_browser__*'],
+    });
+    expect(parseTaskIpcData(clearPayload, 'team')).toMatchObject({
+      type: 'scheduler_update_job',
+      jobId: 'job-1',
+      allowedTools: [],
+    });
+  });
+
   it('requires browser IPC signatures to match the chat-scoped token', () => {
     const payload = {
       requestId: 'browser-1',

--- a/apps/core/test/unit/shared/tool-rule-matcher.test.ts
+++ b/apps/core/test/unit/shared/tool-rule-matcher.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  anyToolRuleMatches,
+  validateAutonomousToolRule,
+} from '@core/shared/tool-rule-matcher.js';
+
+describe('autonomous tool rule matcher', () => {
+  it('supports exact tool names and mcp server wildcards', () => {
+    expect(anyToolRuleMatches(['Bash'], 'Bash')).toBe(true);
+    expect(anyToolRuleMatches(['Bash'], 'Read')).toBe(false);
+    expect(anyToolRuleMatches(['mcp__github__*'], 'mcp__github__search')).toBe(
+      true,
+    );
+    expect(anyToolRuleMatches(['mcp__github__*'], 'mcp__linear__search')).toBe(
+      false,
+    );
+  });
+
+  it('rejects empty, global, and unsupported wildcard rules', () => {
+    expect(validateAutonomousToolRule('').ok).toBe(false);
+    expect(validateAutonomousToolRule('*').ok).toBe(false);
+    expect(validateAutonomousToolRule('mcp__github__search*').ok).toBe(false);
+    expect(validateAutonomousToolRule('mcp__github__*').ok).toBe(true);
+  });
+});

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -13,3 +13,4 @@
 - Prefer repo-relative paths and current commands such as `apps/core/...`, `packages/agent-runner/...`, and `ops/...` when describing the codebase.
 - When docs change operational commands, verify the command still exists in this repo before publishing it.
 - Treat `/v1/webhooks` as outbound callback delivery only. Signed inbound sidecar systems use external ingress records under `/v1/ingresses`; do not describe webhooks as ingress authority.
+- Job docs must preserve the settings/runtime boundary: job instances, prompts, schedules, leases, runs, notification targets, and job-scoped tool extras are Postgres runtime state, not `settings.yaml` desired state.

--- a/docs/architecture/autonomous-jobs.md
+++ b/docs/architecture/autonomous-jobs.md
@@ -1,0 +1,47 @@
+# Autonomous Jobs
+
+Autonomous jobs are runtime state, not desired-state configuration. Recurring,
+one-time, and manually triggered scheduler jobs are stored in Postgres and must
+not be written to `settings.yaml`.
+
+## Capability Policy
+
+At execution time, a job resolves its target agent from the job runtime target:
+`group_scope`, linked conversation/session, and optional thread/DM context. The
+job inherits that target agent's currently selected tool bindings for the run.
+
+Job-scoped extra tool rules are persisted in `jobs.target_json` under:
+
+```json
+{
+  "capabilityPolicy": {
+    "allowedTools": ["mcp__agent_browser__*"]
+  }
+}
+```
+
+Missing `capabilityPolicy.allowedTools` means an empty extra-tool list.
+
+Allowed job tool rules support exact tool names and `mcp__server__*`. Empty
+rules, global `*`, and other wildcard forms are invalid. Non-main jobs cannot
+add main/admin-only MyClaw tools as job extras.
+
+## Execution
+
+Scheduled job execution keeps protected capability and memory guards active
+before autonomous allowance. It must not write permission IPC or wait for chat
+approval during execution. If a tool is outside the effective job allowlist, the
+runner denies it immediately with:
+
+```text
+tool not on autonomous job allowlist
+```
+
+The scheduler records the failure summary, emits `job.tool_denied`, and notifies
+the linked group/thread or DM unless the job is silent.
+
+## Visibility
+
+Jobs are inspectable through chat scheduler tools, Control API, SDK, and CLI.
+List/detail output should include the target, schedule, status, model, prompt,
+notification target, job extra tools, and effective autonomous tool surface.

--- a/packages/contracts/src/jobs/index.ts
+++ b/packages/contracts/src/jobs/index.ts
@@ -72,6 +72,21 @@ export const JobTargetSchema = z.object({
 });
 export type JobTarget = z.infer<typeof JobTargetSchema>;
 
+export const JobResolvedTargetSchema = z.object({
+  appId: z.string(),
+  agentId: z.string(),
+  groupScope: z.string(),
+  conversationJids: z.array(z.string()),
+  threadId: z.string().nullable(),
+});
+
+export const JobRecentRunErrorSchema = z.object({
+  runId: z.string(),
+  status: z.string(),
+  errorSummary: z.string(),
+  endedAt: IsoDateTimeSchema.nullable(),
+});
+
 export const CreateJobRequestSchema = z
   .object({
     name: z.string().min(1),
@@ -89,6 +104,7 @@ export const CreateJobRequestSchema = z
     threadId: z.string().optional(),
     modelAlias: z.string().optional(),
     modelProfileId: z.string().optional(),
+    allowedTools: z.array(z.string()).optional(),
     dryRun: z.boolean().optional(),
   })
   .strict()
@@ -107,6 +123,7 @@ export const UpdateJobRequestSchema = z
     status: z.enum(['active', 'paused']).optional(),
     modelAlias: z.string().nullable().optional(),
     modelProfileId: z.string().nullable().optional(),
+    allowedTools: z.array(z.string()).optional(),
   })
   .strict()
   .refine(
@@ -122,7 +139,9 @@ export type UpdateJobRequest = z.infer<typeof UpdateJobRequestSchema>;
 export const JobResponseSchema = z.object({
   jobId: z.string(),
   name: z.string(),
-  prompt: z.string(),
+  prompt: z.string().optional(),
+  promptPreview: z.string().optional(),
+  fullPrompt: z.string().optional(),
   kind: z.enum(['manual', 'once', 'recurring']),
   status: JobStatusSchema,
   schedule: z
@@ -142,6 +161,21 @@ export const JobResponseSchema = z.object({
   threadId: z.string().nullable(),
   groupScope: z.string(),
   sessionId: z.string().nullable(),
+  target: JobResolvedTargetSchema.optional(),
+  inheritedTools: z.array(z.string()).optional(),
+  jobExtraTools: z.array(z.string()).optional(),
+  effectiveAllowedTools: z.array(z.string()).optional(),
+  inheritedToolCount: z.number().int().nonnegative().optional(),
+  jobExtraToolCount: z.number().int().nonnegative().optional(),
+  effectiveAllowedToolCount: z.number().int().nonnegative().optional(),
+  recentRunErrors: z.array(JobRecentRunErrorSchema).optional(),
+  notificationTarget: z
+    .object({
+      linkedSessions: z.array(z.string()),
+      threadId: z.string().nullable(),
+      silent: z.boolean(),
+    })
+    .optional(),
 });
 export type JobResponse = z.infer<typeof JobResponseSchema>;
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,11 +21,13 @@ import type {
 import { createIngressesClient } from './ingresses.js';
 export type { RuntimeSettingsResponse } from './settings.js';
 import * as mcpServerClients from './mcp-servers.js';
+import { jobListQuery } from './job-list-query.js';
 import type {
   CreateJobInput,
   CreateJobResponse,
   JobRecord,
   JobTriggerWaitResult,
+  ListJobsInput,
   ModelRecord,
   UpdateJobInput,
 } from './job-model-types.js';
@@ -37,6 +39,7 @@ export type {
   JobRecord,
   JobStatus,
   JobTriggerWaitResult,
+  ListJobsInput,
   ModelRecord,
   UpdateJobInput,
 } from './job-model-types.js';
@@ -343,10 +346,10 @@ export class MyClawClient {
         path: '/v1/jobs',
         body: input,
       }),
-    list: () =>
+    list: (input?: ListJobsInput) =>
       this.transport.request<{ jobs: JobRecord[] }>({
         method: 'GET',
-        path: '/v1/jobs',
+        path: `/v1/jobs${jobListQuery(input)}`,
       }),
     get: (jobId: string) =>
       this.transport.request<JobRecord>({
@@ -678,6 +681,7 @@ export class MyClawClient {
 }
 export const createClient = (options: ClientOptions) =>
   new MyClawClient(options);
+
 export {
   buildIngressSignaturePayload,
   signIngressRequest,

--- a/packages/sdk/src/job-list-query.ts
+++ b/packages/sdk/src/job-list-query.ts
@@ -1,0 +1,19 @@
+import type { ListJobsInput } from './job-model-types.js';
+
+export function jobListQuery(input?: ListJobsInput): string {
+  if (!input) return '';
+  const params = new URLSearchParams();
+  if (input.agentId) params.set('agentId', input.agentId);
+  if (input.groupScope) params.set('groupScope', input.groupScope);
+  if (input.conversationJid)
+    params.set('conversationJid', input.conversationJid);
+  if (input.kind) params.set('kind', input.kind);
+  if (input.limit !== undefined) params.set('limit', String(input.limit));
+  const statuses = Array.isArray(input.status)
+    ? input.status
+    : input.status
+      ? [input.status]
+      : [];
+  for (const status of statuses) params.append('status', status);
+  return params.toString() ? `?${params}` : '';
+}

--- a/packages/sdk/src/job-model-types.ts
+++ b/packages/sdk/src/job-model-types.ts
@@ -12,7 +12,9 @@ export type JobStatus =
 export interface JobRecord {
   jobId: string;
   name: string;
-  prompt: string;
+  prompt?: string;
+  promptPreview?: string;
+  fullPrompt?: string;
   kind: JobKind;
   status: JobStatus;
   schedule:
@@ -29,6 +31,30 @@ export interface JobRecord {
   threadId: string | null;
   groupScope: string;
   sessionId: string | null;
+  target?: {
+    appId: string;
+    agentId: string;
+    groupScope: string;
+    conversationJids: string[];
+    threadId: string | null;
+  };
+  inheritedTools?: string[];
+  jobExtraTools?: string[];
+  effectiveAllowedTools?: string[];
+  inheritedToolCount?: number;
+  jobExtraToolCount?: number;
+  effectiveAllowedToolCount?: number;
+  recentRunErrors?: Array<{
+    runId: string;
+    status: string;
+    errorSummary: string;
+    endedAt: string | null;
+  }>;
+  notificationTarget?: {
+    linkedSessions: string[];
+    threadId: string | null;
+    silent: boolean;
+  };
 }
 
 export interface ModelRecord {
@@ -58,6 +84,7 @@ export interface CreateJobInput {
   threadId?: string;
   modelAlias?: string;
   modelProfileId?: string;
+  allowedTools?: string[];
   dryRun?: boolean;
 }
 
@@ -69,6 +96,16 @@ export interface UpdateJobInput {
   status?: 'active' | 'paused';
   modelAlias?: string | null;
   modelProfileId?: string | null;
+  allowedTools?: string[];
+}
+
+export interface ListJobsInput {
+  agentId?: string;
+  groupScope?: string;
+  conversationJid?: string;
+  kind?: JobKind;
+  status?: JobStatus | JobStatus[];
+  limit?: number;
 }
 
 export interface CreateJobResponse {


### PR DESCRIPTION
## Summary

Implements autonomous job ownership, tool policy, runtime enforcement, and visibility for group and DM agents across recurring, one-time, and manually triggered scheduler jobs.

## What Changed

- Added job-scoped capability policy persisted at `target_json.capabilityPolicy.allowedTools` with strict rule validation for exact tool names and `mcp__server__*` patterns.
- Computes effective autonomous job tools dynamically from the target agent plus approved job extras and scheduler/runtime built-ins.
- Applies fail-fast autonomous permission enforcement for scheduler jobs without writing permission IPC or waiting on chat prompts.
- Adds denied-tool error summaries, `job.tool_denied` events, and group/thread or DM notifications unless silent.
- Adds browser projection/fail-fast behavior when effective job tools include browser tools.
- Adds job list/detail visibility across MCP scheduler tools, Control API, SDK contracts, and CLI `myclaw jobs list/show`.
- Adds access-control filtering so main/admin can inspect all jobs and normal agents only inspect their own group/DM context.
- Keeps job instances out of `settings.yaml`; runtime state remains in Postgres/projection.
- Adds docs and AGENTS lessons for autonomous jobs and runtime/settings boundaries.

## Review Notes

- Scheduler job extra-tool approvals now route to the originating group/DM conversation by stamping `chatJid`, `targetJid`, and `authThreadId` in scheduler MCP create/update IPC payloads.
- Host approval validation rejects missing origins and target overrides before calling `requestPermissionApproval`, leaving existing jobs unchanged on denial/failure.

## Validation

- `npm run typecheck` PASS
- `npm run format:check` PASS
- `npm run build` PASS
- `npm test` PASS
  - 166 unit files / 1624 tests passed
  - 9 integration files / 53 tests passed
  - 6 integration files skipped
- `python3 .codex/scripts/check_task_completion.py` PASS
  - Warning only: provider adapter/session files changed without provider-session or resume tests.

## Reviewer Approvals

- Quality: APPROVED
- Security: APPROVED
- Performance: APPROVED
