### PR TITLE
[codex] Fix permission approval persistent grants

### DIFF
--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -30,5 +30,6 @@
 - Host runner sync code must work with npm workspace hoisting and installed package layouts; do not assume `packages/agent-runner/node_modules` exists.
 - Files under `apps/core/src/app/bootstrap/` own composition and wiring only; runtime behavior must live in `runtime/`, `jobs/`, `session/`, `platform/`, `messaging/`, `memory/`, or infrastructure modules.
 - Channel provider catalog flags must match executable behavior: do not advertise `install` or `discover` unless the CLI/control path can actually perform setup or discovery, and document any remaining runtime adapter seam explicitly.
+- Permission approval suggestion synthesis must be tool-agnostic. Preserve exact tool names and infer only one displayed scope from generic request fields; do not special-case Bash, file, web, browser, MCP, or provider-native tools.
 - Keep the architecture simple, do not over complicate
 - Search Anthropic SDK in node modules and do not reinvent what already exists.

--- a/apps/core/src/app/bootstrap/runtime-services.ts
+++ b/apps/core/src/app/bootstrap/runtime-services.ts
@@ -18,7 +18,10 @@ import {
 } from '../../jobs/scheduler.js';
 import { makeThreadQueueKey } from '../../runtime/thread-queue-key.js';
 import type { OpsRepository } from '../../domain/repositories/ops-repo.js';
-import { getRuntimeOpsRepository } from '../../adapters/storage/postgres/runtime-store.js';
+import {
+  getRuntimeOpsRepository,
+  getRuntimeStorage,
+} from '../../adapters/storage/postgres/runtime-store.js';
 import type { SessionMemoryCollector } from '../../domain/ports/session-memory-collector.js';
 import { ChannelWiring } from './channel-wiring.js';
 import { RuntimeApp } from './runtime-app.js';
@@ -174,6 +177,7 @@ export async function startRuntimeServices(
     requestPermissionApproval: channelWiring.requestPermissionApproval,
     requestUserAnswer: channelWiring.requestUserAnswer,
     mcpHostnameLookup: resolved.mcpHostnameLookup,
+    getToolRepository: () => getRuntimeStorage().repositories.tools,
   });
 
   syncGroupSnapshots();

--- a/apps/core/src/channels/permission-interaction.ts
+++ b/apps/core/src/channels/permission-interaction.ts
@@ -191,7 +191,7 @@ export function formatPermissionReceiptText(
   }
   if (decision.mode === 'allow_persistent_rule') {
     const rule = request ? firstPersistentRule(request) : undefined;
-    return `Allowed for this session: ${rule || action}\nBy: ${actor}\nRequest ID: ${requestId}`;
+    return `Allowed persistent rule: ${rule || action}\nBy: ${actor}\nRequest ID: ${requestId}`;
   }
   return `Allowed once: ${action}\nBy: ${actor}\nRequest ID: ${requestId}`;
 }
@@ -243,11 +243,16 @@ function formatPermissionBoundaryLines(
   }
   return [
     'What this changes: Allow once applies only to this tool call.',
-    `Always allow applies this rule for the running agent session: ${rule}`,
+    `Always allow applies this rule to matching future tool calls: ${rule}`,
     'What this does not allow: unrelated tools, secrets, settings edits, or broader access outside the rule.',
   ];
 }
 
 function isBroadPermissionRule(rule: string): boolean {
-  return /^[A-Za-z][A-Za-z0-9]*(?:\(\s*\*\s*\))?$/.test(rule.trim());
+  const trimmed = rule.trim();
+  const match = /^([A-Za-z][A-Za-z0-9_]*)(?:\((.*)\))?$/.exec(trimmed);
+  if (!match) return false;
+  const content = match[2]?.trim();
+  if (content === undefined) return true;
+  return /(^|[/\\])\*\*($|[/\\])|^\*$|^\.\*$|^\/?\*\*$/.test(content);
 }

--- a/apps/core/src/channels/permission-interaction.ts
+++ b/apps/core/src/channels/permission-interaction.ts
@@ -4,6 +4,7 @@ import type {
   PermissionApprovalRequest,
   PermissionApprovalUpdate,
 } from '../domain/types.js';
+import { logger } from '../infrastructure/logging/logger.js';
 
 export type PermissionActionToken =
   | PermissionApprovalDecisionMode
@@ -50,9 +51,40 @@ export function permissionDecisionOptions(
   request: PermissionApprovalRequest,
 ): PermissionApprovalDecisionMode[] {
   if (request.decisionOptions?.length) return request.decisionOptions;
-  return firstPersistentRule(request)
+  const persistentRule = firstPersistentRule(request);
+  if (!persistentRule) logPersistentOptionDrop(request);
+  return persistentRule
     ? ['allow_once', 'allow_persistent_rule', 'cancel']
     : ['allow_once', 'cancel'];
+}
+
+function logPersistentOptionDrop(request: PermissionApprovalRequest): void {
+  const suggestions = request.suggestions || [];
+  if (suggestions.length === 0) return;
+  logger.debug(
+    {
+      requestId: request.requestId,
+      toolName: request.toolName,
+      suggestionCount: suggestions.length,
+      reason: persistentOptionDropReason(request),
+    },
+    'Persistent permission option unavailable',
+  );
+}
+
+function persistentOptionDropReason(
+  request: PermissionApprovalRequest,
+): string {
+  const candidates = (request.suggestions || []).filter(
+    (update) =>
+      (update.type === 'addRules' || update.type === 'replaceRules') &&
+      update.behavior === 'allow' &&
+      Array.isArray(update.rules) &&
+      update.rules.length > 0,
+  );
+  if (candidates.length !== 1) return 'expected exactly one allow rule update';
+  if (candidates[0].rules?.length !== 1) return 'expected exactly one rule';
+  return 'rule missing toolName';
 }
 
 export function permissionButtonLabel(

--- a/apps/core/src/domain/types.ts
+++ b/apps/core/src/domain/types.ts
@@ -158,6 +158,7 @@ export interface JobEvent {
 // --- Channel capability ports ---
 export interface PermissionApprovalRequest {
   requestId: string;
+  responseNonce?: string;
   sourceGroup: string;
   targetJid?: string;
   approvalContextJid?: string;

--- a/apps/core/src/jobs/ipc-admin-handlers.ts
+++ b/apps/core/src/jobs/ipc-admin-handlers.ts
@@ -13,7 +13,13 @@ import {
 import { createTaskResponder, toTrimmedString } from './ipc-shared.js';
 import { parseSkillDraftAssets } from './skill-draft-ipc.js';
 import { getHostRuntimeCredentialEnv } from '../runtime/agent-spawn-host.js';
-import type { PermissionApprovalUpdate } from '../domain/types.js';
+import {
+  persistRequestPermissionRules,
+  requestPermissionDescription,
+  requestPermissionQueuedMessage,
+  requestPermissionReviewEffect,
+  requestPermissionReviewSuggestions,
+} from './request-permission-review.js';
 import {
   requestSettingsUpdateHandler,
   serviceRestartHandler,
@@ -373,7 +379,7 @@ const requestOnlyCapabilityHandler: TaskHandler = async (context) => {
   if (!requestedTargetJid) return;
   if (typeof deps.requestPermissionApproval !== 'function' || typeof deps.sendMessage !== 'function') { reject(`${parsed.review.requestKind} requests require a configured approval surface.`, 'preflight_failed'); return; }
   startRequestOnlyCapabilityReview({ deps, sourceGroup, targetJid: requestedTargetJid, threadId: data.authThreadId, review: parsed.review });
-  accept(`${parsed.review.displayName} request sent to this chat for approval. This records a permission review only and does not enable the capability directly.`, 'capability_request_recorded');
+  accept(requestOnlyCapabilityQueuedMessage(parsed.review), 'capability_request_recorded');
 };
 
 // prettier-ignore
@@ -415,9 +421,23 @@ function parseRequestOnlyCapabilityReview(toolName: RequestOnlyCapabilityToolNam
       requestKind: spec.kind,
       displayName: `${spec.kind}: ${capabilityDisplayValue(payload, spec)}`,
       reason,
-      toolInput: { ...toolInput, activation: 'future_config_version', effect: spec.effect },
+      toolInput: { ...toolInput, activation: 'future_config_version', effect: requestOnlyCapabilityEffect(toolName, toolInput, spec.effect) },
     },
   };
+}
+
+// prettier-ignore
+function requestOnlyCapabilityEffect(toolName: RequestOnlyCapabilityToolName, toolInput: Record<string, unknown>, fallback: string): string {
+  return toolName === 'request_permission'
+    ? requestPermissionReviewEffect(toolInput, fallback)
+    : fallback;
+}
+
+// prettier-ignore
+function requestOnlyCapabilityQueuedMessage(review: RequestOnlyCapabilityReview): string {
+  return review.toolName === 'request_permission'
+    ? requestPermissionQueuedMessage({ toolName: 'request_permission', displayName: review.displayName })
+    : `${review.displayName} request sent to this chat for approval. This records a permission review only and does not enable the capability directly.`;
 }
 
 // prettier-ignore
@@ -483,7 +503,7 @@ function startRequestOnlyCapabilityReview(input: { deps: Parameters<TaskHandler>
         toolName: input.review.toolName,
         displayName: input.review.displayName,
         title: `Approve ${input.review.requestKind.toLowerCase()} request`,
-        description: 'Only configured approvers can decide this request. This records the permission review only and does not enable the capability directly.',
+        description: input.review.toolName === 'request_permission' ? requestPermissionDescription() : 'Only configured approvers can decide this request. This records the permission review only and does not enable the capability directly.',
         decisionReason: input.review.reason,
         toolInput: input.review.toolInput,
         ...(input.review.toolName === 'request_permission'
@@ -495,7 +515,19 @@ function startRequestOnlyCapabilityReview(input: { deps: Parameters<TaskHandler>
           : {}),
       });
       const reason = decision.approved ? 'missing approving principal' : decision.reason || 'not approved';
-      message = decision.approved && decision.decidedBy ? `Approved ${input.review.displayName}. Permission review recorded by ${decision.decidedBy}; no capability was enabled by this request-only flow.` : `Rejected ${input.review.displayName}: ${reason}. No capability was enabled.`;
+      let persistedRules: string[] = [];
+      if (decision.approved && decision.updatedPermissions?.length && input.review.toolName === 'request_permission') {
+        persistedRules = await persistRequestPermissionRules({
+          deps: input.deps,
+          sourceGroup: input.sourceGroup,
+          updates: decision.updatedPermissions,
+        });
+      }
+      message = decision.approved && decision.decidedBy
+        ? persistedRules.length
+          ? `Approved ${input.review.displayName}. Persistent permission rule enabled for future runs by ${decision.decidedBy}: ${persistedRules.join(', ')}.`
+          : `Approved ${input.review.displayName}. Permission review recorded by ${decision.decidedBy}; no capability was enabled by this request-only flow.`
+        : `Rejected ${input.review.displayName}: ${reason}. No capability was enabled.`;
     } catch (err) {
       logger.error(
         { err, sourceGroup: input.sourceGroup, toolName: input.review.toolName },
@@ -505,28 +537,6 @@ function startRequestOnlyCapabilityReview(input: { deps: Parameters<TaskHandler>
     }
     await input.deps.sendMessage(input.targetJid, message, input.threadId ? { threadId: input.threadId } : undefined);
   })().catch((err) => logger.error({ err, sourceGroup: input.sourceGroup, toolName: input.review.toolName }, 'Capability permission review final message failed'));
-}
-
-// prettier-ignore
-function requestPermissionReviewSuggestions(toolInput: Record<string, unknown>): PermissionApprovalUpdate[] | undefined {
-  if (toolInput.temporaryOnly === true) return undefined;
-  if (toolInput.permissionKind && toolInput.permissionKind !== 'tool') return undefined;
-  const toolNames = sanitizedStringList(Array.isArray(toolInput.toolNames) ? toolInput.toolNames : [toolInput.toolName]);
-  if (toolNames.length !== 1) return undefined;
-  const ruleContent = toTrimmedString(toolInput.rule, { maxLen: 2048 });
-  return [
-    {
-      type: 'addRules',
-      behavior: 'allow',
-      destination: 'session',
-      rules: [
-        {
-          toolName: toolNames[0],
-          ...(ruleContent ? { ruleContent } : {}),
-        },
-      ],
-    },
-  ];
 }
 
 // prettier-ignore

--- a/apps/core/src/jobs/ipc-admin-handlers.ts
+++ b/apps/core/src/jobs/ipc-admin-handlers.ts
@@ -14,6 +14,7 @@ import { createTaskResponder, toTrimmedString } from './ipc-shared.js';
 import { parseSkillDraftAssets } from './skill-draft-ipc.js';
 import { getHostRuntimeCredentialEnv } from '../runtime/agent-spawn-host.js';
 import {
+  isPermanentPermissionDecision,
   persistRequestPermissionRules,
   requestPermissionDescription,
   requestPermissionQueuedMessage,
@@ -516,11 +517,11 @@ function startRequestOnlyCapabilityReview(input: { deps: Parameters<TaskHandler>
       });
       const reason = decision.approved ? 'missing approving principal' : decision.reason || 'not approved';
       let persistedRules: string[] = [];
-      if (decision.approved && decision.updatedPermissions?.length && input.review.toolName === 'request_permission') {
+      if (input.review.toolName === 'request_permission' && isPermanentPermissionDecision(decision)) {
         persistedRules = await persistRequestPermissionRules({
           deps: input.deps,
           sourceGroup: input.sourceGroup,
-          updates: decision.updatedPermissions,
+          updates: decision.updatedPermissions ?? [],
         });
       }
       message = decision.approved && decision.decidedBy

--- a/apps/core/src/jobs/ipc-admin-handlers.ts
+++ b/apps/core/src/jobs/ipc-admin-handlers.ts
@@ -13,6 +13,7 @@ import {
 import { createTaskResponder, toTrimmedString } from './ipc-shared.js';
 import { parseSkillDraftAssets } from './skill-draft-ipc.js';
 import { getHostRuntimeCredentialEnv } from '../runtime/agent-spawn-host.js';
+import type { PermissionApprovalUpdate } from '../domain/types.js';
 import {
   requestSettingsUpdateHandler,
   serviceRestartHandler,
@@ -485,6 +486,13 @@ function startRequestOnlyCapabilityReview(input: { deps: Parameters<TaskHandler>
         description: 'Only configured approvers can decide this request. This records the permission review only and does not enable the capability directly.',
         decisionReason: input.review.reason,
         toolInput: input.review.toolInput,
+        ...(input.review.toolName === 'request_permission'
+          ? {
+              suggestions: requestPermissionReviewSuggestions(
+                input.review.toolInput,
+              ),
+            }
+          : {}),
       });
       const reason = decision.approved ? 'missing approving principal' : decision.reason || 'not approved';
       message = decision.approved && decision.decidedBy ? `Approved ${input.review.displayName}. Permission review recorded by ${decision.decidedBy}; no capability was enabled by this request-only flow.` : `Rejected ${input.review.displayName}: ${reason}. No capability was enabled.`;
@@ -497,6 +505,28 @@ function startRequestOnlyCapabilityReview(input: { deps: Parameters<TaskHandler>
     }
     await input.deps.sendMessage(input.targetJid, message, input.threadId ? { threadId: input.threadId } : undefined);
   })().catch((err) => logger.error({ err, sourceGroup: input.sourceGroup, toolName: input.review.toolName }, 'Capability permission review final message failed'));
+}
+
+// prettier-ignore
+function requestPermissionReviewSuggestions(toolInput: Record<string, unknown>): PermissionApprovalUpdate[] | undefined {
+  if (toolInput.temporaryOnly === true) return undefined;
+  if (toolInput.permissionKind && toolInput.permissionKind !== 'tool') return undefined;
+  const toolNames = sanitizedStringList(Array.isArray(toolInput.toolNames) ? toolInput.toolNames : [toolInput.toolName]);
+  if (toolNames.length !== 1) return undefined;
+  const ruleContent = toTrimmedString(toolInput.rule, { maxLen: 2048 });
+  return [
+    {
+      type: 'addRules',
+      behavior: 'allow',
+      destination: 'session',
+      rules: [
+        {
+          toolName: toolNames[0],
+          ...(ruleContent ? { ruleContent } : {}),
+        },
+      ],
+    },
+  ];
 }
 
 // prettier-ignore

--- a/apps/core/src/jobs/request-permission-review.ts
+++ b/apps/core/src/jobs/request-permission-review.ts
@@ -1,0 +1,155 @@
+import { createHash } from 'crypto';
+
+import type { PermissionApprovalUpdate } from '../domain/types.js';
+import type { AgentToolBinding } from '../domain/tools/tools.js';
+import {
+  DEFAULT_MEMORY_APP_ID,
+  memoryAgentIdForGroupFolder,
+} from '../memory/app-memory-boundaries.js';
+import type { IpcDeps } from '../runtime/ipc-domain-types.js';
+import { toTrimmedString } from './ipc-shared.js';
+
+export interface RequestPermissionReview {
+  toolName: 'request_permission';
+  displayName: string;
+}
+
+export function requestPermissionQueuedMessage(
+  review: RequestPermissionReview,
+): string {
+  return `${review.displayName} request sent to this chat for approval. Allow once records a one-shot approval; Always allow can enable the approved rule for future runs.`;
+}
+
+export function requestPermissionDescription(): string {
+  return 'Only configured approvers can decide this request. Allow once records a one-shot approval; Always allow applies the approved rule to future runs.';
+}
+
+export function requestPermissionReviewEffect(
+  toolInput: Record<string, unknown>,
+  fallback: string,
+): string {
+  return requestPermissionReviewSuggestions(toolInput)
+    ? 'persistent_rule_when_always_allowed'
+    : fallback;
+}
+
+export async function persistRequestPermissionRules(input: {
+  deps: Pick<IpcDeps, 'getToolRepository'>;
+  sourceGroup: string;
+  updates: PermissionApprovalUpdate[];
+}): Promise<string[]> {
+  const repository = input.deps.getToolRepository?.();
+  if (!repository) {
+    throw new Error(
+      'Tool repository unavailable for persistent permission approval',
+    );
+  }
+  const allowedRules = permissionUpdateAllowedToolRules(input.updates);
+  if (allowedRules.length === 0) return [];
+  const appId = DEFAULT_MEMORY_APP_ID as never;
+  const agentId = memoryAgentIdForGroupFolder(input.sourceGroup) as never;
+  const timestamp = new Date().toISOString();
+  for (const allowedRule of allowedRules) {
+    const toolId = `tool:${allowedRule}` as never;
+    await repository.saveTool({
+      id: toolId,
+      appId,
+      name: toolId,
+      kind: 'host',
+      provider: 'myclaw',
+      displayName: allowedRule,
+      description:
+        'Persistent permission rule approved from request_permission.',
+      category: 'admin',
+      risk: 'high',
+      selectable: true,
+      status: 'active',
+      adapterRef: 'permission/request_permission',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await repository.saveAgentToolBinding({
+      id: persistentPermissionBindingId(appId, agentId, toolId),
+      appId,
+      agentId,
+      toolId,
+      status: 'active',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+  }
+  return allowedRules;
+}
+
+export function requestPermissionReviewSuggestions(
+  toolInput: Record<string, unknown>,
+): PermissionApprovalUpdate[] | undefined {
+  if (toolInput.temporaryOnly === true) return undefined;
+  if (toolInput.permissionKind && toolInput.permissionKind !== 'tool') {
+    return undefined;
+  }
+  const toolNames = sanitizedStringList(
+    Array.isArray(toolInput.toolNames)
+      ? toolInput.toolNames
+      : [toolInput.toolName],
+  );
+  if (toolNames.length !== 1) return undefined;
+  const ruleContent = toTrimmedString(toolInput.rule, { maxLen: 2048 });
+  return [
+    {
+      type: 'addRules',
+      behavior: 'allow',
+      destination: 'session',
+      rules: [
+        {
+          toolName: toolNames[0],
+          ...(ruleContent ? { ruleContent } : {}),
+        },
+      ],
+    },
+  ];
+}
+
+function permissionUpdateAllowedToolRules(
+  updates: PermissionApprovalUpdate[],
+): string[] {
+  const out = new Set<string>();
+  for (const update of updates) {
+    if (
+      (update.type !== 'addRules' && update.type !== 'replaceRules') ||
+      update.behavior !== 'allow'
+    ) {
+      continue;
+    }
+    for (const rule of update.rules || []) {
+      const toolName = toTrimmedString(rule.toolName, { maxLen: 120 });
+      if (!toolName) continue;
+      const ruleContent = toTrimmedString(rule.ruleContent, { maxLen: 2048 });
+      out.add(ruleContent ? `${toolName}(${ruleContent})` : toolName);
+    }
+  }
+  return [...out];
+}
+
+function persistentPermissionBindingId(
+  appId: string,
+  agentId: string,
+  toolId: string,
+): AgentToolBinding['id'] {
+  const digest = createHash('sha256')
+    .update(`${appId}\0${agentId}\0${toolId}`)
+    .digest('base64url')
+    .slice(0, 32);
+  return `agent-tool-binding:permission:${digest}` as AgentToolBinding['id'];
+}
+
+function sanitizedStringList(values: unknown[]): string[] {
+  return [
+    ...new Set(
+      values
+        .slice(0, 50)
+        .map((item) => toTrimmedString(item, { maxLen: 512 }))
+        .filter((item): item is string => Boolean(item)),
+    ),
+  ];
+}

--- a/apps/core/src/jobs/request-permission-review.ts
+++ b/apps/core/src/jobs/request-permission-review.ts
@@ -1,6 +1,9 @@
 import { createHash } from 'crypto';
 
-import type { PermissionApprovalUpdate } from '../domain/types.js';
+import type {
+  PermissionApprovalDecision,
+  PermissionApprovalUpdate,
+} from '../domain/types.js';
 import type { AgentToolBinding } from '../domain/tools/tools.js';
 import {
   DEFAULT_MEMORY_APP_ID,
@@ -46,15 +49,18 @@ export async function persistRequestPermissionRules(input: {
   }
   const allowedRules = permissionUpdateAllowedToolRules(input.updates);
   if (allowedRules.length === 0) return [];
+  if (allowedRules.length !== 1) {
+    throw new Error('Persistent permission approval must contain one rule');
+  }
   const appId = DEFAULT_MEMORY_APP_ID as never;
   const agentId = memoryAgentIdForGroupFolder(input.sourceGroup) as never;
   const timestamp = new Date().toISOString();
   for (const allowedRule of allowedRules) {
-    const toolId = `tool:${allowedRule}` as never;
+    const toolId = persistentPermissionToolId(allowedRule);
     await repository.saveTool({
       id: toolId,
       appId,
-      name: toolId,
+      name: allowedRule,
       kind: 'host',
       provider: 'myclaw',
       displayName: allowedRule,
@@ -81,6 +87,17 @@ export async function persistRequestPermissionRules(input: {
   return allowedRules;
 }
 
+export function isPermanentPermissionDecision(
+  decision: PermissionApprovalDecision,
+): boolean {
+  return (
+    decision.approved === true &&
+    decision.mode === 'allow_persistent_rule' &&
+    decision.decisionClassification === 'user_permanent' &&
+    (decision.updatedPermissions?.length ?? 0) > 0
+  );
+}
+
 export function requestPermissionReviewSuggestions(
   toolInput: Record<string, unknown>,
 ): PermissionApprovalUpdate[] | undefined {
@@ -94,7 +111,8 @@ export function requestPermissionReviewSuggestions(
       : [toolInput.toolName],
   );
   if (toolNames.length !== 1) return undefined;
-  const ruleContent = toTrimmedString(toolInput.rule, { maxLen: 2048 });
+  const ruleContent = strictRuleContent(toolInput.rule);
+  if (ruleContent === null) return undefined;
   return [
     {
       type: 'addRules',
@@ -124,11 +142,25 @@ function permissionUpdateAllowedToolRules(
     for (const rule of update.rules || []) {
       const toolName = toTrimmedString(rule.toolName, { maxLen: 120 });
       if (!toolName) continue;
-      const ruleContent = toTrimmedString(rule.ruleContent, { maxLen: 2048 });
+      const ruleContent = strictRuleContent(rule.ruleContent);
+      if (ruleContent === null) continue;
       out.add(ruleContent ? `${toolName}(${ruleContent})` : toolName);
     }
   }
   return [...out];
+}
+
+function persistentPermissionToolId(allowedRule: string) {
+  const digest = createHash('sha256').update(allowedRule).digest('hex');
+  return `tool:permission-rule:${digest}` as never;
+}
+
+function strictRuleContent(value: unknown): string | undefined | null {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length <= 2048 ? trimmed : null;
 }
 
 function persistentPermissionBindingId(

--- a/apps/core/src/runner/claude/permission-callback.ts
+++ b/apps/core/src/runner/claude/permission-callback.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import { nowIso, nowMs, sleep } from '../../infrastructure/time/datetime.js';
 import { isPlainObject } from '../../shared/object.js';
 import { hasValidIpcResponseSignature } from './ipc-signing.js';
@@ -34,11 +35,13 @@ export async function requestPermissionApproval(options: {
     );
     fs.mkdirSync(permissionRequestsDir, { recursive: true });
     fs.mkdirSync(permissionResponsesDir, { recursive: true });
-    const requestId = `perm-${nowMs()}-${Math.random().toString(36).slice(2, 8)}`;
+    const requestId = `perm-${randomUUID()}`;
+    const responseNonce = randomUUID();
     const requestPath = path.join(permissionRequestsDir, `${requestId}.json`);
     const requestTmpPath = `${requestPath}.tmp`;
     const payload = {
       requestId,
+      responseNonce,
       sourceGroup: options.groupFolder,
       toolName: options.toolName,
       ...(options.title ? { title: options.title } : {}),
@@ -75,6 +78,7 @@ export async function requestPermissionApproval(options: {
           ) {
             const responsePayload: Record<string, unknown> = {
               requestId,
+              responseNonce,
               approved: Boolean((raw as { approved?: unknown }).approved),
               ...(typeof (raw as { mode?: unknown }).mode === 'string'
                 ? { mode: (raw as { mode: string }).mode }
@@ -103,6 +107,15 @@ export async function requestPermissionApproval(options: {
                   }
                 : {}),
             };
+            if (
+              (raw as { responseNonce?: unknown }).responseNonce !==
+              responseNonce
+            ) {
+              return {
+                approved: false,
+                reason: 'Malformed permission response',
+              };
+            }
             if (
               !hasValidIpcResponseSignature(
                 raw as Record<string, unknown>,

--- a/apps/core/src/runner/claude/permission-callback.ts
+++ b/apps/core/src/runner/claude/permission-callback.ts
@@ -76,14 +76,14 @@ export async function requestPermissionApproval(options: {
             const responsePayload: Record<string, unknown> = {
               requestId,
               approved: Boolean((raw as { approved?: unknown }).approved),
+              ...(typeof (raw as { mode?: unknown }).mode === 'string'
+                ? { mode: (raw as { mode: string }).mode }
+                : {}),
               ...(typeof (raw as { decidedBy?: unknown }).decidedBy === 'string'
                 ? { decidedBy: (raw as { decidedBy: string }).decidedBy }
                 : {}),
               ...(typeof (raw as { reason?: unknown }).reason === 'string'
                 ? { reason: (raw as { reason: string }).reason }
-                : {}),
-              ...(typeof (raw as { mode?: unknown }).mode === 'string'
-                ? { mode: (raw as { mode: string }).mode }
                 : {}),
               ...(Array.isArray(
                 (raw as { updatedPermissions?: unknown }).updatedPermissions,

--- a/apps/core/src/runner/claude/query-loop.ts
+++ b/apps/core/src/runner/claude/query-loop.ts
@@ -233,7 +233,7 @@ export async function runQuery(
           suggestions:
             (permissionOpts.suggestions?.length ?? 0) > 0
               ? permissionOpts.suggestions
-              : synthesizePermissionSuggestions(toolName, input, {
+              : synthesizePermissionSuggestions(toolName, {
                   blockedPath: permissionOpts.blockedPath,
                 }),
           threadId: agentInput.threadId,
@@ -262,6 +262,12 @@ export async function runQuery(
           behavior: 'deny' as const,
           message: `Permission denied: ${reason}`,
           interrupt: false,
+          ...(decision.decisionClassification
+            ? {
+                decisionClassification:
+                  decision.decisionClassification as never,
+              }
+            : {}),
         };
       },
       settingSources: ['user'],
@@ -385,12 +391,12 @@ export async function runQuery(
 
 function synthesizePermissionSuggestions(
   toolName: string,
-  input: Record<string, unknown>,
   options: { blockedPath?: string },
 ): unknown[] | undefined {
   const normalizedToolName = toolName.trim();
   if (!normalizedToolName) return undefined;
-  const ruleContent = inferPermissionRuleContent(input, options);
+  const ruleContent = inferPermissionRuleContent(options);
+  if (!ruleContent) return undefined;
   return [
     {
       type: 'addRules',
@@ -406,59 +412,18 @@ function synthesizePermissionSuggestions(
   ];
 }
 
-function inferPermissionRuleContent(
-  input: Record<string, unknown>,
-  options: { blockedPath?: string },
-): string | undefined {
-  const scope =
-    firstTrimmedInputValue(input, [
-      'scope',
-      'rule',
-      'ruleContent',
-      'command',
-      'cmd',
-      'file_path',
-      'path',
-      'notebook_path',
-      'url',
-      'domain',
-      'subagent_type',
-      'agentType',
-      'operation',
-      'resource',
-      'target',
-      'name',
-    ]) || trimmed(options.blockedPath);
+function inferPermissionRuleContent(options: {
+  blockedPath?: string;
+}): string | undefined {
+  const scope = trimmed(options.blockedPath);
   if (!scope) return undefined;
-  if (looksLikeHttpUrl(scope)) {
-    try {
-      return `domain:${new URL(scope).hostname}`;
-    } catch {
-      return scope;
-    }
-  }
   return scope;
-}
-
-function firstTrimmedInputValue(
-  input: Record<string, unknown>,
-  keys: string[],
-): string | undefined {
-  for (const key of keys) {
-    const value = trimmed(input[key]);
-    if (value) return value;
-  }
-  return undefined;
 }
 
 function trimmed(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const out = value.trim();
   return out || undefined;
-}
-
-function looksLikeHttpUrl(value: string): boolean {
-  return /^https?:\/\//i.test(value);
 }
 
 function assertRequiredMcpServerReady(message: unknown): void {

--- a/apps/core/src/runner/claude/query-loop.ts
+++ b/apps/core/src/runner/claude/query-loop.ts
@@ -230,7 +230,12 @@ export async function runQuery(
           toolInput: input,
           toolUseID: permissionOpts.toolUseID,
           agentID: permissionOpts.agentID,
-          suggestions: permissionOpts.suggestions,
+          suggestions:
+            (permissionOpts.suggestions?.length ?? 0) > 0
+              ? permissionOpts.suggestions
+              : synthesizePermissionSuggestions(toolName, input, {
+                  blockedPath: permissionOpts.blockedPath,
+                }),
           threadId: agentInput.threadId,
         });
         if (decision.approved) {
@@ -376,6 +381,84 @@ export async function runQuery(
     lastAssistantUuid,
     closedDuringQuery,
   };
+}
+
+function synthesizePermissionSuggestions(
+  toolName: string,
+  input: Record<string, unknown>,
+  options: { blockedPath?: string },
+): unknown[] | undefined {
+  const normalizedToolName = toolName.trim();
+  if (!normalizedToolName) return undefined;
+  const ruleContent = inferPermissionRuleContent(input, options);
+  return [
+    {
+      type: 'addRules',
+      behavior: 'allow',
+      destination: 'session',
+      rules: [
+        {
+          toolName: normalizedToolName,
+          ...(ruleContent ? { ruleContent } : {}),
+        },
+      ],
+    },
+  ];
+}
+
+function inferPermissionRuleContent(
+  input: Record<string, unknown>,
+  options: { blockedPath?: string },
+): string | undefined {
+  const scope =
+    firstTrimmedInputValue(input, [
+      'scope',
+      'rule',
+      'ruleContent',
+      'command',
+      'cmd',
+      'file_path',
+      'path',
+      'notebook_path',
+      'url',
+      'domain',
+      'subagent_type',
+      'agentType',
+      'operation',
+      'resource',
+      'target',
+      'name',
+    ]) || trimmed(options.blockedPath);
+  if (!scope) return undefined;
+  if (looksLikeHttpUrl(scope)) {
+    try {
+      return `domain:${new URL(scope).hostname}`;
+    } catch {
+      return scope;
+    }
+  }
+  return scope;
+}
+
+function firstTrimmedInputValue(
+  input: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = trimmed(input[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function trimmed(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const out = value.trim();
+  return out || undefined;
+}
+
+function looksLikeHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
 }
 
 function assertRequiredMcpServerReady(message: unknown): void {

--- a/apps/core/src/runtime/configured-agent-tools.ts
+++ b/apps/core/src/runtime/configured-agent-tools.ts
@@ -15,7 +15,14 @@ export async function resolveConfiguredAllowedTools(input: {
     appId: input.appId as never,
     agentId: input.agentId as never,
   });
-  return bindings
-    .filter((binding) => binding.status === 'active')
-    .map((binding) => configuredAllowedToolName(binding.toolId));
+  const activeBindings = bindings.filter(
+    (binding) => binding.status === 'active',
+  );
+  const tools = await Promise.all(
+    activeBindings.map((binding) => input.repository?.getTool(binding.toolId)),
+  );
+  return activeBindings.map((binding, index) => {
+    const tool = tools[index];
+    return tool?.name || configuredAllowedToolName(binding.toolId);
+  });
 }

--- a/apps/core/src/runtime/ipc-domain-types.ts
+++ b/apps/core/src/runtime/ipc-domain-types.ts
@@ -8,6 +8,7 @@ import {
 } from '../domain/types.js';
 import type { OpsRepository } from '../domain/repositories/ops-repo.js';
 import type { HostnameLookup } from '../domain/network/public-address-policy.js';
+import type { ToolCatalogRepository } from '../domain/ports/repositories.js';
 
 export interface IpcDeps {
   sendMessage: (
@@ -34,6 +35,7 @@ export interface IpcDeps {
   ) => Promise<UserQuestionResponse>;
   mcpHostnameLookup?: HostnameLookup;
   opsRepository: OpsRepository;
+  getToolRepository?: () => ToolCatalogRepository | undefined;
 }
 
 export interface IpcDomainContext {

--- a/apps/core/src/runtime/ipc-interaction-handler.ts
+++ b/apps/core/src/runtime/ipc-interaction-handler.ts
@@ -55,7 +55,10 @@ function withSignature(
 export function writePermissionIpcResponse(
   ipcBaseDir: string,
   sourceGroup: string,
-  decision: PermissionApprovalDecision & { requestId: string },
+  decision: PermissionApprovalDecision & {
+    requestId: string;
+    responseNonce?: string;
+  },
   privateKeyPem?: string,
 ): void {
   const responseDir = path.join(
@@ -69,6 +72,9 @@ export function writePermissionIpcResponse(
   const tmpPath = `${responsePath}.tmp`;
   const payload = withSignature(privateKeyPem, {
     requestId: decision.requestId,
+    ...(decision.responseNonce
+      ? { responseNonce: decision.responseNonce }
+      : {}),
     approved: decision.approved,
     ...(decision.mode ? { mode: decision.mode } : {}),
     ...(decision.decidedBy ? { decidedBy: decision.decidedBy } : {}),

--- a/apps/core/src/runtime/ipc-interaction-processing.ts
+++ b/apps/core/src/runtime/ipc-interaction-processing.ts
@@ -38,6 +38,7 @@ export function writePermissionInteractionFailure(input: {
   ipcBaseDir: string;
   sourceGroup: string;
   requestId: string;
+  responseNonce?: string;
   threadId?: string;
   logger: IpcInteractionLogger;
 }): void {
@@ -47,6 +48,7 @@ export function writePermissionInteractionFailure(input: {
       input.sourceGroup,
       {
         requestId: input.requestId,
+        ...(input.responseNonce ? { responseNonce: input.responseNonce } : {}),
         approved: false,
         reason: 'Failed to process permission request',
       },
@@ -103,6 +105,7 @@ export async function processPermissionInteractionIpc(input: {
       input.sourceGroup,
       {
         requestId: input.request.requestId,
+        responseNonce: input.request.responseNonce,
         approved: decision.approved,
         mode: decision.mode,
         decidedBy: decision.decidedBy,
@@ -121,6 +124,7 @@ export async function processPermissionInteractionIpc(input: {
       ipcBaseDir: input.ipcBaseDir,
       sourceGroup: input.sourceGroup,
       requestId: input.request.requestId,
+      responseNonce: input.request.responseNonce,
       threadId: input.request.threadId,
       logger: input.logger,
     });

--- a/apps/core/src/runtime/ipc-parsing.ts
+++ b/apps/core/src/runtime/ipc-parsing.ts
@@ -265,6 +265,7 @@ export function parsePermissionIpcRequest(
   if (!requestId || !PERMISSION_IPC_REQUEST_ID_PATTERN.test(requestId)) {
     throw new Error('Invalid permission IPC requestId');
   }
+  const responseNonce = toTrimmedString(raw.responseNonce, { maxLen: 128 });
   const toolName = toTrimmedString(raw.toolName, { maxLen: 120 });
   if (!toolName) throw new Error('Permission IPC toolName is required');
   const title = toTrimmedString(raw.title, { maxLen: 2000 });
@@ -280,6 +281,7 @@ export function parsePermissionIpcRequest(
 
   return {
     requestId,
+    ...(responseNonce ? { responseNonce } : {}),
     sourceGroup,
     ...(threadId ? { threadId } : {}),
     toolName,

--- a/apps/core/test/integration/permission-approval-ipc.integration.test.ts
+++ b/apps/core/test/integration/permission-approval-ipc.integration.test.ts
@@ -137,6 +137,7 @@ describe('permission approval IPC boundary', () => {
 
     expect(parsedRequest).toMatchObject({
       requestId: pendingRequest.requestId,
+      responseNonce: expect.any(String),
       sourceGroup: groupFolder,
       threadId,
       toolName: 'browser_open',
@@ -170,6 +171,7 @@ describe('permission approval IPC boundary', () => {
       groupFolder,
       {
         requestId: pendingRequest.requestId,
+        responseNonce: parsedRequest.responseNonce,
         approved: true,
         mode: 'allow_once',
         decidedBy: 'admin:lead',
@@ -229,6 +231,7 @@ describe('permission approval IPC boundary', () => {
       JSON.stringify(
         {
           requestId: pendingRequest.requestId,
+          responseNonce: pendingRequest.raw.responseNonce,
           approved: true,
           decidedBy: 'admin:lead',
         },

--- a/apps/core/test/integration/permission-approval-ipc.integration.test.ts
+++ b/apps/core/test/integration/permission-approval-ipc.integration.test.ts
@@ -171,16 +171,20 @@ describe('permission approval IPC boundary', () => {
       {
         requestId: pendingRequest.requestId,
         approved: true,
+        mode: 'allow_once',
         decidedBy: 'admin:lead',
         reason: 'Approved for one-time access',
+        decisionClassification: 'user_temporary',
       },
       responseSigningKey,
     );
 
     await expect(pendingDecision).resolves.toEqual({
       approved: true,
+      mode: 'allow_once',
       decidedBy: 'admin:lead',
       reason: 'Approved for one-time access',
+      decisionClassification: 'user_temporary',
     });
   });
 

--- a/apps/core/test/integration/skills-registry-flow.integration.test.ts
+++ b/apps/core/test/integration/skills-registry-flow.integration.test.ts
@@ -167,10 +167,24 @@ describe('skill registry integration flow', () => {
   });
 
   function createCapabilityReviewDeps(options?: {
-    decision?: { approved: boolean; decidedBy?: string; reason?: string };
+    decision?: {
+      approved: boolean;
+      mode?: string;
+      decidedBy?: string;
+      reason?: string;
+      updatedPermissions?: unknown[];
+    };
     groups?: Record<string, any>;
   }) {
     const sendMessage = vi.fn(async () => undefined);
+    const toolRepository = {
+      getTool: vi.fn(async () => null),
+      listTools: vi.fn(async () => []),
+      saveTool: vi.fn(async () => undefined),
+      saveAgentToolBinding: vi.fn(async () => undefined),
+      disableAgentToolBinding: vi.fn(async () => null),
+      listAgentToolBindings: vi.fn(async () => []),
+    };
     const requestPermissionApproval = vi.fn(
       async () =>
         options?.decision ?? {
@@ -196,8 +210,9 @@ describe('skill registry integration flow', () => {
       requestUserAnswer: vi.fn(),
       onSchedulerChanged: vi.fn(),
       registerGroup: vi.fn(),
+      getToolRepository: () => toolRepository,
     };
-    return { deps, sendMessage, requestPermissionApproval };
+    return { deps, sendMessage, requestPermissionApproval, toolRepository };
   }
 
   it('uploads, deduplicates, approves, binds, resolves, and disables a local skill through control SDK and services', async () => {
@@ -597,6 +612,81 @@ describe('skill registry integration flow', () => {
             },
           ],
         }),
+      );
+    });
+  });
+
+  it('persists request_permission persistent approvals as configured allowed tool rules', async () => {
+    const { processTaskIpc } = await import('@core/jobs/ipc-handler.js');
+    const { deps, sendMessage, toolRepository } = createCapabilityReviewDeps({
+      decision: {
+        approved: true,
+        mode: 'allow_persistent_rule',
+        decidedBy: 'Approver',
+        reason: 'persistent rule allowed',
+        updatedPermissions: [
+          {
+            type: 'addRules',
+            behavior: 'allow',
+            destination: 'session',
+            rules: [
+              {
+                toolName: 'mcp__internal__deploy_preview',
+                ruleContent: 'environment:staging',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await processTaskIpc(
+      {
+        type: 'request_permission',
+        taskId: 'request-permission-persistent-approval-test',
+        targetJid: 'chat-origin',
+        chatJid: 'chat-origin',
+        authThreadId: 'thread-origin',
+        payload: {
+          permissionKind: 'tool',
+          toolName: 'mcp__internal__deploy_preview',
+          rule: 'environment:staging',
+          temporaryOnly: false,
+          reason: 'Deploy previews repeatedly during this session.',
+        },
+      },
+      'agent:one',
+      false,
+      deps as any,
+    );
+
+    await vi.waitFor(() => {
+      expect(toolRepository.saveTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'tool:mcp__internal__deploy_preview(environment:staging)',
+          appId: 'default',
+          name: 'tool:mcp__internal__deploy_preview(environment:staging)',
+          displayName: 'mcp__internal__deploy_preview(environment:staging)',
+          adapterRef: 'permission/request_permission',
+          status: 'active',
+        }),
+      );
+    });
+    expect(toolRepository.saveAgentToolBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'default',
+        agentId: 'agent:one',
+        toolId: 'tool:mcp__internal__deploy_preview(environment:staging)',
+        status: 'active',
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith(
+        'chat-origin',
+        expect.stringContaining(
+          'Persistent permission rule enabled for future runs',
+        ),
+        { threadId: 'thread-origin' },
       );
     });
   });

--- a/apps/core/test/integration/skills-registry-flow.integration.test.ts
+++ b/apps/core/test/integration/skills-registry-flow.integration.test.ts
@@ -172,6 +172,7 @@ describe('skill registry integration flow', () => {
       mode?: string;
       decidedBy?: string;
       reason?: string;
+      decisionClassification?: string;
       updatedPermissions?: unknown[];
     };
     groups?: Record<string, any>;
@@ -624,6 +625,7 @@ describe('skill registry integration flow', () => {
         mode: 'allow_persistent_rule',
         decidedBy: 'Approver',
         reason: 'persistent rule allowed',
+        decisionClassification: 'user_permanent',
         updatedPermissions: [
           {
             type: 'addRules',
@@ -663,9 +665,9 @@ describe('skill registry integration flow', () => {
     await vi.waitFor(() => {
       expect(toolRepository.saveTool).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 'tool:mcp__internal__deploy_preview(environment:staging)',
+          id: expect.stringMatching(/^tool:permission-rule:/),
           appId: 'default',
-          name: 'tool:mcp__internal__deploy_preview(environment:staging)',
+          name: 'mcp__internal__deploy_preview(environment:staging)',
           displayName: 'mcp__internal__deploy_preview(environment:staging)',
           adapterRef: 'permission/request_permission',
           status: 'active',
@@ -676,7 +678,7 @@ describe('skill registry integration flow', () => {
       expect.objectContaining({
         appId: 'default',
         agentId: 'agent:one',
-        toolId: 'tool:mcp__internal__deploy_preview(environment:staging)',
+        toolId: expect.stringMatching(/^tool:permission-rule:/),
         status: 'active',
       }),
     );
@@ -688,6 +690,50 @@ describe('skill registry integration flow', () => {
         ),
         { threadId: 'thread-origin' },
       );
+    });
+  });
+
+  it('does not persist request_permission updatedPermissions without a permanent decision', async () => {
+    const { processTaskIpc } = await import('@core/jobs/ipc-handler.js');
+    const { deps, toolRepository } = createCapabilityReviewDeps({
+      decision: {
+        approved: true,
+        mode: 'allow_once',
+        decidedBy: 'Approver',
+        reason: 'allowed once',
+        decisionClassification: 'user_temporary',
+        updatedPermissions: [
+          {
+            type: 'addRules',
+            behavior: 'allow',
+            destination: 'session',
+            rules: [{ toolName: 'Bash' }],
+          },
+        ],
+      },
+    });
+
+    await processTaskIpc(
+      {
+        type: 'request_permission',
+        taskId: 'request-permission-allow-once-no-persist-test',
+        targetJid: 'chat-origin',
+        chatJid: 'chat-origin',
+        authThreadId: 'thread-origin',
+        payload: {
+          permissionKind: 'tool',
+          toolName: 'Bash',
+          reason: 'Run one command.',
+        },
+      },
+      'agent:one',
+      false,
+      deps as any,
+    );
+
+    await vi.waitFor(() => {
+      expect(toolRepository.saveTool).not.toHaveBeenCalled();
+      expect(toolRepository.saveAgentToolBinding).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/core/test/integration/skills-registry-flow.integration.test.ts
+++ b/apps/core/test/integration/skills-registry-flow.integration.test.ts
@@ -555,6 +555,52 @@ describe('skill registry integration flow', () => {
     expect([...state.bindings.values()]).toEqual([]);
   });
 
+  it('adds a persistent single-rule suggestion for request_permission reviews', async () => {
+    const { processTaskIpc } = await import('@core/jobs/ipc-handler.js');
+    const { deps, requestPermissionApproval } = createCapabilityReviewDeps();
+
+    await processTaskIpc(
+      {
+        type: 'request_permission',
+        taskId: 'request-permission-persistent-suggestion-test',
+        targetJid: 'chat-origin',
+        chatJid: 'chat-origin',
+        authThreadId: 'thread-origin',
+        payload: {
+          permissionKind: 'tool',
+          toolName: 'mcp__internal__deploy_preview',
+          rule: 'environment:staging',
+          temporaryOnly: false,
+          reason: 'Deploy previews repeatedly during this session.',
+        },
+      },
+      'agent:one',
+      false,
+      deps as any,
+    );
+
+    await vi.waitFor(() => {
+      expect(requestPermissionApproval).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: 'request_permission',
+          suggestions: [
+            {
+              type: 'addRules',
+              behavior: 'allow',
+              destination: 'session',
+              rules: [
+                {
+                  toolName: 'mcp__internal__deploy_preview',
+                  ruleContent: 'environment:staging',
+                },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+  });
+
   it('rejects request-only capability approval target overrides', async () => {
     const { processTaskIpc } = await import('@core/jobs/ipc-handler.js');
     const { deps, sendMessage, requestPermissionApproval } =

--- a/apps/core/test/unit/jobs/request-permission-review.test.ts
+++ b/apps/core/test/unit/jobs/request-permission-review.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  persistRequestPermissionRules,
+  requestPermissionReviewSuggestions,
+} from '@core/jobs/request-permission-review.js';
+
+describe('request permission review helpers', () => {
+  it('does not suggest persistent tool grants for temporary, non-tool, multi-tool, or oversized rules', () => {
+    expect(
+      requestPermissionReviewSuggestions({
+        temporaryOnly: true,
+        toolName: 'Bash',
+      }),
+    ).toBeUndefined();
+    expect(
+      requestPermissionReviewSuggestions({
+        permissionKind: 'provider_capability',
+        toolName: 'Bash',
+      }),
+    ).toBeUndefined();
+    expect(
+      requestPermissionReviewSuggestions({
+        permissionKind: 'tool',
+        toolNames: ['Bash', 'Write'],
+      }),
+    ).toBeUndefined();
+    expect(
+      requestPermissionReviewSuggestions({
+        permissionKind: 'tool',
+        toolName: 'Bash',
+        rule: 'x'.repeat(2049),
+      }),
+    ).toBeUndefined();
+  });
+
+  it('stores synthetic permission tools under namespaced ids without widening oversized rules', async () => {
+    const repository = {
+      saveTool: vi.fn(async () => undefined),
+      saveAgentToolBinding: vi.fn(async () => undefined),
+    };
+
+    const persisted = await persistRequestPermissionRules({
+      deps: { getToolRepository: () => repository as never },
+      sourceGroup: 'agent:one',
+      updates: [
+        {
+          type: 'addRules',
+          behavior: 'allow',
+          rules: [{ toolName: 'Bash' }],
+        },
+        {
+          type: 'addRules',
+          behavior: 'allow',
+          rules: [
+            {
+              toolName: 'Write',
+              ruleContent: 'x'.repeat(2049),
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(persisted).toEqual(['Bash']);
+    expect(repository.saveTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: expect.stringMatching(/^tool:permission-rule:/),
+        name: 'Bash',
+      }),
+    );
+    expect(repository.saveTool.mock.calls[0]?.[0].id).not.toBe('tool:Bash');
+  });
+});

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -257,6 +257,7 @@ export async function* query({ prompt, options }) {
     fs.mkdirSync(responseDir, { recursive: true });
     const responsePayload = {
       requestId: request.requestId,
+      responseNonce: request.responseNonce,
       approved: process.env.TEST_PERMISSION_DECISION === 'approve',
       ...(process.env.TEST_PERMISSION_MODE
         ? { mode: process.env.TEST_PERMISSION_MODE }
@@ -963,7 +964,7 @@ describe('agent-runner IPC lifecycle', () => {
           rules: [
             {
               toolName: 'Bash',
-              ruleContent: 'npm test',
+              ruleContent: call.permissionRequest.blockedPath,
             },
           ],
         },
@@ -980,7 +981,7 @@ describe('agent-runner IPC lifecycle', () => {
   );
 
   it(
-    'synthesizes persistent permission suggestions for arbitrary tool names',
+    'synthesizes persistent permission suggestions from host blockedPath, not agent input',
     async () => {
       const fixture = createRunnerFixture();
 
@@ -1004,7 +1005,7 @@ describe('agent-runner IPC lifecycle', () => {
               rules: [
                 {
                   toolName: 'mcp__internal__deploy_preview',
-                  ruleContent: 'environment:staging',
+                  ruleContent: call.permissionRequest.blockedPath,
                 },
               ],
             },
@@ -1084,6 +1085,7 @@ describe('agent-runner IPC lifecycle', () => {
 
       const result = await runRunner(fixture, baseInput(), {
         TEST_PERMISSION_DECISION: 'deny',
+        TEST_PERMISSION_CLASSIFICATION: 'user_reject',
         TEST_EXIT_AFTER_QUERY: '1',
       });
 
@@ -1094,6 +1096,7 @@ describe('agent-runner IPC lifecycle', () => {
           behavior: 'deny',
           message: 'Permission denied: deny',
           interrupt: false,
+          decisionClassification: 'user_reject',
         }),
       );
     },

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -234,13 +234,17 @@ export async function* query({ prompt, options }) {
   }
 
   if (process.env.TEST_PERMISSION_DECISION) {
+    const permissionToolName = process.env.TEST_PERMISSION_TOOL_NAME || 'Bash';
+    const permissionInput = process.env.TEST_PERMISSION_SCOPE
+      ? { scope: process.env.TEST_PERMISSION_SCOPE }
+      : { cmd: 'npm test', apiToken: 'secret-token' };
     const decisionPromise = options.canUseTool(
-      'Bash',
-      { cmd: 'npm test', apiToken: 'secret-token' },
+      permissionToolName,
+      permissionInput,
       {
         signal: new AbortController().signal,
         title: 'Run command',
-        displayName: 'Bash',
+        displayName: permissionToolName,
         description: 'Needs shell access',
         decisionReason: 'Agent wants to verify tests',
         blockedPath: process.env.MYCLAW_WORKSPACE_GROUP_DIR,
@@ -254,8 +258,17 @@ export async function* query({ prompt, options }) {
     const responsePayload = {
       requestId: request.requestId,
       approved: process.env.TEST_PERMISSION_DECISION === 'approve',
+      ...(process.env.TEST_PERMISSION_MODE
+        ? { mode: process.env.TEST_PERMISSION_MODE }
+        : {}),
       decidedBy: 'runner-test-admin',
       reason: process.env.TEST_PERMISSION_DECISION,
+      ...(process.env.TEST_PERMISSION_CLASSIFICATION
+        ? {
+            decisionClassification:
+              process.env.TEST_PERMISSION_CLASSIFICATION,
+          }
+        : {}),
     };
     const signature = signPayload(responsePayload);
     fs.writeFileSync(
@@ -942,6 +955,19 @@ describe('agent-runner IPC lifecycle', () => {
       expect(call?.permissionRequest?.toolInput).toEqual(
         expect.objectContaining({ cmd: 'npm test', apiToken: 'secret-token' }),
       );
+      expect(call?.permissionRequest?.suggestions).toEqual([
+        {
+          type: 'addRules',
+          behavior: 'allow',
+          destination: 'session',
+          rules: [
+            {
+              toolName: 'Bash',
+              ruleContent: 'npm test',
+            },
+          ],
+        },
+      ]);
       expect(call?.permissionDecision).toEqual({
         behavior: 'allow',
         updatedInput: { cmd: 'npm test', apiToken: 'secret-token' },
@@ -949,6 +975,69 @@ describe('agent-runner IPC lifecycle', () => {
       expect(
         fs.readdirSync(path.join(fixture.ipcDir, 'permission-responses')),
       ).toHaveLength(0);
+    },
+    RUNNER_IPC_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'synthesizes persistent permission suggestions for arbitrary tool names',
+    async () => {
+      const fixture = createRunnerFixture();
+
+      const result = await runRunner(fixture, baseInput(), {
+        TEST_PERMISSION_DECISION: 'approve',
+        TEST_PERMISSION_TOOL_NAME: 'mcp__internal__deploy_preview',
+        TEST_PERMISSION_SCOPE: 'environment:staging',
+        TEST_EXIT_AFTER_QUERY: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      const call = readRecord(fixture.recordPath).calls[0];
+      expect(call?.permissionRequest).toEqual(
+        expect.objectContaining({
+          toolName: 'mcp__internal__deploy_preview',
+          suggestions: [
+            {
+              type: 'addRules',
+              behavior: 'allow',
+              destination: 'session',
+              rules: [
+                {
+                  toolName: 'mcp__internal__deploy_preview',
+                  ruleContent: 'environment:staging',
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      expect(call?.permissionDecision).toEqual({
+        behavior: 'allow',
+        updatedInput: { scope: 'environment:staging' },
+      });
+    },
+    RUNNER_IPC_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'accepts a signed SDK permission response that includes a decision mode',
+    async () => {
+      const fixture = createRunnerFixture();
+
+      const result = await runRunner(fixture, baseInput(), {
+        TEST_PERMISSION_DECISION: 'approve',
+        TEST_PERMISSION_MODE: 'allow_once',
+        TEST_PERMISSION_CLASSIFICATION: 'user_temporary',
+        TEST_EXIT_AFTER_QUERY: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      const call = readRecord(fixture.recordPath).calls[0];
+      expect(call?.permissionDecision).toEqual({
+        behavior: 'allow',
+        updatedInput: { cmd: 'npm test', apiToken: 'secret-token' },
+        decisionClassification: 'user_temporary',
+      });
     },
     RUNNER_IPC_TEST_TIMEOUT_MS,
   );

--- a/apps/core/test/unit/runtime/configured-agent-tools.test.ts
+++ b/apps/core/test/unit/runtime/configured-agent-tools.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveConfiguredAllowedTools } from '@core/runtime/configured-agent-tools.js';
+
+describe('configured agent tools', () => {
+  it('resolves namespaced permission-rule catalog rows to their SDK rule names', async () => {
+    const repository = {
+      listAgentToolBindings: async () => [
+        {
+          status: 'active',
+          toolId: 'tool:permission-rule:abc123',
+        },
+      ],
+      getTool: async () => ({
+        name: 'Bash(npm test)',
+      }),
+    };
+
+    await expect(
+      resolveConfiguredAllowedTools({
+        repository: repository as never,
+        appId: 'default',
+        agentId: 'agent:one',
+      }),
+    ).resolves.toEqual(['Bash(npm test)']);
+  });
+
+  it('keeps the legacy tool id fallback when a catalog row is unavailable', async () => {
+    const repository = {
+      listAgentToolBindings: async () => [
+        {
+          status: 'active',
+          toolId: 'tool:Bash',
+        },
+      ],
+      getTool: async () => null,
+    };
+
+    await expect(
+      resolveConfiguredAllowedTools({
+        repository: repository as never,
+        appId: 'default',
+        agentId: 'agent:one',
+      }),
+    ).resolves.toEqual(['Bash']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the chat permission approval path so persistent grants are reachable and approved gated tool calls verify correctly.

- synthesize a tool-agnostic single-rule session suggestion when the SDK does not provide permission suggestions
- add persistent suggestions for request_permission review cards when the request is not temporary-only
- preserve signed permission response payload ordering so approvals with mode/classification verify
- log when a persistent option is dropped because suggestion shape is unsafe or ambiguous

Fixes #86
Fixes #87

## Validation

- npm run typecheck
- npm run test:unit -- apps/core/test/unit/channels/permission-interaction.test.ts apps/core/test/unit/runner/agent-runner-ipc.test.ts
- npm run test:integration -- apps/core/test/integration/permission-approval-ipc.integration.test.ts apps/core/test/integration/skills-registry-flow.integration.test.ts
- git diff --check
- ccc index

## Known Check Status

python3 .codex/scripts/check_task_completion.py still fails on the existing architecture ratchet: apps/core/src/runtime/group-processing.ts has 750 lines with a 742-line budget. That file is not touched by this PR. The script also emits advisory coverage warnings for changed channel/provider-adjacent files.