### PR TITLE
fix(browser): keep adapter projection neutral

### DIFF
--- a/apps/core/src/adapters/browser/AGENTS.md
+++ b/apps/core/src/adapters/browser/AGENTS.md
@@ -38,6 +38,9 @@
   or unhealthy browser action must not leave background-created files behind.
   Inline uploads need bounded file count, per-file bytes, total bytes, and plain
   filenames only.
+- Inline upload materialization must use collision-safe per-request paths.
+  Duplicate filenames in one request, same-name concurrent requests, and
+  existing files under `uploads/` must not overwrite or alias each other.
 - Keep artifact path policy separate from provider argument compatibility.
   File confinement is MyClaw-owned safety policy; Playwright MCP field-shape
   enrichment is backend projection.

--- a/apps/core/src/adapters/browser/AGENTS.md
+++ b/apps/core/src/adapters/browser/AGENTS.md
@@ -6,8 +6,11 @@
   0-based visible tab indices after filtering internal Chrome targets, and
   select/close requests translate those visible indices to backend indices
   inside the adapter. Numeric select/close must fail closed when that mapping
-  is missing or stale, and text-only tab lists must not be shown as stable tab
-  lists.
+  is missing or stale. Backend-specific output compatibility, such as
+  Playwright MCP markdown tab lists, belongs in a clearly named provider
+  compatibility helper before the neutral tab projection consumes it.
+- Treat Chrome internal targets by both URL and title. Omnibox popups can
+  surface with a non-`chrome://` URL but title `Omnibox Popup`.
 - `timeout_ms` must reach both budgets: the signed IPC/backend call timeout and
   the private Playwright MCP action budget. Keep backend process identity
   stable across per-call timeout changes; use a stable backend max/default
@@ -26,8 +29,14 @@
   inner viewport makes Playwright report every target outside the viewport and
   causes click, hover, and screenshot failures downstream.
 - Headed `browser_resize` should resize the visible Chrome window with CDP
-  `Browser.setWindowBounds`. Keep headless and emulated resize behavior
-  backend-native.
+  `Browser.setWindowBounds` and force `windowState: normal` with the requested
+  bounds. Keep headless and emulated resize behavior backend-native.
+- `browser_file_upload` should accept inline file content and materialize it
+  under the run artifact root. Requiring agents to pre-create files there is
+  not usable from restricted tool sandboxes.
+- Keep artifact path policy separate from provider argument compatibility.
+  File confinement is MyClaw-owned safety policy; Playwright MCP field-shape
+  enrichment is backend projection.
 - Browser deadline and artifact timestamp code should use the shared
   datetime helpers (`nowMs`/`nowIso`) instead of direct `Date.now()` or
   `new Date()` current-time reads so runtime timeout behavior stays

--- a/apps/core/src/adapters/browser/AGENTS.md
+++ b/apps/core/src/adapters/browser/AGENTS.md
@@ -34,9 +34,19 @@
 - `browser_file_upload` should accept inline file content and materialize it
   under the run artifact root. Requiring agents to pre-create files there is
   not usable from restricted tool sandboxes.
+- Check browser readiness before materializing inline upload files. A timed-out
+  or unhealthy browser action must not leave background-created files behind.
+  Inline uploads need bounded file count, per-file bytes, total bytes, and plain
+  filenames only.
 - Keep artifact path policy separate from provider argument compatibility.
   File confinement is MyClaw-owned safety policy; Playwright MCP field-shape
   enrichment is backend projection.
+- Text-only backend tab lists are not trusted UI state unless the compatibility
+  layer can parse them into adapter-owned tab metadata. Unparseable tab lists
+  must fail closed and clear stale visible-index mappings.
+- Treat an unhealthy tool-capability broker as a non-driveable browser status
+  for agent tools. Reporting `cdpReady: true` while the credential broker is
+  down is misleading because backend browser actions still cannot run.
 - Browser deadline and artifact timestamp code should use the shared
   datetime helpers (`nowMs`/`nowIso`) instead of direct `Date.now()` or
   `new Date()` current-time reads so runtime timeout behavior stays

--- a/apps/core/src/adapters/browser/browser-artifact-policy.ts
+++ b/apps/core/src/adapters/browser/browser-artifact-policy.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 import type { BrowserIpcAction } from '@myclaw/contracts';
 
@@ -16,11 +17,13 @@ export function writeBrowserArtifactFileSync(
   filename: string,
   content: Buffer | string,
   encoding?: BufferEncoding,
+  options: { exclusive?: boolean } = {},
 ): void {
   const flags =
     fs.constants.O_WRONLY |
     fs.constants.O_CREAT |
     fs.constants.O_TRUNC |
+    (options.exclusive ? fs.constants.O_EXCL : 0) |
     (fs.constants.O_NOFOLLOW ?? 0);
   const fd = fs.openSync(filename, flags, 0o600);
   try {
@@ -76,8 +79,9 @@ function materializeBrowserUploadFiles(
       `Browser inline uploads are limited to ${MAX_INLINE_UPLOAD_FILES} files.`,
     );
   }
+  const requestDir = `inline-${randomUUID()}`;
   const files = value.map((item, index) =>
-    parseBrowserUploadFile(item, index, fileAccessRoot),
+    parseBrowserUploadFile(item, index, requestDir, fileAccessRoot),
   );
   const totalBytes = files.reduce((sum, file) => sum + file.sizeBytes, 0);
   if (totalBytes > MAX_INLINE_UPLOAD_TOTAL_BYTES) {
@@ -86,7 +90,9 @@ function materializeBrowserUploadFiles(
     );
   }
   return files.map((file) => {
-    writeBrowserArtifactFileSync(file.outputPath, file.bytes);
+    writeBrowserArtifactFileSync(file.outputPath, file.bytes, undefined, {
+      exclusive: true,
+    });
     return path.relative(
       ensureBrowserArtifactRoot(fileAccessRoot),
       file.outputPath,
@@ -97,6 +103,7 @@ function materializeBrowserUploadFiles(
 function parseBrowserUploadFile(
   value: unknown,
   index: number,
+  requestDir: string,
   fileAccessRoot: string,
 ): { outputPath: string; bytes: Buffer; sizeBytes: number } {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -104,7 +111,7 @@ function parseBrowserUploadFile(
   }
   const row = value as Record<string, unknown>;
   const rawName = uploadFileName(row.name, index);
-  const filename = path.join('uploads', rawName);
+  const filename = path.join('uploads', requestDir, `${index + 1}-${rawName}`);
   const outputPath = resolveBrowserOutputPath(filename, fileAccessRoot);
   const content = row.content;
   if (typeof content !== 'string') {

--- a/apps/core/src/adapters/browser/browser-artifact-policy.ts
+++ b/apps/core/src/adapters/browser/browser-artifact-policy.ts
@@ -3,9 +3,35 @@ import path from 'node:path';
 
 import type { BrowserIpcAction } from '@myclaw/contracts';
 
+const MAX_INLINE_UPLOAD_FILES = 8;
+const MAX_INLINE_UPLOAD_FILE_BYTES = 8 * 1024 * 1024;
+const MAX_INLINE_UPLOAD_TOTAL_BYTES = 32 * 1024 * 1024;
+
 export function ensureBrowserArtifactRoot(dir: string): string {
   fs.mkdirSync(dir, { recursive: true });
   return fs.realpathSync.native(dir);
+}
+
+export function writeBrowserArtifactFileSync(
+  filename: string,
+  content: Buffer | string,
+  encoding?: BufferEncoding,
+): void {
+  const flags =
+    fs.constants.O_WRONLY |
+    fs.constants.O_CREAT |
+    fs.constants.O_TRUNC |
+    (fs.constants.O_NOFOLLOW ?? 0);
+  const fd = fs.openSync(filename, flags, 0o600);
+  try {
+    if (typeof content === 'string') {
+      fs.writeFileSync(fd, content, encoding);
+    } else {
+      fs.writeFileSync(fd, content);
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 export function normalizeBrowserFilePayload(
@@ -45,21 +71,39 @@ function materializeBrowserUploadFiles(
   if (!Array.isArray(value)) {
     throw new Error('Browser upload/drop files must be an array.');
   }
-  return value.map((item, index) =>
-    materializeBrowserUploadFile(item, index, fileAccessRoot),
+  if (value.length > MAX_INLINE_UPLOAD_FILES) {
+    throw new Error(
+      `Browser inline uploads are limited to ${MAX_INLINE_UPLOAD_FILES} files.`,
+    );
+  }
+  const files = value.map((item, index) =>
+    parseBrowserUploadFile(item, index, fileAccessRoot),
   );
+  const totalBytes = files.reduce((sum, file) => sum + file.sizeBytes, 0);
+  if (totalBytes > MAX_INLINE_UPLOAD_TOTAL_BYTES) {
+    throw new Error(
+      `Browser inline uploads are limited to ${MAX_INLINE_UPLOAD_TOTAL_BYTES} decoded bytes per request.`,
+    );
+  }
+  return files.map((file) => {
+    writeBrowserArtifactFileSync(file.outputPath, file.bytes);
+    return path.relative(
+      ensureBrowserArtifactRoot(fileAccessRoot),
+      file.outputPath,
+    );
+  });
 }
 
-function materializeBrowserUploadFile(
+function parseBrowserUploadFile(
   value: unknown,
   index: number,
   fileAccessRoot: string,
-): string {
+): { outputPath: string; bytes: Buffer; sizeBytes: number } {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('Browser upload/drop file entries must be objects.');
   }
   const row = value as Record<string, unknown>;
-  const rawName = stringValue(row.name) || `upload-${index + 1}.txt`;
+  const rawName = uploadFileName(row.name, index);
   const filename = path.join('uploads', rawName);
   const outputPath = resolveBrowserOutputPath(filename, fileAccessRoot);
   const content = row.content;
@@ -67,8 +111,46 @@ function materializeBrowserUploadFile(
     throw new Error('Browser upload/drop file content must be a string.');
   }
   const encoding = row.encoding === 'base64' ? 'base64' : 'utf8';
-  fs.writeFileSync(outputPath, Buffer.from(content, encoding));
-  return path.relative(ensureBrowserArtifactRoot(fileAccessRoot), outputPath);
+  const normalizedContent =
+    encoding === 'base64' ? content.replace(/\s/g, '') : content;
+  if (encoding === 'base64' && !isValidBase64(normalizedContent)) {
+    throw new Error('Browser inline upload base64 content is invalid.');
+  }
+  const sizeBytes = Buffer.byteLength(normalizedContent, encoding);
+  if (sizeBytes > MAX_INLINE_UPLOAD_FILE_BYTES) {
+    throw new Error(
+      `Browser inline upload files are limited to ${MAX_INLINE_UPLOAD_FILE_BYTES} decoded bytes each.`,
+    );
+  }
+  return {
+    outputPath,
+    bytes: Buffer.from(normalizedContent, encoding),
+    sizeBytes,
+  };
+}
+
+function uploadFileName(value: unknown, index: number): string {
+  const raw = stringValue(value) || `upload-${index + 1}.txt`;
+  if (
+    raw !== path.basename(raw) ||
+    raw.includes('/') ||
+    raw.includes('\\') ||
+    raw === '.' ||
+    raw === '..'
+  ) {
+    throw new Error(
+      'Browser inline upload file names must be plain filenames.',
+    );
+  }
+  return raw;
+}
+
+function isValidBase64(value: string): boolean {
+  return (
+    value.length % 4 === 0 &&
+    /^[A-Za-z0-9+/]*={0,2}$/.test(value) &&
+    !/=.+[^=]/.test(value)
+  );
 }
 
 function arrayValue(value: unknown): unknown[] {

--- a/apps/core/src/adapters/browser/browser-artifact-policy.ts
+++ b/apps/core/src/adapters/browser/browser-artifact-policy.ts
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { BrowserIpcAction } from '@myclaw/contracts';
+
+export function ensureBrowserArtifactRoot(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  return fs.realpathSync.native(dir);
+}
+
+export function normalizeBrowserFilePayload(
+  toolName: BrowserIpcAction,
+  payload: Record<string, unknown>,
+  options: { fileAccessRoot: string },
+): Record<string, unknown> {
+  const next = { ...payload };
+  if (next.filename !== undefined) {
+    next.filename = resolveBrowserOutputPath(
+      next.filename,
+      options.fileAccessRoot,
+    );
+  }
+  if (toolName === 'browser_file_upload' && next.files !== undefined) {
+    next.paths = [
+      ...arrayValue(next.paths),
+      ...materializeBrowserUploadFiles(next.files, options.fileAccessRoot),
+    ];
+    delete next.files;
+  }
+  if (next.paths !== undefined) {
+    if (!Array.isArray(next.paths)) {
+      throw new Error('Browser upload/drop paths must be an array.');
+    }
+    next.paths = next.paths.map((item) =>
+      resolveBrowserInputFilePath(item, options.fileAccessRoot),
+    );
+  }
+  return next;
+}
+
+function materializeBrowserUploadFiles(
+  value: unknown,
+  fileAccessRoot: string,
+): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Browser upload/drop files must be an array.');
+  }
+  return value.map((item, index) =>
+    materializeBrowserUploadFile(item, index, fileAccessRoot),
+  );
+}
+
+function materializeBrowserUploadFile(
+  value: unknown,
+  index: number,
+  fileAccessRoot: string,
+): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Browser upload/drop file entries must be objects.');
+  }
+  const row = value as Record<string, unknown>;
+  const rawName = stringValue(row.name) || `upload-${index + 1}.txt`;
+  const filename = path.join('uploads', rawName);
+  const outputPath = resolveBrowserOutputPath(filename, fileAccessRoot);
+  const content = row.content;
+  if (typeof content !== 'string') {
+    throw new Error('Browser upload/drop file content must be a string.');
+  }
+  const encoding = row.encoding === 'base64' ? 'base64' : 'utf8';
+  fs.writeFileSync(outputPath, Buffer.from(content, encoding));
+  return path.relative(ensureBrowserArtifactRoot(fileAccessRoot), outputPath);
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function resolveBrowserPath(value: unknown, fileAccessRoot: string): string {
+  const raw = stringValue(value);
+  if (!raw) throw new Error('Browser file action requires a path.');
+  const root = path.resolve(fileAccessRoot);
+  const candidate = path.resolve(root, raw);
+  const relative = path.relative(root, candidate);
+  if (
+    relative === '' ||
+    relative.startsWith('..') ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(
+      'Browser file actions are limited to the run browser artifact root.',
+    );
+  }
+  const segments = relative.split(path.sep);
+  if (segments.some(isSensitivePathSegment)) {
+    throw new Error(
+      'Browser file actions cannot access hidden or sensitive paths.',
+    );
+  }
+  return candidate;
+}
+
+function resolveBrowserInputFilePath(
+  value: unknown,
+  fileAccessRoot: string,
+): string {
+  const candidate = resolveBrowserPath(value, fileAccessRoot);
+  const root = ensureBrowserArtifactRoot(fileAccessRoot);
+  const stat = fs.lstatSync(candidate);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error('Browser upload/drop paths must be regular files.');
+  }
+  assertInsideRoot(fs.realpathSync.native(candidate), root);
+  return candidate;
+}
+
+function resolveBrowserOutputPath(
+  value: unknown,
+  fileAccessRoot: string,
+): string {
+  const candidate = resolveBrowserPath(value, fileAccessRoot);
+  const root = ensureBrowserArtifactRoot(fileAccessRoot);
+  const parent = path.dirname(candidate);
+  fs.mkdirSync(parent, { recursive: true });
+  assertNoSymlinkPath(parent, path.resolve(fileAccessRoot));
+  assertInsideRoot(fs.realpathSync.native(parent), root);
+  if (fs.existsSync(candidate) && fs.lstatSync(candidate).isSymbolicLink()) {
+    throw new Error('Browser file actions cannot write through symlinks.');
+  }
+  return candidate;
+}
+
+function assertInsideRoot(candidate: string, root: string): void {
+  const relative = path.relative(root, candidate);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(
+      'Browser file actions are limited to the run browser artifact root.',
+    );
+  }
+}
+
+function assertNoSymlinkPath(target: string, root: string): void {
+  let current = root;
+  for (const segment of path.relative(root, target).split(path.sep)) {
+    if (!segment) continue;
+    current = path.join(current, segment);
+    if (fs.lstatSync(current).isSymbolicLink()) {
+      throw new Error('Browser file actions cannot traverse symlinks.');
+    }
+  }
+}
+
+function isSensitivePathSegment(segment: string): boolean {
+  const lower = segment.toLowerCase();
+  return (
+    lower.startsWith('.') ||
+    lower === 'settings.yaml' ||
+    lower === 'secrets' ||
+    lower === 'credentials' ||
+    lower === 'browser-profiles' ||
+    lower === 'ipc'
+  );
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/apps/core/src/adapters/browser/browser-tabs.ts
+++ b/apps/core/src/adapters/browser/browser-tabs.ts
@@ -1,5 +1,7 @@
 import type { BrowserIpcAction } from '@myclaw/contracts';
 
+import { parsePlaywrightMcpTabListText } from './playwright-mcp-compat.js';
+
 const tabIndexMappings = new Map<string, Map<number, number>>();
 
 export function clearBrowserTabIndexMappings(profileName?: string): void {
@@ -30,13 +32,13 @@ export function translateBrowserTabsInput(
   const mapping = tabIndexMappings.get(sessionKey);
   if (!mapping) {
     throw new Error(
-      `Browser tab ${action} requires a current tab list for index ${visibleIndex}.`,
+      `Browser tab ${action} needs a fresh browser_tabs list before using visible index ${visibleIndex}.`,
     );
   }
   const backendIndex = mapping.get(visibleIndex);
   if (backendIndex === undefined) {
     throw new Error(
-      `Browser tab ${action} index ${visibleIndex} is not visible.`,
+      `Browser tab ${action} index ${visibleIndex} is not in the current visible tab list. Run browser_tabs list to refresh.`,
     );
   }
   return { ...args, index: backendIndex };
@@ -53,6 +55,7 @@ export function projectBrowserTabsResult(
   const record = result as Record<string, unknown>;
   const isBrowserTabsList =
     toolName === 'browser_tabs' && args.action === 'list';
+  const isBrowserTabsAction = toolName === 'browser_tabs';
   const isBrowserTabsMutation =
     toolName === 'browser_tabs' &&
     (args.action === 'close' || args.action === 'new');
@@ -62,6 +65,16 @@ export function projectBrowserTabsResult(
     typeof structuredContent !== 'object' ||
     Array.isArray(structuredContent)
   ) {
+    const parsedTabs = isBrowserTabsAction
+      ? parsePlaywrightMcpTabListText(record.content)
+      : [];
+    if (parsedTabs.length > 0) {
+      return projectStructuredBrowserTabsResult(
+        record,
+        { tabs: parsedTabs },
+        sessionKey,
+      );
+    }
     if (isBrowserTabsMutation && sessionKey)
       tabIndexMappings.delete(sessionKey);
     if (isBrowserTabsList) return unsafeBrowserTabsListResult(sessionKey);
@@ -69,12 +82,35 @@ export function projectBrowserTabsResult(
   }
   const tabs = (structuredContent as { tabs?: unknown }).tabs;
   if (!Array.isArray(tabs)) {
+    const parsedTabs = isBrowserTabsAction
+      ? parsePlaywrightMcpTabListText(record.content)
+      : [];
+    if (parsedTabs.length > 0) {
+      return projectStructuredBrowserTabsResult(
+        record,
+        { ...(structuredContent as Record<string, unknown>), tabs: parsedTabs },
+        sessionKey,
+      );
+    }
     if (isBrowserTabsMutation && sessionKey)
       tabIndexMappings.delete(sessionKey);
     if (isBrowserTabsList) return unsafeBrowserTabsListResult(sessionKey);
     return result;
   }
+  return projectStructuredBrowserTabsResult(
+    record,
+    structuredContent as Record<string, unknown>,
+    sessionKey,
+  );
+}
 
+function projectStructuredBrowserTabsResult(
+  record: Record<string, unknown>,
+  structuredContent: Record<string, unknown>,
+  sessionKey?: string,
+): unknown {
+  const tabs = structuredContent.tabs;
+  if (!Array.isArray(tabs)) return record;
   const indexProjection = new Map<number, number>();
   const userToBackend = new Map<number, number>();
   const projectedTabs = tabs.map((tab, userIndex) => {

--- a/apps/core/src/adapters/browser/browser-tabs.ts
+++ b/apps/core/src/adapters/browser/browser-tabs.ts
@@ -75,7 +75,7 @@ export function projectBrowserTabsResult(
         sessionKey,
       );
     }
-    if (isBrowserTabsMutation && sessionKey)
+    if ((isBrowserTabsList || isBrowserTabsMutation) && sessionKey)
       tabIndexMappings.delete(sessionKey);
     if (isBrowserTabsList) return unsafeBrowserTabsListResult(sessionKey);
     return result;
@@ -92,7 +92,7 @@ export function projectBrowserTabsResult(
         sessionKey,
       );
     }
-    if (isBrowserTabsMutation && sessionKey)
+    if ((isBrowserTabsList || isBrowserTabsMutation) && sessionKey)
       tabIndexMappings.delete(sessionKey);
     if (isBrowserTabsList) return unsafeBrowserTabsListResult(sessionKey);
     return result;

--- a/apps/core/src/adapters/browser/browser-tool-proxy.ts
+++ b/apps/core/src/adapters/browser/browser-tool-proxy.ts
@@ -10,11 +10,16 @@ import {
   createBrowserActionMcpServerConfig,
   type BrowserActionMcpServerConfig,
 } from './action-mcp.js';
+import { ensureBrowserArtifactRoot } from './browser-artifact-policy.js';
 import {
   clearBrowserTabIndexMappings,
   projectBrowserTabsResult,
   translateBrowserTabsInput,
 } from './browser-tabs.js';
+import {
+  isStalePlaywrightMcpSnapshotRefResult,
+  normalizePlaywrightMcpPayload,
+} from './playwright-mcp-compat.js';
 import { nowMs } from '../../shared/time/datetime.js';
 import { applyAgentEgressNoProxyEnv } from '../../shared/no-proxy.js';
 
@@ -30,6 +35,17 @@ const BROWSER_FILE_OUTPUT_TOOLS = new Set<BrowserIpcAction>([
   'browser_snapshot',
   'browser_console_messages',
   'browser_network_requests',
+  'browser_evaluate',
+]);
+const TARGET_RESOLUTION_RETRY_ACTIONS = new Set<BrowserIpcAction>([
+  'browser_click',
+  'browser_type',
+  'browser_hover',
+  'browser_drag',
+  'browser_drop',
+  'browser_select_option',
+  'browser_fill_form',
+  'browser_take_screenshot',
   'browser_evaluate',
 ]);
 
@@ -51,7 +67,7 @@ export async function callBrowserTool(input: {
     options: { outputDir?: string; actionTimeoutMs?: number },
   ) => BrowserActionMcpServerConfig;
 }): Promise<unknown> {
-  const args = normalizeBrowserFilePayload(input.arguments, {
+  const args = normalizePlaywrightMcpPayload(input.toolName, input.arguments, {
     fileAccessRoot: input.fileAccessRoot,
   });
   if (
@@ -85,11 +101,11 @@ export async function callBrowserTool(input: {
   });
 
   try {
-    const remainingTimeoutMs = remainingBrowserActionTimeoutMs(deadline);
-    const result = await backend.client.callTool(
-      { name: input.toolName, arguments: backendArgs },
-      undefined,
-      { timeout: remainingTimeoutMs },
+    const result = await callBackendBrowserToolWithRetry(
+      backend.client,
+      input.toolName,
+      backendArgs,
+      deadline,
     );
     return normalizeBrowserToolResult(input.toolName, args, result, {
       artifactRoot: outputDir,
@@ -101,6 +117,56 @@ export async function callBrowserTool(input: {
   } finally {
     scheduleBackendIdleClose(backend.key);
   }
+}
+
+async function callBackendBrowserToolWithRetry(
+  client: Client,
+  toolName: BrowserIpcAction,
+  args: Record<string, unknown>,
+  deadline: number,
+): Promise<unknown> {
+  try {
+    const result = await callBackendBrowserTool(
+      client,
+      toolName,
+      args,
+      deadline,
+    );
+    if (!shouldRefreshSnapshotAndRetry(toolName, result)) return result;
+  } catch (err) {
+    if (!shouldRefreshSnapshotAndRetry(toolName, err)) throw err;
+  }
+  await refreshBackendTargetModel(client, deadline);
+  return await callBackendBrowserTool(client, toolName, args, deadline);
+}
+
+async function refreshBackendTargetModel(
+  client: Client,
+  deadline: number,
+): Promise<void> {
+  await callBackendBrowserTool(client, 'browser_snapshot', {}, deadline).catch(
+    () => undefined,
+  );
+}
+
+async function callBackendBrowserTool(
+  client: Client,
+  toolName: BrowserIpcAction,
+  args: Record<string, unknown>,
+  deadline: number,
+): Promise<unknown> {
+  const remainingTimeoutMs = remainingBrowserActionTimeoutMs(deadline);
+  return await client.callTool({ name: toolName, arguments: args }, undefined, {
+    timeout: remainingTimeoutMs,
+  });
+}
+
+function shouldRefreshSnapshotAndRetry(
+  toolName: BrowserIpcAction,
+  err: unknown,
+): boolean {
+  if (!TARGET_RESOLUTION_RETRY_ACTIONS.has(toolName)) return false;
+  return isStalePlaywrightMcpSnapshotRefResult(err);
 }
 
 export function normalizeBrowserToolResult(
@@ -210,6 +276,10 @@ function browserOutputFileStat(filename: string): fs.Stats | undefined {
   return stat.isFile() ? stat : undefined;
 }
 
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
 export function sanitizeBrowserTabsResult(result: unknown): unknown {
   return projectBrowserTabsResult(
     sanitizeInternalChromeTargets(result),
@@ -273,7 +343,9 @@ function isInternalChromeTargetText(value: string): boolean {
   const normalized = value.trim().toLowerCase();
   return (
     normalized.includes('chrome://new-tab-page') ||
-    normalized.includes('chrome://omnibox-popup')
+    normalized.includes('chrome://omnibox-popup') ||
+    normalized === 'omnibox popup' ||
+    normalized.includes('omnibox popup')
   );
 }
 
@@ -499,123 +571,6 @@ function backendEnv(configEnv: Record<string, string>): Record<string, string> {
   const env: Record<string, string> = { ...configEnv };
   applyAgentEgressNoProxyEnv(env);
   return env;
-}
-
-export function ensureBrowserArtifactRoot(dir: string): string {
-  fs.mkdirSync(dir, { recursive: true });
-  return fs.realpathSync.native(dir);
-}
-
-function normalizeBrowserFilePayload(
-  payload: Record<string, unknown>,
-  options: { fileAccessRoot: string },
-): Record<string, unknown> {
-  const next = { ...payload };
-  if (next.filename !== undefined) {
-    next.filename = resolveBrowserOutputPath(
-      next.filename,
-      options.fileAccessRoot,
-    );
-  }
-  if (next.paths !== undefined) {
-    if (!Array.isArray(next.paths)) {
-      throw new Error('Browser upload/drop paths must be an array.');
-    }
-    next.paths = next.paths.map((item) =>
-      resolveBrowserInputFilePath(item, options.fileAccessRoot),
-    );
-  }
-  return next;
-}
-
-function resolveBrowserPath(value: unknown, fileAccessRoot: string): string {
-  const raw = stringValue(value);
-  if (!raw) throw new Error('Browser file action requires a path.');
-  const root = path.resolve(fileAccessRoot);
-  const candidate = path.resolve(root, raw);
-  const relative = path.relative(root, candidate);
-  if (
-    relative === '' ||
-    relative.startsWith('..') ||
-    path.isAbsolute(relative)
-  ) {
-    throw new Error(
-      'Browser file actions are limited to the run browser artifact root.',
-    );
-  }
-  const segments = relative.split(path.sep);
-  if (segments.some(isSensitivePathSegment)) {
-    throw new Error(
-      'Browser file actions cannot access hidden or sensitive paths.',
-    );
-  }
-  return candidate;
-}
-
-function resolveBrowserInputFilePath(
-  value: unknown,
-  fileAccessRoot: string,
-): string {
-  const candidate = resolveBrowserPath(value, fileAccessRoot);
-  const root = ensureBrowserArtifactRoot(fileAccessRoot);
-  const stat = fs.lstatSync(candidate);
-  if (stat.isSymbolicLink() || !stat.isFile()) {
-    throw new Error('Browser upload/drop paths must be regular files.');
-  }
-  assertInsideRoot(fs.realpathSync.native(candidate), root);
-  return candidate;
-}
-
-function resolveBrowserOutputPath(
-  value: unknown,
-  fileAccessRoot: string,
-): string {
-  const candidate = resolveBrowserPath(value, fileAccessRoot);
-  const root = ensureBrowserArtifactRoot(fileAccessRoot);
-  const parent = path.dirname(candidate);
-  fs.mkdirSync(parent, { recursive: true });
-  assertNoSymlinkPath(parent, path.resolve(fileAccessRoot));
-  assertInsideRoot(fs.realpathSync.native(parent), root);
-  if (fs.existsSync(candidate) && fs.lstatSync(candidate).isSymbolicLink()) {
-    throw new Error('Browser file actions cannot write through symlinks.');
-  }
-  return candidate;
-}
-
-function assertInsideRoot(candidate: string, root: string): void {
-  const relative = path.relative(root, candidate);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(
-      'Browser file actions are limited to the run browser artifact root.',
-    );
-  }
-}
-
-function assertNoSymlinkPath(target: string, root: string): void {
-  let current = root;
-  for (const segment of path.relative(root, target).split(path.sep)) {
-    if (!segment) continue;
-    current = path.join(current, segment);
-    if (fs.lstatSync(current).isSymbolicLink()) {
-      throw new Error('Browser file actions cannot traverse symlinks.');
-    }
-  }
-}
-
-function isSensitivePathSegment(segment: string): boolean {
-  const lower = segment.toLowerCase();
-  return (
-    lower.startsWith('.') ||
-    lower === 'settings.yaml' ||
-    lower === 'secrets' ||
-    lower === 'credentials' ||
-    lower === 'browser-profiles' ||
-    lower === 'ipc'
-  );
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
 function browserActionTimeoutMs(value: number | undefined): number {

--- a/apps/core/src/adapters/browser/browser-tool-proxy.ts
+++ b/apps/core/src/adapters/browser/browser-tool-proxy.ts
@@ -10,7 +10,10 @@ import {
   createBrowserActionMcpServerConfig,
   type BrowserActionMcpServerConfig,
 } from './action-mcp.js';
-import { ensureBrowserArtifactRoot } from './browser-artifact-policy.js';
+import {
+  ensureBrowserArtifactRoot,
+  writeBrowserArtifactFileSync,
+} from './browser-artifact-policy.js';
 import {
   clearBrowserTabIndexMappings,
   projectBrowserTabsResult,
@@ -45,6 +48,7 @@ const TARGET_RESOLUTION_RETRY_ACTIONS = new Set<BrowserIpcAction>([
   'browser_drop',
   'browser_select_option',
   'browser_fill_form',
+  'browser_snapshot',
   'browser_take_screenshot',
   'browser_evaluate',
 ]);
@@ -67,9 +71,6 @@ export async function callBrowserTool(input: {
     options: { outputDir?: string; actionTimeoutMs?: number },
   ) => BrowserActionMcpServerConfig;
 }): Promise<unknown> {
-  const args = normalizePlaywrightMcpPayload(input.toolName, input.arguments, {
-    fileAccessRoot: input.fileAccessRoot,
-  });
   if (
     !input.session.running ||
     !input.session.cdpReady ||
@@ -80,6 +81,9 @@ export async function callBrowserTool(input: {
 
   const cdpEndpoint = `http://127.0.0.1:${input.session.port}`;
   const outputDir = ensureBrowserArtifactRoot(input.fileAccessRoot);
+  const args = normalizePlaywrightMcpPayload(input.toolName, input.arguments, {
+    fileAccessRoot: outputDir,
+  });
   const actionTimeoutMs = browserActionTimeoutMs(input.timeoutMs);
   const deadline = nowMs() + actionTimeoutMs;
   const sessionKey = `${input.session.profileName || 'default'}\0${cdpEndpoint}`;
@@ -204,7 +208,7 @@ function compactLargeBrowserSnapshot(result: unknown, artifactRoot: string) {
   }
   const root = ensureBrowserArtifactRoot(artifactRoot);
   const filename = path.join(root, `snapshot-${nowMs()}.txt`);
-  fs.writeFileSync(filename, text, 'utf8');
+  writeBrowserArtifactFileSync(filename, text, 'utf8');
   const stat = fs.statSync(filename);
   const preview = truncateUtf8(text, SNAPSHOT_PREVIEW_BYTES);
   return {
@@ -355,7 +359,7 @@ function persistInlineScreenshot(
 ): { wroteFile: boolean; mimeType?: string } {
   const image = firstInlineImage(result);
   if (!image) return { wroteFile: false };
-  fs.writeFileSync(filename, Buffer.from(image.data, 'base64'));
+  writeBrowserArtifactFileSync(filename, Buffer.from(image.data, 'base64'));
   return { wroteFile: true, mimeType: image.mimeType };
 }
 

--- a/apps/core/src/adapters/browser/playwright-mcp-compat.ts
+++ b/apps/core/src/adapters/browser/playwright-mcp-compat.ts
@@ -103,6 +103,7 @@ function parsePlaywrightMcpTabLine(
   const rest = match[2]?.trim() || '';
   const urlMatch = rest.match(/\s((?:https?:\/\/|file:\/\/|about:)[^\s]+)\s*$/);
   const url = urlMatch?.[1] || '';
+  if (!url) return undefined;
   const title = url ? rest.slice(0, -url.length).trim() : rest;
   return {
     index,

--- a/apps/core/src/adapters/browser/playwright-mcp-compat.ts
+++ b/apps/core/src/adapters/browser/playwright-mcp-compat.ts
@@ -1,0 +1,136 @@
+import type { BrowserIpcAction } from '@myclaw/contracts';
+
+import { normalizeBrowserFilePayload } from './browser-artifact-policy.js';
+
+export function normalizePlaywrightMcpPayload(
+  toolName: BrowserIpcAction,
+  payload: Record<string, unknown>,
+  options: { fileAccessRoot: string },
+): Record<string, unknown> {
+  const fileNormalized = normalizeBrowserFilePayload(
+    toolName,
+    payload,
+    options,
+  );
+  if (toolName === 'browser_fill_form') {
+    return normalizePlaywrightMcpFillFormPayload(fileNormalized);
+  }
+  return fileNormalized;
+}
+
+export function parsePlaywrightMcpTabListText(
+  content: unknown,
+): Array<Record<string, unknown>> {
+  const text = browserTextContent(content);
+  if (!text) return [];
+  const tabs: Array<Record<string, unknown>> = [];
+  for (const line of text.split('\n')) {
+    const parsed = parsePlaywrightMcpTabLine(line);
+    if (parsed) tabs.push(parsed);
+  }
+  return tabs;
+}
+
+export function isStalePlaywrightMcpSnapshotRefResult(value: unknown): boolean {
+  const message =
+    value &&
+    typeof value === 'object' &&
+    (value as { isError?: unknown }).isError
+      ? browserTextContent((value as { content?: unknown }).content)
+      : errorMessage(value);
+  return /Ref .+ not found in the current page snapshot/i.test(message);
+}
+
+function normalizePlaywrightMcpFillFormPayload(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  const fields = payload.fields;
+  if (!Array.isArray(fields)) return payload;
+  return {
+    ...payload,
+    fields: fields.map((field) => {
+      if (!field || typeof field !== 'object' || Array.isArray(field)) {
+        return field;
+      }
+      const row = field as Record<string, unknown>;
+      const target = stringValue(row.target);
+      const value = row.value;
+      if (!target || value === undefined) return field;
+      const name = stringValue(row.name) || stringValue(row.element) || target;
+      const type = normalizePlaywrightMcpFieldType(row.type, value);
+      return {
+        ...row,
+        target,
+        element: stringValue(row.element) || name,
+        name,
+        type,
+        value: normalizePlaywrightMcpFieldValue(value),
+      };
+    }),
+  };
+}
+
+function normalizePlaywrightMcpFieldType(
+  value: unknown,
+  fieldValue: unknown,
+): string {
+  if (
+    value === 'textbox' ||
+    value === 'checkbox' ||
+    value === 'radio' ||
+    value === 'combobox' ||
+    value === 'slider'
+  ) {
+    return value;
+  }
+  return typeof fieldValue === 'boolean' ? 'checkbox' : 'textbox';
+}
+
+function normalizePlaywrightMcpFieldValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return String(value ?? '');
+}
+
+function parsePlaywrightMcpTabLine(
+  line: string,
+): Record<string, unknown> | undefined {
+  const match = line.match(/^\s*-\s*(\d+):\s*(.+)$/);
+  if (!match) return undefined;
+  const index = Number(match[1]);
+  if (!Number.isInteger(index)) return undefined;
+  const rest = match[2]?.trim() || '';
+  const urlMatch = rest.match(/\s((?:https?:\/\/|file:\/\/|about:)[^\s]+)\s*$/);
+  const url = urlMatch?.[1] || '';
+  const title = url ? rest.slice(0, -url.length).trim() : rest;
+  return {
+    index,
+    title,
+    ...(url ? { url } : {}),
+  };
+}
+
+function browserTextContent(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((block) => {
+      if (!block || typeof block !== 'object' || Array.isArray(block)) {
+        return '';
+      }
+      const row = block as Record<string, unknown>;
+      return row.type === 'text' && typeof row.text === 'string'
+        ? row.text
+        : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/core/src/runner/mcp/tools/browser.ts
+++ b/apps/core/src/runner/mcp/tools/browser.ts
@@ -88,13 +88,30 @@ const fileName = z
 const target = z
   .string()
   .describe(
-    'Exact target element reference from browser_snapshot, or a unique selector.',
+    'Target handle from the latest browser inspection, or a unique selector.',
   );
 const optionalTarget = target.optional();
 const element = z
   .string()
   .optional()
   .describe('Human-readable element description for audit context.');
+const browserUploadFile = z.object({
+  name: z
+    .string()
+    .optional()
+    .describe('Safe relative filename to create under browser uploads.'),
+  content: z.string().describe('File contents.'),
+  encoding: z.enum(['utf8', 'base64']).optional(),
+});
+const browserFillField = z.object({
+  target,
+  value: z.union([z.string(), z.number(), z.boolean()]),
+  element,
+  name: z.string().optional(),
+  type: z
+    .enum(['textbox', 'checkbox', 'radio', 'combobox', 'slider'])
+    .optional(),
+});
 
 export function registerBrowserTools(server: McpServer): void {
   register(
@@ -206,7 +223,7 @@ export function registerBrowserTools(server: McpServer): void {
     values: z.array(z.string()),
   });
   register(server, 'browser_fill_form', 'Fill multiple form fields.', {
-    fields: z.array(z.record(z.string(), z.unknown())),
+    fields: z.array(browserFillField),
   });
   register(server, 'browser_wait_for', 'Wait for text or time.', {
     time: z.number().optional(),
@@ -221,6 +238,7 @@ export function registerBrowserTools(server: McpServer): void {
   });
   register(server, 'browser_file_upload', 'Upload one or more files.', {
     paths: z.array(z.string()).optional(),
+    files: z.array(browserUploadFile).optional(),
   });
   register(server, 'browser_handle_dialog', 'Handle a browser dialog.', {
     accept: z.boolean(),

--- a/apps/core/src/runtime/browser-capability-types.ts
+++ b/apps/core/src/runtime/browser-capability-types.ts
@@ -2,6 +2,7 @@ export interface LaunchBrowserOptions {
   profileName?: string;
   headless?: boolean;
   keepAliveMs?: number;
+  deadlineAtMs?: number;
 }
 
 export interface BrowserSessionStatus {

--- a/apps/core/src/runtime/browser-capability.ts
+++ b/apps/core/src/runtime/browser-capability.ts
@@ -81,7 +81,7 @@ async function waitForCdpHttp(port: number, timeoutMs: number): Promise<void> {
   const startedAt = currentTimeMs();
   while (currentTimeMs() - startedAt < timeoutMs) {
     if (await isCdpHttpHealthy(port)) return;
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await sleepWithinDeadline(startedAt, timeoutMs, 500);
   }
 
   throw new Error(
@@ -107,12 +107,39 @@ async function waitForDevToolsActivePort(
     } catch {
       // Chrome creates DevToolsActivePort asynchronously after process launch.
     }
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await sleepWithinDeadline(startedAt, timeoutMs, 100);
   }
 
   throw new Error(
     `Chrome did not publish DevToolsActivePort within ${timeoutMs}ms`,
   );
+}
+
+async function sleepWithinDeadline(
+  startedAt: number,
+  timeoutMs: number,
+  maxSleepMs: number,
+): Promise<void> {
+  const elapsedMs = currentTimeMs() - startedAt;
+  const remainingMs = Math.max(0, timeoutMs - elapsedMs);
+  await new Promise((resolve) =>
+    setTimeout(resolve, Math.max(1, Math.min(maxSleepMs, remainingMs))),
+  );
+}
+
+function browserLaunchTimeoutMs(
+  opts: LaunchBrowserOptions,
+  maxTimeoutMs: number,
+): number {
+  const deadlineAtMs = opts.deadlineAtMs;
+  if (typeof deadlineAtMs !== 'number' || !Number.isFinite(deadlineAtMs)) {
+    return maxTimeoutMs;
+  }
+  const remainingMs = Math.trunc(deadlineAtMs - currentTimeMs());
+  if (remainingMs <= 0) {
+    throw new Error('Browser launch deadline exceeded');
+  }
+  return Math.min(maxTimeoutMs, remainingMs);
 }
 
 function isChromeAlive(session: BrowserSession): boolean {
@@ -384,9 +411,17 @@ export async function launchBrowser(
       throw new Error('Failed to launch Chrome process');
     }
 
-    const port = await waitForDevToolsActivePort(profile.userDataDir, 10_000);
-    await waitForCdpHttp(port, 10_000);
-    const targetId = await ensureBrowserTarget(port);
+    const port = await waitForDevToolsActivePort(
+      profile.userDataDir,
+      browserLaunchTimeoutMs(opts, 10_000),
+    );
+    await waitForCdpHttp(port, browserLaunchTimeoutMs(opts, 10_000));
+    const targetId = await ensureBrowserTarget(
+      port,
+      typeof opts.deadlineAtMs === 'number'
+        ? { deadlineAtMs: opts.deadlineAtMs }
+        : undefined,
+    );
 
     const session: BrowserSession = {
       profileName,

--- a/apps/core/src/runtime/browser-cdp-targets.ts
+++ b/apps/core/src/runtime/browser-cdp-targets.ts
@@ -423,11 +423,19 @@ async function cdpBrowserSessionCommand(
   });
 }
 
-function isInternalChromeTarget(url: string): boolean {
-  const normalized = url.trim().toLowerCase();
+function isInternalChromeTargetText(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
   return (
     normalized.startsWith('chrome://new-tab-page') ||
-    normalized.startsWith('chrome://omnibox-popup')
+    normalized.startsWith('chrome://omnibox-popup') ||
+    normalized === 'omnibox popup' ||
+    normalized.includes('omnibox popup')
+  );
+}
+
+function isInternalChromeTarget(row: Record<string, unknown>): boolean {
+  return [row.url, row.title].some(
+    (value) => typeof value === 'string' && isInternalChromeTargetText(value),
   );
 }
 
@@ -498,6 +506,7 @@ export async function resizeHeadedBrowserWindow(
     {
       windowId,
       bounds: {
+        windowState: 'normal',
         width: normalizedWidth,
         height: normalizedHeight,
       },
@@ -543,8 +552,7 @@ async function closeInternalPageTargets(
     const targets = await listPageTargets(port, options);
     const internalTargets = targets.flatMap((row) => {
       const id = typeof row.id === 'string' ? row.id : '';
-      const url = typeof row.url === 'string' ? row.url : '';
-      return id && isInternalChromeTarget(url) ? [id] : [];
+      return id && isInternalChromeTarget(row) ? [id] : [];
     });
     if (internalTargets.length === 0) return;
     await closeInternalTargets(port, internalTargets, options);
@@ -560,13 +568,11 @@ export async function ensureBrowserTarget(
   if (pageTargets.length > 0) {
     for (const row of pageTargets) {
       const id = typeof row.id === 'string' ? row.id : '';
-      const url = typeof row.url === 'string' ? row.url : '';
-      if (id && isInternalChromeTarget(url))
+      if (id && isInternalChromeTarget(row))
         await closeInternalTargets(port, [id], options);
     }
     const firstContentPage = pageTargets.find((row) => {
-      const url = typeof row.url === 'string' ? row.url : '';
-      return !isInternalChromeTarget(url);
+      return !isInternalChromeTarget(row);
     });
     const id =
       firstContentPage && typeof firstContentPage.id === 'string'

--- a/apps/core/src/runtime/ipc-browser-handler.ts
+++ b/apps/core/src/runtime/ipc-browser-handler.ts
@@ -264,8 +264,9 @@ async function attachToolCapabilityBrokerHealth(
     brokerHealth,
   };
   if (brokerHealth.status !== 'pass') {
+    next.cdpReady = false;
     next.warning = [
-      'Browser CDP may be ready, but third-party MCP tools can fail because the tool-capability credential broker is not healthy.',
+      'Browser CDP is not driveable because the tool-capability credential broker is not healthy.',
       brokerHealth.nextAction,
     ]
       .filter(Boolean)
@@ -310,6 +311,7 @@ async function handleBrowserToolAction(
           min: 10_000,
           max: 3_600_000,
         }),
+        deadlineAtMs: deadline.deadlineAtMs,
       });
       return {
         ok: true,
@@ -328,7 +330,10 @@ async function handleBrowserToolAction(
   }
 
   browserIpcRemainingMs(deadline);
-  const session = await ensureBrowserReady({ profileName });
+  const session = await ensureBrowserReady({
+    profileName,
+    deadlineAtMs: deadline.deadlineAtMs,
+  });
   const cdpOptions = browserCdpOptions(deadline);
   const targetId = session.port
     ? cdpOptions

--- a/apps/core/test/unit/adapters/browser/browser-tool-proxy.test.ts
+++ b/apps/core/test/unit/adapters/browser/browser-tool-proxy.test.ts
@@ -547,25 +547,14 @@ describe('browser tool proxy file policy', () => {
       fileAccessRoot: root,
     });
 
-    expect(fs.readFileSync(path.join(root, 'uploads/note.txt'), 'utf8')).toBe(
-      'hello',
-    );
-    expect(
-      fs.readFileSync(path.join(root, 'uploads/encoded.bin'), 'utf8'),
-    ).toBe('bytes');
-    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledWith(
-      {
-        name: 'browser_file_upload',
-        arguments: {
-          paths: [
-            fs.realpathSync.native(path.join(root, 'uploads/note.txt')),
-            fs.realpathSync.native(path.join(root, 'uploads/encoded.bin')),
-          ],
-        },
-      },
-      undefined,
-      { timeout: expect.any(Number) },
-    );
+    const paths = browserMcpMocks.clients[0]?.callTool.mock.calls[0]?.[0]
+      ?.arguments?.paths as string[];
+    expect(paths).toHaveLength(2);
+    expect(new Set(paths).size).toBe(2);
+    expect(paths[0]).toContain(`${path.sep}uploads${path.sep}inline-`);
+    expect(paths[1]).toContain(`${path.sep}uploads${path.sep}inline-`);
+    expect(fs.readFileSync(paths[0]!, 'utf8')).toBe('hello');
+    expect(fs.readFileSync(paths[1]!, 'utf8')).toBe('bytes');
   });
 
   it('combines existing upload paths with inline upload files', async () => {
@@ -588,19 +577,147 @@ describe('browser tool proxy file policy', () => {
       fileAccessRoot: root,
     });
 
-    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledWith(
-      {
-        name: 'browser_file_upload',
-        arguments: {
-          paths: [
-            fs.realpathSync.native(path.join(root, 'existing.txt')),
-            fs.realpathSync.native(path.join(root, 'uploads/note.txt')),
-          ],
-        },
-      },
-      undefined,
-      { timeout: expect.any(Number) },
+    const paths = browserMcpMocks.clients[0]?.callTool.mock.calls[0]?.[0]
+      ?.arguments?.paths as string[];
+    expect(paths).toHaveLength(2);
+    expect(paths[0]).toBe(
+      fs.realpathSync.native(path.join(root, 'existing.txt')),
     );
+    expect(paths[1]).toContain(`${path.sep}uploads${path.sep}inline-`);
+    expect(fs.readFileSync(paths[1]!, 'utf8')).toBe('hello');
+  });
+
+  it('does not overwrite an existing uploads file with the same inline filename', async () => {
+    const root = tempRoot();
+    fs.mkdirSync(path.join(root, 'uploads'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'uploads/note.txt'), 'existing');
+    browserMcpMocks.nextResult = { content: [{ type: 'text', text: 'ok' }] };
+
+    await callBrowserTool({
+      toolName: 'browser_file_upload',
+      arguments: {
+        files: [{ name: 'note.txt', content: 'inline' }],
+      },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    const paths = browserMcpMocks.clients[0]?.callTool.mock.calls[0]?.[0]
+      ?.arguments?.paths as string[];
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).not.toBe(
+      fs.realpathSync.native(path.join(root, 'uploads/note.txt')),
+    );
+    expect(fs.readFileSync(path.join(root, 'uploads/note.txt'), 'utf8')).toBe(
+      'existing',
+    );
+    expect(fs.readFileSync(paths[0]!, 'utf8')).toBe('inline');
+  });
+
+  it('keeps existing upload paths distinct from inline files with the same basename', async () => {
+    const root = tempRoot();
+    fs.mkdirSync(path.join(root, 'uploads'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'uploads/note.txt'), 'existing');
+    browserMcpMocks.nextResult = { content: [{ type: 'text', text: 'ok' }] };
+
+    await callBrowserTool({
+      toolName: 'browser_file_upload',
+      arguments: {
+        paths: ['uploads/note.txt'],
+        files: [{ name: 'note.txt', content: 'inline' }],
+      },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    const paths = browserMcpMocks.clients[0]?.callTool.mock.calls[0]?.[0]
+      ?.arguments?.paths as string[];
+    expect(paths).toHaveLength(2);
+    expect(paths[0]).toBe(
+      fs.realpathSync.native(path.join(root, 'uploads/note.txt')),
+    );
+    expect(paths[1]).not.toBe(paths[0]);
+    expect(fs.readFileSync(paths[0]!, 'utf8')).toBe('existing');
+    expect(fs.readFileSync(paths[1]!, 'utf8')).toBe('inline');
+  });
+
+  it('uses distinct inline upload paths for duplicate filenames', async () => {
+    const root = tempRoot();
+    browserMcpMocks.nextResult = { content: [{ type: 'text', text: 'ok' }] };
+
+    await callBrowserTool({
+      toolName: 'browser_file_upload',
+      arguments: {
+        files: [
+          { name: 'same.txt', content: 'first' },
+          { name: 'same.txt', content: 'second' },
+        ],
+      },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    const paths = browserMcpMocks.clients[0]?.callTool.mock.calls[0]?.[0]
+      ?.arguments?.paths as string[];
+    expect(paths).toHaveLength(2);
+    expect(new Set(paths).size).toBe(2);
+    expect(fs.readFileSync(paths[0]!, 'utf8')).toBe('first');
+    expect(fs.readFileSync(paths[1]!, 'utf8')).toBe('second');
+  });
+
+  it('uses distinct inline upload paths for concurrent same-name requests', async () => {
+    const root = tempRoot();
+    const session = {
+      running: true,
+      cdpReady: true,
+      port: 12345,
+      profileName: 'c-main',
+    };
+    browserMcpMocks.nextResult = { content: [{ type: 'text', text: 'ok' }] };
+
+    await Promise.all([
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: { files: [{ name: 'same.txt', content: 'first' }] },
+        session,
+        fileAccessRoot: root,
+      }),
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: { files: [{ name: 'same.txt', content: 'second' }] },
+        session,
+        fileAccessRoot: root,
+      }),
+    ]);
+
+    const firstPaths = browserMcpMocks.clients[0]?.callTool.mock.calls[0]?.[0]
+      ?.arguments?.paths as string[];
+    const secondPaths = browserMcpMocks.clients[0]?.callTool.mock.calls[1]?.[0]
+      ?.arguments?.paths as string[];
+    expect(firstPaths).toHaveLength(1);
+    expect(secondPaths).toHaveLength(1);
+    expect(firstPaths[0]).not.toBe(secondPaths[0]);
+    expect(
+      [
+        fs.readFileSync(firstPaths[0]!, 'utf8'),
+        fs.readFileSync(secondPaths[0]!, 'utf8'),
+      ].sort(),
+    ).toEqual(['first', 'second']);
   });
 
   it('does not materialize inline upload files when the browser is not ready', async () => {

--- a/apps/core/test/unit/adapters/browser/browser-tool-proxy.test.ts
+++ b/apps/core/test/unit/adapters/browser/browser-tool-proxy.test.ts
@@ -15,6 +15,9 @@ const browserMcpMocks = vi.hoisted(() => ({
     close: ReturnType<typeof vi.fn>;
   }>,
   nextResult: undefined as unknown,
+  callToolImpl: undefined as
+    | ((request: unknown, extra: unknown, options: unknown) => Promise<unknown>)
+    | undefined,
   connectImpl: undefined as
     | ((transport: unknown, options: unknown) => Promise<unknown>)
     | undefined,
@@ -25,7 +28,10 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
     const client = {
       connect: vi.fn(async () => undefined),
       callTool: vi.fn(
-        async () => browserMcpMocks.nextResult ?? { content: [] },
+        async (request: unknown, extra: unknown, options: unknown) =>
+          browserMcpMocks.callToolImpl
+            ? browserMcpMocks.callToolImpl(request, extra, options)
+            : (browserMcpMocks.nextResult ?? { content: [] }),
       ),
       close: vi.fn(async () => undefined),
     };
@@ -82,6 +88,7 @@ afterEach(async () => {
   browserMcpMocks.clients.splice(0);
   browserMcpMocks.transports.splice(0);
   browserMcpMocks.nextResult = undefined;
+  browserMcpMocks.callToolImpl = undefined;
   browserMcpMocks.connectImpl = undefined;
   vi.useRealTimers();
 });
@@ -498,6 +505,108 @@ describe('browser tool proxy file policy', () => {
     ).rejects.toThrow('regular files');
   });
 
+  it('materializes inline upload files under the browser artifact root', async () => {
+    const root = tempRoot();
+    browserMcpMocks.nextResult = { content: [{ type: 'text', text: 'ok' }] };
+
+    await callBrowserTool({
+      toolName: 'browser_file_upload',
+      arguments: {
+        files: [
+          { name: 'note.txt', content: 'hello' },
+          {
+            name: 'encoded.bin',
+            content: Buffer.from('bytes').toString('base64'),
+            encoding: 'base64',
+          },
+        ],
+      },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    expect(fs.readFileSync(path.join(root, 'uploads/note.txt'), 'utf8')).toBe(
+      'hello',
+    );
+    expect(
+      fs.readFileSync(path.join(root, 'uploads/encoded.bin'), 'utf8'),
+    ).toBe('bytes');
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledWith(
+      {
+        name: 'browser_file_upload',
+        arguments: {
+          paths: [
+            path.join(root, 'uploads/note.txt'),
+            path.join(root, 'uploads/encoded.bin'),
+          ],
+        },
+      },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+  });
+
+  it('infers fill_form field metadata from target and value', async () => {
+    const root = tempRoot();
+    browserMcpMocks.nextResult = { content: [{ type: 'text', text: 'ok' }] };
+
+    await callBrowserTool({
+      toolName: 'browser_fill_form',
+      arguments: {
+        fields: [
+          { target: 'e1', value: 'Ravi' },
+          { target: 'e2', element: 'Subscribe', value: true },
+          { target: 'e3', name: 'Age', type: 'slider', value: 42 },
+        ],
+      },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledWith(
+      {
+        name: 'browser_fill_form',
+        arguments: {
+          fields: [
+            {
+              target: 'e1',
+              element: 'e1',
+              name: 'e1',
+              type: 'textbox',
+              value: 'Ravi',
+            },
+            {
+              target: 'e2',
+              element: 'Subscribe',
+              name: 'Subscribe',
+              type: 'checkbox',
+              value: 'true',
+            },
+            {
+              target: 'e3',
+              element: 'Age',
+              name: 'Age',
+              type: 'slider',
+              value: '42',
+            },
+          ],
+        },
+      },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+  });
+
   it('rejects output paths that traverse symlinked parents', async () => {
     const root = tempRoot();
     const outside = tempRoot();
@@ -538,6 +647,55 @@ describe('browser tool proxy file policy', () => {
       outputDir: fs.realpathSync.native(root),
       actionTimeoutMs: 120_000,
     });
+  });
+
+  it('refreshes the snapshot once when an aria ref is stale', async () => {
+    const root = tempRoot();
+    browserMcpMocks.callToolImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'text',
+            text: 'Ref e6 not found in the current page snapshot. Try capturing new snapshot.',
+          },
+        ],
+        isError: true,
+      })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'snapshot' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'clicked' }] });
+
+    const result = await callBrowserTool({
+      toolName: 'browser_click',
+      arguments: { target: 'e6' },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    expect(result).toEqual({ content: [{ type: 'text', text: 'clicked' }] });
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
+      1,
+      { name: 'browser_click', arguments: { target: 'e6' } },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
+      2,
+      { name: 'browser_snapshot', arguments: {} },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
+      3,
+      { name: 'browser_click', arguments: { target: 'e6' } },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
   });
 
   it('returns a compact file ref for screenshot filenames instead of inline image bytes', () => {
@@ -877,7 +1035,7 @@ describe('browser tool proxy file policy', () => {
         session,
         fileAccessRoot: root,
       }),
-    ).rejects.toThrow('requires a current tab list');
+    ).rejects.toThrow('needs a fresh browser_tabs list');
     expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledTimes(2);
   });
 
@@ -920,7 +1078,7 @@ describe('browser tool proxy file policy', () => {
         session,
         fileAccessRoot: root,
       }),
-    ).rejects.toThrow('requires a current tab list');
+    ).rejects.toThrow('needs a fresh browser_tabs list');
     expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledTimes(2);
   });
 
@@ -999,7 +1157,7 @@ describe('browser tool proxy file policy', () => {
         session,
         fileAccessRoot: root,
       }),
-    ).rejects.toThrow('requires a current tab list');
+    ).rejects.toThrow('needs a fresh browser_tabs list');
     await expect(
       callBrowserTool({
         toolName: 'browser_tabs',
@@ -1007,7 +1165,7 @@ describe('browser tool proxy file policy', () => {
         session,
         fileAccessRoot: root,
       }),
-    ).rejects.toThrow('requires a current tab list');
+    ).rejects.toThrow('needs a fresh browser_tabs list');
 
     expect(browserMcpMocks.clients).toHaveLength(0);
   });
@@ -1073,7 +1231,7 @@ describe('browser tool proxy file policy', () => {
         session,
         fileAccessRoot: root,
       }),
-    ).rejects.toThrow('is not visible');
+    ).rejects.toThrow('is not in the current visible tab list');
     await expect(
       callBrowserTool({
         toolName: 'browser_tabs',
@@ -1081,12 +1239,12 @@ describe('browser tool proxy file policy', () => {
         session,
         fileAccessRoot: root,
       }),
-    ).rejects.toThrow('is not visible');
+    ).rejects.toThrow('is not in the current visible tab list');
 
     expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledTimes(1);
   });
 
-  it('does not leak raw backend tab indices from text-only tab lists', async () => {
+  it('projects markdown-only backend tab lists into stable visible indices', async () => {
     const root = tempRoot();
     const session = {
       running: true,
@@ -1114,17 +1272,68 @@ describe('browser tool proxy file policy', () => {
       fileAccessRoot: root,
     });
 
+    expect(result).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: [
+            '- 0: Example https://example.test/',
+            '- 1: Other https://other.test/',
+          ].join('\n'),
+        },
+      ],
+      structuredContent: {
+        tabs: [
+          { index: 0, title: 'Example', url: 'https://example.test/' },
+          { index: 1, title: 'Other', url: 'https://other.test/' },
+        ],
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('- 4:');
+    expect(JSON.stringify(result)).not.toContain('- 9:');
+
+    browserMcpMocks.nextResult = {
+      content: [{ type: 'text', text: 'selected' }],
+    };
+    await callBrowserTool({
+      toolName: 'browser_tabs',
+      arguments: { action: 'select', index: 1 },
+      session,
+      fileAccessRoot: root,
+    });
+
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
+      2,
+      { name: 'browser_tabs', arguments: { action: 'select', index: 9 } },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+  });
+
+  it('does not parse tab-shaped markdown from non-tab tool results', () => {
+    const result = normalizeBrowserToolResult(
+      'browser_evaluate',
+      {},
+      {
+        content: [
+          {
+            type: 'text',
+            text: '- 4: Example https://example.test/',
+          },
+        ],
+      },
+      { tabSessionKey: 'c-main\0http://127.0.0.1:12345' },
+    );
+
     expect(result).toEqual({
       content: [
         {
           type: 'text',
-          text: 'Browser tab list failed closed because the backend did not return structured tab metadata.',
+          text: '- 4: Example https://example.test/',
         },
       ],
-      isError: true,
     });
-    expect(JSON.stringify(result)).not.toContain('- 4:');
-    expect(JSON.stringify(result)).not.toContain('- 9:');
+    expect(JSON.stringify(result)).not.toContain('structuredContent');
   });
 
   it('keeps visible tab index mappings isolated per browser session', async () => {

--- a/apps/core/test/unit/adapters/browser/browser-tool-proxy.test.ts
+++ b/apps/core/test/unit/adapters/browser/browser-tool-proxy.test.ts
@@ -450,6 +450,12 @@ describe('browser tool proxy file policy', () => {
 
   it('sanitizes filename on snapshot, console, and evaluate before backend dispatch', async () => {
     const root = tempRoot();
+    const session = {
+      running: true,
+      cdpReady: true,
+      port: 12345,
+      profileName: 'c-main',
+    };
 
     for (const toolName of [
       'browser_snapshot',
@@ -462,7 +468,7 @@ describe('browser tool proxy file policy', () => {
           arguments: {
             filename: '/tmp/outside-browser-facade.txt',
           },
-          session: { running: false, cdpReady: false },
+          session,
           fileAccessRoot: root,
         }),
       ).rejects.toThrow('limited to the run browser artifact root');
@@ -471,6 +477,12 @@ describe('browser tool proxy file policy', () => {
 
   it('rejects hidden and sensitive browser output path segments', async () => {
     const root = tempRoot();
+    const session = {
+      running: true,
+      cdpReady: true,
+      port: 12345,
+      profileName: 'c-main',
+    };
 
     for (const filename of [
       '.hidden/out.txt',
@@ -482,7 +494,7 @@ describe('browser tool proxy file policy', () => {
         callBrowserTool({
           toolName: 'browser_snapshot',
           arguments: { filename },
-          session: { running: false, cdpReady: false },
+          session,
           fileAccessRoot: root,
         }),
       ).rejects.toThrow('hidden or sensitive paths');
@@ -499,7 +511,12 @@ describe('browser tool proxy file policy', () => {
       callBrowserTool({
         toolName: 'browser_file_upload',
         arguments: { paths: ['linked.txt'] },
-        session: { running: false, cdpReady: false },
+        session: {
+          running: true,
+          cdpReady: true,
+          port: 12345,
+          profileName: 'c-main',
+        },
         fileAccessRoot: root,
       }),
     ).rejects.toThrow('regular files');
@@ -541,14 +558,150 @@ describe('browser tool proxy file policy', () => {
         name: 'browser_file_upload',
         arguments: {
           paths: [
-            path.join(root, 'uploads/note.txt'),
-            path.join(root, 'uploads/encoded.bin'),
+            fs.realpathSync.native(path.join(root, 'uploads/note.txt')),
+            fs.realpathSync.native(path.join(root, 'uploads/encoded.bin')),
           ],
         },
       },
       undefined,
       { timeout: expect.any(Number) },
     );
+  });
+
+  it('combines existing upload paths with inline upload files', async () => {
+    const root = tempRoot();
+    fs.writeFileSync(path.join(root, 'existing.txt'), 'existing');
+    browserMcpMocks.nextResult = { content: [{ type: 'text', text: 'ok' }] };
+
+    await callBrowserTool({
+      toolName: 'browser_file_upload',
+      arguments: {
+        paths: ['existing.txt'],
+        files: [{ name: 'note.txt', content: 'hello' }],
+      },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledWith(
+      {
+        name: 'browser_file_upload',
+        arguments: {
+          paths: [
+            fs.realpathSync.native(path.join(root, 'existing.txt')),
+            fs.realpathSync.native(path.join(root, 'uploads/note.txt')),
+          ],
+        },
+      },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+  });
+
+  it('does not materialize inline upload files when the browser is not ready', async () => {
+    const root = tempRoot();
+
+    await expect(
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: {
+          files: [{ name: 'note.txt', content: 'hello' }],
+        },
+        session: { running: false, cdpReady: false },
+        fileAccessRoot: root,
+      }),
+    ).rejects.toThrow('Browser is not ready');
+
+    expect(fs.existsSync(path.join(root, 'uploads/note.txt'))).toBe(false);
+  });
+
+  it('rejects inline upload file names with path segments', async () => {
+    const root = tempRoot();
+
+    for (const name of ['../note.txt', 'nested/note.txt', 'nested\\note.txt']) {
+      await expect(
+        callBrowserTool({
+          toolName: 'browser_file_upload',
+          arguments: {
+            files: [{ name, content: 'hello' }],
+          },
+          session: {
+            running: true,
+            cdpReady: true,
+            port: 12345,
+            profileName: 'c-main',
+          },
+          fileAccessRoot: root,
+        }),
+      ).rejects.toThrow('plain filenames');
+    }
+  });
+
+  it('rejects malformed and oversized inline upload payloads', async () => {
+    const root = tempRoot();
+    const session = {
+      running: true,
+      cdpReady: true,
+      port: 12345,
+      profileName: 'c-main',
+    };
+
+    await expect(
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: { files: 'not-array' },
+        session,
+        fileAccessRoot: root,
+      }),
+    ).rejects.toThrow('files must be an array');
+    await expect(
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: { files: ['not-object'] },
+        session,
+        fileAccessRoot: root,
+      }),
+    ).rejects.toThrow('file entries must be objects');
+    await expect(
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: { files: [{ name: 'note.txt', content: 42 }] },
+        session,
+        fileAccessRoot: root,
+      }),
+    ).rejects.toThrow('content must be a string');
+    await expect(
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: {
+          files: [
+            { name: 'note.txt', content: 'not-base64', encoding: 'base64' },
+          ],
+        },
+        session,
+        fileAccessRoot: root,
+      }),
+    ).rejects.toThrow('base64 content is invalid');
+    await expect(
+      callBrowserTool({
+        toolName: 'browser_file_upload',
+        arguments: {
+          files: [
+            {
+              name: 'large.txt',
+              content: 'x'.repeat(8 * 1024 * 1024 + 1),
+            },
+          ],
+        },
+        session,
+        fileAccessRoot: root,
+      }),
+    ).rejects.toThrow('decoded bytes each');
   });
 
   it('infers fill_form field metadata from target and value', async () => {
@@ -616,7 +769,12 @@ describe('browser tool proxy file policy', () => {
       callBrowserTool({
         toolName: 'browser_take_screenshot',
         arguments: { filename: 'linked-dir/out.png' },
-        session: { running: false, cdpReady: false },
+        session: {
+          running: true,
+          cdpReady: true,
+          port: 12345,
+          profileName: 'c-main',
+        },
         fileAccessRoot: root,
       }),
     ).rejects.toThrow('cannot traverse symlinks');
@@ -693,6 +851,51 @@ describe('browser tool proxy file policy', () => {
     expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
       3,
       { name: 'browser_click', arguments: { target: 'e6' } },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+  });
+
+  it('refreshes the target model for targeted snapshot stale refs', async () => {
+    const root = tempRoot();
+    browserMcpMocks.callToolImpl = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          'Ref e6 not found in the current page snapshot. Try capturing new snapshot.',
+        ),
+      )
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'snapshot' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'section' }] });
+
+    const result = await callBrowserTool({
+      toolName: 'browser_snapshot',
+      arguments: { target: 'e6' },
+      session: {
+        running: true,
+        cdpReady: true,
+        port: 12345,
+        profileName: 'c-main',
+      },
+      fileAccessRoot: root,
+    });
+
+    expect(result).toEqual({ content: [{ type: 'text', text: 'section' }] });
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
+      1,
+      { name: 'browser_snapshot', arguments: { target: 'e6' } },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
+      2,
+      { name: 'browser_snapshot', arguments: {} },
+      undefined,
+      { timeout: expect.any(Number) },
+    );
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenNthCalledWith(
+      3,
+      { name: 'browser_snapshot', arguments: { target: 'e6' } },
       undefined,
       { timeout: expect.any(Number) },
     );
@@ -1308,6 +1511,50 @@ describe('browser tool proxy file policy', () => {
       undefined,
       { timeout: expect.any(Number) },
     );
+  });
+
+  it('fails closed and clears stale mapping for unparseable markdown tab lists', async () => {
+    const root = tempRoot();
+    const session = {
+      running: true,
+      cdpReady: true,
+      port: 12345,
+      profileName: 'c-main',
+    };
+
+    browserMcpMocks.nextResult = {
+      content: [{ type: 'text', text: '- 4: Example https://example.test/' }],
+      structuredContent: {
+        tabs: [{ index: 4, title: 'Example', url: 'https://example.test/' }],
+      },
+    };
+    await callBrowserTool({
+      toolName: 'browser_tabs',
+      arguments: { action: 'list' },
+      session,
+      fileAccessRoot: root,
+    });
+
+    browserMcpMocks.nextResult = {
+      content: [{ type: 'text', text: '- 4: files processed' }],
+    };
+    const result = await callBrowserTool({
+      toolName: 'browser_tabs',
+      arguments: { action: 'list' },
+      session,
+      fileAccessRoot: root,
+    });
+
+    expect(result).toMatchObject({ isError: true });
+    await expect(
+      callBrowserTool({
+        toolName: 'browser_tabs',
+        arguments: { action: 'select', index: 0 },
+        session,
+        fileAccessRoot: root,
+      }),
+    ).rejects.toThrow('needs a fresh browser_tabs list');
+    expect(browserMcpMocks.clients[0]?.callTool).toHaveBeenCalledTimes(2);
   });
 
   it('does not parse tab-shaped markdown from non-tab tool results', () => {

--- a/apps/core/test/unit/runner/browser-tools.test.ts
+++ b/apps/core/test/unit/runner/browser-tools.test.ts
@@ -14,13 +14,15 @@ import { registerBrowserTools } from '@core/runner/mcp/tools/browser.js';
 
 class TestMcpServer {
   readonly tools = new Map<string, (args: unknown) => Promise<unknown>>();
+  readonly schemas = new Map<string, unknown>();
 
   tool(
     name: string,
     _description: string,
-    _schema: unknown,
+    schema: unknown,
     handler: (args: unknown) => Promise<unknown>,
   ) {
+    this.schemas.set(name, schema);
     this.tools.set(name, handler);
   }
 }
@@ -127,5 +129,36 @@ describe('runner browser MCP projected tools', () => {
     });
 
     expect(result).toBe(compactResult);
+  });
+
+  it('passes simpler fill form fields and inline upload files through IPC', async () => {
+    requestBrowserAction.mockResolvedValue({
+      ok: true,
+      data: { content: [{ type: 'text', text: 'ok' }] },
+    });
+    const server = new TestMcpServer();
+    registerBrowserTools(server as never);
+
+    await server.tools.get('browser_fill_form')?.({
+      fields: [{ target: 'e1', value: 'Ravi' }],
+    });
+    await server.tools.get('browser_file_upload')?.({
+      files: [{ name: 'note.txt', content: 'hello' }],
+    });
+
+    expect(requestBrowserAction).toHaveBeenNthCalledWith(
+      1,
+      'browser_fill_form',
+      { fields: [{ target: 'e1', value: 'Ravi' }] },
+      { timeoutMs: 120_000 },
+    );
+    expect(requestBrowserAction).toHaveBeenNthCalledWith(
+      2,
+      'browser_file_upload',
+      { files: [{ name: 'note.txt', content: 'hello' }] },
+      { timeoutMs: 120_000 },
+    );
+    expect(server.schemas.get('browser_fill_form')).toHaveProperty('fields');
+    expect(server.schemas.get('browser_file_upload')).toHaveProperty('files');
   });
 });

--- a/apps/core/test/unit/runner/browser-tools.test.ts
+++ b/apps/core/test/unit/runner/browser-tools.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
 const requestBrowserAction = vi.hoisted(() => vi.fn());
 
@@ -160,5 +161,36 @@ describe('runner browser MCP projected tools', () => {
     );
     expect(server.schemas.get('browser_fill_form')).toHaveProperty('fields');
     expect(server.schemas.get('browser_file_upload')).toHaveProperty('files');
+  });
+
+  it('keeps projected browser tool schemas parseable for simplified inputs', () => {
+    const server = new TestMcpServer();
+    registerBrowserTools(server as never);
+
+    const fillFormSchema = z.object(
+      server.schemas.get('browser_fill_form') as z.ZodRawShape,
+    );
+    const uploadSchema = z.object(
+      server.schemas.get('browser_file_upload') as z.ZodRawShape,
+    );
+    const snapshotSchema = z.object(
+      server.schemas.get('browser_snapshot') as z.ZodRawShape,
+    );
+
+    expect(
+      fillFormSchema.safeParse({
+        fields: [{ target: 'e1', value: 'Ravi' }],
+      }).success,
+    ).toBe(true);
+    expect(
+      uploadSchema.safeParse({
+        paths: ['existing.txt'],
+        files: [{ name: 'note.txt', content: 'hello' }],
+      }).success,
+    ).toBe(true);
+    expect(
+      snapshotSchema.safeParse({ target: 'e1', filename: 'snapshot.json' })
+        .success,
+    ).toBe(true);
   });
 });

--- a/apps/core/test/unit/runtime/browser-capability.test.ts
+++ b/apps/core/test/unit/runtime/browser-capability.test.ts
@@ -223,6 +223,24 @@ describe('browser-capability', () => {
     expect(mocks.release).not.toHaveBeenCalled();
   });
 
+  it('fails browser launch when the startup deadline is exhausted', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const manager = await import('@core/runtime/browser-capability.js');
+
+    await expect(manager.launchBrowser({ deadlineAtMs: 999 })).rejects.toThrow(
+      'Browser launch deadline exceeded',
+    );
+
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+    const launched = mocks.spawn.mock.results[0]?.value as
+      | { pid: number }
+      | undefined;
+    expect(launched?.pid).toEqual(expect.any(Number));
+    expect(killSpy).toHaveBeenCalledWith(launched?.pid, 'SIGTERM');
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+  });
+
   it('relaunches instead of reusing a process with an unhealthy CDP endpoint', async () => {
     const manager = await import('@core/runtime/browser-capability.js');
     queueHealthyContentTarget('target-1');

--- a/apps/core/test/unit/runtime/browser-cdp-targets.test.ts
+++ b/apps/core/test/unit/runtime/browser-cdp-targets.test.ts
@@ -80,8 +80,15 @@ describe('browser CDP target cleanup', () => {
           { id: 'content', type: 'page', url: 'https://example.com' },
           { id: 'omnibox-1', type: 'page', url: 'chrome://omnibox-popup/' },
           { id: 'omnibox-2', type: 'page', url: 'chrome://omnibox-popup/2' },
+          {
+            id: 'omnibox-3',
+            type: 'page',
+            title: 'Omnibox Popup',
+            url: 'about:blank',
+          },
         ]),
       )
+      .mockResolvedValueOnce(textResponse())
       .mockResolvedValueOnce(textResponse())
       .mockResolvedValueOnce(textResponse())
       .mockResolvedValueOnce(
@@ -115,6 +122,10 @@ describe('browser CDP target cleanup', () => {
     );
     expect(fetchMock).toHaveBeenCalledWith(
       'http://127.0.0.1:9222/json/close/omnibox-2',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:9222/json/close/omnibox-3',
       expect.objectContaining({ method: 'GET' }),
     );
     expect(cdp.urls).toEqual(['ws://127.0.0.1:9222/devtools/browser/root']);
@@ -392,7 +403,7 @@ describe('browser CDP target cleanup', () => {
         method: 'Browser.setWindowBounds',
         params: {
           windowId: 42,
-          bounds: { width: 1200, height: 800 },
+          bounds: { windowState: 'normal', width: 1200, height: 800 },
         },
       },
     ]);

--- a/apps/core/test/unit/runtime/ipc-browser-handler.test.ts
+++ b/apps/core/test/unit/runtime/ipc-browser-handler.test.ts
@@ -181,6 +181,7 @@ describe('ipc-browser-handler', () => {
     expect(response.ok).toBe(true);
     expect(ensureBrowserReady).toHaveBeenCalledWith({
       profileName: 'c-main-abc123abc123',
+      deadlineAtMs: undefined,
     });
     expect(callBrowserTool).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -831,6 +832,7 @@ describe('ipc-browser-handler', () => {
       profileName: 'default',
       headless: true,
       keepAliveMs: undefined,
+      deadlineAtMs: undefined,
     });
   });
 
@@ -854,6 +856,32 @@ describe('ipc-browser-handler', () => {
     expect(response.ok).toBe(false);
     expect(response.error).toContain('Browser IPC deadline exceeded');
     expect(ensureBrowserReady).not.toHaveBeenCalled();
+  });
+
+  it('passes signed browser IPC deadlines into launch work', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    const response = await processBrowserIpcRequest(
+      {
+        requestId: 'req-launch-deadline',
+        action: 'browser_launch',
+        payload: { headless: true },
+      },
+      {
+        sourceAgentFolder: 'main',
+        browserIpcAuthorized: true,
+        timeoutMs: 2_000,
+      },
+    );
+
+    expect(response.ok).toBe(true);
+    expect(ensureBrowserReady).toHaveBeenCalledWith({
+      profileName: 'default',
+      headless: true,
+      keepAliveMs: undefined,
+      deadlineAtMs: 3_000,
+    });
   });
 
   it('includes tool-capability broker health on browser launch', async () => {
@@ -889,13 +917,14 @@ describe('ipc-browser-handler', () => {
 
     expect(response.ok).toBe(true);
     expect(response.data).toMatchObject({
+      cdpReady: false,
       brokerHealthy: false,
       brokerHealth: {
         status: 'fail',
         message:
           'Could not reach OneCLI at http://localhost:10254: connect ECONNREFUSED',
       },
-      warning: expect.stringContaining('third-party MCP tools can fail'),
+      warning: expect.stringContaining('CDP is not driveable'),
     });
     expect(healthCheck).toHaveBeenCalledWith({
       binding: {
@@ -933,13 +962,13 @@ describe('ipc-browser-handler', () => {
     expect(response.ok).toBe(true);
     expect(response.data).toMatchObject({
       running: true,
-      cdpReady: true,
+      cdpReady: false,
       brokerHealthy: false,
       brokerHealth: {
         status: 'fail',
         message: 'Credential broker health check failed.',
       },
-      warning: expect.stringContaining('third-party MCP tools can fail'),
+      warning: expect.stringContaining('CDP is not driveable'),
     });
   });
 

--- a/docs/architecture/browser-capability.md
+++ b/docs/architecture/browser-capability.md
@@ -91,8 +91,11 @@ model, and translates `browser_tabs` select and close requests from those
 visible indices back to the backend's raw tab indices internally. Raw backend
 tab indices must not leak into model-facing structured or text results. Numeric
 select and close requests fail closed unless a current visible-to-backend tab
-mapping exists. Text-only tab lists without `structuredContent.tabs` also fail
-closed instead of presenting backend indices as stable model-facing indices.
+mapping exists. If a backend returns tab metadata only as provider-specific
+text, the browser adapter must first parse it into adapter-owned structured
+metadata, then apply the same visible-index projection; unparseable text-only
+tab lists fail closed instead of presenting backend indices as stable
+model-facing indices.
 Successful tab-set mutations such as close and new invalidate that mapping
 unless the backend returns a fresh structured tab list, which replaces it.
 


### PR DESCRIPTION
## Summary
- split MyClaw-owned browser artifact/file policy from Playwright MCP compatibility projection
- keep browser tab visible-index mapping neutral while adapting Playwright MCP markdown tab output at the adapter edge
- make file upload usable with inline content while preserving artifact-root confinement
- harden headed Chrome target filtering/resize behavior for Omnibox popup and window bounds issues

## Verification
- npx vitest run -c vitest.unit.config.ts apps/core/test/unit/adapters/browser/browser-tool-proxy.test.ts apps/core/test/unit/runtime/browser-cdp-targets.test.ts apps/core/test/unit/runtime/ipc-browser-handler.test.ts apps/core/test/unit/runner/browser-tools.test.ts
- npm run build
- python3 .codex/scripts/check_architecture.py
- python3 .codex/scripts/check_task_completion.py