### PR TITLE
Restore live SDK session resume

### DIFF
--- a/apps/core/src/runner/AGENTS.md
+++ b/apps/core/src/runner/AGENTS.md
@@ -16,6 +16,12 @@
   memory-boundary, and fail-closed sandbox hard guards before the timed grant so
   this option reduces prompts without bypassing safety checks.
 - One-shot scheduled jobs must close the SDK prompt stream after the initial prompt is queued. Keeping that async iterable open is live-run behavior for IPC continuations; in scheduled jobs it can leave the SDK waiting for another user turn after tool execution and produce an idle stall instead of a terminal result.
+- Claude SDK session persistence is split by run type. Live channel turns may
+  use `AgentInput.sessionId` to set `persistSession: true` and `resume`, but
+  scheduled/autonomous jobs must keep `isScheduledJob: true`, omit
+  `AgentInput.sessionId`, and run the SDK with `persistSession: false` even
+  when job metadata has `session_id` or `executionContext.sessionId` for
+  app/control correlation.
 - Scoped Bash approval is argv-leaf based. Parse `&&`, `||`, `;`, pipes, newlines, and subshell leaves; every simple command leaf must match its own durable `Bash(...)` rule. Unsupported shell grammar and destructive redirects fail closed to one-time approval, and persistent suggestions must list separate safe leaf rules instead of the compound command.
 - Native SDK `Agent` and `Task` tool calls are always background work. Force `run_in_background: true` in runner tool input before validation, permission checks, sandbox/network gates, and SDK allow responses; SDK `task_notification` system messages should be emitted as structured runtime events instead of log-only observations.
 - The compact `mcp__myclaw__file` tool is the agent-facing durable-file

--- a/apps/core/src/runner/claude/index.ts
+++ b/apps/core/src/runner/claude/index.ts
@@ -180,7 +180,7 @@ async function runScheduledQuery(opts: {
       opts.configuredModel,
       opts.configuredThinking,
       opts.configuredEffort,
-      false,
+      { enableIpcFollowups: false, persistSdkSession: false },
     );
     if (queryResult.newSessionId) {
       diagnosticSessionId = queryResult.newSessionId;
@@ -233,7 +233,7 @@ async function runInteractiveQueryLoop(opts: {
       opts.configuredModel,
       opts.configuredThinking,
       opts.configuredEffort,
-      true,
+      { enableIpcFollowups: true, persistSdkSession: true },
     );
     if (queryResult.newSessionId) {
       diagnosticSessionId = queryResult.newSessionId;

--- a/apps/core/src/runner/claude/query-loop.ts
+++ b/apps/core/src/runner/claude/query-loop.ts
@@ -48,6 +48,12 @@ import { logUsage } from './usage-logging.js';
 import { readContextUsage } from './context-usage.js';
 import { RUNTIME_EVENT_TYPES } from '../../domain/events/runtime-event-types.js';
 import { createCanUseToolCallback } from './tool-permission-gate.js';
+
+interface RunQueryOptions {
+  enableIpcFollowups?: boolean;
+  persistSdkSession?: boolean;
+}
+
 export async function runQuery(
   prompt: string,
   mcpServerPath: string,
@@ -56,13 +62,15 @@ export async function runQuery(
   configuredModel: string | undefined,
   queryThinking: ThinkingConfig | undefined,
   queryEffort: EffortLevel | undefined,
-  enableIpcFollowups = true,
+  options: RunQueryOptions = {},
 ): Promise<{
   newSessionId?: string;
   lastAssistantUuid?: string;
   closedDuringQuery: boolean;
   primeToolAttempts: AgentRunnerToolAttemptOutput[];
 }> {
+  const enableIpcFollowups = options.enableIpcFollowups ?? true;
+  const persistSdkSession = options.persistSdkSession ?? true;
   const stream = new MessageStream();
   const queryRunId = randomUUID();
   const memoryBlock = readMemoryContextBlock(agentInput);
@@ -127,7 +135,6 @@ export async function runQuery(
   const extraDirs = discoverAdditionalDirectories();
   const protectedFilesystemPaths = readProtectedFilesystemPaths();
   const workspaceFolder = agentInput.groupFolder;
-  const shouldPersistSdkSession = agentInput.isScheduledJob !== true;
   const capabilities = composeAgentCapabilities({
     mcpServerPath,
     appId: agentInput.appId,
@@ -162,8 +169,8 @@ export async function runQuery(
       effort: queryEffort,
       cwd: WORKSPACE_GROUP_DIR,
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
-      persistSession: shouldPersistSdkSession,
-      ...(shouldPersistSdkSession && agentInput.sessionId
+      persistSession: persistSdkSession,
+      ...(persistSdkSession && agentInput.sessionId
         ? { resume: agentInput.sessionId }
         : {}),
       systemPrompt,

--- a/apps/core/src/runner/claude/tool-permission-gate.ts
+++ b/apps/core/src/runner/claude/tool-permission-gate.ts
@@ -47,9 +47,6 @@ const TIMED_GRANT_DURATION_MS = 5 * 60 * 1000;
 const TIMED_GRANT_CLOCK_SKEW_MS = 10_000;
 
 interface TimedToolGrant {
-  scope: 'all_tools';
-  principal: string;
-  conversationJid: string;
   expiresAt: number;
 }
 
@@ -116,7 +113,7 @@ export function createCanUseToolCallback(
       return false;
     }
     log(
-      `Timed grant honored for tool ${toolName}: scope=${grant.scope} principal=${grant.principal} conversationJid=${grant.conversationJid} ttlMs=${grant.expiresAt - Date.now()}`,
+      `Timed grant honored for tool ${toolName}: scope=all_tools principal=${principal} conversationJid=${timedGrantConversationJid} ttlMs=${grant.expiresAt - Date.now()}`,
     );
     return true;
   };
@@ -140,9 +137,6 @@ export function createCanUseToolCallback(
       return;
     }
     const grant: TimedToolGrant = {
-      scope: 'all_tools',
-      principal,
-      conversationJid: timedGrantConversationJid,
       expiresAt: requestedExpiresAtMs,
     };
     timedToolGrants.set(timedGrantKey(principal), grant);
@@ -151,7 +145,7 @@ export function createCanUseToolCallback(
       requestedExpiresAtMs,
     );
     log(
-      `Timed grant activated for tool ${toolName}: scope=${grant.scope} principal=${grant.principal} conversationJid=${grant.conversationJid} expiresAt=${new Date(requestedExpiresAtMs).toISOString()}`,
+      `Timed grant activated for tool ${toolName}: scope=all_tools principal=${principal} conversationJid=${timedGrantConversationJid} expiresAt=${new Date(requestedExpiresAtMs).toISOString()}`,
     );
   };
 

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -128,11 +128,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       ...(args.done !== undefined ? { done: args.done } : {}),
     });
     const buildProgressOptions = (
-      args: {
-        threadId?: string;
-        done?: boolean;
-        replaceOnly?: boolean;
-      } = {},
+      args: { threadId?: string; done?: boolean; replaceOnly?: boolean } = {},
     ): ProgressUpdateOptions => ({
       ...(resolveThreadId(args.threadId)
         ? { threadId: resolveThreadId(args.threadId) }

--- a/docs/architecture/session-resume.md
+++ b/docs/architecture/session-resume.md
@@ -18,19 +18,24 @@ instruction authority, permissions, credentials, or sandbox access.
 ## Provider Session Metadata
 
 Provider session handles may exist as adapter metadata attached to canonical
-`AgentSession` records, but normal agent turns do not use them for provider
-continuity.
+`AgentSession` records. Live user-facing turns use those handles only as an
+adapter resume optimization; canonical continuity still belongs to Postgres.
 
 - Canonical continuity record: `AgentSession` (provider-neutral app contract).
 - Adapter projection field: `ProviderSession.externalSessionId`.
-- Current runtime projection: Anthropic/Claude SDK runs set
-  `persistSession: false` and do not pass `resume` or `resumeSessionAt`.
+- Current live runtime projection: Anthropic/Claude SDK runs set
+  `persistSession: true` and pass `resume` from the trusted
+  `AgentInput.sessionId` when a provider handle exists.
+- Current scheduled/autonomous job projection: jobs set `isScheduledJob: true`,
+  do not pass `AgentInput.sessionId`, and the Claude SDK query runs with
+  `persistSession: false`.
 - Conversation evidence belongs in Postgres messages, runs, jobs, memory,
   digests, and runtime events; provider JSONL files are not continuity state.
 
-This keeps normal agent conversations provider-stateless. If transcript export
-is needed, generate it from Postgres evidence into a FileArtifact instead of
-depending on provider-local session files.
+This keeps normal agent conversations canonically provider-neutral while
+allowing live runs to use the provider's own efficient resume path. If
+transcript export is needed, generate it from Postgres evidence into a
+FileArtifact instead of depending on provider-local session files.
 
 ## Scope And Ownership Isolation
 
@@ -89,8 +94,9 @@ fallback, or repair branches for that state.
 - Reset preserves canonical `agent_sessions` identity and scoped
   `agent_session_digests`; digest hydration still works after reset.
 - During live runs, MyClaw persists canonical messages, runs, jobs, memory,
-  digests, and runtime events. It does not persist newly emitted SDK session ids
-  as continuity handles for the next run.
+  digests, and runtime events. Newly emitted SDK session ids are sensitive
+  adapter metadata attached to the canonical session, not standalone continuity
+  identity.
 - Expiring or clearing provider-session metadata does not delete canonical
   session identity.
 
@@ -110,8 +116,12 @@ fallback, or repair branches for that state.
 
 ## Runtime Guardrails
 
-- `apps/core/src/runner/claude/query-loop.ts` must keep `persistSession: false`.
-- Host runner inputs must not pass `turnContext.externalSessionId` as an SDK
-  `sessionId`/`resume` value.
-- Tests should assert both live turns and scheduled jobs run without SDK resume
-  options, while Postgres persistence remains the canonical evidence path.
+- `apps/core/src/runner/claude/index.ts` must pass explicit query-loop SDK
+  persistence options: live turns persist/resume, scheduled jobs do not.
+- Host live runner inputs may pass the trusted `turnContext.externalSessionId`
+  as `AgentInput.sessionId`; scheduler execution must not copy
+  `jobs.session_id` or `executionContext.sessionId` into that field.
+- Tests should assert live turns set `persistSession: true` and `resume` when
+  `AgentInput.sessionId` exists, while scheduled jobs run with
+  `persistSession: false` and no `resume` options. Postgres remains the
+  canonical evidence path for messages, runs, memory, jobs, and events.


### PR DESCRIPTION
## Summary
- restore live channel Claude SDK persistence/resume via explicit query-loop options
- keep scheduled/autonomous jobs non-persistent
- update session-resume docs and runner guidance
- satisfy current architecture line-count ratchets with behavior-preserving cleanup

## Verification
- npm run build
- npm run test:unit -- apps/core/test/unit/runner/agent-runner-ipc.test.ts apps/core/test/unit/runtime/group-processing.test.ts apps/core/test/unit/runner/tool-permission-gate.test.ts
- npm run test:integration -- apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
- git diff --check
- python3 .codex/scripts/check_task_completion.py
- launchctl kickstart/status smoke check after build