### PR TITLE
Add provider gates, JSONB payloads, and Postgres event hardening

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -15,5 +15,6 @@ This folder owns factory prompts, hook wiring, agent prompt contracts, and tests
 - Do not let prompt changes invent new product behavior or bypass the existing PR-ready review gates.
 - Deterministic verify includes an architecture phase (`python3 .codex/scripts/check_architecture.py`) before typecheck/tests.
 - Architecture exceptions belong in `.codex/architecture-exceptions.json`, use the file/rule/reason/removeByPhase schema, and should stay empty unless a narrow temporary waiver makes the codebase stronger. File line-budget violations are strict and must not be excepted.
+- Anthropic/Claude provider-boundary debt belongs in `.codex/provider-boundary-exceptions.json` with exact file paths and exact token counts. Do not approve broad config, memory, or shared paths for this gate.
 - Direct provider-send guardrails must cover alias receiver forms, not just canonical local names. Keep Slack `*.chat.postMessage`, Telegram `*.sendMessage`, and Teams SDK `*.sendMessage` regressions covered in `.codex/scripts/tests/test_check_architecture.py`.
 - Refactor line-delta checks have two explicit modes: phase progress reads a recorded T0 commit with `--baseline-file`, while final/overall deletion-budget checks use `--base-ref`. Keep both filtered to the source extensions counted by `--baseline`.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -237,6 +237,8 @@ Reads `architecture-map.json` and enforces:
 
 - Layer import rules (`domain` cannot import adapters/runtime/etc.).
 - Provider-specific imports allowed only inside approved adapter paths.
+- Anthropic/Claude provider-boundary tokens outside the approved adapter
+  boundary, with exact-count debt tracked in `provider-boundary-exceptions.json`.
 - Per-file line budgets (`defaultLineBudget = 700`, with named overrides).
 - Forbidden patterns: direct provider sends, IPC monoliths, runtime
   materialization in runner code, browser default-profile paths, old terms
@@ -248,6 +250,10 @@ Reads `architecture-map.json` and enforces:
 `architecture-exceptions.json` only with `file`, `rule`, `reason`, and
 `removeByPhase`. File line-budget violations cannot be excepted. Stale or
 over-capped exceptions fail the check.
+
+Anthropic/Claude provider-boundary exceptions live separately in
+`provider-boundary-exceptions.json`. They must use exact file paths and exact
+token counts; changing a count without updating the exception fails the check.
 
 ---
 

--- a/.codex/architecture-exceptions.json
+++ b/.codex/architecture-exceptions.json
@@ -455,11 +455,46 @@
     "maxViolations": 3
   },
   {
+    "file": "apps/core/src/config/env/index.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact config provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/config/index.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact config provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 10
+  },
+  {
     "file": "apps/core/src/config/preflight.ts",
     "rule": "forbidden_import_by_layer",
     "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
     "removeByPhase": "canonical-boundary-cleanup-phase",
     "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/config/settings/desired-state-provider-conversations.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings provider-conversation debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 14
+  },
+  {
+    "file": "apps/core/src/config/settings/memory-snapshot.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings memory model debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-settings-memory-parser.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings memory model debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 1
   },
   {
     "file": "apps/core/src/config/settings/control-allowlist.ts",
@@ -497,6 +532,13 @@
     "maxViolations": 2
   },
   {
+    "file": "apps/core/src/config/settings/runtime-settings.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 11
+  },
+  {
     "file": "apps/core/src/config/settings/runtime-settings-validation.ts",
     "rule": "forbidden_import_by_layer",
     "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
@@ -516,6 +558,13 @@
     "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
     "removeByPhase": "canonical-boundary-cleanup-phase",
     "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/source-classification.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact config source-classification provider debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 17
   },
   {
     "file": "apps/core/src/control/server/handler-context.ts",
@@ -1336,6 +1385,13 @@
     "reason": "Baseline channel formatting dialect name remains in the messaging formatter until provider-specific rendering is moved fully behind channel adapters.",
     "removeByPhase": "canonical-boundary-cleanup-phase",
     "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/shared/model-catalog.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact shared model-catalog provider debt after removing the broad shared provider allowlist; capped so new provider-specific shared leakage fails.",
+    "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
+    "maxViolations": 28
   },
   {
     "file": "apps/core/src/platform/index.ts",

--- a/.codex/architecture-map.json
+++ b/.codex/architecture-map.json
@@ -120,11 +120,12 @@
     "apps/core/src/adapters/browser",
     "apps/core/src/channels",
     "apps/core/src/cli",
-    "apps/core/src/config",
     "apps/core/src/runner/claude",
     "apps/core/src/runner/mcp",
-    "apps/core/src/memory/claude-query.ts",
-    "apps/core/src/shared/model-catalog.ts"
+    "apps/core/src/memory/claude-query.ts"
+  ],
+  "approvedProviderBoundaryPaths": [
+    "apps/core/src/adapters/llm/anthropic-claude-agent"
   ],
   "providerImportSpecifiers": [
     "@anthropic-ai/sdk",

--- a/.codex/provider-boundary-exceptions.json
+++ b/.codex/provider-boundary-exceptions.json
@@ -1,0 +1,567 @@
+{
+  "version": 1,
+  "cleanupPlanId": "myclaw-architecture-gates-20260517-provider-boundary-sentinels",
+  "exceptions": [
+    {
+      "file": "apps/core/src/adapters/credentials/onecli/broker.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/adapters/credentials/onecli/env-policy.ts",
+      "matches": {
+        "ANTHROPIC_": 6,
+        "CLAUDE_CODE_OAUTH_TOKEN": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/adapters/llm/external-credential-injection.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/adapters/storage/postgres/repositories/canonical-session-repository.postgres.ts",
+      "matches": {
+        "const PROVIDER = 'anthropic'": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/adapters/storage/postgres/seeds.ts",
+      "matches": {
+        "provider: 'anthropic'": 2,
+        "anthropic_sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/adapters/storage/postgres/schema/agents.ts",
+      "matches": {
+        "default('anthropic')": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/domain/tools/tools.ts",
+      "matches": {
+        "anthropic_sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/cli/model.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/cli/onboarding-config.ts",
+      "matches": {
+        "ANTHROPIC_": 6,
+        "CLAUDE_CODE_OAUTH_TOKEN": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/config/credentials/broker-url-policy.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/config/index.ts",
+      "matches": {
+        "ANTHROPIC_": 8
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/config/source-classification.ts",
+      "matches": {
+        "ANTHROPIC_": 14,
+        "CLAUDE_CODE_OAUTH_TOKEN": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/memory/claude-query.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/filesystem-sandbox.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/index.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/model-config.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1,
+        "ANTHROPIC_": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/protected-capability-hook.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/query-loop.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/runtime-env.ts",
+      "matches": {
+        "ANTHROPIC_": 6,
+        "CLAUDE_CONFIG_DIR": 2,
+        "CLAUDE_CODE_OAUTH_TOKEN": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/session-slash.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/tool-permission-gate.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runner/claude/types.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/runtime/agent-spawn.ts",
+      "matches": {
+        "ANTHROPIC_": 6,
+        "CLAUDE_CONFIG_DIR": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/src/shared/model-catalog.ts",
+      "matches": {
+        "provider: 'anthropic'": 4
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/e2e/runtime-setup-doctor.e2e.test.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1,
+        "ANTHROPIC_": 1,
+        "CLAUDE_CONFIG_DIR": 6,
+        "CLAUDE_CODE_OAUTH_TOKEN": 1,
+        "runner/claude": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/integration/config-credential-boundary.integration.test.ts",
+      "matches": {
+        "ANTHROPIC_": 3,
+        "CLAUDE_CODE_OAUTH_TOKEN": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/integration/permission-approval-ipc.integration.test.ts",
+      "matches": {
+        "runner/claude": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/integration/postgres-domain-repositories.integration.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 15
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/integration/runtime-host-child-process.integration.test.ts",
+      "matches": {
+        "ANTHROPIC_": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/integration/session-continuity-postgres.integration.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/adapters/claude-config-materializer.test.ts",
+      "matches": {
+        "ANTHROPIC_": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/adapters/credentials/env-runtime-secret-provider.test.ts",
+      "matches": {
+        "ANTHROPIC_": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/adapters/storage/postgres/canonical-ops-repo.postgres.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/application/sessions/session-interaction-module.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 4
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/cli/config.test.ts",
+      "matches": {
+        "ANTHROPIC_": 2,
+        "CLAUDE_CODE_OAUTH_TOKEN": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/cli/doctor.test.ts",
+      "matches": {
+        "ANTHROPIC_": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/cli/group.test.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/cli/onboarding-config.test.ts",
+      "matches": {
+        "ANTHROPIC_": 5,
+        "CLAUDE_CODE_OAUTH_TOKEN": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/cli/setup-credentials.test.ts",
+      "matches": {
+        "ANTHROPIC_": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/core/agent-credential-service.test.ts",
+      "matches": {
+        "ANTHROPIC_": 8
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/core/config-credential-auth.test.ts",
+      "matches": {
+        "ANTHROPIC_": 4
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/core/onecli-credential-broker.test.ts",
+      "matches": {
+        "ANTHROPIC_": 21
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/core/onecli-env-policy.test.ts",
+      "matches": {
+        "ANTHROPIC_": 36,
+        "CLAUDE_CODE_OAUTH_TOKEN": 4
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/core/onecli-policy.test.ts",
+      "matches": {
+        "ANTHROPIC_": 6
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/core/preflight.test.ts",
+      "matches": {
+        "ANTHROPIC_": 4
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/domain/canonical-domain.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/memory/claude-query.test.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1,
+        "ANTHROPIC_": 21,
+        "CLAUDE_CODE_OAUTH_TOKEN": 7
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/memory/extractor-llm.test.ts",
+      "matches": {
+        "@anthropic-ai/claude-agent-sdk": 1,
+        "ANTHROPIC_": 7,
+        "CLAUDE_CODE_OAUTH_TOKEN": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/memory/memory-embeddings-brokered.test.ts",
+      "matches": {
+        "ANTHROPIC_": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/models/model-catalog.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/agent-runner-ipc.test.ts",
+      "matches": {
+        "ANTHROPIC_": 8,
+        "CLAUDE_CODE_OAUTH_TOKEN": 4,
+        "runner/claude": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/bash-trust-env.test.ts",
+      "matches": {
+        "runner/claude": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/filesystem-sandbox.test.ts",
+      "matches": {
+        "runner/claude": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/model-config.test.ts",
+      "matches": {
+        "ANTHROPIC_": 12
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/permission-callback.test.ts",
+      "matches": {
+        "runner/claude": 5
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/permission-suggestions.test.ts",
+      "matches": {
+        "runner/claude": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/protected-capability-guard.test.ts",
+      "matches": {
+        "runner/claude": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/sdk-sandbox-network-gate.test.ts",
+      "matches": {
+        "runner/claude": 6
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/steering-delivery-gate.test.ts",
+      "matches": {
+        "runner/claude": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runner/tool-permission-gate.test.ts",
+      "matches": {
+        "runner/claude": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runtime/agent-spawn-host.test.ts",
+      "matches": {
+        "ANTHROPIC_": 23
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runtime/agent-spawn.test.ts",
+      "matches": {
+        "ANTHROPIC_": 23,
+        "CLAUDE_CONFIG_DIR": 3,
+        "CLAUDE_CODE_OAUTH_TOKEN": 1,
+        "runner/claude": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/runtime/model-status-store.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "apps/core/test/unit/session/session-commands.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 2
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "packages/contracts/test/unit/index.test.ts",
+      "matches": {
+        "provider: 'anthropic'": 3
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    },
+    {
+      "file": "packages/contracts/src/tools/index.ts",
+      "matches": {
+        "anthropic_sdk": 1
+      },
+      "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",
+      "removeByPlan": "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+    }
+  ]
+}

--- a/.codex/scripts/architecture_rules.py
+++ b/.codex/scripts/architecture_rules.py
@@ -226,6 +226,42 @@ EXPORT_FROM_STATEMENT_RE = re.compile(
 )
 COMMENT_OR_BLANK_RE = re.compile(r"^\s*(?://.*|/\*.*\*/)?\s*$")
 
+PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID = (
+    "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+)
+PROVIDER_BOUNDARY_TOKENS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "@anthropic-ai/claude-agent-sdk",
+        re.compile(re.escape("@anthropic-ai/claude-agent-sdk")),
+    ),
+    ("@anthropic-ai/sdk", re.compile(re.escape("@anthropic-ai/sdk"))),
+    ("ANTHROPIC_", re.compile(r"ANTHROPIC_")),
+    ("CLAUDE_CONFIG_DIR", re.compile(r"CLAUDE_CONFIG_DIR")),
+    ("CLAUDE_CODE_OAUTH_TOKEN", re.compile(r"CLAUDE_CODE_OAUTH_TOKEN")),
+    ("claude-jsonl", re.compile(r"claude-jsonl")),
+    ("runner/claude", re.compile(r"runner/claude")),
+    ("provider = 'anthropic'", re.compile(r"\bprovider\s*=\s*['\"]anthropic['\"]")),
+    (
+        "provider: 'anthropic'",
+        re.compile(r"(?:(?<![\w$])provider|['\"]provider['\"])\s*:\s*(?:['\"`]anthropic['\"`]|`anth\$\{\s*['\"]ropic['\"]\s*\}`)"),
+    ),
+    (
+        "const PROVIDER = 'anthropic'",
+        re.compile(r"\bconst\s+PROVIDER\s*=\s*['\"]anthropic['\"]"),
+    ),
+    ("default('anthropic')", re.compile(r"\.default\(\s*['\"]anthropic['\"]\s*\)")),
+    ("anthropic_sdk", re.compile(r"\banthropic_sdk\b")),
+)
+PROVIDER_BOUNDARY_DEFAULT_APPROVED_PATHS = (
+    "apps/core/src/adapters/llm/anthropic-claude-agent",
+)
+PROVIDER_BOUNDARY_ALLOWED_APPROVED_PATHS = set(PROVIDER_BOUNDARY_DEFAULT_APPROVED_PATHS)
+PROVIDER_BOUNDARY_DISALLOWED_BROAD_PATHS = (
+    "apps/core/src/config",
+    "apps/core/src/memory",
+    "apps/core/src/shared",
+)
+
 
 @dataclass(frozen=True)
 class ExceptionEntry:
@@ -261,6 +297,20 @@ class ExceptionRegistry:
                 stale.append(f"{entry.file} has stale exception for `{entry.rule}`; remove it.")
         return stale
 
+
+@dataclass(frozen=True)
+class ProviderBoundaryException:
+    file: str
+    matches: dict[str, int]
+    reason: str
+    remove_by_plan: str
+
+
+@dataclass(frozen=True)
+class ProviderBoundaryExceptions:
+    cleanup_plan_id: str
+    entries: dict[str, ProviderBoundaryException]
+
 FRAMEWORK_BOUNDARY_RULES = (
     {
         "name": "enterprise frameworks in core runtime layers",
@@ -286,6 +336,7 @@ FRAMEWORK_BOUNDARY_RULES = (
         "specifier_prefixes": ("@anthropic-ai/sdk", "@anthropic-ai/claude-agent-sdk"),
         "allowed_prefixes": (
             "apps/core/src/adapters/llm/anthropic",
+            "apps/core/src/adapters/llm/anthropic-claude-agent",
             "apps/core/src/runner/claude",
             "apps/core/src/memory/claude-query.ts",
         ),
@@ -372,6 +423,43 @@ def iter_production_sources(root: Path) -> list[Path]:
             for file_path in base.rglob(glob):
                 rel_path = file_path.relative_to(root)
                 if is_production_source(rel_path):
+                    files.append(file_path)
+    return sorted(set(files))
+
+
+def is_provider_boundary_source(rel_path: Path) -> bool:
+    rel_text = rel_path.as_posix()
+    lower = rel_text.lower()
+    if rel_path.suffix not in {".ts", ".tsx"}:
+        return False
+    if ".d.ts" in lower:
+        return False
+    ignored_parts = {
+        "node_modules",
+        "dist",
+        "coverage",
+        "generated",
+        "__generated__",
+        ".factory",
+        ".cocoindex_code",
+    }
+    if any(part.lower() in ignored_parts for part in rel_path.parts):
+        return False
+    if "/src/" not in rel_text and "/test/" not in rel_text:
+        return False
+    return rel_text.startswith("apps/") or rel_text.startswith("packages/")
+
+
+def iter_provider_boundary_sources(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for top in ("apps", "packages"):
+        base = root / top
+        if not base.exists():
+            continue
+        for glob in ("*.ts", "*.tsx"):
+            for file_path in base.rglob(glob):
+                rel_path = file_path.relative_to(root)
+                if is_provider_boundary_source(rel_path):
                     files.append(file_path)
     return sorted(set(files))
 
@@ -475,6 +563,108 @@ def validate_exceptions(
     return ExceptionRegistry(entries), sorted(issues)
 
 
+def load_provider_boundary_exceptions(
+    root: Path,
+    exceptions_path: Path,
+) -> tuple[ProviderBoundaryExceptions, list[str]]:
+    if not exceptions_path.exists():
+        return ProviderBoundaryExceptions(PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID, {}), [
+            f"Missing provider boundary exceptions file: {exceptions_path.as_posix()}"
+        ]
+    try:
+        payload = json.loads(exceptions_path.read_text())
+    except json.JSONDecodeError as exc:
+        return ProviderBoundaryExceptions(PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID, {}), [
+            f"Invalid JSON in {exceptions_path.as_posix()}: {exc}"
+        ]
+    if not isinstance(payload, dict):
+        return ProviderBoundaryExceptions(PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID, {}), [
+            f"{exceptions_path.as_posix()} must be a JSON object."
+        ]
+
+    issues: list[str] = []
+    cleanup_plan_id = str(
+        payload.get("cleanupPlanId", PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID)
+    ).strip()
+    if not cleanup_plan_id:
+        issues.append("provider boundary exceptions must include cleanupPlanId.")
+        cleanup_plan_id = PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID
+
+    raw_entries = payload.get("exceptions")
+    if not isinstance(raw_entries, list):
+        issues.append("provider boundary exceptions must include an exceptions array.")
+        raw_entries = []
+
+    entries: dict[str, ProviderBoundaryException] = {}
+    supported_tokens = {name for name, _pattern in PROVIDER_BOUNDARY_TOKENS}
+    for index, item in enumerate(raw_entries):
+        prefix = f"[{index}]"
+        if not isinstance(item, dict):
+            issues.append(f"{prefix} must be an object.")
+            continue
+
+        rel = normalize_repo_relative(str(item.get("file", "")).strip())
+        reason = str(item.get("reason", "")).strip()
+        remove_by_plan = str(item.get("removeByPlan", "")).strip()
+        matches = item.get("matches")
+        item_issues: list[str] = []
+
+        if not rel:
+            item_issues.append(f"{prefix} file must be non-empty.")
+        elif Path(rel).is_absolute():
+            item_issues.append(f"{prefix} file must be repo-relative: {rel}")
+        elif any(ch in rel for ch in ("*", "?")) or rel.endswith("/"):
+            item_issues.append(
+                f"{prefix} file must be an exact file path, not a glob or directory: {rel}"
+            )
+        elif not (root / rel).exists():
+            item_issues.append(f"{prefix} points to a missing file: {rel}")
+        elif not (root / rel).is_file():
+            item_issues.append(f"{prefix} file must point to an exact file: {rel}")
+
+        if rel in entries:
+            item_issues.append(f"{prefix} duplicates provider boundary exception for {rel}.")
+
+        if not reason:
+            item_issues.append(f"{prefix} is missing reason.")
+        if not remove_by_plan:
+            item_issues.append(f"{prefix} is missing removeByPlan.")
+        elif remove_by_plan.lower() in {"never", "permanent", "none"}:
+            item_issues.append(
+                f"{prefix} removeByPlan must be time-bounded, not `{remove_by_plan}`."
+            )
+
+        if not isinstance(matches, dict) or not matches:
+            item_issues.append(f"{prefix} matches must be a non-empty object.")
+            normalized_matches: dict[str, int] = {}
+        else:
+            normalized_matches = {}
+            for token, count in matches.items():
+                token_name = str(token)
+                if token_name not in supported_tokens:
+                    item_issues.append(f"{prefix} has unsupported token `{token_name}`.")
+                    continue
+                if not isinstance(count, int) or count <= 0:
+                    item_issues.append(
+                        f"{prefix} count for `{token_name}` must be a positive integer."
+                    )
+                    continue
+                normalized_matches[token_name] = count
+
+        if item_issues:
+            issues.extend(item_issues)
+            continue
+
+        entries[rel] = ProviderBoundaryException(
+            file=rel,
+            matches=normalized_matches,
+            reason=reason,
+            remove_by_plan=remove_by_plan,
+        )
+
+    return ProviderBoundaryExceptions(cleanup_plan_id=cleanup_plan_id, entries=entries), sorted(issues)
+
+
 def count_lines(path: Path) -> int:
     return len(path.read_text().splitlines())
 
@@ -568,6 +758,12 @@ def resolve_import_target(root: Path, source_file: Path, specifier: str) -> str 
 
 def path_matches_prefix(path: str, prefix: str) -> bool:
     return path == prefix or path.startswith(f"{prefix}/")
+
+
+def is_broad_directory_approval(prefix: str, broad_path: str) -> bool:
+    return prefix == broad_path or (
+        prefix.startswith(f"{broad_path}/") and Path(prefix).suffix == ""
+    )
 
 
 def import_matches_prefix(specifier: str, prefix: str) -> bool:
@@ -683,6 +879,21 @@ def check_architecture_map_hygiene(root: Path, architecture_map: dict[str, Any])
             issues.append(f"layer `{layer_name}` must include allowedImportLayers.")
         elif any(not isinstance(item, str) for item in allowed):
             issues.append(f"layer `{layer_name}` allowedImportLayers must contain strings only.")
+
+    provider_paths = architecture_map.get("approvedProviderSpecificPaths", [])
+    if isinstance(provider_paths, list):
+        normalized_provider_paths = [
+            normalize_repo_relative(item) for item in provider_paths if isinstance(item, str)
+        ]
+        for broad_path in PROVIDER_BOUNDARY_DISALLOWED_BROAD_PATHS:
+            if any(
+                is_broad_directory_approval(prefix, broad_path)
+                for prefix in normalized_provider_paths
+            ):
+                issues.append(
+                    f"approvedProviderSpecificPaths must not broadly approve `{broad_path}`; "
+                    "use exact architecture exceptions for current debt."
+                )
 
     return sorted(issues)
 
@@ -909,6 +1120,107 @@ def check_provider_imports(
             if issue:
                 issues.add(issue)
     return sorted(issues), active_counts
+
+
+def provider_boundary_approved_paths(architecture_map: dict[str, Any]) -> list[str]:
+    if "approvedProviderBoundaryPaths" not in architecture_map:
+        return list(PROVIDER_BOUNDARY_DEFAULT_APPROVED_PATHS)
+    value = architecture_map.get("approvedProviderBoundaryPaths")
+    if not isinstance(value, list):
+        return []
+    return [normalize_repo_relative(item) for item in value if isinstance(item, str)]
+
+
+def count_provider_boundary_tokens(source_text: str) -> dict[str, int]:
+    return {
+        name: count
+        for name, pattern in PROVIDER_BOUNDARY_TOKENS
+        if (count := len(pattern.findall(source_text))) > 0
+    }
+
+
+def check_provider_boundary(
+    source_files: list[Path],
+    root: Path,
+    architecture_map: dict[str, Any],
+    exceptions: ProviderBoundaryExceptions,
+) -> list[str]:
+    issues: list[str] = []
+    approved_paths = provider_boundary_approved_paths(architecture_map)
+    if not approved_paths:
+        issues.append(
+            "approvedProviderBoundaryPaths must include at least one provider adapter path."
+        )
+
+    for broad_path in PROVIDER_BOUNDARY_DISALLOWED_BROAD_PATHS:
+        if any(
+            path_matches_prefix(broad_path, prefix)
+            or path_matches_prefix(prefix, broad_path)
+            for prefix in approved_paths
+        ):
+            issues.append(
+                f"approvedProviderBoundaryPaths must not broadly approve `{broad_path}`; "
+                "record exact current debt in .codex/provider-boundary-exceptions.json."
+            )
+
+    for prefix in approved_paths:
+        if prefix not in PROVIDER_BOUNDARY_ALLOWED_APPROVED_PATHS:
+            issues.append(
+                f"approvedProviderBoundaryPaths contains unsupported path `{prefix}`; "
+                "this gate currently approves only "
+                f"{sorted(PROVIDER_BOUNDARY_ALLOWED_APPROVED_PATHS)}."
+            )
+
+    expected_boundary = ", ".join(approved_paths) if approved_paths else "<none>"
+    active_matches: dict[str, dict[str, int]] = {}
+    first_lines: dict[tuple[str, str], int] = {}
+    for source_file in source_files:
+        source_rel = source_file.relative_to(root).as_posix()
+        source_text = source_file.read_text()
+        matches = count_provider_boundary_tokens(source_text)
+        if not matches:
+            continue
+        if any(path_matches_prefix(source_rel, prefix) for prefix in approved_paths):
+            continue
+        active_matches[source_rel] = matches
+        for token, pattern in PROVIDER_BOUNDARY_TOKENS:
+            if token not in matches:
+                continue
+            match = pattern.search(source_text)
+            if match is not None:
+                first_lines[(source_rel, token)] = source_text.count("\n", 0, match.start()) + 1
+
+    for rel, matches in sorted(active_matches.items()):
+        entry = exceptions.entries.get(rel)
+        if entry is None:
+            for token, count in sorted(matches.items()):
+                line = first_lines.get((rel, token), 1)
+                issues.append(
+                    f"{rel}:{line}: matched provider token `{token}` {count} time(s) outside "
+                    f"approved provider adapter boundary `{expected_boundary}`; either move the code "
+                    f"behind that boundary or record exact debt for cleanup plan "
+                    f"`{exceptions.cleanup_plan_id}`."
+                )
+            continue
+        if entry.matches != matches:
+            issues.append(
+                f"{rel}: provider boundary exception count changed for cleanup plan "
+                f"`{exceptions.cleanup_plan_id}`; expected {entry.matches}, actual {matches}."
+            )
+
+    for rel, entry in sorted(exceptions.entries.items()):
+        if rel not in active_matches:
+            issues.append(
+                f"{rel}: stale provider boundary exception for cleanup plan "
+                f"`{exceptions.cleanup_plan_id}`; remove it or move the file out of approved paths."
+            )
+        elif entry.remove_by_plan != exceptions.cleanup_plan_id:
+            issues.append(
+                f"{rel}: provider boundary exception removeByPlan `{entry.remove_by_plan}` "
+                f"must match cleanup plan `{exceptions.cleanup_plan_id}`."
+            )
+
+    return sorted(issues)
 
 
 def risky_child_process_names(source_text: str) -> set[str]:

--- a/.codex/scripts/architecture_rules.py
+++ b/.codex/scripts/architecture_rules.py
@@ -226,6 +226,42 @@ EXPORT_FROM_STATEMENT_RE = re.compile(
 )
 COMMENT_OR_BLANK_RE = re.compile(r"^\s*(?://.*|/\*.*\*/)?\s*$")
 
+PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID = (
+    "myclaw-architecture-gates-20260517-provider-boundary-sentinels"
+)
+PROVIDER_BOUNDARY_TOKENS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "@anthropic-ai/claude-agent-sdk",
+        re.compile(re.escape("@anthropic-ai/claude-agent-sdk")),
+    ),
+    ("@anthropic-ai/sdk", re.compile(re.escape("@anthropic-ai/sdk"))),
+    ("ANTHROPIC_", re.compile(r"ANTHROPIC_")),
+    ("CLAUDE_CONFIG_DIR", re.compile(r"CLAUDE_CONFIG_DIR")),
+    ("CLAUDE_CODE_OAUTH_TOKEN", re.compile(r"CLAUDE_CODE_OAUTH_TOKEN")),
+    ("claude-jsonl", re.compile(r"claude-jsonl")),
+    ("runner/claude", re.compile(r"runner/claude")),
+    ("provider = 'anthropic'", re.compile(r"\bprovider\s*=\s*['\"]anthropic['\"]")),
+    (
+        "provider: 'anthropic'",
+        re.compile(r"\bprovider\s*:\s*(?:['\"]anthropic['\"]|`anth\$\{\s*['\"]ropic['\"]\s*\}`)"),
+    ),
+    (
+        "const PROVIDER = 'anthropic'",
+        re.compile(r"\bconst\s+PROVIDER\s*=\s*['\"]anthropic['\"]"),
+    ),
+    ("default('anthropic')", re.compile(r"\.default\(\s*['\"]anthropic['\"]\s*\)")),
+    ("anthropic_sdk", re.compile(r"\banthropic_sdk\b")),
+)
+PROVIDER_BOUNDARY_DEFAULT_APPROVED_PATHS = (
+    "apps/core/src/adapters/llm/anthropic-claude-agent",
+)
+PROVIDER_BOUNDARY_ALLOWED_APPROVED_PATHS = set(PROVIDER_BOUNDARY_DEFAULT_APPROVED_PATHS)
+PROVIDER_BOUNDARY_DISALLOWED_BROAD_PATHS = (
+    "apps/core/src/config",
+    "apps/core/src/memory",
+    "apps/core/src/shared",
+)
+
 
 @dataclass(frozen=True)
 class ExceptionEntry:
@@ -261,6 +297,20 @@ class ExceptionRegistry:
                 stale.append(f"{entry.file} has stale exception for `{entry.rule}`; remove it.")
         return stale
 
+
+@dataclass(frozen=True)
+class ProviderBoundaryException:
+    file: str
+    matches: dict[str, int]
+    reason: str
+    remove_by_plan: str
+
+
+@dataclass(frozen=True)
+class ProviderBoundaryExceptions:
+    cleanup_plan_id: str
+    entries: dict[str, ProviderBoundaryException]
+
 FRAMEWORK_BOUNDARY_RULES = (
     {
         "name": "enterprise frameworks in core runtime layers",
@@ -286,6 +336,7 @@ FRAMEWORK_BOUNDARY_RULES = (
         "specifier_prefixes": ("@anthropic-ai/sdk", "@anthropic-ai/claude-agent-sdk"),
         "allowed_prefixes": (
             "apps/core/src/adapters/llm/anthropic",
+            "apps/core/src/adapters/llm/anthropic-claude-agent",
             "apps/core/src/runner/claude",
             "apps/core/src/memory/claude-query.ts",
         ),
@@ -372,6 +423,43 @@ def iter_production_sources(root: Path) -> list[Path]:
             for file_path in base.rglob(glob):
                 rel_path = file_path.relative_to(root)
                 if is_production_source(rel_path):
+                    files.append(file_path)
+    return sorted(set(files))
+
+
+def is_provider_boundary_source(rel_path: Path) -> bool:
+    rel_text = rel_path.as_posix()
+    lower = rel_text.lower()
+    if rel_path.suffix not in {".ts", ".tsx"}:
+        return False
+    if ".d.ts" in lower:
+        return False
+    ignored_parts = {
+        "node_modules",
+        "dist",
+        "coverage",
+        "generated",
+        "__generated__",
+        ".factory",
+        ".cocoindex_code",
+    }
+    if any(part.lower() in ignored_parts for part in rel_path.parts):
+        return False
+    if "/src/" not in rel_text and "/test/" not in rel_text:
+        return False
+    return rel_text.startswith("apps/") or rel_text.startswith("packages/")
+
+
+def iter_provider_boundary_sources(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for top in ("apps", "packages"):
+        base = root / top
+        if not base.exists():
+            continue
+        for glob in ("*.ts", "*.tsx"):
+            for file_path in base.rglob(glob):
+                rel_path = file_path.relative_to(root)
+                if is_provider_boundary_source(rel_path):
                     files.append(file_path)
     return sorted(set(files))
 
@@ -475,6 +563,108 @@ def validate_exceptions(
     return ExceptionRegistry(entries), sorted(issues)
 
 
+def load_provider_boundary_exceptions(
+    root: Path,
+    exceptions_path: Path,
+) -> tuple[ProviderBoundaryExceptions, list[str]]:
+    if not exceptions_path.exists():
+        return ProviderBoundaryExceptions(PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID, {}), [
+            f"Missing provider boundary exceptions file: {exceptions_path.as_posix()}"
+        ]
+    try:
+        payload = json.loads(exceptions_path.read_text())
+    except json.JSONDecodeError as exc:
+        return ProviderBoundaryExceptions(PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID, {}), [
+            f"Invalid JSON in {exceptions_path.as_posix()}: {exc}"
+        ]
+    if not isinstance(payload, dict):
+        return ProviderBoundaryExceptions(PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID, {}), [
+            f"{exceptions_path.as_posix()} must be a JSON object."
+        ]
+
+    issues: list[str] = []
+    cleanup_plan_id = str(
+        payload.get("cleanupPlanId", PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID)
+    ).strip()
+    if not cleanup_plan_id:
+        issues.append("provider boundary exceptions must include cleanupPlanId.")
+        cleanup_plan_id = PROVIDER_BOUNDARY_DEFAULT_CLEANUP_PLAN_ID
+
+    raw_entries = payload.get("exceptions")
+    if not isinstance(raw_entries, list):
+        issues.append("provider boundary exceptions must include an exceptions array.")
+        raw_entries = []
+
+    entries: dict[str, ProviderBoundaryException] = {}
+    supported_tokens = {name for name, _pattern in PROVIDER_BOUNDARY_TOKENS}
+    for index, item in enumerate(raw_entries):
+        prefix = f"[{index}]"
+        if not isinstance(item, dict):
+            issues.append(f"{prefix} must be an object.")
+            continue
+
+        rel = normalize_repo_relative(str(item.get("file", "")).strip())
+        reason = str(item.get("reason", "")).strip()
+        remove_by_plan = str(item.get("removeByPlan", "")).strip()
+        matches = item.get("matches")
+        item_issues: list[str] = []
+
+        if not rel:
+            item_issues.append(f"{prefix} file must be non-empty.")
+        elif Path(rel).is_absolute():
+            item_issues.append(f"{prefix} file must be repo-relative: {rel}")
+        elif any(ch in rel for ch in ("*", "?")) or rel.endswith("/"):
+            item_issues.append(
+                f"{prefix} file must be an exact file path, not a glob or directory: {rel}"
+            )
+        elif not (root / rel).exists():
+            item_issues.append(f"{prefix} points to a missing file: {rel}")
+        elif not (root / rel).is_file():
+            item_issues.append(f"{prefix} file must point to an exact file: {rel}")
+
+        if rel in entries:
+            item_issues.append(f"{prefix} duplicates provider boundary exception for {rel}.")
+
+        if not reason:
+            item_issues.append(f"{prefix} is missing reason.")
+        if not remove_by_plan:
+            item_issues.append(f"{prefix} is missing removeByPlan.")
+        elif remove_by_plan.lower() in {"never", "permanent", "none"}:
+            item_issues.append(
+                f"{prefix} removeByPlan must be time-bounded, not `{remove_by_plan}`."
+            )
+
+        if not isinstance(matches, dict) or not matches:
+            item_issues.append(f"{prefix} matches must be a non-empty object.")
+            normalized_matches: dict[str, int] = {}
+        else:
+            normalized_matches = {}
+            for token, count in matches.items():
+                token_name = str(token)
+                if token_name not in supported_tokens:
+                    item_issues.append(f"{prefix} has unsupported token `{token_name}`.")
+                    continue
+                if not isinstance(count, int) or count <= 0:
+                    item_issues.append(
+                        f"{prefix} count for `{token_name}` must be a positive integer."
+                    )
+                    continue
+                normalized_matches[token_name] = count
+
+        if item_issues:
+            issues.extend(item_issues)
+            continue
+
+        entries[rel] = ProviderBoundaryException(
+            file=rel,
+            matches=normalized_matches,
+            reason=reason,
+            remove_by_plan=remove_by_plan,
+        )
+
+    return ProviderBoundaryExceptions(cleanup_plan_id=cleanup_plan_id, entries=entries), sorted(issues)
+
+
 def count_lines(path: Path) -> int:
     return len(path.read_text().splitlines())
 
@@ -568,6 +758,12 @@ def resolve_import_target(root: Path, source_file: Path, specifier: str) -> str 
 
 def path_matches_prefix(path: str, prefix: str) -> bool:
     return path == prefix or path.startswith(f"{prefix}/")
+
+
+def is_broad_directory_approval(prefix: str, broad_path: str) -> bool:
+    return prefix == broad_path or (
+        prefix.startswith(f"{broad_path}/") and Path(prefix).suffix == ""
+    )
 
 
 def import_matches_prefix(specifier: str, prefix: str) -> bool:
@@ -683,6 +879,21 @@ def check_architecture_map_hygiene(root: Path, architecture_map: dict[str, Any])
             issues.append(f"layer `{layer_name}` must include allowedImportLayers.")
         elif any(not isinstance(item, str) for item in allowed):
             issues.append(f"layer `{layer_name}` allowedImportLayers must contain strings only.")
+
+    provider_paths = architecture_map.get("approvedProviderSpecificPaths", [])
+    if isinstance(provider_paths, list):
+        normalized_provider_paths = [
+            normalize_repo_relative(item) for item in provider_paths if isinstance(item, str)
+        ]
+        for broad_path in PROVIDER_BOUNDARY_DISALLOWED_BROAD_PATHS:
+            if any(
+                is_broad_directory_approval(prefix, broad_path)
+                for prefix in normalized_provider_paths
+            ):
+                issues.append(
+                    f"approvedProviderSpecificPaths must not broadly approve `{broad_path}`; "
+                    "use exact architecture exceptions for current debt."
+                )
 
     return sorted(issues)
 
@@ -909,6 +1120,107 @@ def check_provider_imports(
             if issue:
                 issues.add(issue)
     return sorted(issues), active_counts
+
+
+def provider_boundary_approved_paths(architecture_map: dict[str, Any]) -> list[str]:
+    if "approvedProviderBoundaryPaths" not in architecture_map:
+        return list(PROVIDER_BOUNDARY_DEFAULT_APPROVED_PATHS)
+    value = architecture_map.get("approvedProviderBoundaryPaths")
+    if not isinstance(value, list):
+        return []
+    return [normalize_repo_relative(item) for item in value if isinstance(item, str)]
+
+
+def count_provider_boundary_tokens(source_text: str) -> dict[str, int]:
+    return {
+        name: count
+        for name, pattern in PROVIDER_BOUNDARY_TOKENS
+        if (count := len(pattern.findall(source_text))) > 0
+    }
+
+
+def check_provider_boundary(
+    source_files: list[Path],
+    root: Path,
+    architecture_map: dict[str, Any],
+    exceptions: ProviderBoundaryExceptions,
+) -> list[str]:
+    issues: list[str] = []
+    approved_paths = provider_boundary_approved_paths(architecture_map)
+    if not approved_paths:
+        issues.append(
+            "approvedProviderBoundaryPaths must include at least one provider adapter path."
+        )
+
+    for broad_path in PROVIDER_BOUNDARY_DISALLOWED_BROAD_PATHS:
+        if any(
+            path_matches_prefix(broad_path, prefix)
+            or path_matches_prefix(prefix, broad_path)
+            for prefix in approved_paths
+        ):
+            issues.append(
+                f"approvedProviderBoundaryPaths must not broadly approve `{broad_path}`; "
+                "record exact current debt in .codex/provider-boundary-exceptions.json."
+            )
+
+    for prefix in approved_paths:
+        if prefix not in PROVIDER_BOUNDARY_ALLOWED_APPROVED_PATHS:
+            issues.append(
+                f"approvedProviderBoundaryPaths contains unsupported path `{prefix}`; "
+                "this gate currently approves only "
+                f"{sorted(PROVIDER_BOUNDARY_ALLOWED_APPROVED_PATHS)}."
+            )
+
+    expected_boundary = ", ".join(approved_paths) if approved_paths else "<none>"
+    active_matches: dict[str, dict[str, int]] = {}
+    first_lines: dict[tuple[str, str], int] = {}
+    for source_file in source_files:
+        source_rel = source_file.relative_to(root).as_posix()
+        source_text = source_file.read_text()
+        matches = count_provider_boundary_tokens(source_text)
+        if not matches:
+            continue
+        if any(path_matches_prefix(source_rel, prefix) for prefix in approved_paths):
+            continue
+        active_matches[source_rel] = matches
+        for token, pattern in PROVIDER_BOUNDARY_TOKENS:
+            if token not in matches:
+                continue
+            match = pattern.search(source_text)
+            if match is not None:
+                first_lines[(source_rel, token)] = source_text.count("\n", 0, match.start()) + 1
+
+    for rel, matches in sorted(active_matches.items()):
+        entry = exceptions.entries.get(rel)
+        if entry is None:
+            for token, count in sorted(matches.items()):
+                line = first_lines.get((rel, token), 1)
+                issues.append(
+                    f"{rel}:{line}: matched provider token `{token}` {count} time(s) outside "
+                    f"approved provider adapter boundary `{expected_boundary}`; either move the code "
+                    f"behind that boundary or record exact debt for cleanup plan "
+                    f"`{exceptions.cleanup_plan_id}`."
+                )
+            continue
+        if entry.matches != matches:
+            issues.append(
+                f"{rel}: provider boundary exception count changed for cleanup plan "
+                f"`{exceptions.cleanup_plan_id}`; expected {entry.matches}, actual {matches}."
+            )
+
+    for rel, entry in sorted(exceptions.entries.items()):
+        if rel not in active_matches:
+            issues.append(
+                f"{rel}: stale provider boundary exception for cleanup plan "
+                f"`{exceptions.cleanup_plan_id}`; remove it or move the file out of approved paths."
+            )
+        elif entry.remove_by_plan != exceptions.cleanup_plan_id:
+            issues.append(
+                f"{rel}: provider boundary exception removeByPlan `{entry.remove_by_plan}` "
+                f"must match cleanup plan `{exceptions.cleanup_plan_id}`."
+            )
+
+    return sorted(issues)
 
 
 def risky_child_process_names(source_text: str) -> set[str]:

--- a/.codex/scripts/check_architecture.py
+++ b/.codex/scripts/check_architecture.py
@@ -21,11 +21,14 @@ from architecture_rules import (
     check_framework_boundary_imports,
     check_map_layer_imports,
     check_old_terms,
+    check_provider_boundary,
     check_provider_imports,
     check_provider_specific_paths,
     check_wrapper_only_files,
     iter_production_sources,
+    iter_provider_boundary_sources,
     load_architecture_map,
+    load_provider_boundary_exceptions,
     repo_root_from_git,
     validate_exceptions,
 )
@@ -44,6 +47,11 @@ def parse_args() -> argparse.Namespace:
         default=".codex/architecture-map.json",
         help="Path to architecture map JSON (absolute or relative to --root).",
     )
+    parser.add_argument(
+        "--provider-boundary-exceptions",
+        default=".codex/provider-boundary-exceptions.json",
+        help="Path to provider boundary exceptions JSON (absolute or relative to --root).",
+    )
     return parser.parse_args()
 
 
@@ -56,6 +64,7 @@ def print_grouped_failures(issues: dict[str, list[str]]) -> None:
         ("layer_imports", "Layer Import Rules"),
         ("external_imports", "External Import Rules"),
         ("provider_imports", "Provider Imports"),
+        ("provider_boundary", "Provider Boundary"),
         ("provider_specific_paths", "Provider-Specific Paths"),
         ("direct_risky_execution", "Direct Risky Execution"),
         ("browser_default_profile_paths", "Browser Default Profile Paths"),
@@ -88,10 +97,18 @@ def main() -> int:
     map_path = Path(args.map)
     if not map_path.is_absolute():
         map_path = (root / map_path).resolve()
+    provider_boundary_exceptions_path = Path(args.provider_boundary_exceptions)
+    if not provider_boundary_exceptions_path.is_absolute():
+        provider_boundary_exceptions_path = (root / provider_boundary_exceptions_path).resolve()
 
     production_files = iter_production_sources(root)
+    provider_boundary_files = iter_provider_boundary_sources(root)
     production_rel_paths = {path.relative_to(root).as_posix() for path in production_files}
     exceptions, exception_hygiene = validate_exceptions(root, exceptions_path, production_rel_paths, date.today())
+    provider_boundary_exceptions, provider_boundary_exception_hygiene = load_provider_boundary_exceptions(
+        root, provider_boundary_exceptions_path
+    )
+    exception_hygiene.extend(provider_boundary_exception_hygiene)
     architecture_map, architecture_map_load_issues = load_architecture_map(map_path)
     architecture_map_hygiene = architecture_map_load_issues
     active_exception_counts = {}
@@ -105,6 +122,9 @@ def main() -> int:
         )
         provider_import_issues, provider_import_counts = check_provider_imports(
             production_files, root, architecture_map, exceptions
+        )
+        provider_boundary_issues = check_provider_boundary(
+            provider_boundary_files, root, architecture_map, provider_boundary_exceptions
         )
         provider_path_issues, provider_path_counts = check_provider_specific_paths(
             production_files, root, architecture_map, exceptions
@@ -132,6 +152,7 @@ def main() -> int:
         layer_import_issues = []
         external_import_issues = []
         provider_import_issues = []
+        provider_boundary_issues = []
         provider_path_issues = []
         risky_execution_issues = []
         browser_profile_issues = []
@@ -144,6 +165,7 @@ def main() -> int:
         "layer_imports": layer_import_issues,
         "external_imports": external_import_issues,
         "provider_imports": provider_import_issues,
+        "provider_boundary": provider_boundary_issues,
         "provider_specific_paths": provider_path_issues,
         "direct_risky_execution": risky_execution_issues,
         "browser_default_profile_paths": browser_profile_issues,

--- a/.codex/scripts/tests/test_check_architecture.py
+++ b/.codex/scripts/tests/test_check_architecture.py
@@ -48,6 +48,14 @@ def make_base_fixture(root: Path) -> Path:
         write_text(root / rel_dir / "README.md", "Fixture purpose.\n")
     write_json(root / ".codex/architecture-exceptions.json", [])
     write_json(
+        root / ".codex/provider-boundary-exceptions.json",
+        {
+            "version": 1,
+            "cleanupPlanId": "test-provider-boundary-plan",
+            "exceptions": [],
+        },
+    )
+    write_json(
         root / ".codex/architecture-map.json",
         {
             "version": 1,
@@ -124,6 +132,9 @@ def make_base_fixture(root: Path) -> Path:
                 "apps/core/src/adapters/browser",
                 "apps/core/src/channels",
                 "apps/core/src/runner/claude",
+            ],
+            "approvedProviderBoundaryPaths": [
+                "apps/core/src/adapters/llm/anthropic-claude-agent"
             ],
             "providerImportSpecifiers": [
                 "@anthropic-ai/sdk",
@@ -332,15 +343,192 @@ class CheckArchitectureTests(unittest.TestCase):
             self.assertIn("[Framework Boundary Imports]", result.stdout)
             self.assertIn("Anthropic SDK imports must stay in approved provider adapter paths", result.stdout)
 
-    def test_current_anthropic_provider_adapter_path_passes(self) -> None:
+    def test_anthropic_provider_adapter_path_passes_provider_boundary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = make_base_fixture(Path(tmp))
             write_text(
-                root / "apps/core/src/runner/claude/query-loop.ts",
+                root / "apps/core/src/adapters/llm/anthropic-claude-agent/query-loop.ts",
                 'import { query } from "@anthropic-ai/claude-agent-sdk";\nexport const value = query;\n',
             )
             result = run_architecture_check(root)
             self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_anthropic_import_in_memory_fails_provider_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                'import { query } from "@anthropic-ai/claude-agent-sdk";\nexport const value = query;\n',
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("apps/core/src/memory/claude-query.ts:1", result.stdout)
+            self.assertIn("approved provider adapter boundary", result.stdout)
+
+    def test_provider_boundary_exception_counts_are_exact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                "export const env = 'ANTHROPIC_MODEL';\n",
+            )
+            write_json(
+                root / ".codex/provider-boundary-exceptions.json",
+                {
+                    "version": 1,
+                    "cleanupPlanId": "test-provider-boundary-plan",
+                    "exceptions": [
+                        {
+                            "file": "apps/core/src/memory/claude-query.ts",
+                            "matches": {"ANTHROPIC_": 1},
+                            "reason": "Fixture baseline provider debt.",
+                            "removeByPlan": "test-provider-boundary-plan",
+                        }
+                    ],
+                },
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                "export const env = 'ANTHROPIC_MODEL ANTHROPIC_API_KEY';\n",
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("provider boundary exception count changed", result.stdout)
+
+    def test_provider_boundary_detects_composed_anthropic_provider_literal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/adapters/storage/postgres/seeds.ts",
+                "export const seed = { provider: `anth${'ropic'}`, kind: 'anthropic_sdk' };\n"
+                "export const json = { \"provider\": \"anthropic\" };\n",
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("provider token `provider: 'anthropic'` 2 time(s)", result.stdout)
+            self.assertIn("anthropic_sdk", result.stdout)
+
+    def test_provider_boundary_detects_anthropic_schema_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/adapters/storage/postgres/schema/agents.ts",
+                "export const provider = text('provider').notNull().default('anthropic');\n",
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("default('anthropic')", result.stdout)
+
+    def test_provider_boundary_rejects_broad_config_memory_shared_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+            architecture_map["approvedProviderBoundaryPaths"] = ["apps/core/src/config"]
+            write_json(root / ".codex/architecture-map.json", architecture_map)
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("must not broadly approve `apps/core/src/config`", result.stdout)
+
+    def test_provider_specific_paths_reject_broad_config_memory_shared_approval(self) -> None:
+        for broad_path in [
+            "apps/core/src/config",
+            "apps/core/src/memory",
+            "apps/core/src/shared",
+        ]:
+            with self.subTest(broad_path=broad_path):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = make_base_fixture(Path(tmp))
+                    architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+                    architecture_map["approvedProviderSpecificPaths"] = [broad_path]
+                    write_json(root / ".codex/architecture-map.json", architecture_map)
+                    result = run_architecture_check(root)
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn("[Architecture Map Hygiene]", result.stdout)
+                    self.assertIn(
+                        f"approvedProviderSpecificPaths must not broadly approve `{broad_path}`",
+                        result.stdout,
+                    )
+
+    def test_provider_boundary_rejects_runtime_approval_bypass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+            architecture_map["approvedProviderBoundaryPaths"] = ["apps/core/src/runtime"]
+            write_json(root / ".codex/architecture-map.json", architecture_map)
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("contains unsupported path `apps/core/src/runtime`", result.stdout)
+
+    def test_provider_boundary_empty_config_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+            architecture_map["approvedProviderBoundaryPaths"] = []
+            write_json(root / ".codex/architecture-map.json", architecture_map)
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("must include at least one provider adapter path", result.stdout)
+
+    def test_anthropic_llm_adapter_import_path_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/adapters/llm/anthropic-claude-agent/client.ts",
+                'import Anthropic from "@anthropic-ai/sdk";\nexport const value = Anthropic;\n',
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_memory_anthropic_import_fails_provider_boundary_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                'import { query } from "@anthropic-ai/claude-agent-sdk";\nexport const value = query;\n',
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Imports]", result.stdout)
+            self.assertIn(
+                "apps/core/src/memory/claude-query.ts:1: imports provider package",
+                result.stdout,
+            )
+
+    def test_provider_import_exception_enforces_max_violations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/runtime/model-break.ts",
+                'import { query } from "@anthropic-ai/claude-agent-sdk";\n'
+                'import OpenAI from "openai";\n'
+                "export const value = { query, OpenAI };\n",
+            )
+            write_json(
+                root / ".codex/architecture-exceptions.json",
+                [
+                    {
+                        "file": "apps/core/src/runtime/model-break.ts",
+                        "rule": "forbidden_provider_import",
+                        "reason": "Fixture baseline",
+                        "removeByPhase": "test-phase",
+                        "maxViolations": 1,
+                    }
+                ],
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Imports]", result.stdout)
+            self.assertIn("Exception maxViolations is 1", result.stdout)
 
     def test_onecli_sdk_import_outside_credential_adapter_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.codex/scripts/tests/test_check_architecture.py
+++ b/.codex/scripts/tests/test_check_architecture.py
@@ -48,6 +48,14 @@ def make_base_fixture(root: Path) -> Path:
         write_text(root / rel_dir / "README.md", "Fixture purpose.\n")
     write_json(root / ".codex/architecture-exceptions.json", [])
     write_json(
+        root / ".codex/provider-boundary-exceptions.json",
+        {
+            "version": 1,
+            "cleanupPlanId": "test-provider-boundary-plan",
+            "exceptions": [],
+        },
+    )
+    write_json(
         root / ".codex/architecture-map.json",
         {
             "version": 1,
@@ -124,6 +132,9 @@ def make_base_fixture(root: Path) -> Path:
                 "apps/core/src/adapters/browser",
                 "apps/core/src/channels",
                 "apps/core/src/runner/claude",
+            ],
+            "approvedProviderBoundaryPaths": [
+                "apps/core/src/adapters/llm/anthropic-claude-agent"
             ],
             "providerImportSpecifiers": [
                 "@anthropic-ai/sdk",
@@ -332,15 +343,191 @@ class CheckArchitectureTests(unittest.TestCase):
             self.assertIn("[Framework Boundary Imports]", result.stdout)
             self.assertIn("Anthropic SDK imports must stay in approved provider adapter paths", result.stdout)
 
-    def test_current_anthropic_provider_adapter_path_passes(self) -> None:
+    def test_anthropic_provider_adapter_path_passes_provider_boundary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = make_base_fixture(Path(tmp))
             write_text(
-                root / "apps/core/src/runner/claude/query-loop.ts",
+                root / "apps/core/src/adapters/llm/anthropic-claude-agent/query-loop.ts",
                 'import { query } from "@anthropic-ai/claude-agent-sdk";\nexport const value = query;\n',
             )
             result = run_architecture_check(root)
             self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_anthropic_import_in_memory_fails_provider_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                'import { query } from "@anthropic-ai/claude-agent-sdk";\nexport const value = query;\n',
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("apps/core/src/memory/claude-query.ts:1", result.stdout)
+            self.assertIn("approved provider adapter boundary", result.stdout)
+
+    def test_provider_boundary_exception_counts_are_exact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                "export const env = 'ANTHROPIC_MODEL';\n",
+            )
+            write_json(
+                root / ".codex/provider-boundary-exceptions.json",
+                {
+                    "version": 1,
+                    "cleanupPlanId": "test-provider-boundary-plan",
+                    "exceptions": [
+                        {
+                            "file": "apps/core/src/memory/claude-query.ts",
+                            "matches": {"ANTHROPIC_": 1},
+                            "reason": "Fixture baseline provider debt.",
+                            "removeByPlan": "test-provider-boundary-plan",
+                        }
+                    ],
+                },
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                "export const env = 'ANTHROPIC_MODEL ANTHROPIC_API_KEY';\n",
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("provider boundary exception count changed", result.stdout)
+
+    def test_provider_boundary_detects_composed_anthropic_provider_literal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/adapters/storage/postgres/seeds.ts",
+                "export const seed = { provider: `anth${'ropic'}`, kind: 'anthropic_sdk' };\n",
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("provider: 'anthropic'", result.stdout)
+            self.assertIn("anthropic_sdk", result.stdout)
+
+    def test_provider_boundary_detects_anthropic_schema_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/adapters/storage/postgres/schema/agents.ts",
+                "export const provider = text('provider').notNull().default('anthropic');\n",
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("default('anthropic')", result.stdout)
+
+    def test_provider_boundary_rejects_broad_config_memory_shared_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+            architecture_map["approvedProviderBoundaryPaths"] = ["apps/core/src/config"]
+            write_json(root / ".codex/architecture-map.json", architecture_map)
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("must not broadly approve `apps/core/src/config`", result.stdout)
+
+    def test_provider_specific_paths_reject_broad_config_memory_shared_approval(self) -> None:
+        for broad_path in [
+            "apps/core/src/config",
+            "apps/core/src/memory",
+            "apps/core/src/shared",
+        ]:
+            with self.subTest(broad_path=broad_path):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = make_base_fixture(Path(tmp))
+                    architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+                    architecture_map["approvedProviderSpecificPaths"] = [broad_path]
+                    write_json(root / ".codex/architecture-map.json", architecture_map)
+                    result = run_architecture_check(root)
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn("[Architecture Map Hygiene]", result.stdout)
+                    self.assertIn(
+                        f"approvedProviderSpecificPaths must not broadly approve `{broad_path}`",
+                        result.stdout,
+                    )
+
+    def test_provider_boundary_rejects_runtime_approval_bypass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+            architecture_map["approvedProviderBoundaryPaths"] = ["apps/core/src/runtime"]
+            write_json(root / ".codex/architecture-map.json", architecture_map)
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("contains unsupported path `apps/core/src/runtime`", result.stdout)
+
+    def test_provider_boundary_empty_config_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            architecture_map = json.loads((root / ".codex/architecture-map.json").read_text())
+            architecture_map["approvedProviderBoundaryPaths"] = []
+            write_json(root / ".codex/architecture-map.json", architecture_map)
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Boundary]", result.stdout)
+            self.assertIn("must include at least one provider adapter path", result.stdout)
+
+    def test_anthropic_llm_adapter_import_path_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/adapters/llm/anthropic-claude-agent/client.ts",
+                'import Anthropic from "@anthropic-ai/sdk";\nexport const value = Anthropic;\n',
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_memory_anthropic_import_fails_provider_boundary_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/memory/claude-query.ts",
+                'import { query } from "@anthropic-ai/claude-agent-sdk";\nexport const value = query;\n',
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Imports]", result.stdout)
+            self.assertIn(
+                "apps/core/src/memory/claude-query.ts:1: imports provider package",
+                result.stdout,
+            )
+
+    def test_provider_import_exception_enforces_max_violations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_base_fixture(Path(tmp))
+            write_text(
+                root / "apps/core/src/runtime/model-break.ts",
+                'import { query } from "@anthropic-ai/claude-agent-sdk";\n'
+                'import OpenAI from "openai";\n'
+                "export const value = { query, OpenAI };\n",
+            )
+            write_json(
+                root / ".codex/architecture-exceptions.json",
+                [
+                    {
+                        "file": "apps/core/src/runtime/model-break.ts",
+                        "rule": "forbidden_provider_import",
+                        "reason": "Fixture baseline",
+                        "removeByPhase": "test-phase",
+                        "maxViolations": 1,
+                    }
+                ],
+            )
+            result = run_architecture_check(root)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[Provider Imports]", result.stdout)
+            self.assertIn("Exception maxViolations is 1", result.stdout)
 
     def test_onecli_sdk_import_outside_credential_adapter_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/apps/core/src/adapters/storage/postgres/AGENTS.md
+++ b/apps/core/src/adapters/storage/postgres/AGENTS.md
@@ -37,3 +37,7 @@
   `direct`/`dm` rows return runtime `conversationKind: "dm"` and group/channel
   rows return `conversationKind: "channel"`. Do not infer DM-vs-group memory
   scope from trigger settings or binding memory-subject blobs.
+- JSON-shaped runtime payload columns that are queried, indexed, validated, or
+  partially updated belong in native `jsonb`. Pass objects/arrays to Drizzle
+  `jsonb` columns, keep canonical route/lease/audit/join fields typed, and do
+  not add `::jsonb` casts around columns that are already `jsonb`.

--- a/apps/core/src/adapters/storage/postgres/readiness.ts
+++ b/apps/core/src/adapters/storage/postgres/readiness.ts
@@ -23,6 +23,18 @@ export function evaluatePostgresStorageCapabilities(
   if (!capabilities.jobQueue) {
     details.push(capabilities.jobQueueReason || 'pg-boss schema is required.');
   }
+  if (!capabilities.runtimeEvents) {
+    details.push(
+      capabilities.runtimeEventsReason ||
+        'runtime_events table and cursor indexes are required.',
+    );
+  }
+  if (!capabilities.eventBusOutbox) {
+    details.push(
+      capabilities.eventBusOutboxReason ||
+        'event_bus_outbox table, claim indexes, and runtime-event uniqueness constraint are required.',
+    );
+  }
   if (details.length === 0) {
     return null;
   }

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
@@ -61,8 +61,27 @@ export function json(value: unknown): string {
   return JSON.stringify(value ?? null);
 }
 
+export function jsonb(value: unknown): unknown {
+  if (typeof value !== 'string') return value ?? null;
+  if (value.length === 0) return null;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON string passed to jsonb column writer: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export function jsonText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value ?? null);
+}
+
 export function parseJson<T>(value: unknown, fallback: T): T {
-  if (typeof value !== 'string' || value.length === 0) return fallback;
+  if (value === null || value === undefined) return fallback;
+  if (typeof value !== 'string') return value as T;
+  if (value.length === 0) return fallback;
   try {
     return JSON.parse(value) as T;
   } catch {

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-job-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-job-repository.postgres.ts
@@ -12,6 +12,8 @@ import {
   type CanonicalDb,
   PostgresCanonicalGraphRepository,
   configVersionIdForAgent,
+  jsonb,
+  jsonText,
   parseJson,
 } from './canonical-graph-repository.postgres.js';
 // prettier-ignore
@@ -121,12 +123,12 @@ function kindClause(
   scheduleJson: unknown,
 ) {
   if (kind === 'manual') {
-    return sql`${scheduleJson}::jsonb ->> 'type' = 'manual'`;
+    return sql`${scheduleJson} ->> 'type' = 'manual'`;
   }
   if (kind === 'once') {
-    return sql`${scheduleJson}::jsonb ->> 'type' = 'once'`;
+    return sql`${scheduleJson} ->> 'type' = 'once'`;
   }
-  return sql`${scheduleJson}::jsonb ->> 'type' in ('cron', 'interval')`;
+  return sql`${scheduleJson} ->> 'type' in ('cron', 'interval')`;
 }
 
 function ownedByAppClause(jobId: unknown, ownerAppId?: string) {
@@ -135,8 +137,8 @@ function ownedByAppClause(jobId: unknown, ownerAppId?: string) {
         select 1
         from ${pgSchema.canonicalJobsPostgres} owned_job
         join ${pgSchema.controlHttpSessionsPostgres} app_session
-          on (app_session.session_id = owned_job.target_json::jsonb #>> '{executionContext,sessionId}'
-            or app_session.external_ref_json::jsonb->>'chatJid' = owned_job.target_json::jsonb #>> '{executionContext,conversationJid}')
+          on ((owned_job.target_json #>> '{executionContext,sessionId}' is not null and app_session.session_id = owned_job.target_json #>> '{executionContext,sessionId}')
+            or (owned_job.target_json #>> '{executionContext,sessionId}' is null and app_session.external_ref_json->>'chatJid' = owned_job.target_json #>> '{executionContext,conversationJid}'))
         where owned_job.id = ${jobId}
           and app_session.app_id = ${ownerAppId}
       )`
@@ -144,22 +146,33 @@ function ownedByAppClause(jobId: unknown, ownerAppId?: string) {
 }
 
 // prettier-ignore
-function canonicalJobSessionId() { return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,sessionId}'`; }
-// prettier-ignore
-function canonicalJobConversationJid() { return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,conversationJid}'`; }
-// prettier-ignore
-function canonicalJobGroupScope() { return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,groupScope}'`; }
+function canonicalJobSessionJoinClause() { return sql`((${canonicalJobSessionId()} is not null and ${pgSchema.controlHttpSessionsPostgres.sessionId} = ${canonicalJobSessionId()}) or (${canonicalJobSessionId()} is null and ${pgSchema.controlHttpSessionsPostgres.externalRefJson}->>'chatJid' = ${canonicalJobConversationJid()}))`; }
 
-function canonicalJobThreadId() {
-  return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,threadId}'`;
-}
+// prettier-ignore
+function canonicalJobSessionId() { return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,sessionId}'`; }
+// prettier-ignore
+function canonicalJobConversationJid() { return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,conversationJid}'`; }
+// prettier-ignore
+function canonicalJobGroupScope() { return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,groupScope}'`; }
+// prettier-ignore
+function canonicalJobThreadId() { return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,threadId}'`; }
 
 function canonicalJobThreadIdNormalized() {
   return sql`coalesce(${canonicalJobThreadId()}, '')`;
 }
 
 function canonicalJobNotificationRoutes() {
-  return sql`coalesce(${pgSchema.canonicalJobsPostgres.targetJson}::jsonb -> 'notificationRoutes', '[]'::jsonb)`;
+  return sql`coalesce(${pgSchema.canonicalJobsPostgres.targetJson} -> 'notificationRoutes', '[]'::jsonb)`;
+}
+
+function jobRecordFromRow(
+  row: typeof pgSchema.canonicalJobsPostgres.$inferSelect,
+): CanonicalJobRecord {
+  return {
+    ...row,
+    scheduleJson: jsonText(row.scheduleJson),
+    targetJson: jsonText(row.targetJson),
+  };
 }
 
 export class PostgresCanonicalJobRepository {
@@ -175,7 +188,7 @@ export class PostgresCanonicalJobRepository {
       .from(pgSchema.canonicalJobsPostgres)
       .where(eq(pgSchema.canonicalJobsPostgres.id, id))
       .limit(1);
-    return rows[0];
+    return rows[0] ? jobRecordFromRow(rows[0]) : undefined;
   }
 
   async listJobs(filters?: JobListFilters): Promise<CanonicalJobRecord[]> {
@@ -188,8 +201,10 @@ export class PostgresCanonicalJobRepository {
         ? sql`exists (
             select 1
             from ${pgSchema.controlHttpSessionsPostgres} app_session
-            where (app_session.session_id = ${canonicalJobSessionId()}
-              or app_session.external_ref_json::jsonb->>'chatJid' = ${canonicalJobConversationJid()})
+            where (
+              (${canonicalJobSessionId()} is not null and app_session.session_id = ${canonicalJobSessionId()})
+              or (${canonicalJobSessionId()} is null and app_session.external_ref_json->>'chatJid' = ${canonicalJobConversationJid()})
+            )
               and app_session.app_id = ${filters.appId}
           )`
         : undefined,
@@ -223,7 +238,10 @@ export class PostgresCanonicalJobRepository {
       desc(pgSchema.canonicalJobsPostgres.updatedAt),
       desc(pgSchema.canonicalJobsPostgres.createdAt),
     );
-    return filters?.limit ? ordered.limit(filters.limit) : ordered;
+    const rows = filters?.limit
+      ? await ordered.limit(filters.limit)
+      : await ordered;
+    return rows.map(jobRecordFromRow);
   }
 
   async upsertJob(record: JobRecordInput): Promise<void> {
@@ -235,6 +253,8 @@ export class PostgresCanonicalJobRepository {
         createdByActorId: 'runtime',
         createdBySource: 'runtime',
         ...record,
+        scheduleJson: jsonb(record.scheduleJson),
+        targetJson: jsonb(record.targetJson),
       })
       .onConflictDoUpdate({
         target: pgSchema.canonicalJobsPostgres.id,
@@ -243,9 +263,9 @@ export class PostgresCanonicalJobRepository {
           name: record.name,
           prompt: record.prompt,
           model: record.model,
-          scheduleJson: record.scheduleJson,
+          scheduleJson: jsonb(record.scheduleJson),
           status: record.status,
-          targetJson: record.targetJson,
+          targetJson: jsonb(record.targetJson),
           silent: record.silent,
           timeoutMs: record.timeoutMs,
           maxRetries: record.maxRetries,
@@ -268,6 +288,8 @@ export class PostgresCanonicalJobRepository {
       .update(pgSchema.canonicalJobsPostgres)
       .set({
         ...record,
+        scheduleJson: jsonb(record.scheduleJson),
+        targetJson: jsonb(record.targetJson),
         createdByActorId: 'runtime',
         createdBySource: 'runtime',
       })
@@ -440,8 +462,7 @@ export class PostgresCanonicalJobRepository {
       .from(pgSchema.controlHttpSessionsPostgres)
       .innerJoin(
         pgSchema.canonicalJobsPostgres,
-        sql`(${pgSchema.controlHttpSessionsPostgres.sessionId} = ${canonicalJobSessionId()}
-          or ${pgSchema.controlHttpSessionsPostgres.externalRefJson}::jsonb->>'chatJid' = ${canonicalJobConversationJid()})`,
+        canonicalJobSessionJoinClause(),
       )
       .innerJoin(
         pgSchema.agentRunsPostgres,
@@ -597,7 +618,7 @@ export class PostgresCanonicalJobRepository {
       .from(pgSchema.controlHttpSessionsPostgres)
       .innerJoin(
         pgSchema.canonicalJobsPostgres,
-        sql`${pgSchema.controlHttpSessionsPostgres.sessionId} = ${canonicalJobSessionId()}`,
+        canonicalJobSessionJoinClause(),
       )
       .innerJoin(
         pgSchema.runtimeEventsPostgres,

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-job-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-job-repository.postgres.ts
@@ -12,6 +12,8 @@ import {
   type CanonicalDb,
   PostgresCanonicalGraphRepository,
   configVersionIdForAgent,
+  jsonb,
+  jsonText,
   parseJson,
 } from './canonical-graph-repository.postgres.js';
 // prettier-ignore
@@ -121,12 +123,12 @@ function kindClause(
   scheduleJson: unknown,
 ) {
   if (kind === 'manual') {
-    return sql`${scheduleJson}::jsonb ->> 'type' = 'manual'`;
+    return sql`${scheduleJson} ->> 'type' = 'manual'`;
   }
   if (kind === 'once') {
-    return sql`${scheduleJson}::jsonb ->> 'type' = 'once'`;
+    return sql`${scheduleJson} ->> 'type' = 'once'`;
   }
-  return sql`${scheduleJson}::jsonb ->> 'type' in ('cron', 'interval')`;
+  return sql`${scheduleJson} ->> 'type' in ('cron', 'interval')`;
 }
 
 function ownedByAppClause(jobId: unknown, ownerAppId?: string) {
@@ -135,8 +137,8 @@ function ownedByAppClause(jobId: unknown, ownerAppId?: string) {
         select 1
         from ${pgSchema.canonicalJobsPostgres} owned_job
         join ${pgSchema.controlHttpSessionsPostgres} app_session
-          on (app_session.session_id = owned_job.target_json::jsonb #>> '{executionContext,sessionId}'
-            or app_session.external_ref_json::jsonb->>'chatJid' = owned_job.target_json::jsonb #>> '{executionContext,conversationJid}')
+          on ((owned_job.target_json #>> '{executionContext,sessionId}' is not null and app_session.session_id = owned_job.target_json #>> '{executionContext,sessionId}')
+            or (owned_job.target_json #>> '{executionContext,sessionId}' is null and app_session.external_ref_json->>'chatJid' = owned_job.target_json #>> '{executionContext,conversationJid}'))
         where owned_job.id = ${jobId}
           and app_session.app_id = ${ownerAppId}
       )`
@@ -144,14 +146,17 @@ function ownedByAppClause(jobId: unknown, ownerAppId?: string) {
 }
 
 // prettier-ignore
-function canonicalJobSessionId() { return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,sessionId}'`; }
+function canonicalJobSessionJoinClause() { return sql`((${canonicalJobSessionId()} is not null and ${pgSchema.controlHttpSessionsPostgres.sessionId} = ${canonicalJobSessionId()}) or (${canonicalJobSessionId()} is null and ${pgSchema.controlHttpSessionsPostgres.externalRefJson}->>'chatJid' = ${canonicalJobConversationJid()}))`; }
+
 // prettier-ignore
-function canonicalJobConversationJid() { return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,conversationJid}'`; }
+function canonicalJobSessionId() { return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,sessionId}'`; }
 // prettier-ignore
-function canonicalJobGroupScope() { return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,groupScope}'`; }
+function canonicalJobConversationJid() { return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,conversationJid}'`; }
+// prettier-ignore
+function canonicalJobGroupScope() { return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,groupScope}'`; }
 
 function canonicalJobThreadId() {
-  return sql`${pgSchema.canonicalJobsPostgres.targetJson}::jsonb #>> '{executionContext,threadId}'`;
+  return sql`${pgSchema.canonicalJobsPostgres.targetJson} #>> '{executionContext,threadId}'`;
 }
 
 function canonicalJobThreadIdNormalized() {
@@ -159,7 +164,17 @@ function canonicalJobThreadIdNormalized() {
 }
 
 function canonicalJobNotificationRoutes() {
-  return sql`coalesce(${pgSchema.canonicalJobsPostgres.targetJson}::jsonb -> 'notificationRoutes', '[]'::jsonb)`;
+  return sql`coalesce(${pgSchema.canonicalJobsPostgres.targetJson} -> 'notificationRoutes', '[]'::jsonb)`;
+}
+
+function jobRecordFromRow(
+  row: typeof pgSchema.canonicalJobsPostgres.$inferSelect,
+): CanonicalJobRecord {
+  return {
+    ...row,
+    scheduleJson: jsonText(row.scheduleJson),
+    targetJson: jsonText(row.targetJson),
+  };
 }
 
 export class PostgresCanonicalJobRepository {
@@ -175,7 +190,7 @@ export class PostgresCanonicalJobRepository {
       .from(pgSchema.canonicalJobsPostgres)
       .where(eq(pgSchema.canonicalJobsPostgres.id, id))
       .limit(1);
-    return rows[0];
+    return rows[0] ? jobRecordFromRow(rows[0]) : undefined;
   }
 
   async listJobs(filters?: JobListFilters): Promise<CanonicalJobRecord[]> {
@@ -188,8 +203,10 @@ export class PostgresCanonicalJobRepository {
         ? sql`exists (
             select 1
             from ${pgSchema.controlHttpSessionsPostgres} app_session
-            where (app_session.session_id = ${canonicalJobSessionId()}
-              or app_session.external_ref_json::jsonb->>'chatJid' = ${canonicalJobConversationJid()})
+            where (
+              (${canonicalJobSessionId()} is not null and app_session.session_id = ${canonicalJobSessionId()})
+              or (${canonicalJobSessionId()} is null and app_session.external_ref_json->>'chatJid' = ${canonicalJobConversationJid()})
+            )
               and app_session.app_id = ${filters.appId}
           )`
         : undefined,
@@ -223,7 +240,10 @@ export class PostgresCanonicalJobRepository {
       desc(pgSchema.canonicalJobsPostgres.updatedAt),
       desc(pgSchema.canonicalJobsPostgres.createdAt),
     );
-    return filters?.limit ? ordered.limit(filters.limit) : ordered;
+    const rows = filters?.limit
+      ? await ordered.limit(filters.limit)
+      : await ordered;
+    return rows.map(jobRecordFromRow);
   }
 
   async upsertJob(record: JobRecordInput): Promise<void> {
@@ -235,6 +255,8 @@ export class PostgresCanonicalJobRepository {
         createdByActorId: 'runtime',
         createdBySource: 'runtime',
         ...record,
+        scheduleJson: jsonb(record.scheduleJson),
+        targetJson: jsonb(record.targetJson),
       })
       .onConflictDoUpdate({
         target: pgSchema.canonicalJobsPostgres.id,
@@ -243,9 +265,9 @@ export class PostgresCanonicalJobRepository {
           name: record.name,
           prompt: record.prompt,
           model: record.model,
-          scheduleJson: record.scheduleJson,
+          scheduleJson: jsonb(record.scheduleJson),
           status: record.status,
-          targetJson: record.targetJson,
+          targetJson: jsonb(record.targetJson),
           silent: record.silent,
           timeoutMs: record.timeoutMs,
           maxRetries: record.maxRetries,
@@ -268,6 +290,8 @@ export class PostgresCanonicalJobRepository {
       .update(pgSchema.canonicalJobsPostgres)
       .set({
         ...record,
+        scheduleJson: jsonb(record.scheduleJson),
+        targetJson: jsonb(record.targetJson),
         createdByActorId: 'runtime',
         createdBySource: 'runtime',
       })
@@ -440,8 +464,7 @@ export class PostgresCanonicalJobRepository {
       .from(pgSchema.controlHttpSessionsPostgres)
       .innerJoin(
         pgSchema.canonicalJobsPostgres,
-        sql`(${pgSchema.controlHttpSessionsPostgres.sessionId} = ${canonicalJobSessionId()}
-          or ${pgSchema.controlHttpSessionsPostgres.externalRefJson}::jsonb->>'chatJid' = ${canonicalJobConversationJid()})`,
+        canonicalJobSessionJoinClause(),
       )
       .innerJoin(
         pgSchema.agentRunsPostgres,
@@ -597,7 +620,7 @@ export class PostgresCanonicalJobRepository {
       .from(pgSchema.controlHttpSessionsPostgres)
       .innerJoin(
         pgSchema.canonicalJobsPostgres,
-        sql`${pgSchema.controlHttpSessionsPostgres.sessionId} = ${canonicalJobSessionId()}`,
+        canonicalJobSessionJoinClause(),
       )
       .innerJoin(
         pgSchema.runtimeEventsPostgres,

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
@@ -8,7 +8,7 @@ import {
   CANONICAL_APP_ID,
   type CanonicalDb,
   conversationIdForJid,
-  json,
+  jsonb,
   PostgresCanonicalGraphRepository,
   providerIdForJid,
   threadIdFor,
@@ -120,7 +120,7 @@ export class PostgresCanonicalMessageRepository {
           conversationId,
           threadId: canonicalThreadId,
           externalMessageId,
-          externalRefJson: json(externalRefForMessage(msg)),
+          externalRefJson: jsonb(externalRefForMessage(msg)),
           direction,
           senderUserId: msg.sender,
           senderDisplayName: msg.sender_name,
@@ -135,7 +135,7 @@ export class PostgresCanonicalMessageRepository {
           target: pgSchema.messagesPostgres.id,
           set: {
             externalMessageId,
-            externalRefJson: json(externalRefForMessage(msg)),
+            externalRefJson: jsonb(externalRefForMessage(msg)),
             direction,
             senderUserId: msg.sender,
             senderDisplayName: msg.sender_name,
@@ -151,7 +151,7 @@ export class PostgresCanonicalMessageRepository {
           messageId: canonicalMessageId,
           ordinal: 0,
           kind: 'text',
-          payloadJson: json({ kind: 'text', text: msg.content }),
+          payloadJson: jsonb({ kind: 'text', text: msg.content }),
         })
         .onConflictDoUpdate({
           target: [
@@ -179,7 +179,7 @@ export class PostgresCanonicalMessageRepository {
             contentType: attachment.contentType ?? null,
             sizeBytes: attachment.sizeBytes ?? null,
             externalRefJson: attachment.externalId
-              ? json({
+              ? jsonb({
                   kind: 'message_attachment',
                   value: attachment.externalId,
                 })
@@ -247,7 +247,7 @@ export class PostgresCanonicalMessageRepository {
         id: m.id,
         conversation_id: m.conversationId,
         thread_id: m.threadId,
-        external_ref_json: m.externalRefJson,
+        external_ref_json: sql<string | null>`${m.externalRefJson}::text`,
         direction: m.direction,
         sender_user_id: m.senderUserId,
         sender_display_name: m.senderDisplayName,
@@ -257,7 +257,7 @@ export class PostgresCanonicalMessageRepository {
         delivery_status: m.deliveryStatus,
         delivered_at: m.deliveredAt,
         delivery_error: m.deliveryError,
-        payload_json: firstPart.payloadJson,
+        payload_json: sql<string | null>`${firstPart.payloadJson}::text`,
       })
       .from(m)
       .leftJoinLateral(firstPart, sql`true`)
@@ -302,7 +302,7 @@ export class PostgresCanonicalMessageRepository {
         id: m.id,
         conversation_id: m.conversationId,
         thread_id: m.threadId,
-        external_ref_json: m.externalRefJson,
+        external_ref_json: sql<string | null>`${m.externalRefJson}::text`,
         direction: m.direction,
         sender_user_id: m.senderUserId,
         sender_display_name: m.senderDisplayName,
@@ -312,7 +312,7 @@ export class PostgresCanonicalMessageRepository {
         delivery_status: m.deliveryStatus,
         delivered_at: m.deliveredAt,
         delivery_error: m.deliveryError,
-        payload_json: p.payloadJson,
+        payload_json: sql<string | null>`${p.payloadJson}::text`,
       })
       .from(m)
       .innerJoin(p, and(eq(p.messageId, m.id), eq(p.ordinal, 0)))

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-session-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-session-repository.postgres.ts
@@ -6,7 +6,7 @@ import {
   type CanonicalExecutor,
   type CanonicalDb,
   conversationIdForJid,
-  json,
+  jsonb,
   PostgresCanonicalGraphRepository,
   threadIdFor,
 } from './canonical-graph-repository.postgres.js';
@@ -383,13 +383,13 @@ export class PostgresCanonicalSessionRepository {
           agentSessionId,
           provider: PROVIDER,
           externalSessionId: sessionId,
-          providerRefJson: json({
+          providerRefJson: jsonb({
             kind: 'provider_session',
             value: `${PROVIDER}:${sessionId}`,
             provider: PROVIDER,
             externalSessionId: sessionId,
           }),
-          metadataJson: json({
+          metadataJson: jsonb({
             chatJid: chatJid ?? null,
             conversationKind: conversationKind ?? null,
             memoryUserId: resolvedMemoryUserId,
@@ -425,13 +425,13 @@ export class PostgresCanonicalSessionRepository {
         .update(pgSchema.providerSessionsPostgres)
         .set({
           externalSessionId: sessionId,
-          providerRefJson: json({
+          providerRefJson: jsonb({
             kind: 'provider_session',
             value: `${PROVIDER}:${sessionId}`,
             provider: PROVIDER,
             externalSessionId: sessionId,
           }),
-          metadataJson: json({
+          metadataJson: jsonb({
             chatJid: chatJid ?? null,
             conversationKind: conversationKind ?? null,
             memoryUserId: resolvedMemoryUserId,

--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-repository.postgres.ts
@@ -21,7 +21,10 @@ import {
   text,
   type CanonicalControlRow,
 } from '../schema/control-plane-canonical.postgres.js';
-import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
+import {
+  jsonb,
+  type CanonicalDb,
+} from './canonical-graph-repository.postgres.js';
 import { ensureControlGraph } from './control-plane-graph.postgres.js';
 import { PostgresExternalIngressRepository } from './control-plane-external-ingress.postgres.js';
 import { PostgresJobTriggerRepository } from './control-plane-job-triggers.postgres.js';
@@ -105,7 +108,7 @@ export class PostgresControlPlaneRepository {
           agentId: graph.agentId,
           defaultResponseMode: input.defaultResponseMode ?? 'sse',
           defaultWebhookId: input.defaultWebhookId ?? null,
-          externalRefJson: JSON.stringify({
+          externalRefJson: jsonb({
             externalConversationId: input.conversationId,
             chatJid: input.chatJid,
             groupFolder: workspaceKey,
@@ -124,7 +127,7 @@ export class PostgresControlPlaneRepository {
             agentId: graph.agentId,
             defaultResponseMode: input.defaultResponseMode ?? 'sse',
             defaultWebhookId: input.defaultWebhookId ?? null,
-            externalRefJson: JSON.stringify({
+            externalRefJson: jsonb({
               externalConversationId: input.conversationId,
               chatJid: input.chatJid,
               groupFolder: workspaceKey,

--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-sessions.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-sessions.postgres.ts
@@ -49,7 +49,7 @@ export async function getControlSessionByChatJid(
     .select()
     .from(pgSchema.controlHttpSessionsPostgres)
     .where(
-      sql`${pgSchema.controlHttpSessionsPostgres.externalRefJson}::jsonb->>'chatJid' = ${chatJid}`,
+      sql`${pgSchema.controlHttpSessionsPostgres.externalRefJson}->>'chatJid' = ${chatJid}`,
     )
     .limit(1);
   return rows[0] ? mapSession(rows[0] as CanonicalControlRow) : undefined;
@@ -66,7 +66,7 @@ export async function getControlSessionsByChatJids(
     .from(pgSchema.controlHttpSessionsPostgres)
     .where(
       inArray(
-        sql`${pgSchema.controlHttpSessionsPostgres.externalRefJson}::jsonb->>'chatJid'`,
+        sql`${pgSchema.controlHttpSessionsPostgres.externalRefJson}->>'chatJid'`,
         uniqueChatJids,
       ),
     );

--- a/apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/domain-repositories.postgres.ts
@@ -68,7 +68,10 @@ import type {
 import type { AgentSession } from '../../../../domain/sessions/sessions.js';
 import type { ExternalRef } from '../../../../shared/ids/branded-id.js';
 import * as pgSchema from '../schema/schema.js';
-import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
+import {
+  jsonb,
+  type CanonicalDb,
+} from './canonical-graph-repository.postgres.js';
 import {
   PostgresAgentSessionRepository,
   PostgresAgentSessionDigestRepository,
@@ -110,8 +113,13 @@ function encodeJson(value: unknown): string {
 function encodeJsonOrNull(value: unknown | undefined): string | null {
   return value === undefined ? null : encodeJson(value);
 }
+function jsonbOrNull(value: unknown | undefined): unknown | null {
+  return value === undefined ? null : value;
+}
 function parseJson<T>(value: unknown, fallback: T): T {
-  if (typeof value !== 'string' || value.length === 0) return fallback;
+  if (value === null || value === undefined) return fallback;
+  if (typeof value !== 'string') return value as T;
+  if (value.length === 0) return fallback;
   try {
     return JSON.parse(value) as T;
   } catch (err) {
@@ -215,23 +223,23 @@ function _memorySubjectFromRow(row: {
   }
   return { kind: 'app', appId: row.appId } as MemorySubject;
 }
-function messagePartToPayload(part: MessagePart): string {
+function messagePartToPayload(part: MessagePart): Record<string, unknown> {
   switch (part.kind) {
     case 'text':
-      return encodeJson({ text: part.text });
+      return { text: part.text };
     case 'markdown':
-      return encodeJson({ markdown: part.markdown });
+      return { markdown: part.markdown };
     case 'code':
-      return encodeJson({ language: part.language, code: part.code });
+      return { language: part.language, code: part.code };
     case 'structured':
-      return encodeJson({ value: part.value });
+      return { value: part.value };
     case 'tool_result':
-      return encodeJson({ toolId: part.toolId, value: part.value });
+      return { toolId: part.toolId, value: part.value };
     case 'redacted':
-      return encodeJson({ reason: part.reason });
+      return { reason: part.reason };
   }
 }
-function payloadToMessagePart(kind: string, payloadJson: string): MessagePart {
+function payloadToMessagePart(kind: string, payloadJson: unknown): MessagePart {
   const payload = parseJson<JsonRecord>(payloadJson, {});
   switch (kind) {
     case 'markdown':
@@ -1065,7 +1073,7 @@ export class PostgresMessageRepository implements MessageRepository {
           conversationId: message.conversationId,
           threadId: message.threadId ?? null,
           externalMessageId,
-          externalRefJson: encodeJsonOrNull(message.externalRef),
+          externalRefJson: jsonbOrNull(message.externalRef),
           direction: message.direction,
           senderUserId: message.senderUserId ?? null,
           senderDisplayName: message.senderDisplayName ?? null,
@@ -1080,7 +1088,7 @@ export class PostgresMessageRepository implements MessageRepository {
           target: pgSchema.messagesPostgres.id,
           set: {
             externalMessageId,
-            externalRefJson: encodeJsonOrNull(message.externalRef),
+            externalRefJson: jsonbOrNull(message.externalRef),
             direction: message.direction,
             senderUserId: message.senderUserId ?? null,
             senderDisplayName: message.senderDisplayName ?? null,
@@ -1105,7 +1113,7 @@ export class PostgresMessageRepository implements MessageRepository {
             messageId: targetMessageId,
             ordinal,
             kind: part.kind,
-            payloadJson: messagePartToPayload(part),
+            payloadJson: jsonb(messagePartToPayload(part)),
           })),
         );
       }
@@ -1117,7 +1125,7 @@ export class PostgresMessageRepository implements MessageRepository {
             kind: attachment.kind,
             contentType: attachment.contentType ?? null,
             sizeBytes: attachment.sizeBytes ?? null,
-            externalRefJson: encodeJsonOrNull(attachment.externalRef),
+            externalRefJson: jsonbOrNull(attachment.externalRef),
             storageRef: attachment.storageRef ?? null,
             trust: attachment.trust,
           })),

--- a/apps/core/src/adapters/storage/postgres/repositories/session-repositories.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/session-repositories.postgres.ts
@@ -21,16 +21,17 @@ import type {
 } from '../../../../domain/sessions/sessions.js';
 import type { ExternalRef } from '../../../../shared/ids/branded-id.js';
 import * as pgSchema from '../schema/schema.js';
-import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
+import {
+  jsonb,
+  type CanonicalDb,
+} from './canonical-graph-repository.postgres.js';
 
 type JsonRecord = Record<string, unknown>;
 
-function encodeJson(value: unknown): string {
-  return JSON.stringify(value ?? null);
-}
-
 function parseJson<T>(value: unknown, fallback: T): T {
-  if (typeof value !== 'string' || value.length === 0) return fallback;
+  if (value === null || value === undefined) return fallback;
+  if (typeof value !== 'string') return value as T;
+  if (value.length === 0) return fallback;
   try {
     return JSON.parse(value) as T;
   } catch (err) {
@@ -272,8 +273,8 @@ export class PostgresProviderSessionRepository implements ProviderSessionReposit
           agentSessionId: session.agentSessionId,
           provider,
           externalSessionId,
-          providerRefJson: encodeJson(session.providerRef),
-          metadataJson: encodeJson(session.metadata ?? {}),
+          providerRefJson: jsonb(session.providerRef),
+          metadataJson: jsonb(session.metadata ?? {}),
           status: session.status,
           createdAt: session.createdAt,
           updatedAt: session.updatedAt,
@@ -307,8 +308,8 @@ export class PostgresProviderSessionRepository implements ProviderSessionReposit
         .set({
           provider,
           externalSessionId,
-          providerRefJson: encodeJson(session.providerRef),
-          metadataJson: encodeJson(session.metadata ?? {}),
+          providerRefJson: jsonb(session.providerRef),
+          metadataJson: jsonb(session.metadata ?? {}),
           status: session.status,
           updatedAt: session.updatedAt,
         })
@@ -544,7 +545,7 @@ export class PostgresAgentSessionDigestRepository implements AgentSessionDigestR
         digest: digest.digest,
         messageCount: digest.messageCount,
         extractedFactCount: digest.extractedFactCount,
-        metadataJson: encodeJson(digest.metadata ?? {}),
+        metadataJson: jsonb(digest.metadata ?? {}),
         scopeAppId: scope.appId,
         scopeAgentId: scope.agentId,
         scopeConversationId: scope.conversationId,
@@ -559,7 +560,7 @@ export class PostgresAgentSessionDigestRepository implements AgentSessionDigestR
           digest: digest.digest,
           messageCount: digest.messageCount,
           extractedFactCount: digest.extractedFactCount,
-          metadataJson: encodeJson(digest.metadata ?? {}),
+          metadataJson: jsonb(digest.metadata ?? {}),
           scopeAppId: scope.appId,
           scopeAgentId: scope.agentId,
           scopeConversationId: scope.conversationId,

--- a/apps/core/src/adapters/storage/postgres/runtime-store.ts
+++ b/apps/core/src/adapters/storage/postgres/runtime-store.ts
@@ -136,7 +136,12 @@ export function _setRuntimeRepositoriesForTest(
   runtime = {
     service: {
       migrate: async () => {},
-      healthCheck: async () => ({ lexicalSearch: true, vectorSearch: false }),
+      healthCheck: async () => ({
+        lexicalSearch: true,
+        vectorSearch: false,
+        runtimeEvents: true,
+        eventBusOutbox: true,
+      }),
       close: async () => {},
     } as StorageRuntime['service'],
     ops,

--- a/apps/core/src/adapters/storage/postgres/schema/control-http.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/control-http.ts
@@ -55,10 +55,6 @@ export const controlHttpSessionsPostgres = pgTable(
     appConversationUnique: unique(
       'control_http_sessions_app_id_external_conversation_id_key',
     ).on(table.appId, table.externalConversationId),
-    externalRefIdx: index('idx_control_http_sessions_external_ref').using(
-      'gin',
-      table.externalRefJson,
-    ),
     chatJidIdx: index('idx_control_http_sessions_chat_jid').on(
       sql`(${table.externalRefJson}->>'chatJid')`,
     ),

--- a/apps/core/src/adapters/storage/postgres/schema/control-http.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/control-http.ts
@@ -3,6 +3,7 @@ import {
   boolean,
   index,
   integer,
+  jsonb,
   pgTable,
   primaryKey,
   text,
@@ -34,7 +35,9 @@ export const controlHttpSessionsPostgres = pgTable(
       .references(() => agentsPostgres.id, { onDelete: 'cascade' }),
     defaultResponseMode: text('default_response_mode').notNull().default('sse'),
     defaultWebhookId: text('default_webhook_id'),
-    externalRefJson: text('external_ref_json').notNull().default('{}'),
+    externalRefJson: jsonb('external_ref_json')
+      .notNull()
+      .default(sql`'{}'::jsonb`),
     createdAt: timestamp('created_at', {
       withTimezone: true,
       mode: 'string',
@@ -54,10 +57,10 @@ export const controlHttpSessionsPostgres = pgTable(
     ).on(table.appId, table.externalConversationId),
     externalRefIdx: index('idx_control_http_sessions_external_ref').using(
       'gin',
-      sql`(${table.externalRefJson}::jsonb)`,
+      table.externalRefJson,
     ),
     chatJidIdx: index('idx_control_http_sessions_chat_jid').on(
-      sql`(${table.externalRefJson}::jsonb->>'chatJid')`,
+      sql`(${table.externalRefJson}->>'chatJid')`,
     ),
   }),
 );

--- a/apps/core/src/adapters/storage/postgres/schema/control-plane-canonical.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/control-plane-canonical.postgres.ts
@@ -23,6 +23,9 @@ export function text(value: unknown): string | null {
 }
 
 function parseJsonObject(value: unknown): CanonicalControlRow {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as CanonicalControlRow;
+  }
   if (typeof value !== 'string' || value.length === 0) return {};
   try {
     const parsed = JSON.parse(value);

--- a/apps/core/src/adapters/storage/postgres/schema/jobs.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/jobs.ts
@@ -96,7 +96,7 @@ export const canonicalJobsPostgres = pgTable(
       'idx_jobs_target_notification_routes',
     ).using(
       'gin',
-      sql`coalesce(${table.targetJson} -> 'notificationRoutes', '[]'::jsonb)`,
+      sql`(coalesce(${table.targetJson} -> 'notificationRoutes', '[]'::jsonb)) jsonb_path_ops`,
     ),
   }),
 );

--- a/apps/core/src/adapters/storage/postgres/schema/jobs.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/jobs.ts
@@ -3,6 +3,7 @@ import {
   boolean,
   index,
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -37,9 +38,11 @@ export const canonicalJobsPostgres = pgTable(
     name: text('name').notNull(),
     prompt: text('prompt').notNull(),
     model: text('model_override'),
-    scheduleJson: text('schedule_json').notNull(),
+    scheduleJson: jsonb('schedule_json').notNull(),
     status: text('status').notNull().default('active'),
-    targetJson: text('target_json').notNull().default('{}'),
+    targetJson: jsonb('target_json')
+      .notNull()
+      .default(sql`'{}'::jsonb`),
     silent: boolean('silent').notNull().default(false),
     timeoutMs: integer('timeout_ms').notNull().default(300000),
     maxRetries: integer('max_retries').notNull().default(3),
@@ -73,19 +76,19 @@ export const canonicalJobsPostgres = pgTable(
       table.nextRunAt,
     ),
     targetSessionUpdatedIdx: index('idx_jobs_target_session_updated').on(
-      sql`(${table.targetJson}::jsonb #>> '{executionContext,sessionId}')`,
+      sql`(${table.targetJson} #>> '{executionContext,sessionId}')`,
       table.updatedAt.desc(),
       table.createdAt.desc(),
     ),
     targetGroupScopeUpdatedIdx: index('idx_jobs_target_group_scope_updated').on(
-      sql`(${table.targetJson}::jsonb #>> '{executionContext,groupScope}')`,
+      sql`(${table.targetJson} #>> '{executionContext,groupScope}')`,
       table.updatedAt.desc(),
       table.createdAt.desc(),
     ),
     targetThreadNormalizedUpdatedIdx: index(
       'idx_jobs_target_thread_normalized_updated',
     ).on(
-      sql`coalesce(${table.targetJson}::jsonb #>> '{executionContext,threadId}', '')`,
+      sql`coalesce(${table.targetJson} #>> '{executionContext,threadId}', '')`,
       table.updatedAt.desc(),
       table.createdAt.desc(),
     ),
@@ -93,7 +96,7 @@ export const canonicalJobsPostgres = pgTable(
       'idx_jobs_target_notification_routes',
     ).using(
       'gin',
-      sql`coalesce(${table.targetJson}::jsonb -> 'notificationRoutes', '[]'::jsonb)`,
+      sql`coalesce(${table.targetJson} -> 'notificationRoutes', '[]'::jsonb)`,
     ),
   }),
 );

--- a/apps/core/src/adapters/storage/postgres/schema/memory.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/memory.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import {
   doublePrecision,
   index,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -25,9 +26,11 @@ export const memoryItemsPostgres = pgTable(
     threadId: text('thread_id'),
     kind: text('kind').notNull(),
     key: text('key').notNull(),
-    valueJson: text('value_json').notNull(),
+    valueJson: jsonb('value_json').notNull(),
     confidence: doublePrecision('confidence').notNull().default(1),
-    sourceRefJson: text('source_ref_json').notNull().default('{}'),
+    sourceRefJson: jsonb('source_ref_json')
+      .notNull()
+      .default(sql`'{}'::jsonb`),
     status: text('status').notNull().default('active'),
     lastObservedAt: timestamp('last_observed_at', {
       withTimezone: true,
@@ -65,7 +68,7 @@ export const memoryItemsPostgres = pgTable(
     ),
     searchIdx: index('idx_memory_items_search').using(
       'gin',
-      sql`to_tsvector('english', ${table.key} || ' ' || COALESCE(${table.valueJson}::jsonb->>'value', '') || ' ' || COALESCE(${table.valueJson}::jsonb->>'why', ''))`,
+      sql`to_tsvector('english', ${table.key} || ' ' || COALESCE(${table.valueJson}->>'value', '') || ' ' || COALESCE(${table.valueJson}->>'why', ''))`,
     ),
   }),
 );

--- a/apps/core/src/adapters/storage/postgres/schema/messages.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/messages.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import {
   index,
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -37,7 +38,7 @@ export const messagesPostgres = pgTable(
       { onDelete: 'cascade' },
     ),
     externalMessageId: text('external_message_id'),
-    externalRefJson: text('external_ref_json'),
+    externalRefJson: jsonb('external_ref_json'),
     direction: text('direction').notNull(),
     senderUserId: text('sender_user_id'),
     senderDisplayName: text('sender_display_name'),
@@ -90,7 +91,7 @@ export const messagePartsPostgres = pgTable(
       .references(() => messagesPostgres.id, { onDelete: 'cascade' }),
     ordinal: integer('ordinal').notNull(),
     kind: text('kind').notNull(),
-    payloadJson: text('payload_json').notNull(),
+    payloadJson: jsonb('payload_json').notNull(),
   },
   (table) => ({
     messageOrdinal: unique('message_parts_message_id_ordinal_unique').on(
@@ -110,7 +111,7 @@ export const messageAttachmentsPostgres = pgTable(
     kind: text('kind').notNull(),
     contentType: text('content_type'),
     sizeBytes: integer('size_bytes'),
-    externalRefJson: text('external_ref_json'),
+    externalRefJson: jsonb('external_ref_json'),
     storageRef: text('storage_ref'),
     trust: text('trust').notNull(),
   },

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0055_runtime_payload_jsonb_columns.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0055_runtime_payload_jsonb_columns.sql
@@ -57,9 +57,6 @@ ALTER TABLE memory_items
   ALTER COLUMN source_ref_json SET DEFAULT '{}'::jsonb;
 --> statement-breakpoint
 
-CREATE INDEX IF NOT EXISTS idx_control_http_sessions_external_ref
-  ON control_http_sessions USING gin (external_ref_json);
---> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_control_http_sessions_chat_jid
   ON control_http_sessions ((external_ref_json->>'chatJid'));
 --> statement-breakpoint
@@ -82,7 +79,7 @@ CREATE INDEX IF NOT EXISTS idx_jobs_target_thread_normalized_updated
   );
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_jobs_target_notification_routes
-  ON jobs USING gin ((coalesce(target_json -> 'notificationRoutes', '[]'::jsonb)));
+  ON jobs USING gin ((coalesce(target_json -> 'notificationRoutes', '[]'::jsonb)) jsonb_path_ops);
 --> statement-breakpoint
 
 CREATE INDEX IF NOT EXISTS idx_memory_items_search

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0055_runtime_payload_jsonb_columns.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0055_runtime_payload_jsonb_columns.sql
@@ -1,0 +1,96 @@
+DROP INDEX IF EXISTS idx_control_http_sessions_external_ref;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_control_http_sessions_chat_jid;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_jobs_target_session_updated;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_jobs_target_group_scope_updated;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_jobs_target_thread_normalized_updated;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_jobs_target_notification_routes;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_memory_items_search;
+--> statement-breakpoint
+
+ALTER TABLE messages
+  ALTER COLUMN external_ref_json TYPE jsonb USING external_ref_json::jsonb;
+--> statement-breakpoint
+ALTER TABLE message_parts
+  ALTER COLUMN payload_json TYPE jsonb USING payload_json::jsonb;
+--> statement-breakpoint
+ALTER TABLE message_attachments
+  ALTER COLUMN external_ref_json TYPE jsonb USING external_ref_json::jsonb;
+--> statement-breakpoint
+
+ALTER TABLE provider_sessions
+  ALTER COLUMN provider_ref_json DROP DEFAULT,
+  ALTER COLUMN provider_ref_json TYPE jsonb USING provider_ref_json::jsonb,
+  ALTER COLUMN provider_ref_json SET DEFAULT '{}'::jsonb,
+  ALTER COLUMN metadata_json DROP DEFAULT,
+  ALTER COLUMN metadata_json TYPE jsonb USING metadata_json::jsonb,
+  ALTER COLUMN metadata_json SET DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+ALTER TABLE agent_session_digests
+  ALTER COLUMN metadata_json DROP DEFAULT,
+  ALTER COLUMN metadata_json TYPE jsonb USING metadata_json::jsonb,
+  ALTER COLUMN metadata_json SET DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+
+ALTER TABLE control_http_sessions
+  ALTER COLUMN external_ref_json DROP DEFAULT,
+  ALTER COLUMN external_ref_json TYPE jsonb USING external_ref_json::jsonb,
+  ALTER COLUMN external_ref_json SET DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+
+ALTER TABLE jobs
+  ALTER COLUMN schedule_json TYPE jsonb USING schedule_json::jsonb,
+  ALTER COLUMN target_json DROP DEFAULT,
+  ALTER COLUMN target_json TYPE jsonb USING target_json::jsonb,
+  ALTER COLUMN target_json SET DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+
+ALTER TABLE memory_items
+  ALTER COLUMN value_json TYPE jsonb USING value_json::jsonb,
+  ALTER COLUMN source_ref_json DROP DEFAULT,
+  ALTER COLUMN source_ref_json TYPE jsonb USING source_ref_json::jsonb,
+  ALTER COLUMN source_ref_json SET DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS idx_control_http_sessions_external_ref
+  ON control_http_sessions USING gin (external_ref_json);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_control_http_sessions_chat_jid
+  ON control_http_sessions ((external_ref_json->>'chatJid'));
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS idx_jobs_target_session_updated
+  ON jobs ((target_json #>> '{executionContext,sessionId}'), updated_at DESC, created_at DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_jobs_target_group_scope_updated
+  ON jobs (
+    (target_json #>> '{executionContext,groupScope}'),
+    updated_at DESC,
+    created_at DESC
+  );
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_jobs_target_thread_normalized_updated
+  ON jobs (
+    (coalesce(target_json #>> '{executionContext,threadId}', '')),
+    updated_at DESC,
+    created_at DESC
+  );
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_jobs_target_notification_routes
+  ON jobs USING gin ((coalesce(target_json -> 'notificationRoutes', '[]'::jsonb)));
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS idx_memory_items_search
+  ON memory_items USING gin (
+    to_tsvector(
+      'english',
+      key || ' ' ||
+      COALESCE(value_json->>'value', '') || ' ' ||
+      COALESCE(value_json->>'why', '')
+    )
+  );

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0056_jsonb_index_performance.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0056_jsonb_index_performance.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_control_http_sessions_external_ref;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_jobs_target_notification_routes;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_jobs_target_notification_routes
+  ON jobs USING gin ((coalesce(target_json -> 'notificationRoutes', '[]'::jsonb)) jsonb_path_ops);
+--> statement-breakpoint

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1777183800000,
       "tag": "0055_runtime_payload_jsonb_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1777187400000,
+      "tag": "0056_jsonb_index_performance",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1777180200000,
       "tag": "0054_drop_skill_provider_refs",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1777183800000,
+      "tag": "0055_runtime_payload_jsonb_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/adapters/storage/postgres/schema/sessions.ts
+++ b/apps/core/src/adapters/storage/postgres/schema/sessions.ts
@@ -1,4 +1,12 @@
-import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+} from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 
 import { agentsPostgres } from './agents.js';
 import { appsPostgres } from './apps.js';
@@ -76,8 +84,12 @@ export const providerSessionsPostgres = pgTable(
     browserProfileId: text('browser_profile_id').references(
       () => browserProfilesPostgres.id,
     ),
-    providerRefJson: text('provider_ref_json').notNull().default('{}'),
-    metadataJson: text('metadata_json').notNull().default('{}'),
+    providerRefJson: jsonb('provider_ref_json')
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    metadataJson: jsonb('metadata_json')
+      .notNull()
+      .default(sql`'{}'::jsonb`),
     status: text('status').notNull().default('active'),
     createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
       .notNull()
@@ -148,7 +160,9 @@ export const agentSessionDigestsPostgres = pgTable(
     digest: text('digest').notNull(),
     messageCount: integer('message_count').notNull().default(0),
     extractedFactCount: integer('extracted_fact_count').notNull().default(0),
-    metadataJson: text('metadata_json').notNull().default('{}'),
+    metadataJson: jsonb('metadata_json')
+      .notNull()
+      .default(sql`'{}'::jsonb`),
     scopeAppId: text('scope_app_id'),
     scopeAgentId: text('scope_agent_id'),
     scopeConversationId: text('scope_conversation_id'),

--- a/apps/core/src/adapters/storage/postgres/storage-readiness.ts
+++ b/apps/core/src/adapters/storage/postgres/storage-readiness.ts
@@ -83,7 +83,7 @@ export async function inspectRuntimeStorageReadiness(
       return {
         status: 'pass',
         message:
-          'Postgres capabilities are ready (pgvector, search extension, pg-boss).',
+          'Postgres capabilities are ready (pgvector, search extension, pg-boss, durable runtime events, event outbox).',
       };
     }
 

--- a/apps/core/src/adapters/storage/postgres/storage-service.ts
+++ b/apps/core/src/adapters/storage/postgres/storage-service.ts
@@ -28,6 +28,10 @@ export interface StorageCapabilities {
   textSearchReason?: string;
   jobQueue?: boolean;
   jobQueueReason?: string;
+  runtimeEvents?: boolean;
+  runtimeEventsReason?: string;
+  eventBusOutbox?: boolean;
+  eventBusOutboxReason?: string;
 }
 
 export interface StorageService {
@@ -160,16 +164,97 @@ export class PostgresStorageService implements StorageService {
       has_vector: boolean;
       has_text_search: boolean;
       has_job_queue: boolean;
+      has_runtime_events_table: boolean;
+      has_event_bus_outbox_table: boolean;
+      has_event_bus_outbox_runtime_event_unique: boolean;
+      missing_runtime_event_indexes: string[] | null;
+      missing_event_bus_outbox_indexes: string[] | null;
     }>(
-      `SELECT
-        EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'vector') AS has_vector,
-        EXISTS(SELECT 1 FROM pg_extension WHERE extname IN ('pg_trgm', 'pg_search')) AS has_text_search,
-        (to_regclass('pgboss.version') IS NOT NULL) AS has_job_queue`,
+      `WITH required_runtime_event_indexes(index_name) AS (
+          VALUES
+            ('idx_runtime_events_app_cursor'),
+            ('idx_runtime_events_session_cursor'),
+            ('idx_runtime_events_run_cursor'),
+            ('idx_runtime_events_job_cursor'),
+            ('idx_runtime_events_trigger_cursor'),
+            ('idx_runtime_events_conversation_thread_cursor'),
+            ('idx_runtime_events_type_cursor'),
+            ('idx_runtime_events_webhook_projection')
+        ),
+        required_event_bus_outbox_indexes(index_name) AS (
+          VALUES
+            ('idx_event_bus_outbox_claim_due'),
+            ('idx_event_bus_outbox_app_event'),
+            ('idx_event_bus_outbox_runtime_event'),
+            ('idx_event_bus_outbox_pending_runtime_event')
+        ),
+        current_schema_name AS (
+          SELECT $1::text AS schema_name
+        ),
+        event_tables AS (
+          SELECT
+            to_regclass(format('%I.%I', $1::text, 'runtime_events')) AS runtime_events_oid,
+            to_regclass(format('%I.%I', $1::text, 'event_bus_outbox')) AS event_bus_outbox_oid
+        )
+        SELECT
+          EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'vector') AS has_vector,
+          EXISTS(SELECT 1 FROM pg_extension WHERE extname IN ('pg_trgm', 'pg_search')) AS has_text_search,
+          (to_regclass('pgboss.version') IS NOT NULL) AS has_job_queue,
+          ((SELECT runtime_events_oid FROM event_tables) IS NOT NULL) AS has_runtime_events_table,
+          ((SELECT event_bus_outbox_oid FROM event_tables) IS NOT NULL) AS has_event_bus_outbox_table,
+          EXISTS(
+            SELECT 1
+            FROM pg_constraint c
+            JOIN event_tables t ON c.conrelid = t.event_bus_outbox_oid
+            WHERE c.conname = 'event_bus_outbox_runtime_event_id_key'
+              AND c.contype = 'u'
+          ) AS has_event_bus_outbox_runtime_event_unique,
+          ARRAY(
+            SELECT r.index_name
+            FROM required_runtime_event_indexes r
+            CROSS JOIN current_schema_name s
+            WHERE NOT EXISTS (
+              SELECT 1
+              FROM pg_indexes i
+              WHERE i.schemaname = s.schema_name
+                AND i.tablename = 'runtime_events'
+                AND i.indexname = r.index_name
+            )
+            ORDER BY r.index_name
+          ) AS missing_runtime_event_indexes,
+          ARRAY(
+            SELECT r.index_name
+            FROM required_event_bus_outbox_indexes r
+            CROSS JOIN current_schema_name s
+            WHERE NOT EXISTS (
+              SELECT 1
+              FROM pg_indexes i
+              WHERE i.schemaname = s.schema_name
+                AND i.tablename = 'event_bus_outbox'
+                AND i.indexname = r.index_name
+            )
+            ORDER BY r.index_name
+          ) AS missing_event_bus_outbox_indexes`,
+      [this.schemaName],
     );
     const row = caps.rows[0];
     const hasVector = Boolean(row?.has_vector);
     const hasTextSearch = Boolean(row?.has_text_search);
     const hasJobQueue = Boolean(row?.has_job_queue);
+    const hasRuntimeEventsTable = Boolean(row?.has_runtime_events_table);
+    const hasEventBusOutboxTable = Boolean(row?.has_event_bus_outbox_table);
+    const hasEventBusOutboxRuntimeEventUnique = Boolean(
+      row?.has_event_bus_outbox_runtime_event_unique,
+    );
+    const missingRuntimeEventIndexes = row?.missing_runtime_event_indexes ?? [];
+    const missingEventBusOutboxIndexes =
+      row?.missing_event_bus_outbox_indexes ?? [];
+    const hasRuntimeEvents =
+      hasRuntimeEventsTable && missingRuntimeEventIndexes.length === 0;
+    const hasEventBusOutbox =
+      hasEventBusOutboxTable &&
+      hasEventBusOutboxRuntimeEventUnique &&
+      missingEventBusOutboxIndexes.length === 0;
     return {
       lexicalSearch: hasTextSearch,
       vectorSearch: hasVector,
@@ -184,6 +269,35 @@ export class PostgresStorageService implements StorageService {
       jobQueueReason: hasJobQueue
         ? undefined
         : 'pg-boss schema is not initialized (expected table pgboss.version)',
+      runtimeEvents: hasRuntimeEvents,
+      runtimeEventsReason: hasRuntimeEvents
+        ? undefined
+        : [
+            hasRuntimeEventsTable
+              ? undefined
+              : 'runtime_events table is missing',
+            hasRuntimeEventsTable && missingRuntimeEventIndexes.length
+              ? `runtime_events indexes are missing: ${missingRuntimeEventIndexes.join(', ')}`
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join('; '),
+      eventBusOutbox: hasEventBusOutbox,
+      eventBusOutboxReason: hasEventBusOutbox
+        ? undefined
+        : [
+            hasEventBusOutboxTable
+              ? undefined
+              : 'event_bus_outbox table is missing',
+            hasEventBusOutboxTable && !hasEventBusOutboxRuntimeEventUnique
+              ? 'event_bus_outbox runtime-event uniqueness constraint is missing: event_bus_outbox_runtime_event_id_key'
+              : undefined,
+            hasEventBusOutboxTable && missingEventBusOutboxIndexes.length
+              ? `event_bus_outbox indexes are missing: ${missingEventBusOutboxIndexes.join(', ')}`
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join('; '),
     };
   }
 

--- a/apps/core/src/application/runtime-events/runtime-event-exchange.ts
+++ b/apps/core/src/application/runtime-events/runtime-event-exchange.ts
@@ -29,7 +29,11 @@ export class RuntimeEventExchange {
     const event = await this.repository.appendRuntimeEvent(
       normalizeRuntimeEventPublishInput(input),
     );
-    await this.notifier.notify(event);
+    try {
+      await this.notifier.notify(event);
+    } catch {
+      // Wakeups are best-effort; durable consumers recover by cursor polling.
+    }
     return event;
   }
 
@@ -84,10 +88,14 @@ class DurableRuntimeEventSubscription implements RuntimeEventSubscription {
     private readonly filter: RuntimeEventFilter,
   ) {
     this.cursor = filter.afterEventId;
-    this.unsubscribe = notifier.subscribe(() => {
-      this.wakeup?.();
-      this.wakeup = null;
-    }, filter);
+    try {
+      this.unsubscribe = notifier.subscribe(() => {
+        this.wakeup?.();
+        this.wakeup = null;
+      }, filter);
+    } catch {
+      this.unsubscribe = () => undefined;
+    }
   }
 
   async next(options: { timeoutMs?: number } = {}): Promise<RuntimeEvent[]> {

--- a/apps/core/src/memory/app-memory-canonical-codec.ts
+++ b/apps/core/src/memory/app-memory-canonical-codec.ts
@@ -19,8 +19,8 @@ export interface CanonicalMemoryItemRow {
   threadId: string | null;
   kind: string;
   key: string;
-  valueJson: string;
-  sourceRefJson: string;
+  valueJson: unknown;
+  sourceRefJson: unknown;
   confidence: number;
   status: string;
   lastObservedAt: string | null;
@@ -32,10 +32,12 @@ export function hashText(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
-export function parseJsonObject(
-  value: string | null | undefined,
-): Record<string, unknown> {
+export function parseJsonObject(value: unknown): Record<string, unknown> {
   if (!value) return {};
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== 'string') return {};
   try {
     const parsed = JSON.parse(value) as unknown;
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
@@ -138,8 +140,8 @@ export function encodeItemSource(input: {
   retrievalCount?: number;
   totalScore?: number;
   maxScore?: number;
-}): string {
-  return JSON.stringify({
+}): Record<string, unknown> {
+  return {
     subject: input.subject,
     source: input.source,
     evidenceIds: input.evidenceIds,
@@ -148,7 +150,7 @@ export function encodeItemSource(input: {
     retrievalCount: input.retrievalCount ?? 0,
     totalScore: input.totalScore ?? 0,
     maxScore: input.maxScore ?? 0,
-  });
+  };
 }
 
 export function clampConfidence(

--- a/apps/core/src/memory/app-memory-dreaming-candidate-guardrails.ts
+++ b/apps/core/src/memory/app-memory-dreaming-candidate-guardrails.ts
@@ -61,7 +61,7 @@ type MemoryCandidateRow = {
 };
 
 type MemoryItemRow = {
-  valueJson: string | null;
+  valueJson: unknown;
 };
 
 function parseJsonArray(value: string | null | undefined): string[] {
@@ -76,10 +76,12 @@ function parseJsonArray(value: string | null | undefined): string[] {
   }
 }
 
-function parseJsonObject(
-  value: string | null | undefined,
-): Record<string, unknown> {
+function parseJsonObject(value: unknown): Record<string, unknown> {
   if (!value) return {};
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== 'string') return {};
   try {
     const parsed = JSON.parse(value) as unknown;
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)

--- a/apps/core/src/memory/app-memory-dreaming.ts
+++ b/apps/core/src/memory/app-memory-dreaming.ts
@@ -41,10 +41,12 @@ function parseJsonArray(value: string | null | undefined): string[] {
   }
 }
 
-function parseJsonObject(
-  value: string | null | undefined,
-): Record<string, unknown> {
+function parseJsonObject(value: unknown): Record<string, unknown> {
   if (!value) return {};
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== 'string') return {};
   try {
     const parsed = JSON.parse(value) as unknown;
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)

--- a/apps/core/src/memory/app-memory-item-queries.ts
+++ b/apps/core/src/memory/app-memory-item-queries.ts
@@ -46,7 +46,7 @@ export async function findActiveMemoryByKey(input: {
         eq(pgSchema.memoryItemsPostgres.agentId, input.subject.agentId),
         eq(pgSchema.memoryItemsPostgres.subjectType, input.subject.subjectType),
         eq(pgSchema.memoryItemsPostgres.subjectId, subjectIdFor(input.subject)),
-        sql`${pgSchema.memoryItemsPostgres.sourceRefJson}::jsonb @> ${JSON.stringify({ subject: { agentId: input.subject.agentId, subjectType: input.subject.subjectType, subjectId: input.subject.subjectId } })}::jsonb`,
+        sql`${pgSchema.memoryItemsPostgres.sourceRefJson} @> ${JSON.stringify({ subject: { agentId: input.subject.agentId, subjectType: input.subject.subjectType, subjectId: input.subject.subjectId } })}::jsonb`,
         sqlThreadIdentityFilter(
           pgSchema.memoryItemsPostgres,
           input.subject.threadId,
@@ -149,7 +149,7 @@ export async function deleteOwnedMemoryItem(input: {
         eq(pgSchema.memoryItemsPostgres.id, current.id),
         input.expectedVersion === undefined
           ? undefined
-          : sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}::jsonb->>'version')::int = ${input.expectedVersion}`,
+          : sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}->>'version')::int = ${input.expectedVersion}`,
       ),
     )
     .returning({ id: pgSchema.memoryItemsPostgres.id });
@@ -190,12 +190,12 @@ export async function demoteDreamingPromotedMemoryItem(input: {
     .update(pgSchema.memoryItemsPostgres)
     .set({
       status: 'demoted',
-      sourceRefJson: JSON.stringify({
+      sourceRefJson: {
         ...sourceRef,
         demoted_at: timestamp,
         demoted_by: input.actorId ?? null,
         demotion_reason: input.reason ?? null,
-      }),
+      },
       updatedAt: timestamp,
     })
     .where(
@@ -204,7 +204,7 @@ export async function demoteDreamingPromotedMemoryItem(input: {
         eq(pgSchema.memoryItemsPostgres.status, 'active'),
         input.expectedVersion === undefined
           ? undefined
-          : sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}::jsonb->>'version')::int = ${input.expectedVersion}`,
+          : sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}->>'version')::int = ${input.expectedVersion}`,
       ),
     )
     .returning({ id: pgSchema.memoryItemsPostgres.id });

--- a/apps/core/src/memory/app-memory-recall.ts
+++ b/apps/core/src/memory/app-memory-recall.ts
@@ -115,8 +115,8 @@ export async function queryAppMemoryItems(
   const context = normalizeSubject(input);
   const query = input.query?.trim() || '';
   const i = deps.schema.memoryItemsPostgres;
-  const valueText = sql`${i.valueJson}::jsonb->>'value'`;
-  const whyText = sql`${i.valueJson}::jsonb->>'why'`;
+  const valueText = sql`${i.valueJson}->>'value'`;
+  const whyText = sql`${i.valueJson}->>'why'`;
   const document = sql`to_tsvector('english', ${i.key} || ' ' || COALESCE(${valueText}, '') || ' ' || COALESCE(${whyText}, ''))`;
   const searchQuery = sql`plainto_tsquery('english', ${query})`;
   const lexicalScore = query
@@ -252,16 +252,16 @@ export async function recordAppMemoryRecallEvents(
       sourceRefJson: sql`jsonb_set(
           jsonb_set(
             jsonb_set(
-              ${items.sourceRefJson}::jsonb,
+              ${items.sourceRefJson},
               '{retrievalCount}',
-              to_jsonb(COALESCE((${items.sourceRefJson}::jsonb->>'retrievalCount')::int, 0) + 1)
+              to_jsonb(COALESCE((${items.sourceRefJson}->>'retrievalCount')::int, 0) + 1)
             ),
             '{totalScore}',
-            to_jsonb(COALESCE((${items.sourceRefJson}::jsonb->>'totalScore')::double precision, 0) + (CASE ${sql.join(scoreCases, sql` `)} ELSE 0 END))
+            to_jsonb(COALESCE((${items.sourceRefJson}->>'totalScore')::double precision, 0) + (CASE ${sql.join(scoreCases, sql` `)} ELSE 0 END))
           ),
           '{maxScore}',
-          to_jsonb(GREATEST(COALESCE((${items.sourceRefJson}::jsonb->>'maxScore')::double precision, 0), (CASE ${sql.join(scoreCases, sql` `)} ELSE 0 END)))
-        )::text`,
+          to_jsonb(GREATEST(COALESCE((${items.sourceRefJson}->>'maxScore')::double precision, 0), (CASE ${sql.join(scoreCases, sql` `)} ELSE 0 END)))
+        )`,
     })
     .where(sql`${idColumn} IN (${sql.join(ids, sql`, `)})`);
 }

--- a/apps/core/src/memory/app-memory-review.ts
+++ b/apps/core/src/memory/app-memory-review.ts
@@ -605,7 +605,7 @@ async function applyMemoryReviewProposal(input: {
               and(
                 eq(pgSchema.memoryItemsPostgres.id, id),
                 eq(pgSchema.memoryItemsPostgres.status, 'active'),
-                sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}::jsonb->>'version')::int = ${expectedVersion}`,
+                sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}->>'version')::int = ${expectedVersion}`,
               ),
             )
             .returning({ id: pgSchema.memoryItemsPostgres.id });

--- a/apps/core/src/memory/app-memory-service-helpers.ts
+++ b/apps/core/src/memory/app-memory-service-helpers.ts
@@ -57,18 +57,16 @@ export function buildMemoryItemWriteBase(input: {
   const nextVersion = input.existingSource
     ? input.existingSource.version + 1
     : 1;
-  const sourceRef = JSON.parse(
-    encodeItemSource({
-      subject: input.subject,
-      source: input.saveInput.source || 'sdk',
-      evidenceIds: nextEvidenceIds,
-      isPinned: input.existingSource?.isPinned ?? false,
-      version: nextVersion,
-      retrievalCount: input.existingSource?.retrievalCount,
-      totalScore: input.existingSource?.totalScore,
-      maxScore: input.existingSource?.maxScore,
-    }),
-  ) as Record<string, unknown>;
+  const sourceRef = encodeItemSource({
+    subject: input.subject,
+    source: input.saveInput.source || 'sdk',
+    evidenceIds: nextEvidenceIds,
+    isPinned: input.existingSource?.isPinned ?? false,
+    version: nextVersion,
+    retrievalCount: input.existingSource?.retrievalCount,
+    totalScore: input.existingSource?.totalScore,
+    maxScore: input.existingSource?.maxScore,
+  });
   if (input.saveInput.dreamingPromotion) {
     sourceRef.promoted_by = 'dreaming';
     sourceRef.promoted_at = input.saveInput.dreamingPromotion.promotedAt;
@@ -88,7 +86,7 @@ export function buildMemoryItemWriteBase(input: {
     threadId: input.subject.threadId ?? null,
     kind: normalizeKind(input.saveInput.kind),
     key: input.key,
-    valueJson: JSON.stringify({
+    valueJson: {
       value: input.value,
       why: input.saveInput.why?.trim() || null,
       contentHash: memoryContentHash({
@@ -99,8 +97,8 @@ export function buildMemoryItemWriteBase(input: {
         key: input.key,
         value: input.value,
       }),
-    }),
-    sourceRefJson: JSON.stringify(sourceRef),
+    },
+    sourceRefJson: sourceRef,
     confidence: clampConfidence(input.saveInput.confidence),
     status: 'active' as const,
     lastObservedAt: input.timestamp,

--- a/apps/core/src/memory/app-memory-service.ts
+++ b/apps/core/src/memory/app-memory-service.ts
@@ -387,7 +387,7 @@ export class AppMemoryService {
         );
       }
     }
-    const nextValueJson = JSON.stringify({
+    const nextValueJson = {
       ...parseJsonObject(current.valueJson),
       value: nextValue,
       why:
@@ -400,7 +400,7 @@ export class AppMemoryService {
         key: nextKey,
         value: nextValue,
       }),
-    });
+    };
     let row: typeof pgSchema.memoryItemsPostgres.$inferSelect | undefined;
     try {
       [row] = await this.db
@@ -423,7 +423,7 @@ export class AppMemoryService {
             eq(pgSchema.memoryItemsPostgres.id, current.id),
             input.expectedVersion === undefined
               ? undefined
-              : sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}::jsonb->>'version')::int = ${input.expectedVersion}`,
+              : sql`(${pgSchema.memoryItemsPostgres.sourceRefJson}->>'version')::int = ${input.expectedVersion}`,
           ),
         )
         .returning();

--- a/apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts
+++ b/apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts
@@ -346,8 +346,8 @@ maybeDescribe('jobs, runs, memory, and scheduler flow', () => {
     const [run] = await runtime.ops.listJobRuns(job.id);
     expect(run).toMatchObject({
       status: 'failed',
-      error_summary: 'planned scheduler failure',
     });
+    expect(run.error_summary).toContain('planned scheduler failure');
     await expect(runtime.ops.getJobById(job.id)).resolves.toMatchObject({
       status: 'active',
       consecutive_failures: 1,
@@ -399,8 +399,8 @@ maybeDescribe('jobs, runs, memory, and scheduler flow', () => {
     const [run] = await runtime.ops.listJobRuns(job.id);
     expect(run).toMatchObject({
       status: 'dead_lettered',
-      error_summary: 'planned dead-letter failure',
     });
+    expect(run.error_summary).toContain('planned dead-letter failure');
     await expect(runtime.ops.getJobById(job.id)).resolves.toMatchObject({
       status: 'dead_lettered',
       pause_reason: expect.stringContaining('planned dead-letter failure'),
@@ -559,7 +559,7 @@ maybeDescribe('jobs, runs, memory, and scheduler flow', () => {
          SELECT r.id
          FROM ${schema}.control_http_sessions s
          JOIN ${schema}.jobs j
-           ON s.session_id = j.target_json::jsonb ->> 'sessionId'
+           ON s.session_id = j.target_json #>> '{executionContext,sessionId}'
          JOIN ${schema}.agent_runs r
            ON r.job_id = j.id
          WHERE s.app_id = $1
@@ -574,7 +574,7 @@ maybeDescribe('jobs, runs, memory, and scheduler flow', () => {
          SELECT e.event_id
          FROM ${schema}.control_http_sessions s
          JOIN ${schema}.jobs j
-           ON s.session_id = j.target_json::jsonb ->> 'sessionId'
+           ON s.session_id = j.target_json #>> '{executionContext,sessionId}'
          JOIN ${schema}.runtime_events e
            ON e.job_id = j.id
          WHERE s.app_id = $1
@@ -583,8 +583,12 @@ maybeDescribe('jobs, runs, memory, and scheduler flow', () => {
          LIMIT 10`,
         ['app-one'],
       );
-      expect(runPlan.rows.map((row) => row['QUERY PLAN']).join('\n')).toContain(
-        'idx_agent_runs_job_started',
+      const runPlanText = runPlan.rows
+        .map((row) => row['QUERY PLAN'])
+        .join('\n');
+      expect(runPlanText).toContain('idx_jobs_target_session_updated');
+      expect(runPlanText).toMatch(
+        /idx_agent_runs_(job_started|job_short_id_unique)/,
       );
       const eventPlanText = eventPlan.rows
         .map((row) => row['QUERY PLAN'])

--- a/apps/core/test/integration/runtime-event-outbox.postgres.integration.test.ts
+++ b/apps/core/test/integration/runtime-event-outbox.postgres.integration.test.ts
@@ -118,4 +118,41 @@ maybeDescribe('Postgres runtime event outbox', () => {
       }),
     ).resolves.toMatchObject([{ eventId: event.eventId }]);
   });
+
+  it('replays durable runtime events by cursor without relying on NOTIFY wakeups', async () => {
+    const appId = DEFAULT_APP_ID as AppId;
+    const jobId = 'job:test:runtime-event-replay' as JobId;
+
+    const first = await runtime.repositories.runtimeEvents.appendRuntimeEvent({
+      appId,
+      jobId,
+      eventType: RUNTIME_EVENT_TYPES.JOB_STARTED,
+      actor: 'scheduler',
+      responseMode: 'none',
+      payload: { jobId, step: 'before-cursor' },
+    });
+    const missedWakeup =
+      await runtime.repositories.runtimeEvents.appendRuntimeEvent({
+        appId,
+        jobId,
+        eventType: RUNTIME_EVENT_TYPES.JOB_COMPLETED,
+        actor: 'scheduler',
+        responseMode: 'none',
+        payload: { jobId, step: 'missed-wakeup' },
+      });
+
+    await expect(
+      runtime.repositories.runtimeEvents.listRuntimeEvents({
+        appId,
+        jobId,
+        afterEventId: first.eventId,
+      }),
+    ).resolves.toMatchObject([
+      {
+        eventId: missedWakeup.eventId,
+        eventType: RUNTIME_EVENT_TYPES.JOB_COMPLETED,
+        payload: { jobId, step: 'missed-wakeup' },
+      },
+    ]);
+  });
 });

--- a/apps/core/test/unit/adapters/storage/postgres/canonical-job-repository.postgres.test.ts
+++ b/apps/core/test/unit/adapters/storage/postgres/canonical-job-repository.postgres.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { jsonb } from '@core/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.js';
 import { PostgresCanonicalJobRepository } from '@core/adapters/storage/postgres/repositories/canonical-job-repository.postgres.js';
 
 function makeInsertOnlyDb() {
@@ -33,6 +34,12 @@ function flattenSqlShape(value: unknown, seen = new Set<object>()): string {
 }
 
 describe('PostgresCanonicalJobRepository', () => {
+  it('fails loudly instead of storing invalid JSON strings in jsonb columns', () => {
+    expect(() => jsonb('{not-json')).toThrow(
+      'Invalid JSON string passed to jsonb column writer',
+    );
+  });
+
   it('marks stale lease runs as timed out when releasing job leases', async () => {
     const selectWhere = vi.fn(async () => [
       { id: 'job-1', leaseRunId: 'run-1' },

--- a/apps/core/test/unit/adapters/storage/postgres/runtime-event-notifier.postgres.test.ts
+++ b/apps/core/test/unit/adapters/storage/postgres/runtime-event-notifier.postgres.test.ts
@@ -6,6 +6,7 @@ import {
   parseRuntimeEventWakeup,
   PostgresRuntimeEventNotifier,
 } from '@core/adapters/storage/postgres/runtime-event-notifier.postgres.js';
+import type { RuntimeEvent } from '@core/domain/events/events.js';
 import { RUNTIME_EVENT_TYPES } from '@core/domain/events/runtime-event-types.js';
 
 class FakeListenClient extends EventEmitter {
@@ -14,6 +15,31 @@ class FakeListenClient extends EventEmitter {
 }
 
 describe('PostgresRuntimeEventNotifier', () => {
+  it('treats failed NOTIFY as a wakeup loss rather than event durability loss', async () => {
+    const pool = {
+      connect: vi.fn(),
+      query: vi.fn(async () => {
+        throw new Error('notify unavailable');
+      }),
+    };
+    const notifier = new PostgresRuntimeEventNotifier(pool as never);
+    const event: RuntimeEvent = {
+      eventId: 12 as never,
+      appId: 'app-one' as never,
+      sessionId: 'session-one' as never,
+      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
+      actor: 'agent',
+      payload: { text: 'already persisted' },
+      createdAt: '2026-05-18T00:00:00.000Z',
+    };
+
+    await expect(notifier.notify(event)).resolves.toBeUndefined();
+    expect(pool.query).toHaveBeenCalledWith('SELECT pg_notify($1, $2)', [
+      'gantry_runtime_events',
+      expect.stringContaining('"eventId":12'),
+    ]);
+  });
+
   it('parses only valid runtime event wakeups', () => {
     expect(
       parseRuntimeEventWakeup(

--- a/apps/core/test/unit/application/runtime-events/runtime-event-exchange.test.ts
+++ b/apps/core/test/unit/application/runtime-events/runtime-event-exchange.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   InMemoryRuntimeEventNotifier,
@@ -101,6 +101,29 @@ describe('RuntimeEventExchange', () => {
     expect(notifier.notifiedEvents).toEqual([event]);
   });
 
+  it('returns the durable event when the live wakeup notifier fails', async () => {
+    const repository = new MemoryRuntimeEventRepository();
+    const exchange = new RuntimeEventExchange(repository, {
+      notify: vi.fn(async () => {
+        throw new Error('wakeup failed');
+      }),
+      subscribe: vi.fn(() => () => undefined),
+    });
+
+    await expect(
+      exchange.publish({
+        appId: 'app:test' as never,
+        eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
+        actor: 'agent',
+        payload: { text: 'durable' },
+      }),
+    ).resolves.toMatchObject({
+      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
+      payload: { text: 'durable' },
+    });
+    expect(repository.events).toHaveLength(1);
+  });
+
   it('canonicalizes provider conversation ids before persistence', async () => {
     const repository = new MemoryRuntimeEventRepository();
     const notifier = new InMemoryRuntimeEventNotifier();
@@ -162,6 +185,65 @@ describe('RuntimeEventExchange', () => {
       {
         eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
         payload: { text: 'existing' },
+      },
+    ]);
+    subscription.close();
+  });
+
+  it('recovers missed wakeups by polling durable events after the cursor', async () => {
+    const repository = new MemoryRuntimeEventRepository();
+    const exchange = new RuntimeEventExchange(
+      repository,
+      new InMemoryRuntimeEventNotifier(),
+    );
+    await repository.appendRuntimeEvent({
+      appId: 'app:test' as never,
+      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
+      actor: 'agent',
+      payload: { text: 'before cursor' },
+    });
+    const missedEvent = await repository.appendRuntimeEvent({
+      appId: 'app:test' as never,
+      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
+      actor: 'agent',
+      payload: { text: 'missed notify' },
+    });
+
+    const subscription = exchange.subscribe({
+      appId: 'app:test' as never,
+      afterEventId: 1 as RuntimeEventId,
+    });
+
+    await expect(subscription.next({ timeoutMs: 0 })).resolves.toMatchObject([
+      {
+        eventId: missedEvent.eventId,
+        payload: { text: 'missed notify' },
+      },
+    ]);
+    subscription.close();
+  });
+
+  it('polls durable events when wakeup subscription registration fails', async () => {
+    const repository = new MemoryRuntimeEventRepository();
+    const exchange = new RuntimeEventExchange(repository, {
+      notify: vi.fn(async () => undefined),
+      subscribe: vi.fn(() => {
+        throw new Error('listen unavailable');
+      }),
+    });
+    const event = await repository.appendRuntimeEvent({
+      appId: 'app:test' as never,
+      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
+      actor: 'agent',
+      payload: { text: 'poll only' },
+    });
+
+    const subscription = exchange.subscribe({ appId: 'app:test' as never });
+
+    await expect(subscription.next({ timeoutMs: 0 })).resolves.toMatchObject([
+      {
+        eventId: event.eventId,
+        payload: { text: 'poll only' },
       },
     ]);
     subscription.close();

--- a/apps/core/test/unit/architecture/runtime-event-cleanup.test.ts
+++ b/apps/core/test/unit/architecture/runtime-event-cleanup.test.ts
@@ -21,10 +21,24 @@ function collectFiles(root: string): string[] {
   return out;
 }
 
+function collectRepoFiles(roots: string[], extensions: RegExp): string[] {
+  return roots.flatMap((root) =>
+    collectFiles(path.join(repoRoot, root))
+      .filter((file) => extensions.test(file))
+      .map((file) => path.relative(repoRoot, file)),
+  );
+}
+
 describe('runtime event cleanup', () => {
   it('keeps runtime_events writes behind PostgresRuntimeEventRepository', () => {
     const sourceRoot = path.join(repoRoot, 'apps/core/src');
-    const directInsertNeedle = `.insert(${['pgSchema', 'runtimeEventsPostgres'].join('.')})`;
+    const directInsertPatterns = [
+      new RegExp(
+        String.raw`\.insert\(\s*${['pgSchema', 'runtimeEventsPostgres'].join('\\.')}\s*\)`,
+      ),
+      /\.insert\(\s*runtimeEventsPostgres\s*\)/,
+      /\binsert\s+into\s+(?:(?:"?[a-z_][a-z0-9_]*"?|\$\{[^}]+\})\s*\.\s*)?"?runtime_events"?\b/i,
+    ];
     const allowed = new Set([
       'apps/core/src/adapters/storage/postgres/repositories/runtime-event-repository.postgres.ts',
     ]);
@@ -37,9 +51,81 @@ describe('runtime event cleanup', () => {
           'utf8',
         );
         return (
-          source.includes(directInsertNeedle) && !allowed.has(relativePath)
+          directInsertPatterns.some((pattern) => pattern.test(source)) &&
+          !allowed.has(relativePath)
         );
       });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps speculative event queue and broker dependencies out of active runtime code', () => {
+    const roots = [
+      'apps/core/src',
+      'apps/core/test',
+      'packages/contracts/src',
+      'packages/sdk/src',
+      'apps/core/src/adapters/storage/postgres/schema/migrations',
+    ];
+    const packageFiles = ['package.json', 'package-lock.json'].filter((file) =>
+      fs.existsSync(path.join(repoRoot, file)),
+    );
+    const allowedFiles = new Set([
+      'apps/core/test/unit/architecture/runtime-event-cleanup.test.ts',
+    ]);
+    const allowedKafkaAdapterPrefix = 'apps/core/src/adapters/events/kafka/';
+    const kafkaModule = String.raw`(?:kafkajs|node-rdkafka|@confluentinc\/[^'"]+)`;
+    const kafkaImport = new RegExp(
+      String.raw`(?:from\s+['"]${kafkaModule}['"]|import\s*\(\s*['"]${kafkaModule}['"]\s*\)|require\s*\(\s*['"]${kafkaModule}['"]\s*\))`,
+    );
+    const blockedPatterns: Array<[string, RegExp]> = [
+      ['pgmq', /(^|[^a-z0-9_])pgmq([^a-z0-9_]|$)/i],
+      ['UNLOGGED pub/sub table', /\bUNLOGGED\b/i],
+      ['Kafka import', kafkaImport],
+    ];
+    const offenders = [
+      ...collectRepoFiles(roots, /\.(ts|md|json|sql)$/),
+      ...packageFiles,
+    ].filter((relativePath) => {
+      if (allowedFiles.has(relativePath)) return false;
+      const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      return blockedPatterns.some(([name, pattern]) => {
+        if (
+          name === 'Kafka import' &&
+          relativePath.startsWith(allowedKafkaAdapterPrefix)
+        ) {
+          return false;
+        }
+        return pattern.test(source);
+      });
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps Kafka and queue backend config out of public runtime surfaces', () => {
+    const roots = [
+      'apps/core/src/config',
+      'apps/core/src/cli',
+      'packages/contracts/src',
+      'packages/sdk/src',
+    ];
+    const forbiddenConfigPatterns = [
+      /\bkafka\b/i,
+      /\bKAFKA_[A-Z0-9_]+\b/,
+      /\bpgmq\b/i,
+      /\bevent[_-]?backend\b/i,
+      /\bevent[_-]?provider\b/i,
+    ];
+    const offenders = collectRepoFiles(roots, /\.(ts|json)$/).filter(
+      (relativePath) => {
+        const source = fs.readFileSync(
+          path.join(repoRoot, relativePath),
+          'utf8',
+        );
+        return forbiddenConfigPatterns.some((pattern) => pattern.test(source));
+      },
+    );
 
     expect(offenders).toEqual([]);
   });
@@ -55,17 +141,14 @@ describe('runtime event cleanup', () => {
       'packages/sdk/src',
       'docs',
     ];
-    const offenders = roots.flatMap((root) =>
-      collectFiles(path.join(repoRoot, root))
-        .filter((file) => /\.(ts|md)$/.test(file))
-        .map((file) => path.relative(repoRoot, file))
-        .filter((relativePath) => {
-          const source = fs.readFileSync(
-            path.join(repoRoot, relativePath),
-            'utf8',
-          );
-          return source.includes(retiredAcceptedEventAlias);
-        }),
+    const offenders = collectRepoFiles(roots, /\.(ts|md)$/).filter(
+      (relativePath) => {
+        const source = fs.readFileSync(
+          path.join(repoRoot, relativePath),
+          'utf8',
+        );
+        return source.includes(retiredAcceptedEventAlias);
+      },
     );
 
     expect(offenders).toEqual([]);

--- a/apps/core/test/unit/cli/storage-readiness.test.ts
+++ b/apps/core/test/unit/cli/storage-readiness.test.ts
@@ -54,6 +54,8 @@ describe('inspectRuntimeStorageReadiness', () => {
       vectorSearch: true,
       textSearch: true,
       jobQueue: true,
+      runtimeEvents: true,
+      eventBusOutbox: true,
     });
     const close = vi.fn().mockResolvedValue(undefined);
     vi.doMock('@core/adapters/storage/postgres/storage-service.js', () => ({

--- a/apps/core/test/unit/domain/canonical-domain.test.ts
+++ b/apps/core/test/unit/domain/canonical-domain.test.ts
@@ -161,7 +161,7 @@ describe('canonical Postgres persistence cut', () => {
     expect(schema).toContain(
       "externalSessionId: text('external_session_id').notNull()",
     );
-    expect(schema).toContain("metadataJson: text('metadata_json')");
+    expect(schema).toContain("metadataJson: jsonb('metadata_json')");
     expect(schema).toContain('agentSessionSummariesPostgres');
     expect(repository).toContain('latestProviderSessionId: sessionId');
   });
@@ -179,6 +179,8 @@ describe('canonical Postgres persistence cut', () => {
     expect(schema).toContain("'memory_items'");
     expect(schema).toContain("subjectType: text('subject_type').notNull()");
     expect(schema).toContain("conversationId: text('conversation_id')");
+    expect(schema).toContain("valueJson: jsonb('value_json').notNull()");
+    expect(schema).toContain("sourceRefJson: jsonb('source_ref_json')");
     expect(aggregateSchema).not.toContain('memorySubjectsPostgres');
   });
 

--- a/apps/core/test/unit/memory/app-memory-service.test.ts
+++ b/apps/core/test/unit/memory/app-memory-service.test.ts
@@ -17,6 +17,13 @@ function collectSqlParamValues(node: unknown): unknown[] {
   return Array.isArray(chunks) ? chunks.flatMap(collectSqlParamValues) : [];
 }
 
+function jsonRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    return JSON.parse(value) as Record<string, unknown>;
+  }
+  return value as Record<string, unknown>;
+}
+
 function memoryRow(input: {
   id?: string;
   appId: string;
@@ -483,7 +490,7 @@ describe('app-grade memory boundaries', () => {
       value: 'updated value',
     });
 
-    const valueJson = JSON.parse(set.mock.calls[0]![0].valueJson);
+    const valueJson = jsonRecord(set.mock.calls[0]![0].valueJson);
     expect(valueJson.value).toBe('updated value');
     expect(valueJson.contentHash).toMatch(/^[a-f0-9]{64}$/);
     expect(valueJson.contentHash).not.toBe(
@@ -643,7 +650,7 @@ describe('app-grade memory boundaries', () => {
     });
 
     const persisted = rows[0]!;
-    const source = JSON.parse(persisted.sourceRefJson);
+    const source = jsonRecord(persisted.sourceRefJson);
     expect(saved.subjectId).toBe('kai');
     expect(persisted.subjectId).toMatch(/^msu_[a-f0-9]{32}$/);
     expect(persisted.subjectId).toBe(
@@ -722,7 +729,7 @@ describe('app-grade memory boundaries', () => {
       },
     });
 
-    expect(JSON.parse(rows[0]!.sourceRefJson)).toMatchObject({
+    expect(jsonRecord(rows[0]!.sourceRefJson)).toMatchObject({
       source: 'dreaming',
       evidenceIds: ['mev-one'],
       promoted_by: 'dreaming',
@@ -790,7 +797,7 @@ describe('app-grade memory boundaries', () => {
         updatedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T.*Z$/),
       }),
     );
-    expect(JSON.parse(set.mock.calls[0]![0].sourceRefJson)).toMatchObject({
+    expect(jsonRecord(set.mock.calls[0]![0].sourceRefJson)).toMatchObject({
       promoted_by: 'dreaming',
       dream_run_id: 'mdr-one',
       demoted_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T.*Z$/),

--- a/apps/core/test/unit/storage/postgres-migration-journal.test.ts
+++ b/apps/core/test/unit/storage/postgres-migration-journal.test.ts
@@ -290,6 +290,59 @@ describe('Postgres migration journal', () => {
     expect(migration).toContain('USING gin');
   });
 
+  it('keeps JSONB performance indexes narrow and operator-specific', () => {
+    const journalPath = path.resolve(
+      'apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json',
+    );
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
+      entries: Array<{ idx: number; tag: string }>;
+    };
+    const jsonbIndexPerformance = journal.entries.find(
+      (entry) => entry.tag === '0056_jsonb_index_performance',
+    );
+    expect(jsonbIndexPerformance).toMatchObject({ idx: 56 });
+
+    const migration55 = fs.readFileSync(
+      path.resolve(
+        'apps/core/src/adapters/storage/postgres/schema/migrations/0055_runtime_payload_jsonb_columns.sql',
+      ),
+      'utf8',
+    );
+    const migration56 = fs.readFileSync(
+      path.resolve(
+        'apps/core/src/adapters/storage/postgres/schema/migrations/0056_jsonb_index_performance.sql',
+      ),
+      'utf8',
+    );
+    const controlSchema = fs.readFileSync(
+      path.resolve(
+        'apps/core/src/adapters/storage/postgres/schema/control-http.ts',
+      ),
+      'utf8',
+    );
+    const jobsSchema = fs.readFileSync(
+      path.resolve('apps/core/src/adapters/storage/postgres/schema/jobs.ts'),
+      'utf8',
+    );
+
+    expect(migration55).not.toContain(
+      'ON control_http_sessions USING gin (external_ref_json)',
+    );
+    expect(migration55).toContain(
+      "ON jobs USING gin ((coalesce(target_json -> 'notificationRoutes', '[]'::jsonb)) jsonb_path_ops)",
+    );
+    expect(migration56).toContain(
+      'DROP INDEX IF EXISTS idx_control_http_sessions_external_ref',
+    );
+    expect(migration56).toContain(
+      "ON jobs USING gin ((coalesce(target_json -> 'notificationRoutes', '[]'::jsonb)) jsonb_path_ops)",
+    );
+    expect(controlSchema).not.toContain(
+      'idx_control_http_sessions_external_ref',
+    );
+    expect(jobsSchema).toContain('jsonb_path_ops');
+  });
+
   it('registers provider session resume lookup index migration and schema', () => {
     const journalPath = path.resolve(
       'apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json',

--- a/apps/core/test/unit/storage/postgres-migration-journal.test.ts
+++ b/apps/core/test/unit/storage/postgres-migration-journal.test.ts
@@ -435,6 +435,44 @@ describe('Postgres migration journal', () => {
     expect(migration).not.toContain('UPDATE agent_session_digests');
   });
 
+  it('registers runtime payload jsonb column conversion migration', () => {
+    const journalPath = path.resolve(
+      'apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json',
+    );
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
+      entries: Array<{ idx: number; tag: string }>;
+    };
+    const jsonbPayloads = journal.entries.find(
+      (entry) => entry.tag === '0055_runtime_payload_jsonb_columns',
+    );
+    expect(jsonbPayloads).toMatchObject({ idx: 55 });
+
+    const migration = fs.readFileSync(
+      path.resolve(
+        'apps/core/src/adapters/storage/postgres/schema/migrations/0055_runtime_payload_jsonb_columns.sql',
+      ),
+      'utf8',
+    );
+    for (const statement of [
+      'ALTER COLUMN external_ref_json TYPE jsonb USING external_ref_json::jsonb',
+      'ALTER COLUMN payload_json TYPE jsonb USING payload_json::jsonb',
+      'ALTER COLUMN provider_ref_json TYPE jsonb USING provider_ref_json::jsonb',
+      'ALTER COLUMN metadata_json TYPE jsonb USING metadata_json::jsonb',
+      'ALTER COLUMN schedule_json TYPE jsonb USING schedule_json::jsonb',
+      'ALTER COLUMN target_json TYPE jsonb USING target_json::jsonb',
+      'ALTER COLUMN value_json TYPE jsonb USING value_json::jsonb',
+      'ALTER COLUMN source_ref_json TYPE jsonb USING source_ref_json::jsonb',
+      "ON jobs ((target_json #>> '{executionContext,sessionId}')",
+      "COALESCE(value_json->>'value', '')",
+    ]) {
+      expect(migration).toContain(statement);
+    }
+    expect(migration).not.toContain('NULLIF(');
+    expect(migration).not.toContain('jsonb_strip_nulls');
+    expect(migration).not.toContain('target_json::jsonb #>>');
+    expect(migration).not.toContain('value_json::jsonb->>');
+  });
+
   it('flattens memory subjects during the canonical persistence cut', () => {
     const migration = fs.readFileSync(
       path.resolve(

--- a/apps/core/test/unit/storage/postgres-readiness.test.ts
+++ b/apps/core/test/unit/storage/postgres-readiness.test.ts
@@ -9,6 +9,8 @@ describe('evaluatePostgresStorageCapabilities', () => {
       vectorSearch: true,
       textSearch: true,
       jobQueue: true,
+      runtimeEvents: true,
+      eventBusOutbox: true,
     });
     expect(failure).toBeNull();
   });
@@ -23,12 +25,39 @@ describe('evaluatePostgresStorageCapabilities', () => {
       jobQueue: false,
       jobQueueReason:
         'pg-boss schema is not initialized (expected table pgboss.version)',
+      runtimeEvents: false,
+      runtimeEventsReason:
+        'runtime_events indexes are missing: idx_runtime_events_app_cursor',
+      eventBusOutbox: false,
+      eventBusOutboxReason:
+        'event_bus_outbox runtime-event uniqueness constraint is missing: event_bus_outbox_runtime_event_id_key',
     });
     expect(failure?.summary).toContain('Postgres runtime capabilities');
     expect(failure?.details).toEqual([
       'pgvector extension is not installed',
       'pg_search or pg_trgm extension is not installed',
       'pg-boss schema is not initialized (expected table pgboss.version)',
+      'runtime_events indexes are missing: idx_runtime_events_app_cursor',
+      'event_bus_outbox runtime-event uniqueness constraint is missing: event_bus_outbox_runtime_event_id_key',
+    ]);
+  });
+
+  it('fails readiness when durable runtime event tables or outbox indexes are missing', () => {
+    const failure = evaluatePostgresStorageCapabilities({
+      lexicalSearch: true,
+      vectorSearch: true,
+      textSearch: true,
+      jobQueue: true,
+      runtimeEvents: false,
+      runtimeEventsReason: 'runtime_events table is missing',
+      eventBusOutbox: false,
+      eventBusOutboxReason:
+        'event_bus_outbox indexes are missing: idx_event_bus_outbox_claim_due',
+    });
+
+    expect(failure?.details).toEqual([
+      'runtime_events table is missing',
+      'event_bus_outbox indexes are missing: idx_event_bus_outbox_claim_due',
     ]);
   });
 });

--- a/docs/architecture/current-verification-commands.md
+++ b/docs/architecture/current-verification-commands.md
@@ -136,6 +136,13 @@ maximum count so `python3 .codex/scripts/check_architecture.py` still fails
 when a branch adds new layer, provider, risky-execution, old-term, or
 wrapper-only debt.
 
+Anthropic/Claude provider-boundary debt is tracked separately in
+`.codex/provider-boundary-exceptions.json`. Entries must use exact file paths
+and exact token counts. The checker fails when a new token appears outside
+`apps/core/src/adapters/llm/anthropic-claude-agent/**`, when an expected count
+changes, or when broad config, memory, or shared paths are approved for this
+gate.
+
 ## Factory And Release Gates
 
 ```bash

--- a/docs/architecture/framework-boundaries.md
+++ b/docs/architecture/framework-boundaries.md
@@ -23,7 +23,7 @@ Gantry keeps the core runtime plain TypeScript and Node.js. Framework dependenci
 - Fastify is allowed only in `apps/core/src/adapters/control-http/`.
 - Slack Bolt is allowed only in `apps/core/src/channels/slack/`.
 - Grammy is allowed only in `apps/core/src/channels/telegram/`.
-- Anthropic SDKs are allowed only in approved Anthropic provider adapter paths. The current approved paths are `apps/core/src/runner/claude/` and `apps/core/src/memory/claude-query.ts`; a later provider cleanup should move these behind a more explicit adapter path.
+- Anthropic SDKs are allowed only in approved Anthropic provider adapter paths. The current provider-boundary target is `apps/core/src/adapters/llm/anthropic-claude-agent/`; remaining runner, memory, config, storage, shared catalog, and test references are exact count-based exceptions tracked by `.codex/provider-boundary-exceptions.json`.
 - Playwright belongs only behind the browser adapter boundary and must not enter domain, application, or core runtime layers.
 - Docker and sandbox libraries are reserved for a future sandbox adapter and must not enter core runtime layers.
 

--- a/docs/architecture/postgres-query-policy.md
+++ b/docs/architecture/postgres-query-policy.md
@@ -12,8 +12,8 @@ not model as durable application data access:
 - readiness and health probes
 - advisory locks that intentionally pin a `pg` client
 - `LISTEN`, `UNLISTEN`, and `pg_notify`
-- narrow Drizzle `sql` fragments for JSON casts, expression predicates,
-  counters, `CASE`, `GREATEST`, and index expressions
+- narrow Drizzle `sql` fragments for expression predicates, counters, `CASE`,
+  `GREATEST`, and index expressions
 
 Concurrency-sensitive claim paths should still use Drizzle transactions and row
 locks when the query builder can express the operation. New raw CRUD queries
@@ -24,3 +24,13 @@ Runtime event append and webhook delivery enqueue are one transaction by design:
 an event that asks for webhook delivery should not become visible without its
 retryable delivery row. Non-webhook subscribers still observe committed events
 through the runtime event exchange after that transaction succeeds.
+
+JSON-shaped runtime payload columns that repositories query, index, validate, or
+partially update belong in native Postgres `jsonb`. Repository writers for
+`jsonb` columns pass objects or arrays through Drizzle rather than JSON strings;
+readers may tolerate legacy string-shaped test mocks at the adapter boundary.
+
+Keep canonical runtime state normalized as typed columns. Use `jsonb` for
+adapter-owned payloads, provider references, metadata, schedules, targets, and
+memory value objects, not as a replacement for fields used to route, authorize,
+lease, resume, dedupe, audit, or join runtime records.

--- a/docs/architecture/runtime-components.md
+++ b/docs/architecture/runtime-components.md
@@ -274,6 +274,30 @@ Jobs have no serialized execution mode. Interactive message admission stays in
 `GroupQueue`; scheduler work enters the background pg-boss lane and uses
 `runtime.queue.max_job_runs` as its worker concurrency bound.
 
+## Runtime Events
+
+Postgres is the default event backend. Runtime-visible output, job lifecycle,
+SDK wait/SSE, webhooks, and app-channel delivery use `runtime_events` as the
+durable stream. `event_bus_outbox` is the only broker boundary for future
+dispatchers such as Kafka or SNS/SQS.
+
+Postgres `LISTEN/NOTIFY` is wakeup-only. Notifications may be missed, coalesced,
+or delayed, so consumers must always recover by replaying `runtime_events` with
+their cursor or by claiming pending `event_bus_outbox` rows.
+
+Storage readiness treats the event path as mandatory. Startup/status checks
+validate that `runtime_events`, `event_bus_outbox`, their cursor/claim indexes,
+and the outbox runtime-event uniqueness constraint are present. These checks do
+not insert probe rows into runtime data.
+
+Gantry intentionally does not use `pgmq`, UNLOGGED pub/sub tables, or Kafka
+configuration in the current runtime. `pg-boss` remains dedicated to scheduled
+and background job execution.
+
+Retention, partitioning, and interrupted in-flight run recovery are separate
+follow-up decisions. They must not introduce a second event truth store or a
+runtime event backend selector.
+
 ## Storage And Retrieval
 
 Postgres is mandatory runtime storage. The supported deployment model is one database with separate schemas and roles: `gantry` for first-party runtime tables, `onecli` for OneCLI broker state, and `pgboss` for pg-boss internals. Gantry provisions and verifies the schema boundary, but it does not query OneCLI-owned tables or run OneCLI migrations. `GANTRY_DATABASE_URL` and `ONECLI_DATABASE_URL` must use different Postgres users; the OneCLI `schema=onecli` URL parameter is not treated as a permission boundary by itself.

--- a/docs/decisions/2026-05-12-event-bus-outbox-boundary.md
+++ b/docs/decisions/2026-05-12-event-bus-outbox-boundary.md
@@ -3,15 +3,31 @@
 ## Context
 
 Gantry may later publish runtime events through SNS/SQS, Kafka, or another
-broker. The runtime already has a clean `runtime_events` stream, while MCP,
-permission, memory, webhook delivery, and provider-session histories own their
-own audit records.
+broker. The runtime already has a clean Postgres-first event path through
+`runtime_events` and `event_bus_outbox`, while MCP, permission, memory, webhook
+delivery, and provider-session histories own their own audit records.
 
 ## Decision
 
-`runtime_events` remains the only runtime-observable stream. Runtime event
-appends synchronously write an `event_bus_outbox` record in the same Postgres
-transaction. Broker dispatch is a later adapter behind the event bus boundary.
+Postgres is the default event backend. `runtime_events` remains the only
+runtime-observable stream. Runtime event appends synchronously write an
+`event_bus_outbox` record in the same Postgres transaction. Broker dispatch is a
+later adapter behind the event bus boundary.
+
+Postgres `LISTEN/NOTIFY` is wakeup-only. It is not durable truth, and consumers
+must replay from `runtime_events` or recover dispatch from `event_bus_outbox`
+after missed notifications.
+
+Runtime storage readiness validates the durable event path by checking
+`runtime_events`, `event_bus_outbox`, their cursor/claim indexes, and the outbox
+runtime-event uniqueness constraint. Readiness checks must not write synthetic
+event or outbox rows.
+
+Kafka, SNS/SQS, or another broker may be introduced only as a dispatcher adapter
+behind `event_bus_outbox` when there is a real scaling or multi-service
+requirement. Until then there is no runtime event provider abstraction, no
+Kafka configuration surface, and no backend selector in settings, control API,
+CLI, SDK, or MCP tools.
 
 Audit histories remain separate stores. They may emit runtime-visible events
 only when the user or public API needs to observe the outcome.
@@ -22,13 +38,21 @@ This is a strict clean cut:
 - no direct `runtime_events` inserts outside the runtime event repository
 - no dual writes to old event tables
 - no fallback readers or compatibility views
+- no `pgmq`
+- no UNLOGGED pub/sub tables
+- no Kafka imports outside a future broker adapter folder
 
 Future Go workers must consume and publish the shared event envelope. Go does
 not own a second event taxonomy.
 
 ## Consequences
 
-Postgres remains the source of truth. Broker lag or downtime cannot lose
-runtime events because dispatchers recover from the outbox. Unknown runtime
-event filter strings fail loudly at application boundaries instead of silently
-querying arbitrary event names.
+Postgres remains the source of truth. `pg-boss` remains the scheduler and
+background job queue; it is not replaced by runtime pub/sub work. Broker lag or
+downtime cannot lose runtime events because dispatchers recover from the
+outbox. Unknown runtime event filter strings fail loudly at application
+boundaries instead of silently querying arbitrary event names.
+
+Retention, partitioning, and interrupted in-flight run recovery are deferred
+follow-up decisions. Those designs must preserve `runtime_events` as the
+runtime-observable stream and `event_bus_outbox` as the broker boundary.

--- a/docs/decisions/2026-05-18-jsonb-runtime-payload-boundary.md
+++ b/docs/decisions/2026-05-18-jsonb-runtime-payload-boundary.md
@@ -1,0 +1,58 @@
+# JSONB Runtime Payload Boundary
+
+Date: 2026-05-18
+
+## Status
+
+Accepted
+
+## Context
+
+Gantry keeps canonical runtime concepts queryable as typed Postgres columns:
+apps, agents, conversations, threads, messages, sessions, jobs, runs, and
+memory records all expose explicit fields for routing, authorization, leasing,
+resuming, deduplication, auditing, and joins.
+
+Some adapter-owned payload columns were still stored as `text` even though the
+runtime and repositories already treated their contents as structured JSON. That
+forced repository code and expression indexes to cast those values back to
+`jsonb` before filtering, indexing, or validating them.
+
+## Decision
+
+Use native Postgres `jsonb` for JSON-shaped runtime payload columns when the
+payload is adapter-owned, metadata-like, or a value object that repositories
+query, index, validate, or partially update.
+
+Keep canonical runtime state in typed columns. Do not collapse messages,
+sessions, jobs, memory items, permission records, provider connections, or
+conversation bindings into generic JSON blobs.
+
+The first conversion covers the P0 runtime payload columns:
+
+- `messages.external_ref_json`
+- `message_parts.payload_json`
+- `message_attachments.external_ref_json`
+- `provider_sessions.provider_ref_json`
+- `provider_sessions.metadata_json`
+- `agent_session_digests.metadata_json`
+- `control_http_sessions.external_ref_json`
+- `jobs.schedule_json`
+- `jobs.target_json`
+- `memory_items.value_json`
+- `memory_items.source_ref_json`
+
+Migrations cast existing values directly with `column::jsonb`; invalid JSON must
+fail the migration loudly instead of being repaired or silently discarded.
+
+## Consequences
+
+Repository writers for converted columns pass objects or arrays to Drizzle
+`jsonb` columns, not pre-serialized JSON strings. Repository readers may accept
+both parsed objects and legacy string-shaped test mocks at adapter boundaries.
+
+Active code should not cast converted P0 columns back to `jsonb`. Historical
+migrations may retain old casts because they describe earlier schema states.
+
+Deferred payload columns remain `text` until separate focused slices convert
+them with their own migration and verification.


### PR DESCRIPTION
## Summary
- add provider-boundary architecture scanning with exact file/count exceptions for current Anthropic debt
- convert P0 runtime payload columns from text JSON to native Postgres jsonb, including migration/index updates
- harden the Postgres-first event path with durable runtime_events/event_bus_outbox readiness checks
- make runtime event wakeups best-effort at the exchange boundary so missed or failed NOTIFY paths recover by cursor polling
- update architecture docs and guardrail tests to keep pgmq, UNLOGGED pub/sub, and speculative Kafka config out of active runtime surfaces

## Verification
- python3 -m unittest discover -s .codex/scripts/tests -p test_check_architecture.py
- npm run check:architecture
- npm run typecheck
- npm run test:unit -- apps/core/test/unit/adapters/storage/postgres/canonical-job-repository.postgres.test.ts apps/core/test/unit/domain/canonical-domain.test.ts apps/core/test/unit/storage/postgres-migration-journal.test.ts apps/core/test/unit/memory/app-memory-service.test.ts apps/core/test/unit/memory/app-memory-dreaming.test.ts
- npm run test:unit -- apps/core/test/unit/storage/postgres-readiness.test.ts apps/core/test/unit/cli/storage-readiness.test.ts apps/core/test/unit/application/runtime-events/runtime-event-exchange.test.ts apps/core/test/unit/adapters/storage/postgres/runtime-event-notifier.postgres.test.ts apps/core/test/unit/adapters/storage/postgres/runtime-event-repository.postgres.test.ts apps/core/test/unit/architecture/runtime-event-cleanup.test.ts
- GANTRY_TEST_DATABASE_URL=postgres://postgres:postgres@localhost:55432/gantry_test npm run test:integration:postgres -- apps/core/test/integration/postgres-domain-repositories.integration.test.ts apps/core/test/integration/session-continuity-postgres.integration.test.ts apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts
- disposable Docker Postgres with vector + pg_trgm: npm run test:integration:postgres -- apps/core/test/integration/runtime-event-outbox.postgres.integration.test.ts
- python3 .codex/scripts/check_task_completion.py
- git diff --check

Note: the first disposable-Postgres integration attempt hit one concurrent redelivery flake in postgres-domain-repositories; reran on a fresh disposable database and it passed.