### PR TITLE
feat: Add WSL local setup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,29 @@ docker compose --env-file ~/gantry/.env up -d
 gantry setup
 ```
 
+On WSL/Docker Desktop amd64 hosts, use the additive WSL override instead of
+editing the default Compose file:
+
+```bash
+docker compose --env-file ~/gantry/.env -f docker-compose.yml -f docker-compose.wsl.yml up -d
+```
+
+The WSL override keeps the repo default unchanged, uses the multi-platform
+Postgres image tag, and keeps the default Postgres host port `5432`. If another
+local Postgres is already using that port, stop it before starting the Gantry
+Compose stack. For example, on a systemd-enabled WSL distro:
+
+```bash
+sudo systemctl stop postgresql
+```
+
+Then keep the runtime URLs pointed at the default host port:
+
+```env
+GANTRY_DATABASE_URL=postgresql://gantry_app:gantry_app_password@127.0.0.1:5432/gantry?schema=gantry
+ONECLI_DATABASE_URL=postgresql://onecli_app:onecli_app_password@127.0.0.1:5432/gantry?schema=onecli
+```
+
 The Compose file hardcodes the local ports, schema names, and non-secret role names. `~/gantry/.env` only needs local passwords, `SECRET_ENCRYPTION_KEY`, and the runtime connection URLs. Gantry setup does not start Docker or create containers; it asks for `GANTRY_DATABASE_URL` and `ONECLI_DATABASE_URL`, creates the `gantry-model-access` Model Access profile, then writes the non-secret OneCLI gateway URL to `settings.yaml` as `credential_broker.onecli.url`.
 
 If an older local `.env` still contains settings-owned keys such as `GANTRY_CREDENTIAL_MODE`, `ONECLI_URL`, `ANTHROPIC_MODEL`, or `SLACK_PERMISSION_APPROVER_IDS`, move those values into `settings.yaml` and remove them from `.env` before starting the runtime.

--- a/apps/core/src/cli/doctor.ts
+++ b/apps/core/src/cli/doctor.ts
@@ -114,7 +114,7 @@ export function runDoctor(
 
   const nodeMajor = getNodeMajorVersion();
   const nodeVersion = getNodeVersion();
-  if (nodeMajor >= 25) {
+  if (nodeMajor >= 24 && nodeMajor < 26) {
     add(checks, {
       id: 'node-version',
       title: 'Node.js Version',
@@ -126,8 +126,8 @@ export function runDoctor(
       id: 'node-version',
       title: 'Node.js Version',
       status: 'fail',
-      message: `Node ${nodeVersion} detected. Gantry requires Node 25 or newer.`,
-      nextAction: 'Install Node.js 25+ and run `gantry doctor` again.',
+      message: `Node ${nodeVersion} detected. Gantry requires Node >=24 <26.`,
+      nextAction: 'Install Node.js 24 or 25 and run `gantry doctor` again.',
     });
   }
 

--- a/apps/core/src/infrastructure/service/manager.ts
+++ b/apps/core/src/infrastructure/service/manager.ts
@@ -192,6 +192,11 @@ function systemdQuote(value: string, label: string): string {
     .replace(/%/g, '%%')}"`;
 }
 
+function systemdPathValue(value: string, label: string): string {
+  assertSystemdUnitValue(value, label);
+  return value.replace(/%/g, '%%');
+}
+
 function writeSystemdUnit(runtimeHome: string, runtimeEntry: string): string {
   const unitDir = path.join(os.homedir(), '.config', 'systemd', 'user');
   const unitPath = path.join(unitDir, 'gantry.service');
@@ -207,7 +212,7 @@ Environment=${systemdQuote(`GANTRY_HOME=${runtimeHome}`, 'GANTRY_HOME')}
 Environment=${systemdQuote(`HOME=${os.homedir()}`, 'HOME')}
 Environment=${systemdQuote(`PATH=${servicePath}`, 'PATH')}
 ExecStart=${systemdQuote(process.execPath, 'node executable')} ${systemdQuote(runtimeEntry, 'runtime entry')}
-WorkingDirectory=${systemdQuote(runtimeHome, 'runtime home')}
+WorkingDirectory=${systemdPathValue(runtimeHome, 'runtime home')}
 Restart=always
 RestartSec=5
 StandardOutput=${systemdQuote(`append:${runtimeLogPath(runtimeHome)}`, 'runtime log path')}

--- a/apps/core/src/infrastructure/service/package-paths.ts
+++ b/apps/core/src/infrastructure/service/package-paths.ts
@@ -7,7 +7,15 @@ function cliDirFromImportMeta(importMetaUrl: string): string {
 }
 
 export function getDistRoot(importMetaUrl: string): string {
-  return path.resolve(cliDirFromImportMeta(importMetaUrl), '..');
+  const cliDir = cliDirFromImportMeta(importMetaUrl);
+  if (
+    path.basename(cliDir) === 'cli' &&
+    path.basename(path.dirname(cliDir)) === 'src' &&
+    path.basename(path.dirname(path.dirname(cliDir))) === 'core'
+  ) {
+    return path.resolve(cliDir, '../../../..', 'dist');
+  }
+  return path.resolve(cliDir, '..');
 }
 
 export function getPackageRoot(importMetaUrl: string): string {

--- a/apps/core/test/unit/cli/doctor.test.ts
+++ b/apps/core/test/unit/cli/doctor.test.ts
@@ -85,6 +85,8 @@ async function loadDoctor(options?: {
   onecliPersistence?: { status: string; message: string };
   onOnecliConstruct?: (options: unknown) => void;
   runtimeGroupCount?: number;
+  nodeMajor?: number;
+  nodeVersion?: string;
 }) {
   const getContainerConfig = vi.fn(async () => ({
     env: options?.onecliEnv || {},
@@ -102,8 +104,8 @@ async function loadDoctor(options?: {
   vi.doMock('@core/infrastructure/service/platform.js', () => ({
     commandExists: vi.fn(() => true),
     detectPlatform: vi.fn(() => 'macos'),
-    getNodeMajorVersion: vi.fn(() => 25),
-    getNodeVersion: vi.fn(() => '25.0.0'),
+    getNodeMajorVersion: vi.fn(() => options?.nodeMajor ?? 25),
+    getNodeVersion: vi.fn(() => options?.nodeVersion ?? '25.0.0'),
     hasSystemdUser: vi.fn(() => false),
   }));
   vi.doMock('@core/adapters/storage/postgres/storage-readiness.js', () => ({
@@ -148,6 +150,43 @@ afterEach(() => {
 });
 
 describe('doctor', () => {
+  it('accepts Node 24 because package engines support Node >=24 <26', async () => {
+    const runtimeHome = makeRuntimeHome([
+      'GANTRY_DATABASE_URL=postgres://gantry_app:pass@localhost:15432/gantry',
+    ]);
+    const { runDoctor } = await loadDoctor({
+      nodeMajor: 24,
+      nodeVersion: '24.12.0',
+    });
+
+    const report = runDoctor(import.meta.url, runtimeHome);
+    const check = report.checks.find((entry) => entry.id === 'node-version');
+
+    expect(check).toMatchObject({
+      status: 'pass',
+      message: 'Node 24.12.0 detected.',
+    });
+  });
+
+  it('rejects Node versions outside the supported engine range', async () => {
+    const runtimeHome = makeRuntimeHome([
+      'GANTRY_DATABASE_URL=postgres://gantry_app:pass@localhost:15432/gantry',
+    ]);
+    const { runDoctor } = await loadDoctor({
+      nodeMajor: 26,
+      nodeVersion: '26.0.0',
+    });
+
+    const report = runDoctor(import.meta.url, runtimeHome);
+    const check = report.checks.find((entry) => entry.id === 'node-version');
+
+    expect(check).toMatchObject({
+      status: 'fail',
+      message: 'Node 26.0.0 detected. Gantry requires Node >=24 <26.',
+      nextAction: 'Install Node.js 24 or 25 and run `gantry doctor` again.',
+    });
+  });
+
   it('fails external model access when the broker endpoint is missing', async () => {
     const runtimeHome = makeRuntimeHome([
       'GANTRY_DATABASE_URL=postgres://gantry_app:pass@localhost:15432/gantry',

--- a/apps/core/test/unit/cli/service-manager.test.ts
+++ b/apps/core/test/unit/cli/service-manager.test.ts
@@ -100,7 +100,7 @@ describe('service manager background start', () => {
     expect(unit).not.toContain('ExecStartPre=');
     expect(unit).not.toContain('--local-services-start');
     expect(unit).toContain('Environment="GANTRY_HOME=');
-    expect(unit).toContain('WorkingDirectory="');
+    expect(unit).toContain(`WorkingDirectory=${runtimeHome}`);
     expect(unit).toContain('StandardOutput="append:');
   });
 

--- a/apps/core/test/unit/infrastructure/package-paths.test.ts
+++ b/apps/core/test/unit/infrastructure/package-paths.test.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getDistRoot,
+  getPackageRoot,
+  getRuntimeEntryPath,
+} from '@core/infrastructure/service/package-paths.js';
+
+describe('service package paths', () => {
+  it('resolves package dist paths from built CLI import URLs', () => {
+    const packageRoot = path.join('/tmp', 'gantry-package');
+    const importMetaUrl = pathToFileURL(
+      path.join(packageRoot, 'dist', 'cli', 'index.js'),
+    ).href;
+
+    expect(getDistRoot(importMetaUrl)).toBe(path.join(packageRoot, 'dist'));
+    expect(getPackageRoot(importMetaUrl)).toBe(packageRoot);
+    expect(getRuntimeEntryPath(importMetaUrl)).toBe(
+      path.join(packageRoot, 'dist', 'index.js'),
+    );
+  });
+
+  it('resolves package dist paths from dev checkout CLI import URLs', () => {
+    const packageRoot = path.join('/tmp', 'Agent.Gantry');
+    const importMetaUrl = pathToFileURL(
+      path.join(packageRoot, 'apps', 'core', 'src', 'cli', 'index.ts'),
+    ).href;
+
+    expect(getDistRoot(importMetaUrl)).toBe(path.join(packageRoot, 'dist'));
+    expect(getPackageRoot(importMetaUrl)).toBe(packageRoot);
+    expect(getRuntimeEntryPath(importMetaUrl)).toBe(
+      path.join(packageRoot, 'dist', 'index.js'),
+    );
+  });
+});

--- a/docker-compose.wsl.yml
+++ b/docker-compose.wsl.yml
@@ -1,0 +1,7 @@
+services:
+  postgres:
+    # WSL/Docker Desktop amd64 hosts can fail on the pinned arm64 digest used by
+    # the default compose file. This opt-in override keeps the normal compose
+    # contract unchanged while using the multi-platform tag locally.
+    image: pgvector/pgvector:0.8.2-pg16-trixie
+    platform: linux/amd64


### PR DESCRIPTION
## Summary

  Adds an opt-in WSL/Docker Desktop local setup path while keeping the default Compose behavior unchanged.

  This fixes the local setup issues found while running Gantry from a WSL Arch checkout:
  - Docker/Postgres platform mismatch with the pinned default image digest
  - `gantry doctor` incorrectly rejecting Node 24
  - Runtime file detection looking in the wrong path when running from a local repo checkout
  - systemd user service generating an invalid quoted `WorkingDirectory`

  ## Changed Files

  ### `docker-compose.wsl.yml`

  Added a WSL-specific Compose override.

  What changed:
  - Uses the multi-platform Postgres image tag:
    `pgvector/pgvector:0.8.2-pg16-trixie`
  - Sets:
    `platform: linux/amd64`

  Why:
  - On WSL/Docker Desktop amd64, the default pinned Postgres image digest can resolve with a platform mismatch.
  - This override is opt-in and does not modify the default `docker-compose.yml`.

  ### `README.md`

  Added WSL setup instructions.

  What changed:
  - Documents running Compose with:
    `-f docker-compose.yml -f docker-compose.wsl.yml`
  - Documents that the WSL override keeps the default Postgres host port `5432`.
  - Adds guidance to stop an existing local Postgres service if it is already using `5432`.

  Why:
  - WSL users need a clear setup path without editing the default Compose file.
  - The repo should keep the same default DB port behavior instead of silently moving WSL users to a different port.

  ### `apps/core/src/cli/doctor.ts`

  Fixed Node.js version validation.

  What changed:
  - Doctor now accepts Node `>=24 <26`.
  - Failure message now matches the supported engine range.

  Why:
  - The repo supports Node `>=24 <26`, but doctor incorrectly required Node 25+.
  - This caused valid Node 24 installs to fail doctor.

  ### `apps/core/src/infrastructure/service/package-paths.ts`

  Fixed runtime path resolution for local repo checkouts.

  What changed:
  - Detects the dev checkout CLI path:
    `apps/core/src/cli`
  - Resolves the runtime entry to:
    `dist/index.js`

  Why:
  - Doctor was looking for:
    `apps/core/src/index.js`
  - In a built local checkout, the runtime entry is:
    `dist/index.js`
  - This caused false “runtime entry missing” doctor failures.

  ### `apps/core/src/infrastructure/service/manager.ts`

  Fixed generated systemd user service formatting.

  What changed:
  - Added a separate systemd path formatter for `WorkingDirectory`.
  - `WorkingDirectory` is now emitted unquoted:
    `WorkingDirectory=/home/...`

  Why:
  - systemd does not accept `WorkingDirectory` in the same quoted format used for `Environment` and `ExecStart`.
  - The old generated unit could fail to start on systemd-enabled WSL/Linux.

  ### `apps/core/test/unit/cli/doctor.test.ts`

  Added coverage for Node version behavior.

  What changed:
  - Added a test that Node 24 passes doctor.
  - Added a test that Node 26 fails doctor.

  Why:
  - Prevents regression between package engine support and doctor validation.

  ### `apps/core/test/unit/cli/service-manager.test.ts`

  Updated service manager test expectation.

  What changed:
  - The test now expects:
    `WorkingDirectory=<runtimeHome>`
  - It no longer expects a quoted `WorkingDirectory`.

  Why:
  - Matches the corrected systemd service file format.

  ### `apps/core/test/unit/infrastructure/package-paths.test.ts`

  Added direct tests for package path resolution.

  What changed:
  - Tests built package layout:
    `dist/cli/index.js -> dist/index.js`
  - Tests dev checkout layout:
    `apps/core/src/cli/index.ts -> dist/index.js`

  Why:
  - Covers the runtime path fix that prevents false doctor failures in local checkouts.

  ## Verification

  - `docker compose --env-file ~/gantry/.env -f docker-compose.yml -f docker-compose.wsl.yml config`
  - `npm exec vitest -- run -c vitest.unit.config.ts apps/core/test/unit/cli/doctor.test.ts apps/core/test/unit/cli/service-manager.test.ts apps/core/test/unit/infrastructure/package-
  paths.test.ts`
  - `npm run build`
  - `python3 .codex/scripts/check_architecture.py`
  - `python3 .codex/scripts/check_task_completion.py`
