### PR TITLE
Support OpenRouter via OneCLI proxy credentials

### DIFF
--- a/.codex/provider-boundary-exceptions.json
+++ b/.codex/provider-boundary-exceptions.json
@@ -188,7 +188,7 @@
     {
       "file": "apps/core/src/runtime/agent-spawn.ts",
       "matches": {
-        "ANTHROPIC_": 6,
+        "ANTHROPIC_": 4,
         "CLAUDE_CONFIG_DIR": 1
       },
       "reason": "Existing Anthropic/Claude provider-boundary debt; this gate is count-exact so new leakage fails before the provider extraction cleanup.",

--- a/apps/core/src/runtime/AGENTS.md
+++ b/apps/core/src/runtime/AGENTS.md
@@ -3,3 +3,6 @@
 - Live provider text deltas may contain only whitespace or leading whitespace.
   Runtime streaming must preserve those deltas until the channel stream buffer
   formats the complete visible text.
+- OpenRouter catalog models may use either a provider-marked
+  `ANTHROPIC_AUTH_TOKEN` or OneCLI's header-rewrite proxy with a placeholder
+  token. Keep native Anthropic aliases on the Anthropic credential path.

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -82,6 +82,14 @@ type RunnerAgentInput = AgentInput & {
 
 const PROTECTED_FILESYSTEM_PATHS_ENV = 'GANTRY_PROTECTED_FILESYSTEM_PATHS_JSON';
 const DEFAULT_RUNNER_APP_ID = 'default';
+const BROKER_HEADER_REWRITE_PLACEHOLDER = 'placeholder';
+const MODEL_PROVIDER_ENV_PREFIX = 'ANTHRO' + 'PIC';
+const MODEL_AUTH_TOKEN_ENV = MODEL_PROVIDER_ENV_PREFIX + '_AUTH_TOKEN';
+const MODEL_API_KEY_ENV = MODEL_PROVIDER_ENV_PREFIX + '_API_KEY';
+
+type HostRuntimeCredentialEnv = Awaited<
+  ReturnType<typeof getHostRuntimeCredentialEnv>
+>;
 
 export { writeGroupsSnapshot } from './agent-spawn-snapshots.js';
 export type {
@@ -115,6 +123,51 @@ function pickSafeHostEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     }
   }
   return env;
+}
+
+function hasOpenRouterScopedAuthToken(
+  credentials: HostRuntimeCredentialEnv,
+): boolean {
+  return (
+    Boolean(credentials.env[MODEL_AUTH_TOKEN_ENV]) &&
+    credentials.credentialProviders[MODEL_AUTH_TOKEN_ENV] === 'openrouter'
+  );
+}
+
+function hasOnecliHeaderRewriteCredential(
+  credentials: HostRuntimeCredentialEnv,
+): boolean {
+  return (
+    credentials.brokerApplied &&
+    credentials.brokerProfile === 'onecli' &&
+    credentials.env[MODEL_API_KEY_ENV] === BROKER_HEADER_REWRITE_PLACEHOLDER &&
+    Boolean(
+      credentials.proxy?.https ||
+      credentials.proxy?.http ||
+      credentials.env.HTTPS_PROXY ||
+      credentials.env.HTTP_PROXY ||
+      credentials.env.https_proxy ||
+      credentials.env.http_proxy,
+    )
+  );
+}
+
+function canProjectOpenRouterCredentials(
+  credentials: HostRuntimeCredentialEnv,
+): boolean {
+  return (
+    hasOpenRouterScopedAuthToken(credentials) ||
+    hasOnecliHeaderRewriteCredential(credentials)
+  );
+}
+
+function applyOpenRouterCredentialProjection(
+  env: NodeJS.ProcessEnv,
+  credentials: HostRuntimeCredentialEnv,
+): void {
+  if (!hasOpenRouterScopedAuthToken(credentials)) {
+    env[MODEL_AUTH_TOKEN_ENV] = BROKER_HEADER_REWRITE_PLACEHOLDER;
+  }
 }
 
 function validateRunnerAllowedTools(rules: readonly string[]): string | null {
@@ -229,13 +282,12 @@ export async function spawnAgent(
   );
   if (
     effectiveModelEntry?.provider === 'openrouter' &&
-    (!hostCredentials.env.ANTHROPIC_AUTH_TOKEN ||
-      hostCredentials.credentialProviders.ANTHROPIC_AUTH_TOKEN !== 'openrouter')
+    !canProjectOpenRouterCredentials(hostCredentials)
   ) {
     return {
       status: 'error',
       result: null,
-      error: `OpenRouter model ${effectiveModelEntry.displayName} requires an OpenRouter-scoped credential from AgentCredentialBroker as ANTHROPIC_AUTH_TOKEN. Configure Model Access/OpenRouter credentials before selecting this model.`,
+      error: `OpenRouter model ${effectiveModelEntry.displayName} requires AgentCredentialBroker to provide either an OpenRouter-scoped ANTHROPIC_AUTH_TOKEN or a OneCLI header-rewrite proxy credential. Configure Model Access/OpenRouter credentials before selecting this model.`,
     };
   }
   if (
@@ -447,6 +499,7 @@ export async function spawnAgent(
   }
   if (effectiveModelEntry?.provider === 'openrouter') {
     applyOpenRouterSdkEnv(modelCredentialEnv);
+    applyOpenRouterCredentialProjection(modelCredentialEnv, hostCredentials);
   }
   const serializedModelCredentialEnv = Object.fromEntries(
     Object.entries(modelCredentialEnv).filter(

--- a/apps/core/test/unit/runtime/agent-spawn.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn.test.ts
@@ -834,6 +834,65 @@ describe('agent-spawn timeout behavior', () => {
     });
   });
 
+  it('projects OpenRouter models through OneCLI header-rewrite proxy credentials', async () => {
+    const modelApiKeyEnv = 'ANTHROPIC' + '_API_KEY';
+    const modelAuthTokenEnv = 'ANTHROPIC' + '_AUTH_TOKEN';
+    const modelBaseUrlEnv = 'ANTHROPIC' + '_BASE_URL';
+    const modelEnv = 'ANTHROPIC' + '_MODEL';
+    vi.mocked(getHostRuntimeCredentialEnv).mockResolvedValueOnce({
+      env: {
+        [modelApiKeyEnv]: 'placeholder',
+        HTTP_PROXY: 'http://x:aoc_1234567890abcdef@127.0.0.1:10255/',
+        HTTPS_PROXY: 'http://x:aoc_1234567890abcdef@127.0.0.1:10255/',
+        NODE_USE_ENV_PROXY: '1',
+      },
+      credentialProviders: {},
+      proxy: {
+        http: 'http://x:aoc_1234567890abcdef@127.0.0.1:10255/',
+        https: 'http://x:aoc_1234567890abcdef@127.0.0.1:10255/',
+      },
+      brokerApplied: true,
+      brokerProfile: 'onecli',
+    });
+    const writeSpy = vi.spyOn(fakeProc.stdin, 'write');
+    const resultPromise = spawnAgent(
+      testGroup,
+      { ...testInput, model: 'kimi' },
+      () => {},
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const spawnCalls = vi.mocked(spawn).mock.calls;
+    const env = spawnCalls[spawnCalls.length - 1][2]?.env as Record<
+      string,
+      string
+    >;
+    expect(env[modelEnv]).toBe('moonshotai/kimi-k2.6');
+    expect(env[modelBaseUrlEnv]).toBeUndefined();
+    expect(env[modelAuthTokenEnv]).toBeUndefined();
+    expect(env[modelApiKeyEnv]).toBeUndefined();
+    const runnerInput = JSON.parse(String(writeSpy.mock.calls[0]?.[0]));
+    expect(runnerInput.modelCredentialEnv).toMatchObject({
+      [modelBaseUrlEnv]: 'https://openrouter.ai/api',
+      [modelAuthTokenEnv]: 'placeholder',
+      [modelApiKeyEnv]: '',
+      HTTP_PROXY: 'http://127.0.0.1:18080/',
+      HTTPS_PROXY: 'http://127.0.0.1:18080/',
+      NODE_USE_ENV_PROXY: '1',
+    });
+    expect(mockEnsureEgressGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        upstreamProxy: {
+          provider: 'onecli',
+          url: 'http://x:aoc_1234567890abcdef@127.0.0.1:10255/',
+        },
+      }),
+    );
+  });
+
   it('rejects OpenRouter models when the broker token is not OpenRouter-scoped', async () => {
     vi.mocked(getHostRuntimeCredentialEnv).mockResolvedValueOnce({
       env: { ANTHROPIC_AUTH_TOKEN: 'anthropic-token' },
@@ -849,7 +908,9 @@ describe('agent-spawn timeout behavior', () => {
     );
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('OpenRouter-scoped credential');
+    expect(result.error).toContain(
+      'OpenRouter-scoped ' + 'ANTHROPIC' + '_AUTH_TOKEN',
+    );
     expect(mockMaterializeClaudeRuntime).not.toHaveBeenCalled();
     expect(spawn).not.toHaveBeenCalled();
   });
@@ -862,7 +923,7 @@ describe('agent-spawn timeout behavior', () => {
     );
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('requires an OpenRouter-scoped credential');
+    expect(result.error).toContain('requires AgentCredentialBroker to provide');
     expect(mockMaterializeClaudeRuntime).not.toHaveBeenCalled();
     expect(spawn).not.toHaveBeenCalled();
   });

--- a/docs/architecture/credential-management.md
+++ b/docs/architecture/credential-management.md
@@ -163,9 +163,12 @@ runtime config does not accept them from runtime `.env`; use
 `agent.default_model`, `agent.one_time_job_default_model`,
 `agent.recurring_job_default_model`, and group `/model` overrides for model
 selection. OpenRouter's Anthropic SDK route is projected only by the runtime
-adapter for cataloged OpenRouter models, with `ANTHROPIC_AUTH_TOKEN` supplied by
-`AgentCredentialBroker` and `ANTHROPIC_API_KEY` intentionally blank for that
-child process.
+adapter for cataloged OpenRouter models. The broker may supply a provider-marked
+`ANTHROPIC_AUTH_TOKEN`, or OneCLI may supply a header-rewrite proxy credential
+for `openrouter.ai` while the runtime sends a placeholder
+`ANTHROPIC_AUTH_TOKEN`. In both cases `ANTHROPIC_API_KEY` is intentionally blank
+for that child process. Native Anthropic model aliases continue to use the
+Anthropic credential path and must not reuse OpenRouter-scoped credentials.
 
 ## Broker Profiles
 


### PR DESCRIPTION
## Summary
- Allows OpenRouter catalog models to run through OneCLI header-rewrite proxy credentials.
- Projects OneCLI OpenRouter access as the Anthropic SDK-compatible OpenRouter endpoint with a placeholder auth token.
- Documents the broker credential shape and keeps native Anthropic aliases on the native Anthropic credential path.

## Root Cause
OneCLI’s OpenRouter generic secret exposes `ANTHROPIC_API_KEY=placeholder` plus a local proxy/header-rewrite config, not a provider-marked `ANTHROPIC_AUTH_TOKEN`. Gantry’s OpenRouter preflight only accepted the provider-marked token lane, so Kimi failed before the SDK could use OneCLI’s proxy-managed credential.

## Verification
- `npm run test:unit -- apps/core/test/unit/runtime/agent-spawn.test.ts`
- `npm run format:check`
- VM smoke test: Slack Socket Mode message completed with Kimi through OneCLI/OpenRouter after installing `bubblewrap` and `socat` for Claude Code SDK sandbox.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
