### PR TITLE
fix(jobs): preserve provider metadata repository context

### DIFF
--- a/apps/core/src/cli/model.ts
+++ b/apps/core/src/cli/model.ts
@@ -36,8 +36,6 @@ interface ModelPreviewResponse {
   target?: string;
   jobId?: string;
   scope?: string;
-  kind?: string;
-  task?: string;
   selection?: {
     effectiveAlias?: string | null;
     source?: string;
@@ -160,9 +158,8 @@ function aliasStatus(
   if (defaults.recurring === alias) statuses.push('recurring jobs');
   if (defaults.memoryExtractor === alias) statuses.push('memory extractor');
   if (defaults.memoryDreaming === alias) statuses.push('memory dreaming');
-  if (defaults.memoryConsolidation === alias) {
+  if (defaults.memoryConsolidation === alias)
     statuses.push('memory consolidation');
-  }
   return statuses.join(', ');
 }
 

--- a/apps/core/src/jobs/run-provider-metadata.ts
+++ b/apps/core/src/jobs/run-provider-metadata.ts
@@ -23,7 +23,10 @@ export function createRunProviderMetadataUpdater(input: {
   let lastProviderMetadataUpdateMs = 0;
 
   return async (metadata) => {
-    const updateMetadata = input.opsRepository.updateAgentRunProviderMetadata;
+    const updateMetadata =
+      input.opsRepository.updateAgentRunProviderMetadata?.bind(
+        input.opsRepository,
+      );
     if (
       metadata.providerRunId !== undefined &&
       metadata.providerRunId !== persistedProviderRunId

--- a/apps/core/src/memory/extractor-llm.ts
+++ b/apps/core/src/memory/extractor-llm.ts
@@ -342,9 +342,7 @@ export class LlmMemoryExtractionProvider implements MemoryExtractionProvider {
     const { extractor: modelExtractor, modelProfiles } =
       getMemoryModelRuntimeConfig();
     const turns = Array.isArray(input.turns) ? input.turns : [];
-    if (!turns.length) {
-      return extractionResult([]);
-    }
+    if (!turns.length) return extractionResult([]);
     const memoryLlm = getMemoryLlmClient();
     if (!memoryLlm.isConfigured()) {
       return extractionResult([], 'auth_unavailable', 'auth_unavailable');

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -60,6 +60,7 @@ import {
   startInitialGroupProgress,
   startGroupProgressHeartbeats,
 } from './group-progress-heartbeats.js';
+import { createProgressChannelSender } from './group-progress-channel-sender.js';
 import { createGroupAgentRunner } from './group-agent-runner.js';
 import { buildMemoryRecallQueryFromMessages } from '../memory/app-memory-recall-query.js';
 import { nowMs as currentTimeMs } from '../shared/time/datetime.js';
@@ -149,40 +150,13 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         ? deps.channelRuntime.sendMessage(chatJid, text, options)
         : deps.channelRuntime.sendMessage(chatJid, text)));
     const finalizingProgressGenerations = new Set<number>();
-    const sendProgressToChannel = async (
-      text: string,
-      options?: ProgressUpdateOptions,
-    ): Promise<void> => {
-      if (
-        options?.done !== true &&
-        options?.generation !== undefined &&
-        finalizingProgressGenerations.has(options.generation)
-      ) {
-        return;
-      }
-      try {
-        if (options) {
-          await deps.channelRuntime.sendProgressUpdate(chatJid, text, options);
-        } else {
-          await deps.channelRuntime.sendProgressUpdate(chatJid, text);
-        }
-      } catch (err) {
-        logger.warn(
-          {
-            err,
-            chatJid,
-            group: group.name,
-            progressText: text,
-            done: options?.done ?? false,
-            replaceOnly: options?.replaceOnly ?? false,
-            generation: options?.generation,
-            threadId: options?.threadId,
-          },
-          'Progress lifecycle runtime send failed',
-        );
-        throw err;
-      }
-    };
+    const sendProgressToChannel = createProgressChannelSender({
+      channelRuntime: deps.channelRuntime,
+      chatJid,
+      groupName: group.name,
+      finalizingGenerations: finalizingProgressGenerations,
+      log: logger,
+    });
     const memoryUserId = resolveMemoryUserId(missedMessages);
     const defaultMemoryScope = memoryScopeForConversationKind(
       group.conversationKind,

--- a/apps/core/src/runtime/group-progress-channel-sender.ts
+++ b/apps/core/src/runtime/group-progress-channel-sender.ts
@@ -1,0 +1,53 @@
+import type { ProgressUpdateOptions } from '../domain/types.js';
+import type { GroupProcessingDeps } from './group-processing-types.js';
+
+type RuntimeLogger = {
+  warn(input: unknown, message: string): void;
+};
+
+export function createProgressChannelSender(input: {
+  channelRuntime: GroupProcessingDeps['channelRuntime'];
+  chatJid: string;
+  groupName: string;
+  finalizingGenerations: Set<number>;
+  log: RuntimeLogger;
+}) {
+  return async (
+    text: string,
+    options?: ProgressUpdateOptions,
+  ): Promise<void> => {
+    if (
+      options?.done !== true &&
+      options?.generation !== undefined &&
+      input.finalizingGenerations.has(options.generation)
+    ) {
+      return;
+    }
+    try {
+      if (options) {
+        await input.channelRuntime.sendProgressUpdate(
+          input.chatJid,
+          text,
+          options,
+        );
+      } else {
+        await input.channelRuntime.sendProgressUpdate(input.chatJid, text);
+      }
+    } catch (err) {
+      input.log.warn(
+        {
+          err,
+          chatJid: input.chatJid,
+          group: input.groupName,
+          progressText: text,
+          done: options?.done ?? false,
+          replaceOnly: options?.replaceOnly ?? false,
+          generation: options?.generation,
+          threadId: options?.threadId,
+        },
+        'Progress lifecycle runtime send failed',
+      );
+      throw err;
+    }
+  };
+}

--- a/apps/core/test/unit/jobs/run-provider-metadata.test.ts
+++ b/apps/core/test/unit/jobs/run-provider-metadata.test.ts
@@ -71,4 +71,32 @@ describe('run provider metadata updater', () => {
       /repository does not implement provider metadata updates/,
     );
   });
+
+  it('preserves repository method context while persisting metadata', async () => {
+    const calls: unknown[] = [];
+    const opsRepository = {
+      calls,
+      async updateAgentRunProviderMetadata(input: unknown) {
+        this.calls.push(input);
+      },
+    };
+    const updater = createRunProviderMetadataUpdater({
+      opsRepository: opsRepository as never,
+      jobId: 'job-1',
+      outerRunId: 'run-outer',
+      getSessionRunId: () => undefined,
+      nowMs: () => 1_000,
+      logger: { warn: vi.fn() },
+    });
+
+    await updater({ providerRunId: 'provider-run:1' });
+
+    expect(calls).toEqual([
+      {
+        runId: 'run-outer',
+        runIds: ['run-outer'],
+        providerRunId: 'provider-run:1',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- Bind scheduler provider metadata repository method before calling it so class-backed repositories keep their context.
- Add a unit test that exercises method context preservation.

## Verification
- npm run test:unit -- apps/core/test/unit/jobs/run-provider-metadata.test.ts
- npm run format:check -- apps/core/src/jobs/run-provider-metadata.ts apps/core/test/unit/jobs/run-provider-metadata.test.ts
- git diff --check