### PR TITLE
[codex] fix runtime memory and stopped-run handling

### DIFF
--- a/.codex/architecture-exceptions.json
+++ b/.codex/architecture-exceptions.json
@@ -1196,13 +1196,6 @@
     "removeByPhase": "canonical-boundary-cleanup-phase"
   },
   {
-    "file": "apps/core/src/runtime/execution-provider-id.ts",
-    "rule": "provider_specific_path",
-    "reason": "Runtime test fallback stores the current execution adapter id as projection metadata; production selection still resolves through the adapter id.",
-    "removeByPhase": "execution-provider-registry-composition",
-    "maxViolations": 2
-  },
-  {
     "file": "apps/core/src/session/index.ts",
     "rule": "wrapper_only_file",
     "reason": "Baseline wrapper-only export surface kept temporarily for package/import compatibility during the canonical module cleanup.",

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/agent-capabilities.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/agent-capabilities.ts
@@ -176,8 +176,8 @@ const gantryMcpProvider: AgentCapabilityProvider = {
       GANTRY_CHAT_JID: ctx.chatJid,
       GANTRY_WORKSPACE_KEY: ctx.workspaceFolder,
       GANTRY_THREAD_ID: ctx.threadId || '',
-      GANTRY_JOB_ID: ctx.jobId || '',
-      GANTRY_JOB_RUN_ID: ctx.runId || '',
+      ...(ctx.jobId ? { GANTRY_JOB_ID: ctx.jobId } : {}),
+      ...(ctx.runId ? { GANTRY_JOB_RUN_ID: ctx.runId } : {}),
       GANTRY_MEMORY_USER_ID: ctx.memoryUserId || '',
       GANTRY_MEMORY_DEFAULT_SCOPE: ctx.memoryDefaultScope || 'group',
       GANTRY_MEMORY_REVIEWER_IS_CONTROL_APPROVER:

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/execution-adapter.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/execution-adapter.ts
@@ -32,8 +32,18 @@ const GANTRY_EFFECTIVE_MODEL_SOURCE_ENV = 'GANTRY_EFFECTIVE_MODEL_SOURCE';
 const GANTRY_MCP_SERVER_PATH_ENV = 'GANTRY_MCP_SERVER_PATH';
 const GANTRY_SKILL_ACTIONS_ENV = 'GANTRY_SKILL_ACTIONS_JSON';
 
+function claudeCodeToolTempDirLeaf(): string {
+  return process.platform === 'win32'
+    ? 'claude'
+    : `claude-${process.getuid?.() ?? 0}`;
+}
+
 export class AnthropicClaudeAgentExecutionAdapter implements AgentExecutionAdapter {
   readonly id = 'anthropic:claude-agent-sdk' as AgentExecutionProviderId;
+
+  isMissingProviderSessionError(error: string | undefined): boolean {
+    return /\bNo conversation found with session ID\b/i.test(error ?? '');
+  }
 
   async prepare(
     input: AgentExecutionAdapterPrepareInput,
@@ -140,7 +150,15 @@ export class AnthropicClaudeAgentExecutionAdapter implements AgentExecutionAdapt
       providerId: this.id,
       runnerPath,
       runnerArgs: [runnerPath],
+      runtimeConfigDir: materialization.claudeConfigDir,
       runnerInputPatch,
+      sandboxRuntime: {
+        toolTempDirLeaf: claudeCodeToolTempDirLeaf(),
+        tempEnv: (runnerTempDir) => ({
+          CLAUDE_CODE_TMPDIR: runnerTempDir,
+          CLAUDE_TMPDIR: runnerTempDir,
+        }),
+      },
       env,
       protectedFilesystemPaths: materialization.protectedFilesystemPaths,
       protectedFilesystemDenyReadPaths:

--- a/apps/core/src/application/agent-execution/agent-execution-adapter.ts
+++ b/apps/core/src/application/agent-execution/agent-execution-adapter.ts
@@ -34,7 +34,7 @@ export interface AgentExecutionRunInput {
   memoryReviewerIsControlApprover?: boolean;
   persona?: AgentPersona;
   browserProfileName?: string;
-  allowedTools?: string[];
+  toolPolicyRules?: string[];
   attachedSkillSourceIds?: string[];
   selectedSkillDisplays?: string[];
   attachedMcpSourceIds?: string[];
@@ -106,10 +106,15 @@ export interface PreparedAgentExecution {
   providerId: AgentExecutionProviderId;
   runnerPath: string;
   runnerArgs: string[];
+  runtimeConfigDir?: string;
   runnerInputPatch?: {
     modelCredentialEnv?: Record<string, string>;
     toolNetworkEnv?: Record<string, string>;
     semanticCapabilities?: SemanticCapabilityDefinition[];
+  };
+  sandboxRuntime?: {
+    toolTempDirLeaf?: string;
+    tempEnv?: (runnerTempDir: string) => NodeJS.ProcessEnv;
   };
   env: NodeJS.ProcessEnv;
   protectedFilesystemPaths: string[];
@@ -121,6 +126,7 @@ export interface PreparedAgentExecution {
 
 export interface AgentExecutionAdapter {
   readonly id: AgentExecutionProviderId;
+  isMissingProviderSessionError?(error: string | undefined): boolean;
   prepare(
     input: AgentExecutionAdapterPrepareInput,
   ): Promise<PreparedAgentExecution>;

--- a/apps/core/src/application/jobs/job-model-resolution.ts
+++ b/apps/core/src/application/jobs/job-model-resolution.ts
@@ -1,4 +1,5 @@
 import type { Job } from '../../domain/types.js';
+import type { ExecutionProviderId } from '../../domain/sessions/sessions.js';
 import {
   resolveModelSelectionForWorkload,
   type ModelCatalogEntry,
@@ -15,6 +16,7 @@ export interface ResolvedJobModel {
   source: string;
   resolution?: ModelResolution;
   entry?: ModelCatalogEntry;
+  defaultExecutionProviderId?: ExecutionProviderId;
 }
 
 export function modelUseKindForJobSchedule(
@@ -33,11 +35,29 @@ export function jobModelWorkloadForSchedule(
     : 'one_time_job';
 }
 
+export function resolveDefaultJobExecutionProviderId(
+  scheduleType: Job['schedule_type'],
+): ExecutionProviderId | undefined {
+  const resolution = resolveModelSelectionForWorkload(
+    'opus',
+    jobModelWorkloadForSchedule(scheduleType),
+  );
+  return resolution.ok
+    ? (resolution.entry.executionProviderId as ExecutionProviderId)
+    : undefined;
+}
+
 export function resolveJobModel(
   job: Pick<Job, 'model' | 'schedule_type'>,
   defaultConfig: JobModelDefaultConfig,
 ): ResolvedJobModel {
   const selectedModel = job.model || defaultConfig.model;
+  const defaultResolution = defaultConfig.model
+    ? resolveModelSelectionForWorkload(
+        defaultConfig.model,
+        jobModelWorkloadForSchedule(job.schedule_type),
+      )
+    : undefined;
   const resolution = selectedModel
     ? resolveModelSelectionForWorkload(
         selectedModel,
@@ -49,5 +69,8 @@ export function resolveJobModel(
     source: job.model ? 'job.model' : defaultConfig.source,
     resolution,
     entry: resolution?.ok ? resolution.entry : undefined,
+    defaultExecutionProviderId: defaultResolution?.ok
+      ? (defaultResolution.entry.executionProviderId as ExecutionProviderId)
+      : undefined,
   };
 }

--- a/apps/core/src/channels/permission-interaction.ts
+++ b/apps/core/src/channels/permission-interaction.ts
@@ -27,7 +27,10 @@ import {
   PERSISTENT_RULE_APPROVAL_MAX_RULES,
 } from './permission-decision.js';
 import { escapeMarkdownFenceDelimiters } from './permission-fenced-content.js';
-import { formatPermissionToolInputLines } from './permission-tool-input-format.js';
+import {
+  formatPermissionToolInputLines,
+  runtimeDisplayCommand,
+} from './permission-tool-input-format.js';
 
 export {
   decisionForMode,
@@ -59,8 +62,6 @@ const USER_FACING_TOOL_LABELS: Record<string, string> = {
   Agent: 'agent delegation',
   Task: 'agent delegation',
 };
-
-export type PermissionActionToken = PermissionApprovalDecisionMode;
 
 export function normalizePermissionAction(
   action: string,
@@ -655,9 +656,14 @@ function formatPermissionReceiptActionSummary(
   }
   const command = permissionCommand(request);
   if (command) {
-    const generatedSkillPath = generatedRuntimeSkillPathDisplay(command);
+    const displayCommand = runtimeDisplayCommand(command);
+    const generatedSkillPath = generatedRuntimeSkillPathDisplay(
+      displayCommand.command,
+    );
     if (generatedSkillPath) {
-      return `Selected skill action (${generatedSkillPath})`;
+      const env = displayCommand.runtimeEnvAssignments.join(' ');
+      const envSummary = env ? `; env: ${sanitizeReceiptDetail(env)}` : '';
+      return `Selected skill action (${generatedSkillPath}${envSummary})`;
     }
     const safeCommand = sanitizeReceiptDetail(command);
     return safeCommand ? `Command (${safeCommand})` : 'Command';

--- a/apps/core/src/channels/permission-tool-input-format.ts
+++ b/apps/core/src/channels/permission-tool-input-format.ts
@@ -31,6 +31,29 @@ function isInternalPlumbingKey(key: string): boolean {
 }
 const REDACTION_MARKER_PATTERN =
   /\[REDACTED_(?:SECRET|POTENTIALLY_SENSITIVE)\]/;
+const RUNTIME_ENV_ASSIGNMENT_KEYS = new Set([
+  'GODEBUG',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'FTP_PROXY',
+  'ftp_proxy',
+  'RSYNC_PROXY',
+  'DOCKER_HTTP_PROXY',
+  'DOCKER_HTTPS_PROXY',
+  'CLOUDSDK_PROXY_TYPE',
+  'CLOUDSDK_PROXY_ADDRESS',
+  'CLOUDSDK_PROXY_PORT',
+  'GRPC_PROXY',
+  'grpc_proxy',
+  'GIT_SSH_COMMAND',
+  'NODE_USE_ENV_PROXY',
+  'NO_PROXY',
+  'no_proxy',
+]);
 
 type PermissionTextSanitizer = (
   input: string,
@@ -46,25 +69,39 @@ export function formatPermissionToolInputLines(
   if (!request.toolInput || typeof request.toolInput !== 'object') return [];
   const input = request.toolInput;
   if (typeof input.command === 'string' && input.command.trim()) {
+    const displayCommand = runtimeDisplayCommand(input.command.trim());
     const generatedSkillPath = generatedRuntimeSkillPathDisplay(
-      input.command.trim(),
+      displayCommand.command,
     );
     if (generatedSkillPath) {
-      const redirectTarget = firstDestructiveRedirectTarget(input.command);
+      const redirectTarget = firstDestructiveRedirectTarget(
+        displayCommand.command,
+      );
+      const runtimeEnvLine =
+        displayCommand.runtimeEnvAssignments.length > 0
+          ? `Runtime environment: ${sanitizePermissionText(
+              displayCommand.runtimeEnvAssignments.join(' '),
+              600,
+              200,
+            )}`
+          : null;
       return [
         'Command: generated skill action command; runtime path hidden.',
         `Action: ${sanitizePermissionText(generatedSkillPath, 180, 80)}`,
+        ...(runtimeEnvLine ? [runtimeEnvLine] : []),
         ...(redirectTarget ? [`Redirect: ${redirectTarget}`] : []),
       ];
     }
     const command = (options.sanitizeCommandText ?? sanitizePermissionText)(
-      input.command.trim(),
+      displayCommand.command,
       900,
       300,
     );
-    const redirectTarget = firstDestructiveRedirectTarget(input.command);
+    const redirectTarget = firstDestructiveRedirectTarget(
+      displayCommand.command,
+    );
     if (hasRedactionMarker(command)) {
-      const program = shellProgramLabel(input.command);
+      const program = shellProgramLabel(displayCommand.command);
       return [
         'Command: hidden because it may contain sensitive values.',
         ...(program
@@ -78,6 +115,15 @@ export function formatPermissionToolInputLines(
       '```',
       command,
       '```',
+      ...(displayCommand.runtimeEnvAssignments.length > 0
+        ? [
+            `Runtime environment: ${sanitizePermissionText(
+              displayCommand.runtimeEnvAssignments.join(' '),
+              600,
+              200,
+            )}`,
+          ]
+        : []),
       ...(redirectTarget ? [`Redirect: ${redirectTarget}`] : []),
     ];
   }
@@ -211,6 +257,89 @@ function shellProgramLabel(command: string): string | null {
   if (!first?.[2]) return null;
   const program = first[2].split('/').pop() || first[2];
   return program || null;
+}
+
+export function runtimeDisplayCommand(command: string): {
+  command: string;
+  runtimeEnvAssignments: string[];
+} {
+  const parsed = splitRuntimeEnvAssignments(command);
+  if (!parsed || !parsed.command.trim()) {
+    return { command, runtimeEnvAssignments: [] };
+  }
+  return {
+    command: parsed.command.trim(),
+    runtimeEnvAssignments: parsed.assignments,
+  };
+}
+
+function splitRuntimeEnvAssignments(
+  command: string,
+): { command: string; assignments: string[] } | null {
+  let offset = 0;
+  const assignments: string[] = [];
+  while (offset < command.length) {
+    const next = parseRuntimeEnvAssignment(command, offset);
+    if (!next) break;
+    assignments.push(
+      command.slice(skipSpaces(command, offset), next.nextOffset).trim(),
+    );
+    offset = next.nextOffset;
+  }
+  if (assignments.length === 0) return null;
+  return { command: command.slice(offset), assignments };
+}
+
+function parseRuntimeEnvAssignment(
+  command: string,
+  offset: number,
+): { nextOffset: number } | null {
+  let cursor = skipSpaces(command, offset);
+  const keyMatch = command.slice(cursor).match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+  if (!keyMatch?.[1] || !RUNTIME_ENV_ASSIGNMENT_KEYS.has(keyMatch[1])) {
+    return null;
+  }
+  cursor += keyMatch[0].length;
+  const parsedValue = parseShellAssignmentValue(command, cursor);
+  if (!parsedValue || parsedValue.nextOffset === cursor) return null;
+  return { nextOffset: skipSpaces(command, parsedValue.nextOffset) };
+}
+
+function parseShellAssignmentValue(
+  command: string,
+  offset: number,
+): { nextOffset: number } | null {
+  const quote = command[offset];
+  if (quote === "'" || quote === '"') {
+    let cursor = offset + 1;
+    while (cursor < command.length) {
+      if (command[cursor] === '\\') {
+        cursor += 2;
+        continue;
+      }
+      if (command[cursor] === quote) {
+        return { nextOffset: cursor + 1 };
+      }
+      cursor += 1;
+    }
+    return null;
+  }
+  let cursor = offset;
+  while (
+    cursor < command.length &&
+    !/[\s;|&<>()]/.test(command[cursor] ?? '')
+  ) {
+    cursor += 1;
+  }
+  return { nextOffset: cursor };
+}
+
+function skipSpaces(command: string, offset: number): number {
+  let cursor = offset;
+  while (cursor < command.length && /\s/.test(command[cursor] ?? '')) {
+    cursor += 1;
+  }
+  return cursor;
 }
 
 function formatApproxBytes(bytes: number): string {

--- a/apps/core/src/jobs/execution-dead-letter.ts
+++ b/apps/core/src/jobs/execution-dead-letter.ts
@@ -17,10 +17,8 @@ import type {
   SchedulerDependencies,
   SchedulerDispatchPayload,
 } from './types.js';
-import {
-  DEFAULT_RUNTIME_EXECUTION_PROVIDER_ID,
-  resolveRuntimeExecutionProviderId,
-} from '../runtime/execution-provider-id.js';
+import { resolveConfiguredRuntimeExecutionProviderId } from '../runtime/execution-provider-id.js';
+import { resolveDefaultJobExecutionProviderId } from './model-resolution.js';
 
 interface SchedulerDeadLetterControl {
   bindTriggerToRun(
@@ -66,10 +64,13 @@ export async function deadLetterUnresolvedExecutionContext(input: {
   await input.deps.opsRepository.createJobRun({
     run_id: input.runId,
     job_id: input.currentJob.id,
-    execution_provider_id:
-      input.deps.executionAdapter || !input.deps.runAgent
-        ? resolveRuntimeExecutionProviderId(input.deps.executionAdapter)
-        : DEFAULT_RUNTIME_EXECUTION_PROVIDER_ID,
+    execution_provider_id: resolveConfiguredRuntimeExecutionProviderId({
+      executionAdapter: input.deps.executionAdapter,
+      executionAdapters: input.deps.executionAdapters,
+      fallbackExecutionProviderId: input.deps.runAgent
+        ? resolveDefaultJobExecutionProviderId(input.currentJob.schedule_type)
+        : undefined,
+    }),
     provider_run_id: null,
     provider_session_id: null,
     worker_id: input.currentJob.execution_context?.workspaceKey ?? null,

--- a/apps/core/src/jobs/execution.ts
+++ b/apps/core/src/jobs/execution.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import { ASSISTANT_NAME, getEffectiveModelConfig } from '../config/index.js';
 import type { Job } from '../domain/types.js';
-import type { ExecutionProviderId } from '../domain/sessions/sessions.js';
 import { logger } from '../infrastructure/logging/logger.js';
 import {
   getRuntimeControlRepository,
@@ -16,6 +15,7 @@ import { RUNTIME_EVENT_TYPES } from '../domain/events/runtime-event-types.js';
 import { nowIso, nowMs, toIso } from '../shared/time/datetime.js';
 import { resolveWorkspaceFolderPath } from '../platform/workspace-folder.js';
 import { AgentOutput, spawnAgent } from '../runtime/agent-spawn.js';
+import { providerSessionExternalSessionId } from '../runtime/agent-output-provider-session.js';
 import {
   buildRuntimeRunOptions,
   completeFailedRuntimeSessionRun,
@@ -27,10 +27,6 @@ import {
   resolveTurnSelectedMcpServerIds,
   resolveTurnSelectedSkillContext,
 } from '../runtime/group-run-context.js';
-import {
-  DEFAULT_RUNTIME_EXECUTION_PROVIDER_ID,
-  resolveRuntimeExecutionProviderId,
-} from '../runtime/execution-provider-id.js';
 import {
   collectCompactBoundaryMemory,
   collectJobCompletionMemory,
@@ -54,6 +50,7 @@ import {
   jobCompletedModelPayload,
   jobStartedModelPayload,
   modelUseKindForJobSchedule,
+  resolveJobExecutionProviderId,
   resolveJobModel,
   type NormalizedModelUsage,
 } from './model-resolution.js';
@@ -89,7 +86,6 @@ export async function runJob(
   queueJid: string,
   dispatch?: SchedulerDispatchPayload,
 ): Promise<void> {
-  const runAgentImpl = deps.runAgent ?? spawnAgent;
   const currentJob = await deps.opsRepository.getJobById(job.id);
   if (!currentJob || currentJob.status !== 'active') return;
   const scheduledFor =
@@ -145,10 +141,12 @@ export async function runJob(
     publishRuntimeEvent,
   });
   if (pausedForSetup) return;
-  const executionProviderId = (resolvedModel.entry?.executionProviderId ??
-    (deps.executionAdapter || !deps.runAgent
-      ? resolveRuntimeExecutionProviderId(deps.executionAdapter)
-      : DEFAULT_RUNTIME_EXECUTION_PROVIDER_ID)) as ExecutionProviderId;
+  const executionProviderId = resolveJobExecutionProviderId({
+    resolvedModel,
+    executionAdapter: deps.executionAdapter,
+    executionAdapters: deps.executionAdapters,
+    fallbackForInjectedRunner: Boolean(deps.runAgent),
+  });
   const claimed = await deps.opsRepository.claimDueJobRunStart({
     jobId: currentJob.id,
     runId,
@@ -413,7 +411,7 @@ export async function runJob(
                   cause: 'job',
                 })
               : undefined;
-            const output = await runAgentImpl(
+            const output = await (deps.runAgent ?? spawnAgent)(
               execution.group,
               {
                 prompt: currentJob.prompt,
@@ -433,7 +431,7 @@ export async function runJob(
                 jobModelUseKind,
                 assistantName: ASSISTANT_NAME,
                 memoryContextBlock: turnContext?.memoryContextBlock,
-                allowedTools: toolPolicy.effectiveAllowedTools,
+                toolPolicyRules: toolPolicy.effectiveAllowedTools,
                 toolAccessRequirements:
                   toolAccessRequirementPreflight.toolAccessRequirements,
                 runtimeAccess: toolPolicy.runtimeAccess,
@@ -463,9 +461,11 @@ export async function runJob(
                   emitJobEvent,
                 });
                 if (streamedOutput.usage) latestUsage = streamedOutput.usage;
-                if (streamedOutput.newSessionId) {
+                const streamedProviderSessionId =
+                  providerSessionExternalSessionId(streamedOutput);
+                if (streamedProviderSessionId) {
                   await updateRunProviderMetadata({
-                    providerSessionId: streamedOutput.newSessionId,
+                    providerSessionId: streamedProviderSessionId,
                   });
                 }
                 await collectCompactBoundaryMemory({

--- a/apps/core/src/jobs/model-resolution.ts
+++ b/apps/core/src/jobs/model-resolution.ts
@@ -1,12 +1,41 @@
+import type { AgentExecutionAdapter } from '../application/agent-execution/agent-execution-adapter.js';
+import type { AgentExecutionAdapterRegistry } from '../application/agent-execution/agent-execution-adapter-registry.js';
+import type { ExecutionProviderId } from '../domain/sessions/sessions.js';
+import { resolveConfiguredRuntimeExecutionProviderId } from '../runtime/execution-provider-id.js';
 import type { NormalizedModelUsage } from '../shared/model-catalog.js';
 import {
   modelUseKindForJobSchedule,
+  resolveDefaultJobExecutionProviderId,
   resolveJobModel,
   type ResolvedJobModel,
 } from '../application/jobs/job-model-resolution.js';
 
 export type { NormalizedModelUsage };
-export { modelUseKindForJobSchedule, resolveJobModel };
+export {
+  modelUseKindForJobSchedule,
+  resolveDefaultJobExecutionProviderId,
+  resolveJobModel,
+};
+
+export function resolveJobExecutionProviderId(input: {
+  resolvedModel: ResolvedJobModel;
+  executionAdapter?: Pick<AgentExecutionAdapter, 'id'>;
+  executionAdapters?: Pick<AgentExecutionAdapterRegistry, 'list'>;
+  fallbackForInjectedRunner?: boolean;
+}): ExecutionProviderId {
+  return (
+    (input.resolvedModel.entry?.executionProviderId as
+      | ExecutionProviderId
+      | undefined) ??
+    resolveConfiguredRuntimeExecutionProviderId({
+      executionAdapter: input.executionAdapter,
+      executionAdapters: input.executionAdapters,
+      fallbackExecutionProviderId: input.fallbackForInjectedRunner
+        ? input.resolvedModel.defaultExecutionProviderId
+        : undefined,
+    })
+  );
+}
 
 function modelAuditPayload(resolved: ResolvedJobModel) {
   return {

--- a/apps/core/src/jobs/recovery.ts
+++ b/apps/core/src/jobs/recovery.ts
@@ -5,6 +5,7 @@ import type { ExecutionProviderId } from '../domain/sessions/sessions.js';
 import type { Job } from '../domain/types.js';
 import { spawnAgent } from '../runtime/agent-spawn.js';
 import type { AgentOutput } from '../runtime/agent-spawn.js';
+import { providerSessionExternalSessionId } from '../runtime/agent-output-provider-session.js';
 import type { AgentInput } from '../runtime/agent-spawn-types.js';
 import {
   buildApprovedSkillContextBlock,
@@ -18,10 +19,7 @@ import {
   resolveTurnSelectedMcpServerIds,
   resolveTurnSelectedSkillContext,
 } from '../runtime/group-run-context.js';
-import {
-  DEFAULT_RUNTIME_EXECUTION_PROVIDER_ID,
-  resolveRuntimeExecutionProviderId,
-} from '../runtime/execution-provider-id.js';
+import { resolveConfiguredRuntimeExecutionProviderId } from '../runtime/execution-provider-id.js';
 import { makeThreadQueueKey } from '../shared/thread-queue-key.js';
 import {
   createJobRecoveryIntent,
@@ -332,9 +330,10 @@ async function runJobRecoveryAgentTurn(input: {
     ),
   );
   const executionProviderId = (resolvedModel.entry?.executionProviderId ??
-    (input.deps.executionAdapter || !input.deps.runAgent
-      ? resolveRuntimeExecutionProviderId(input.deps.executionAdapter)
-      : DEFAULT_RUNTIME_EXECUTION_PROVIDER_ID)) as ExecutionProviderId;
+    resolveConfiguredRuntimeExecutionProviderId({
+      executionAdapter: input.deps.executionAdapter,
+      executionAdapters: input.deps.executionAdapters,
+    })) as ExecutionProviderId;
   const { memoryDefaultScope, memoryUserId } = resolveExecutionMemoryContext({
     conversationKind: input.execution.group.conversationKind,
     executionJid: input.execution.executionJid,
@@ -437,7 +436,7 @@ async function runJobRecoveryAgentTurn(input: {
     memoryContextBlock: [turnContext?.memoryContextBlock, approvedSkillContext]
       .filter((block): block is string => Boolean(block?.trim()))
       .join('\n\n'),
-    allowedTools: toolPolicy.effectiveAllowedTools,
+    toolPolicyRules: toolPolicy.effectiveAllowedTools,
     runtimeAccess: toolPolicy.runtimeAccess,
     attachedSkillSourceIds: selectedSkillContext.ids,
     selectedSkillDisplays: selectedSkillContext.displays,
@@ -472,20 +471,23 @@ async function runJobRecoveryAgentTurn(input: {
       if (streamedOutput.result) {
         resultSummaryAccumulator.append(streamedOutput.result);
       }
-      if (streamedOutput.newSessionId && agentRunId) {
+      const streamedProviderSessionId =
+        providerSessionExternalSessionId(streamedOutput);
+      if (streamedProviderSessionId && agentRunId) {
         await input.deps.opsRepository.updateAgentRunProviderMetadata?.({
           runId: agentRunId,
-          providerSessionId: streamedOutput.newSessionId,
+          providerSessionId: streamedProviderSessionId,
         });
       }
     },
     runOptions,
   );
   if (output.result) resultSummaryAccumulator.append(output.result);
-  if (output.newSessionId && agentRunId) {
+  const providerSessionId = providerSessionExternalSessionId(output);
+  if (providerSessionId && agentRunId) {
     await input.deps.opsRepository.updateAgentRunProviderMetadata?.({
       runId: agentRunId,
-      providerSessionId: output.newSessionId,
+      providerSessionId,
     });
   }
   if (output.status === 'error') {

--- a/apps/core/src/memory/AGENTS.md
+++ b/apps/core/src/memory/AGENTS.md
@@ -44,6 +44,9 @@
   Durable mutation still requires host validation against subject scope,
   evidence ids, current target versions, allowed memory kinds, confidence, and
   shared sensitive-material checks.
+- User-visible memory extractor labels must stay provider-neutral. Specific
+  model/provider choices belong in model settings or LLM adapter code, not
+  `MemoryExtractionProvider.providerName`.
 - Retire, rewrite, contradiction, and merge proposals belong in
   `memory_review_requests` with `pending_review` status; do not route these
   through `request_permission`, because review approves a specific data

--- a/apps/core/src/memory/extractor-llm.ts
+++ b/apps/core/src/memory/extractor-llm.ts
@@ -318,7 +318,7 @@ function buildPromptParts(input: ArcExtractionInput): {
 }
 
 export class LlmMemoryExtractionProvider implements MemoryExtractionProvider {
-  readonly providerName = 'llm-haiku';
+  readonly providerName = 'memory-llm';
 
   async extractFacts(
     input: ArcExtractionInput,

--- a/apps/core/src/runtime/AGENTS.md
+++ b/apps/core/src/runtime/AGENTS.md
@@ -30,3 +30,7 @@
 - Generated `.llm-runtime` access failures are adapter-state failures. Surface
   actionable `.llm-runtime` guidance instead of returning raw `EACCES` as a
   generic runner-exited error.
+- Shared runtime accepts Gantry-owned `toolPolicyRules` and neutral
+  `providerSession` output. Provider-native names such as Claude SDK
+  `allowedTools` and stale provider-session error strings belong behind the
+  execution adapter boundary.

--- a/apps/core/src/runtime/agent-output-provider-session.ts
+++ b/apps/core/src/runtime/agent-output-provider-session.ts
@@ -1,0 +1,40 @@
+import type { AgentOutput } from './agent-spawn-types.js';
+
+export function providerSessionExternalSessionId(
+  output: Pick<AgentOutput, 'providerSession' | 'newSessionId'>,
+): string | undefined {
+  return (
+    output.providerSession?.externalSessionId?.trim() ||
+    output.newSessionId?.trim() ||
+    undefined
+  );
+}
+
+export function outputWithProviderSession(
+  output: AgentOutput,
+  externalSessionId: string | undefined,
+): AgentOutput {
+  const resolved =
+    externalSessionId ?? providerSessionExternalSessionId(output);
+  if (!resolved) return output;
+  return {
+    ...output,
+    providerSession: { externalSessionId: resolved },
+    newSessionId: output.newSessionId ?? resolved,
+  };
+}
+
+export function runnerResultWithProviderSession(input: {
+  status: AgentOutput['status'];
+  externalSessionId: string | undefined;
+  error?: string;
+}): AgentOutput {
+  return outputWithProviderSession(
+    {
+      status: input.status,
+      result: null,
+      ...(input.error ? { error: input.error } : {}),
+    },
+    input.externalSessionId,
+  );
+}

--- a/apps/core/src/runtime/agent-spawn-helpers.ts
+++ b/apps/core/src/runtime/agent-spawn-helpers.ts
@@ -7,7 +7,8 @@ import { projectSandboxRuntimeModelGatewayEnv } from './agent-spawn-runtime-poli
 
 const SANDBOX_RUNTIME_GO_DNS = 'netdns=go';
 
-export type RunnerAgentInput = AgentInput & {
+export type RunnerAgentInput = Omit<AgentInput, 'toolPolicyRules'> & {
+  allowedTools?: string[];
   modelCredentialEnv?: Record<string, string>;
   toolNetworkEnv?: Record<string, string>;
 };
@@ -57,17 +58,6 @@ export function protectedWritePathsForOuterSandbox(
         ]
       : [item],
   );
-}
-
-export function resolveClaudeCodeToolTempDir(
-  baseTempDir: string | undefined,
-): string | undefined {
-  if (!baseTempDir) return undefined;
-  const leaf =
-    process.platform === 'win32'
-      ? ['cla', 'ude'].join('')
-      : `${['cla', 'ude'].join('')}-${process.getuid?.() ?? 0}`;
-  return path.join(baseTempDir, leaf);
 }
 
 export function sandboxRuntimeToolProcessEnv(

--- a/apps/core/src/runtime/agent-spawn-process.ts
+++ b/apps/core/src/runtime/agent-spawn-process.ts
@@ -13,13 +13,18 @@ import { formatDuration } from '../shared/human-format.js';
 import { nowIso, nowMs as currentTimeMs } from '../shared/time/datetime.js';
 import { formatRunnerProcessExitError } from './generated-runtime-path-error.js';
 import type { RunnerSandboxProvider } from '../shared/runner-sandbox-provider.js';
-import { RUNTIME_EVENT_TYPES } from '../domain/events/runtime-event-types.js';
 import {
   formatScheduledJobIdleStallError,
   readScheduledJobHeartbeat,
   scheduledJobIdleTimeoutMs,
   type ScheduledJobHeartbeatPayload,
 } from './agent-spawn-scheduled-idle.js';
+import { sandboxBlockedEvents } from './agent-spawn-sandbox-events.js';
+import {
+  outputWithProviderSession,
+  providerSessionExternalSessionId,
+  runnerResultWithProviderSession,
+} from './agent-output-provider-session.js';
 const OUTPUT_START_MARKER = '---GANTRY_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---GANTRY_OUTPUT_END---';
 
@@ -93,40 +98,6 @@ function runnerContextPayload(input: RunnerProcessSpec['input']) {
   };
 }
 
-function sandboxBlockedEvents(
-  spec: RunnerProcessSpec,
-  message: string,
-): NonNullable<AgentOutput['runtimeEvents']> {
-  const provider = spec.options?.runnerSandboxProvider;
-  return [
-    {
-      appId: spec.sandbox.principal.appId,
-      agentId: spec.sandbox.principal.agentId,
-      runId: spec.sandbox.principal.runId,
-      jobId: spec.sandbox.principal.jobId,
-      conversationId: spec.sandbox.principal.conversationId,
-      threadId: spec.sandbox.principal.threadId,
-      eventType: RUNTIME_EVENT_TYPES.SANDBOX_BLOCKED,
-      actor: 'runner',
-      responseMode: 'none',
-      payload: {
-        provider: provider?.id ?? 'direct',
-        enforcing: provider?.enforcing === true,
-        profileId: spec.sandbox.sandboxProfile.id,
-        networkMode: spec.sandbox.sandboxProfile.network,
-        filesystemMode: spec.sandbox.sandboxProfile.filesystem,
-        allowedNetworkHostCount: spec.sandbox.allowedNetworkHosts.length,
-        runtimeReadPathCount: spec.sandbox.runtimeReadPaths.length,
-        runtimeWritePathCount: spec.sandbox.runtimeWritePaths.length,
-        protectedReadPathCount: spec.sandbox.protectedReadPaths.length,
-        protectedWritePathCount: spec.sandbox.protectedWritePaths.length,
-        resourceLimits: spec.sandbox.resourceLimits,
-        message: sanitizeLogText(message, 500),
-      },
-    },
-  ];
-}
-
 function stderrLooksLikeSandboxBlock(stderr: string): boolean {
   return SANDBOX_BLOCKED_PATTERNS.some((pattern) => pattern.test(stderr));
 }
@@ -158,10 +129,11 @@ export function executeRunnerProcess(
         status: 'error',
         result: null,
         error: `${runnerLabel} sandbox provider is not configured.`,
-        runtimeEvents: sandboxBlockedEvents(
+        runtimeEvents: sandboxBlockedEvents({
           spec,
-          'runner sandbox provider is not configured',
-        ),
+          message: 'runner sandbox provider is not configured',
+          sanitize: sanitizeLogText,
+        }),
       });
       return;
     }
@@ -183,7 +155,11 @@ export function executeRunnerProcess(
         status: 'error',
         result: null,
         error: `Sandbox startup failed: ${error}. The run did not start.`,
-        runtimeEvents: sandboxBlockedEvents(spec, error),
+        runtimeEvents: sandboxBlockedEvents({
+          spec,
+          message: error,
+          sanitize: sanitizeLogText,
+        }),
       });
       return;
     }
@@ -200,7 +176,7 @@ export function executeRunnerProcess(
 
     let parseBuffer = '';
     let parseBufferTruncated = false;
-    let newSessionId: string | undefined;
+    let providerSessionExternalId: string | undefined;
     let outputChain = Promise.resolve();
     let timedOut = false;
     let timeoutReason: RunnerTimeoutReason = 'timeout';
@@ -277,10 +253,16 @@ export function executeRunnerProcess(
           parseBuffer = parseBuffer.slice(endIdx + OUTPUT_END_MARKER.length);
 
           try {
-            const parsed: AgentOutput = JSON.parse(jsonStr);
-            if (parsed.newSessionId) {
-              newSessionId = parsed.newSessionId;
+            let parsed: AgentOutput = JSON.parse(jsonStr);
+            const streamedProviderSessionId =
+              providerSessionExternalSessionId(parsed);
+            if (streamedProviderSessionId) {
+              providerSessionExternalId = streamedProviderSessionId;
             }
+            parsed = outputWithProviderSession(
+              parsed,
+              providerSessionExternalId,
+            );
             const heartbeat = readScheduledJobHeartbeat(parsed);
             if (input.isScheduledJob && heartbeat) {
               lastScheduledJobHeartbeat = heartbeat;
@@ -420,11 +402,12 @@ export function executeRunnerProcess(
             `${runnerLabel} timed out after output (idle cleanup)`,
           );
           outputChain.then(() => {
-            resolve({
-              status: 'success',
-              result: null,
-              newSessionId,
-            });
+            resolve(
+              runnerResultWithProviderSession({
+                status: 'success',
+                externalSessionId: providerSessionExternalId,
+              }),
+            );
           });
           return;
         }
@@ -457,12 +440,13 @@ export function executeRunnerProcess(
         );
 
         outputChain.then(() => {
-          resolve({
-            status: 'error',
-            result: null,
-            newSessionId,
-            error,
-          });
+          resolve(
+            runnerResultWithProviderSession({
+              status: 'error',
+              externalSessionId: providerSessionExternalId,
+              error,
+            }),
+          );
         });
         return;
       }
@@ -550,16 +534,17 @@ export function executeRunnerProcess(
             {
               group: group.name,
               duration,
-              providerSessionCreated: !!newSessionId,
+              providerSessionCreated: !!providerSessionExternalId,
               signal,
             },
             `${runnerLabel} closed after streamed output`,
           );
-          resolve({
-            status: 'success',
-            result: null,
-            newSessionId,
-          });
+          resolve(
+            runnerResultWithProviderSession({
+              status: 'success',
+              externalSessionId: providerSessionExternalId,
+            }),
+          );
         });
         return;
       }
@@ -576,12 +561,13 @@ export function executeRunnerProcess(
             },
             `${runnerLabel} stopped by request`,
           );
-          resolve({
-            status: 'error',
-            result: null,
-            newSessionId,
-            error: `${runnerLabel} stopped by request`,
-          });
+          resolve(
+            runnerResultWithProviderSession({
+              status: 'error',
+              externalSessionId: providerSessionExternalId,
+              error: `${runnerLabel} stopped by request`,
+            }),
+          );
         });
         return;
       }
@@ -616,13 +602,17 @@ export function executeRunnerProcess(
           stdout,
           stderr,
           structuredError,
-          newSessionId,
+          newSessionId: providerSessionExternalId,
           fallbackStderr: sanitizeLogText(stderr.slice(-200), 200),
         });
         if (stderrLooksLikeSandboxBlock(stderr)) {
           processError.runtimeEvents = [
             ...(processError.runtimeEvents ?? []),
-            ...sandboxBlockedEvents(spec, stderr),
+            ...sandboxBlockedEvents({
+              spec,
+              message: stderr,
+              sanitize: sanitizeLogText,
+            }),
           ];
         }
         if (structuredError) outputChain.then(() => resolve(processError));
@@ -636,21 +626,25 @@ export function executeRunnerProcess(
             {
               group: group.name,
               duration,
-              providerSessionCreated: !!newSessionId,
+              providerSessionCreated: !!providerSessionExternalId,
             },
             `${runnerLabel} completed (streaming mode)`,
           );
-          resolve({
-            status: 'success',
-            result: null,
-            newSessionId,
-          });
+          resolve(
+            runnerResultWithProviderSession({
+              status: 'success',
+              externalSessionId: providerSessionExternalId,
+            }),
+          );
         });
         return;
       }
 
       try {
-        const output = parseBufferedRunnerOutput(stdout);
+        const output = outputWithProviderSession(
+          parseBufferedRunnerOutput(stdout),
+          providerSessionExternalId,
+        );
 
         logger.info(
           {

--- a/apps/core/src/runtime/agent-spawn-sandbox-events.ts
+++ b/apps/core/src/runtime/agent-spawn-sandbox-events.ts
@@ -1,0 +1,38 @@
+import type { AgentOutput, RunnerProcessSpec } from './agent-spawn-types.js';
+import { RUNTIME_EVENT_TYPES } from '../domain/events/runtime-event-types.js';
+
+export function sandboxBlockedEvents(input: {
+  spec: RunnerProcessSpec;
+  message: string;
+  sanitize: (value: string, maxChars?: number) => string;
+}): NonNullable<AgentOutput['runtimeEvents']> {
+  const { spec } = input;
+  const provider = spec.options?.runnerSandboxProvider;
+  return [
+    {
+      appId: spec.sandbox.principal.appId,
+      agentId: spec.sandbox.principal.agentId,
+      runId: spec.sandbox.principal.runId,
+      jobId: spec.sandbox.principal.jobId,
+      conversationId: spec.sandbox.principal.conversationId,
+      threadId: spec.sandbox.principal.threadId,
+      eventType: RUNTIME_EVENT_TYPES.SANDBOX_BLOCKED,
+      actor: 'runner',
+      responseMode: 'none',
+      payload: {
+        provider: provider?.id ?? 'direct',
+        enforcing: provider?.enforcing === true,
+        profileId: spec.sandbox.sandboxProfile.id,
+        networkMode: spec.sandbox.sandboxProfile.network,
+        filesystemMode: spec.sandbox.sandboxProfile.filesystem,
+        allowedNetworkHostCount: spec.sandbox.allowedNetworkHosts.length,
+        runtimeReadPathCount: spec.sandbox.runtimeReadPaths.length,
+        runtimeWritePathCount: spec.sandbox.runtimeWritePaths.length,
+        protectedReadPathCount: spec.sandbox.protectedReadPaths.length,
+        protectedWritePathCount: spec.sandbox.protectedWritePaths.length,
+        resourceLimits: spec.sandbox.resourceLimits,
+        message: input.sanitize(input.message, 500),
+      },
+    },
+  ];
+}

--- a/apps/core/src/runtime/agent-spawn-types.ts
+++ b/apps/core/src/runtime/agent-spawn-types.ts
@@ -40,7 +40,7 @@ export interface AgentInput {
   memoryReviewerIsControlApprover?: boolean;
   persona?: AgentPersona;
   browserProfileName?: string;
-  allowedTools?: string[];
+  toolPolicyRules?: string[];
   toolAccessRequirements?: string[];
   attachedSkillSourceIds?: string[];
   selectedSkillDisplays?: string[];
@@ -62,6 +62,7 @@ export interface AgentInput {
 export interface AgentOutput {
   status: 'success' | 'error';
   result: string | null;
+  providerSession?: AgentOutputProviderSession;
   newSessionId?: string;
   compactBoundary?: boolean;
   interactionBoundary?: 'user_interaction';
@@ -71,6 +72,10 @@ export interface AgentOutput {
   contextUsage?: RuntimeContextUsageSnapshot;
   error?: string;
   runtimeEvents?: AgentOutputRuntimeEvent[];
+}
+
+export interface AgentOutputProviderSession {
+  externalSessionId: string;
 }
 
 export interface AgentOutputRuntimeEvent {

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -81,7 +81,6 @@ import {
   cleanupRunnerTempDir,
   buildSandboxRuntimeGatewayOptions,
   protectedWritePathsForOuterSandbox,
-  resolveClaudeCodeToolTempDir,
   sandboxRuntimeToolProcessEnv,
   sandboxRuntimeToolNetworkEnv,
   type RunnerAgentInput,
@@ -149,7 +148,7 @@ export async function spawnAgent(
   const effectiveModel = resolvedModel.value.runnerModel;
   const effectiveModelEntry = resolvedModel.value.modelEntry;
   const allowedToolValidationError = validateRunnerAllowedTools(
-    input.allowedTools ?? [],
+    input.toolPolicyRules ?? [],
   );
   if (allowedToolValidationError) {
     return {
@@ -181,13 +180,13 @@ export async function spawnAgent(
     workspaceKey: group.folder,
     conversationId: input.chatJid,
   });
-  const trustedAllowedTools = input.allowedTools;
-  const browserIpcEnabled = (trustedAllowedTools ?? []).some(
+  const trustedToolPolicyRules = input.toolPolicyRules;
+  const browserIpcEnabled = (trustedToolPolicyRules ?? []).some(
     isCanonicalBrowserCapabilityRule,
   );
   const runnerInput: RunnerAgentInput = {
     ...input,
-    allowedTools: trustedAllowedTools,
+    allowedTools: trustedToolPolicyRules,
     browserProfileName,
     compiledSystemPrompt,
     yoloMode: effectiveYoloModeSettings(
@@ -273,7 +272,7 @@ export async function spawnAgent(
   let mcpConfigPath: string | undefined;
   let sandboxConfigPath: string | undefined;
   let runnerTempDir: string | undefined;
-  let claudeToolTempDir: string | undefined;
+  let providerToolTempDir: string | undefined;
   let egressGateway:
     | Awaited<ReturnType<typeof ensureEgressGateway>>
     | undefined;
@@ -341,7 +340,7 @@ export async function spawnAgent(
     const sandboxAllowedNetworkHosts =
       sandboxAllowedNetworkHostsFromRuntimeAccess(effectiveRuntimeAccess);
     const memoryIpcAllowedActions = selectedMemoryIpcActionsFromToolRules(
-      trustedAllowedTools ?? [],
+      trustedToolPolicyRules ?? [],
       {
         memoryReviewerIsControlApprover: input.memoryReviewerIsControlApprover,
       },
@@ -429,10 +428,12 @@ export async function spawnAgent(
         'tmp',
         processName,
       );
-      claudeToolTempDir = resolveClaudeCodeToolTempDir(runnerTempDir);
       fs.mkdirSync(runnerTempDir, { recursive: true, mode: 0o700 });
-      if (claudeToolTempDir) {
-        fs.mkdirSync(claudeToolTempDir, { recursive: true, mode: 0o700 });
+      const providerToolTempDirLeaf =
+        preparedExecution.sandboxRuntime?.toolTempDirLeaf;
+      if (providerToolTempDirLeaf) {
+        providerToolTempDir = path.join(runnerTempDir, providerToolTempDirLeaf);
+        fs.mkdirSync(providerToolTempDir, { recursive: true, mode: 0o700 });
       }
     }
     const env: NodeJS.ProcessEnv = {
@@ -444,8 +445,8 @@ export async function spawnAgent(
             TMPDIR: runnerTempDir,
             TMP: runnerTempDir,
             TEMP: runnerTempDir,
-            CLAUDE_CODE_TMPDIR: runnerTempDir,
-            CLAUDE_TMPDIR: runnerTempDir,
+            ...(preparedExecution.sandboxRuntime?.tempEnv?.(runnerTempDir) ??
+              {}),
           }
         : {}),
       TZ: TIMEZONE,
@@ -570,8 +571,7 @@ export async function spawnAgent(
         preparedExecution.protectedFilesystemPaths),
       ...(mcpConfigPath ? [mcpConfigPath] : []),
     ];
-    const providerConfigDirKey = ['CLA' + 'UDE', 'CONFIG', 'DIR'].join('_');
-    const providerConfigDir = env[providerConfigDirKey];
+    const providerConfigDir = preparedExecution.runtimeConfigDir;
     const sandboxRunnerReadablePaths = [
       ...(providerConfigDir
         ? [path.join(providerConfigDir, 'settings.json')]
@@ -646,7 +646,7 @@ export async function spawnAgent(
           workspaceExtraDir,
           ...(providerConfigDir ? [providerConfigDir] : []),
           ...(runnerTempDir ? [runnerTempDir] : []),
-          ...(claudeToolTempDir ? [claudeToolTempDir] : []),
+          ...(providerToolTempDir ? [providerToolTempDir] : []),
           ...localCliCredentialPaths,
           ...(mcpConfigPath ? [mcpConfigPath] : []),
         ],
@@ -654,7 +654,7 @@ export async function spawnAgent(
           hostRuntime.workspaceIpcDir,
           ...(providerConfigDir ? [providerConfigDir] : []),
           ...(runnerTempDir ? [runnerTempDir] : []),
-          ...(claudeToolTempDir ? [claudeToolTempDir] : []),
+          ...(providerToolTempDir ? [providerToolTempDir] : []),
         ],
         protectedReadPaths: sandboxProtectedReadPaths,
         protectedWritePaths: sandboxProtectedWritePaths,

--- a/apps/core/src/runtime/configured-agent-tools.ts
+++ b/apps/core/src/runtime/configured-agent-tools.ts
@@ -9,7 +9,7 @@ import {
 import type { CapabilityRuntimeAccess } from '../shared/capability-runtime-access.js';
 
 export interface ConfiguredAgentToolPolicy {
-  allowedTools: string[] | undefined;
+  toolPolicyRules: string[] | undefined;
   runtimeAccess: CapabilityRuntimeAccess[];
 }
 
@@ -37,7 +37,7 @@ export async function resolveConfiguredToolPolicy(input: {
 }): Promise<ConfiguredAgentToolPolicy> {
   if (!input.repository) {
     return {
-      allowedTools: undefined,
+      toolPolicyRules: undefined,
       runtimeAccess: [],
     };
   }
@@ -49,7 +49,7 @@ export async function resolveConfiguredToolPolicy(input: {
     skillRepository: input.skillRepository,
   });
   return {
-    allowedTools: policy.rules,
+    toolPolicyRules: policy.rules,
     runtimeAccess: policy.runtimeAccess,
   };
 }

--- a/apps/core/src/runtime/execution-provider-id.ts
+++ b/apps/core/src/runtime/execution-provider-id.ts
@@ -1,8 +1,6 @@
-import type { ExecutionProviderId } from '../domain/sessions/sessions.js';
 import type { AgentExecutionAdapter } from '../application/agent-execution/agent-execution-adapter.js';
-
-export const DEFAULT_RUNTIME_EXECUTION_PROVIDER_ID =
-  'anthropic:claude-agent-sdk' as ExecutionProviderId;
+import type { AgentExecutionAdapterRegistry } from '../application/agent-execution/agent-execution-adapter-registry.js';
+import type { ExecutionProviderId } from '../domain/sessions/sessions.js';
 
 export function resolveRuntimeExecutionProviderId(
   executionAdapter?: Pick<AgentExecutionAdapter, 'id'>,
@@ -12,4 +10,18 @@ export function resolveRuntimeExecutionProviderId(
     throw new Error('Runtime execution adapter is not configured.');
   }
   return id as ExecutionProviderId;
+}
+
+export function resolveConfiguredRuntimeExecutionProviderId(input: {
+  executionAdapter?: Pick<AgentExecutionAdapter, 'id'>;
+  executionAdapters?: Pick<AgentExecutionAdapterRegistry, 'list'>;
+  fallbackExecutionProviderId?: ExecutionProviderId;
+}): ExecutionProviderId {
+  const executionAdapter =
+    input.executionAdapter ?? input.executionAdapters?.list()[0];
+  if (executionAdapter)
+    return resolveRuntimeExecutionProviderId(executionAdapter);
+  if (input.fallbackExecutionProviderId)
+    return input.fallbackExecutionProviderId;
+  return resolveRuntimeExecutionProviderId();
 }

--- a/apps/core/src/runtime/group-agent-runner.ts
+++ b/apps/core/src/runtime/group-agent-runner.ts
@@ -3,6 +3,7 @@ import { collectCompactBoundaryMemory } from '../jobs/compact-memory.js';
 import { defaultModelStatusSelection } from '../session/session-model-status.js';
 import type { AgentOutput } from './agent-spawn.js';
 import { spawnAgent } from './agent-spawn.js';
+import { resolveAgentExecutionAdapter } from '../application/agent-execution/agent-execution-adapter-registry.js';
 import type {
   GroupProcessingDeps,
   GroupProcessingRepository,
@@ -61,8 +62,20 @@ const RUNTIME_LOG_PROVIDER_VALUE_PATTERNS: RegExp[] = [
 const RUNTIME_LOG_REDACT_KEY_PATTERN =
   /^(sessionId|newSessionId|providerSessionId|externalSessionId|latestProviderSessionId|session_id)$/i;
 const memoryReviewApproverCache = new Map<string, [boolean, number]>();
+
+export type GroupAgentRunResult = 'success' | 'error' | 'stopped';
+
 function isMissingProviderSessionError(error: string | undefined): boolean {
-  return /\bNo conversation found with session ID\b/i.test(error ?? '');
+  return /\bprovider session\b.*\b(?:missing|expired|not found)\b/i.test(
+    error ?? '',
+  );
+}
+
+function isStoppedByRequest(output: AgentOutput): boolean {
+  return (
+    output.status === 'error' &&
+    /\bstopped by request\b/i.test(output.error ?? '')
+  );
 }
 function redactRuntimeLogString(value: string): string {
   let out = value;
@@ -216,7 +229,7 @@ export function createGroupAgentRunner(input: {
         is_from_me?: boolean | null;
       }[];
     },
-  ): Promise<'success' | 'error'> {
+  ): Promise<GroupAgentRunResult> {
     const initialModelSelection = defaultModelStatusSelection(
       group.agentConfig?.model ?? DEFAULT_MODEL_ALIAS,
     );
@@ -278,7 +291,9 @@ export function createGroupAgentRunner(input: {
     };
     const persistProviderSessionFromOutput = async (output: AgentOutput) => {
       if (output.status === 'error') return;
-      const nextSessionId = output.newSessionId?.trim();
+      const nextSessionId = (
+        output.providerSession?.externalSessionId ?? output.newSessionId
+      )?.trim();
       if (
         !nextSessionId ||
         nextSessionId === latestProviderSessionId ||
@@ -415,7 +430,7 @@ export function createGroupAgentRunner(input: {
     const attachedMcpSourceIds = await resolveTurnSelectedMcpServerIds(
       deps,
       turnContext,
-      configuredToolPolicy.allowedTools,
+      configuredToolPolicy.toolPolicyRules,
     );
     const memoryContextBlock = [
       turnContext?.memoryContextBlock,
@@ -492,7 +507,7 @@ export function createGroupAgentRunner(input: {
             memoryDefaultScope: defaultMemoryScope,
             memoryReviewerIsControlApprover,
             persona: group.agentConfig?.persona,
-            allowedTools: configuredToolPolicy.allowedTools,
+            toolPolicyRules: configuredToolPolicy.toolPolicyRules,
             runtimeAccess: configuredToolPolicy.runtimeAccess,
             attachedSkillSourceIds: selectedSkillContext.ids,
             selectedSkillDisplays: selectedSkillContext.displays,
@@ -540,15 +555,35 @@ export function createGroupAgentRunner(input: {
         memoryContextBlock,
         resumeSessionId: turnContext?.externalSessionId,
       });
+      const activeExecutionAdapter = resolveAgentExecutionAdapter({
+        executionProviderId,
+        registry: deps.executionAdapters,
+        fallback: deps.executionAdapter,
+      });
+      const missingProviderSession =
+        activeExecutionAdapter?.isMissingProviderSessionError?.(output.error) ??
+        isMissingProviderSessionError(output.error);
       if (
         output.status === 'error' &&
-        isMissingProviderSessionError(output.error) &&
+        missingProviderSession &&
         (await expireTurnProviderSession(output.error ?? 'missing session'))
       ) {
         output = await invokeAgent({ memoryContextBlock });
       }
       await forwardRuntimeEvents(output);
       if (output.status === 'error') {
+        if (isStoppedByRequest(output)) {
+          runtimeLogger.warn(
+            { group: group.name },
+            'Agent runner stopped by request',
+          );
+          await completeFailedRuntimeSessionRun({
+            ops: ops(),
+            runId: runState.runId,
+            errorSummary: output.error ?? 'Agent runner stopped by request',
+          });
+          return 'stopped';
+        }
         runtimeLogger.error(
           { group: group.name, error: output.error },
           'Agent runner error',

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -64,7 +64,10 @@ import {
   startGroupProgressHeartbeats,
 } from './group-progress-heartbeats.js';
 import { createProgressChannelSender } from './group-progress-channel-sender.js';
-import { createGroupAgentRunner } from './group-agent-runner.js';
+import {
+  createGroupAgentRunner,
+  type GroupAgentRunResult,
+} from './group-agent-runner.js';
 import { buildMemoryRecallQueryFromMessages } from '../memory/app-memory-recall-query.js';
 import { nowMs as currentTimeMs } from '../shared/time/datetime.js';
 import {
@@ -592,7 +595,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       }
       if (settlement === 'delivery_incomplete') sawDeliveryIncomplete = true;
     };
-    let output: 'success' | 'error' = 'error';
+    let output: GroupAgentRunResult = 'error';
     const handleAgentOutput = async (result: AgentOutput) => {
       lastAgentProgressAt = currentTimeMs();
       if (awaitingResponseReceipt && !result.interactionBoundary) {
@@ -775,14 +778,16 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
     }
 
     const finalProgressState: FinalProgressState =
-      output === 'error' || hadError
-        ? 'failed'
-        : sawDeliveryIncomplete ||
-            (sawTerminalDeliveryFailure && outputSentToUser)
-          ? 'delivery_incomplete'
-          : sawTerminalDeliveryFailure
-            ? 'failed'
-            : 'completed';
+      output === 'stopped'
+        ? 'stopped'
+        : output === 'error' || hadError
+          ? 'failed'
+          : sawDeliveryIncomplete ||
+              (sawTerminalDeliveryFailure && outputSentToUser)
+            ? 'delivery_incomplete'
+            : sawTerminalDeliveryFailure
+              ? 'failed'
+              : 'completed';
     if (
       finalProgressState !== 'completed' ||
       !sentAnyTurnDoneProgress ||

--- a/apps/core/src/runtime/group-run-context.ts
+++ b/apps/core/src/runtime/group-run-context.ts
@@ -23,7 +23,7 @@ export async function resolveTurnToolPolicy(
 ): Promise<ConfiguredAgentToolPolicy> {
   if (!turnContext) {
     return {
-      allowedTools: undefined,
+      toolPolicyRules: undefined,
       runtimeAccess: [],
     };
   }
@@ -75,7 +75,7 @@ export async function resolveTurnSelectedMcpServerIds(
     'getMcpServerRepository' | 'getToolRepository' | 'getSkillRepository'
   >,
   turnContext?: { appId: string; agentId: string } | null,
-  allowedTools?: readonly string[],
+  toolPolicyRules?: readonly string[],
 ): Promise<string[] | undefined> {
   const mcpServers = deps.getMcpServerRepository?.();
   const tools = deps.getToolRepository?.();
@@ -86,7 +86,7 @@ export async function resolveTurnSelectedMcpServerIds(
     skills: deps.getSkillRepository?.(),
     appId: turnContext.appId,
     agentId: turnContext.agentId,
-    allowedTools,
+    allowedTools: toolPolicyRules,
   });
 }
 

--- a/apps/core/src/runtime/progress-updates.ts
+++ b/apps/core/src/runtime/progress-updates.ts
@@ -1,6 +1,10 @@
 import type { ProgressUpdateOptions } from '../domain/types.js';
 
-export type FinalProgressState = 'completed' | 'failed' | 'delivery_incomplete';
+export type FinalProgressState =
+  | 'completed'
+  | 'failed'
+  | 'delivery_incomplete'
+  | 'stopped';
 
 export function buildDoneProgressOptions(
   threadId?: string,
@@ -40,6 +44,8 @@ export async function sendFinalProgressUpdate(args: {
       ? `Failed after ${args.elapsed}.`
       : args.state === 'delivery_incomplete'
         ? `Delivery incomplete after ${args.elapsed}.`
-        : `Done in ${args.elapsed}.`;
+        : args.state === 'stopped'
+          ? `Stopped after ${args.elapsed}.`
+          : `Done in ${args.elapsed}.`;
   await args.send(status, args.options).catch((err) => args.onError?.(err));
 }

--- a/apps/core/src/session/session-commands.ts
+++ b/apps/core/src/session/session-commands.ts
@@ -193,7 +193,7 @@ export interface SessionCommandDeps {
     prompt: string,
     onOutput: (result: AgentResult) => Promise<void>,
     options?: { timeoutMs?: number },
-  ) => Promise<'success' | 'error'>;
+  ) => Promise<'success' | 'error' | 'stopped'>;
   closeStdin: () => void;
   advanceCursor: (message: Pick<NewMessage, 'timestamp' | 'id'>) => void;
   formatMessages: (msgs: NewMessage[], timezone: string) => string;
@@ -381,7 +381,7 @@ export async function handleSessionCommand(opts: {
       }
     });
 
-    if (preResult === 'error' || hadPreError) {
+    if (preResult !== 'success' || hadPreError) {
       logger.warn(
         { group: groupName },
         'Pre-command processing failed, aborting session command',
@@ -440,11 +440,10 @@ export async function handleSessionCommand(opts: {
     let compactError: string | undefined;
     const compactResult = await deps.runAgent('/compact', async (result) => {
       if (result.status !== 'error') return;
-      compactError =
-        resultToText(result.result) || 'Provider compact command failed.';
+      compactError = resultToText(result.result) || 'Compact failed.';
     });
 
-    if (compactResult === 'error' || compactError) {
+    if (compactResult !== 'success' || compactError) {
       const suffix = compactError ? ` ${sanitizeErrorText(compactError)}` : '';
       await deps.sendMessage(`/compact failed.${suffix}`);
       return { handled: true, success: false };

--- a/apps/core/test/integration/runtime-host-child-process.integration.test.ts
+++ b/apps/core/test/integration/runtime-host-child-process.integration.test.ts
@@ -236,6 +236,7 @@ describe('host child-process runtime smoke', () => {
     expect(result).toEqual({
       status: 'success',
       result: null,
+      providerSession: { externalSessionId: 'host-child-session' },
       newSessionId: 'host-child-session',
     });
     expect(onProcess).toHaveBeenCalledTimes(1);

--- a/apps/core/test/unit/adapters/anthropic-execution-adapter.test.ts
+++ b/apps/core/test/unit/adapters/anthropic-execution-adapter.test.ts
@@ -100,6 +100,32 @@ describe('AnthropicClaudeAgentExecutionAdapter', () => {
     });
   });
 
+  it('declares Claude runtime paths through the adapter boundary', async () => {
+    const adapter = new AnthropicClaudeAgentExecutionAdapter();
+
+    const prepared = await adapter.prepare(prepareInput());
+
+    expect(prepared.runtimeConfigDir).toBe('/tmp/gantry-runtime/.claude');
+    expect(prepared.sandboxRuntime?.toolTempDirLeaf).toMatch(/^claude/);
+    expect(prepared.sandboxRuntime?.tempEnv?.('/tmp/runner')).toEqual({
+      CLAUDE_CODE_TMPDIR: '/tmp/runner',
+      CLAUDE_TMPDIR: '/tmp/runner',
+    });
+  });
+
+  it('classifies stale Claude SDK resume sessions inside the adapter boundary', () => {
+    const adapter = new AnthropicClaudeAgentExecutionAdapter();
+
+    expect(
+      adapter.isMissingProviderSessionError(
+        'No conversation found with session ID: stale',
+      ),
+    ).toBe(true);
+    expect(adapter.isMissingProviderSessionError('provider auth failed')).toBe(
+      false,
+    );
+  });
+
   it('passes only materialized Gantry skill names to the runner SDK whitelist', async () => {
     mockMaterializeClaudeRuntime.mockResolvedValueOnce({
       claudeConfigDir: '/tmp/gantry-runtime/.claude',

--- a/apps/core/test/unit/channels/permission-interaction.test.ts
+++ b/apps/core/test/unit/channels/permission-interaction.test.ts
@@ -757,6 +757,132 @@ describe('permission interaction', () => {
     expect(text).not.toContain('simple_expansion');
   });
 
+  it('collapses leading runtime environment assignments in command prompts and receipts', () => {
+    const request = {
+      ...requestWithSuggestions([]),
+      toolName: 'RunCommand',
+      toolInput: {
+        command:
+          "GODEBUG=netdns=go HTTP_PROXY='http://127.0.0.1:18790/' HTTPS_PROXY='http://127.0.0.1:18790/' NODE_USE_ENV_PROXY='1' NO_PROXY='127.0.0.1,localhost,::1' gantry credentials --help > /tmp/gantry-help.txt",
+      },
+    } satisfies PermissionApprovalRequest;
+
+    const text = formatPermissionPromptText(request, 60_000);
+
+    expect(text).toContain('Command:\n```\ngantry credentials --help');
+    expect(text).toContain('Runtime environment: GODEBUG=netdns=go');
+    expect(text).toContain("HTTP_PROXY='http://127.0.0.1:18790/'");
+    expect(text).toContain("NODE_USE_ENV_PROXY='1'");
+    expect(text).toContain('Redirect: > /tmp/gantry-help.txt');
+
+    const receipt = formatPermissionReceiptText('permission_123', request, {
+      approved: true,
+      mode: 'allow_once',
+      decidedBy: 'ravi',
+    });
+    expect(receipt).toContain(
+      "Allowed once: Command (GODEBUG=netdns=go HTTP_PROXY='http://127.0.0.1:18790/' HTTPS_PROXY='http://127.0.0.1:18790/' NODE_USE_ENV_PROXY='1' NO_PROXY='127.0.0.1,localhost,::1' gantry credentials --help > /tmp/gantry-help.txt). The agent will continue this request.",
+    );
+  });
+
+  it('keeps user-provided command environment assignments visible', () => {
+    const text = formatPermissionPromptText(
+      {
+        ...requestWithSuggestions([]),
+        toolName: 'Bash',
+        toolInput: {
+          command: 'FEATURE_FLAG=1 npm test',
+        },
+      },
+      60_000,
+    );
+
+    expect(text).toContain('FEATURE_FLAG=1 npm test');
+    expect(text).not.toContain('Runtime environment:');
+  });
+
+  it('keeps user-provided runtime-key environment assignments visible', () => {
+    const text = formatPermissionPromptText(
+      {
+        ...requestWithSuggestions([]),
+        toolName: 'Bash',
+        toolInput: {
+          command:
+            "HTTP_PROXY='http://attacker.example:8080' GIT_SSH_COMMAND='ssh -o ProxyCommand=evil' git clone https://example.com/repo.git",
+        },
+      },
+      60_000,
+    );
+
+    expect(text).toContain("HTTP_PROXY='http://attacker.example:8080'");
+    expect(text).toContain("GIT_SSH_COMMAND='ssh -o ProxyCommand=evil'");
+    expect(text).toContain(
+      "Runtime environment: HTTP_PROXY='http://attacker.example:8080' GIT_SSH_COMMAND='ssh -o ProxyCommand=evil'",
+    );
+  });
+
+  it('keeps TLS trust environment assignments visible', () => {
+    const text = formatPermissionPromptText(
+      {
+        ...requestWithSuggestions([]),
+        toolName: 'Bash',
+        toolInput: {
+          command: 'SSL_CERT_FILE=/tmp/gantry-evil.pem git clone repo',
+        },
+      },
+      60_000,
+    );
+
+    expect(text).toContain('SSL_CERT_FILE=/tmp/gantry-evil.pem git clone repo');
+    expect(text).not.toContain('Runtime environment:');
+  });
+
+  it('keeps runtime environment assignments visible for generated skill action commands', () => {
+    const request = {
+      ...requestWithSuggestions([]),
+      toolName: 'RunCommand',
+      toolInput: {
+        command:
+          "HTTP_PROXY='http://127.0.0.1:8888/' /tmp/.llm-runtime/claude/skills/demo/action.sh",
+      },
+    } satisfies PermissionApprovalRequest;
+
+    const text = formatPermissionPromptText(request, 60_000);
+
+    expect(text).toContain(
+      'Command: generated skill action command; runtime path hidden.',
+    );
+    expect(text).toContain('Action: skills/demo/action.sh');
+    expect(text).toContain(
+      "Runtime environment: HTTP_PROXY='http://127.0.0.1:8888/'",
+    );
+    expect(
+      formatPermissionReceiptText('permission_123', request, {
+        approved: true,
+        mode: 'allow_once',
+        decidedBy: 'ravi',
+      }),
+    ).toContain(
+      "Selected skill action (skills/demo/action.sh; env: HTTP_PROXY='http://127.0.0.1:8888/')",
+    );
+  });
+
+  it('keeps shell control operators in the visible command after env assignments', () => {
+    const text = formatPermissionPromptText(
+      {
+        ...requestWithSuggestions([]),
+        toolName: 'Bash',
+        toolInput: {
+          command: 'GIT_SSH_COMMAND=ssh;rm -rf /repo git clone repo',
+        },
+      },
+      60_000,
+    );
+
+    expect(text).toContain('Runtime environment: GIT_SSH_COMMAND=ssh');
+    expect(text).toContain(';rm -rf /repo git clone repo');
+  });
+
   it('hides Bash commands with secrets in permission prompt previews', () => {
     const text = formatPermissionPromptText(
       {

--- a/apps/core/test/unit/jobs/execution.test.ts
+++ b/apps/core/test/unit/jobs/execution.test.ts
@@ -16,7 +16,7 @@ vi.mock('@core/config/index.js', async (importOriginal) => {
   return {
     ...actual,
     ASSISTANT_NAME: 'Andy',
-    getEffectiveModelConfig: () => ({ model: undefined }),
+    getEffectiveModelConfig: () => ({ model: 'opus' }),
   };
 });
 
@@ -221,6 +221,7 @@ describe('jobs/execution', () => {
         sendMessage: sendMessage as never,
         opsRepository: opsRepository as never,
         runAgent: vi.fn() as never,
+        executionAdapter: { id: 'anthropic:claude-agent-sdk' },
       },
       'tg:scheduler',
     );
@@ -1079,7 +1080,7 @@ describe('jobs/execution', () => {
     expect(runAgent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        allowedTools: ['Browser'],
+        toolPolicyRules: ['Browser'],
       }),
       expect.any(Function),
       expect.any(Function),

--- a/apps/core/test/unit/jobs/recovery.test.ts
+++ b/apps/core/test/unit/jobs/recovery.test.ts
@@ -93,7 +93,7 @@ describe('job recovery turn queueing', () => {
         input: {
           prompt: string;
           isScheduledJob?: boolean;
-          allowedTools?: string[];
+          toolPolicyRules?: string[];
         },
       ) => {
         expect(input.prompt).toContain('<gantry_scheduler_job_recovery>');
@@ -103,7 +103,7 @@ describe('job recovery turn queueing', () => {
         expect(input.prompt).toContain('&lt;evil&gt;');
         expect(input.prompt).toContain('request_access');
         expect(input.isScheduledJob).toBeUndefined();
-        expect(input.allowedTools).toEqual(['mcp__gantry__request_access']);
+        expect(input.toolPolicyRules).toEqual(['mcp__gantry__request_access']);
         return { status: 'success', result: 'Requested Browser access.' };
       },
     );
@@ -168,6 +168,7 @@ describe('job recovery turn queueing', () => {
             })),
           }) as never,
         runAgent: runAgent as never,
+        executionAdapter: { id: 'anthropic:claude-agent-sdk' },
       } as never,
       execution: {
         group: makeRoute(),

--- a/apps/core/test/unit/memory/extractor-llm.test.ts
+++ b/apps/core/test/unit/memory/extractor-llm.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { LlmMemoryExtractionProvider } from '@core/memory/extractor-llm.js';
+
+describe('LlmMemoryExtractionProvider', () => {
+  it('exposes a provider-neutral status label', () => {
+    expect(new LlmMemoryExtractionProvider().providerName).toBe('memory-llm');
+  });
+});

--- a/apps/core/test/unit/runner/agent-capabilities.test.ts
+++ b/apps/core/test/unit/runner/agent-capabilities.test.ts
@@ -148,8 +148,6 @@ describe('agent capability composition', () => {
         GANTRY_CHAT_JID: 'tg:team',
         GANTRY_WORKSPACE_KEY: 'telegram_team',
         GANTRY_THREAD_ID: 'topic-1',
-        GANTRY_JOB_ID: '',
-        GANTRY_JOB_RUN_ID: '',
         GANTRY_MEMORY_USER_ID: '5759865942',
         GANTRY_MEMORY_DEFAULT_SCOPE: 'group',
         GANTRY_MEMORY_REVIEWER_IS_CONTROL_APPROVER: '',

--- a/apps/core/test/unit/runtime/agent-spawn-process.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-process.test.ts
@@ -923,6 +923,7 @@ describe('executeRunnerProcess', () => {
       expect(result).toEqual({
         status: 'success',
         result: null,
+        providerSession: { externalSessionId: 'sess-closed' },
         newSessionId: 'sess-closed',
       });
       expect(mockLogger.error).not.toHaveBeenCalledWith(
@@ -963,6 +964,7 @@ describe('executeRunnerProcess', () => {
       expect(result).toEqual({
         status: 'error',
         result: null,
+        providerSession: { externalSessionId: 'sess-stopped' },
         newSessionId: 'sess-stopped',
         error: 'test-runner stopped by request',
       });

--- a/apps/core/test/unit/runtime/agent-spawn.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn.test.ts
@@ -356,10 +356,18 @@ const testExecutionAdapter: AgentExecutionAdapter = {
       providerId: 'anthropic:claude-agent-sdk' as const,
       runnerPath,
       runnerArgs: [runnerPath],
+      runtimeConfigDir: materialization.claudeConfigDir,
       runnerInputPatch:
         Object.keys(modelCredentialEnv).length > 0
           ? { modelCredentialEnv }
           : {},
+      sandboxRuntime: {
+        toolTempDirLeaf: `claude-${process.getuid?.() ?? 0}`,
+        tempEnv: (runnerTempDir) => ({
+          CLAUDE_CODE_TMPDIR: runnerTempDir,
+          CLAUDE_TMPDIR: runnerTempDir,
+        }),
+      },
       env: {
         CLAUDE_CONFIG_DIR: materialization.claudeConfigDir,
         ...(input.effectiveModel
@@ -722,9 +730,15 @@ describe('agent-spawn timeout behavior', () => {
 
     const result = await resultPromise;
     expect(result.status).toBe('success');
+    expect(result.providerSession).toEqual({
+      externalSessionId: 'session-123',
+    });
     expect(result.newSessionId).toBe('session-123');
     expect(onOutput).toHaveBeenCalledWith(
-      expect.objectContaining({ result: 'Here is my response' }),
+      expect.objectContaining({
+        result: 'Here is my response',
+        providerSession: { externalSessionId: 'session-123' },
+      }),
     );
   });
 
@@ -776,6 +790,9 @@ describe('agent-spawn timeout behavior', () => {
 
     const result = await resultPromise;
     expect(result.status).toBe('success');
+    expect(result.providerSession).toEqual({
+      externalSessionId: 'session-456',
+    });
     expect(result.newSessionId).toBe('session-456');
   });
 
@@ -1709,16 +1726,16 @@ describe('agent-spawn timeout behavior', () => {
     const startInput = start.mock.calls[0]?.[0] as RunnerSandboxSpawnInput;
     const env = startInput.env as Record<string, string>;
     const providerConfigDir = env.CLAUDE_CONFIG_DIR;
-    expect(env.CLAUDE_CODE_TMPDIR).toContain(
+    expect(env.TMPDIR).toContain(
       '/tmp/gantry-test-data/ipc/test-group/tmp/gantry-test-group-',
     );
-    expect(env.TMPDIR).toBe(env.CLAUDE_CODE_TMPDIR);
+    expect(env.CLAUDE_CODE_TMPDIR).toBe(env.TMPDIR);
     expect(startInput.runtimeReadPaths).toContain(
       '/tmp/gantry-test-data/sessions/test-group/extra',
     );
     expect(startInput.runtimeReadPaths).toContain(providerConfigDir);
     expect(startInput.runtimeWritePaths).toContain(providerConfigDir);
-    expect(startInput.runtimeWritePaths).toContain(env.CLAUDE_CODE_TMPDIR);
+    expect(startInput.runtimeWritePaths).toContain(env.TMPDIR);
     const claudeToolTempDir = startInput.runtimeWritePaths.find((item) =>
       /\/tmp\/gantry-test-group-.*\/claude-\d+$/.test(item),
     );
@@ -1809,7 +1826,7 @@ describe('agent-spawn timeout behavior', () => {
       testGroup,
       {
         ...testInput,
-        allowedTools: [
+        toolPolicyRules: [
           'capability:acme.records.get',
           'RunCommand(/opt/homebrew/bin/acme records get *)',
         ],
@@ -1899,7 +1916,7 @@ describe('agent-spawn timeout behavior', () => {
       testGroup,
       {
         ...testInput,
-        allowedTools: [
+        toolPolicyRules: [
           'capability:acme.invoices.read',
           'RunCommand(/usr/local/bin/acme invoices read *)',
         ],
@@ -1964,7 +1981,7 @@ describe('agent-spawn timeout behavior', () => {
         testGroup,
         {
           ...testInput,
-          allowedTools: [
+          toolPolicyRules: [
             'capability:google.sheets.values.get',
             'RunCommand(/opt/homebrew/bin/gog sheets get *)',
             'capability:skill.linkedin-posting.publish',
@@ -2020,7 +2037,7 @@ describe('agent-spawn timeout behavior', () => {
       testGroup,
       {
         ...testInput,
-        allowedTools: [
+        toolPolicyRules: [
           'capability:acme.invoices.read',
           'RunCommand(/usr/local/bin/acme invoices read *)',
         ],
@@ -2786,7 +2803,7 @@ describe('agent-spawn timeout behavior', () => {
   it('does not launch or attach a raw browser backend when Browser is selected', async () => {
     const resultPromise = spawnTestAgent(
       testGroup,
-      { ...testInput, allowedTools: ['Browser'] },
+      { ...testInput, toolPolicyRules: ['Browser'] },
       () => {},
     );
     await vi.advanceTimersByTimeAsync(10);
@@ -2811,7 +2828,7 @@ describe('agent-spawn timeout behavior', () => {
       testGroup,
       {
         ...testInput,
-        allowedTools: ['Read', 'mcp__browser' + '_' + 'backend' + '__*'],
+        toolPolicyRules: ['Read', 'mcp__browser' + '_' + 'backend' + '__*'],
       },
       () => {},
     );
@@ -2827,7 +2844,7 @@ describe('agent-spawn timeout behavior', () => {
   it('fails closed on stale projected browser MCP rules during spawn', async () => {
     const result = await spawnTestAgent(
       testGroup,
-      { ...testInput, allowedTools: ['Read', 'mcp__gantry__browser_act'] },
+      { ...testInput, toolPolicyRules: ['Read', 'mcp__gantry__browser_act'] },
       () => {},
     );
     expect(result).toMatchObject({
@@ -2858,7 +2875,7 @@ describe('agent-spawn timeout behavior', () => {
     async (_label, rules, reason) => {
       const result = await spawnTestAgent(
         testGroup,
-        { ...testInput, allowedTools: rules },
+        { ...testInput, toolPolicyRules: rules },
         () => {},
       );
       expect(result).toMatchObject({
@@ -2888,7 +2905,7 @@ describe('agent-spawn timeout behavior', () => {
       testGroup,
       {
         ...testInput,
-        allowedTools: ['Browser'],
+        toolPolicyRules: ['Browser'],
       },
       () => {},
     );
@@ -2963,7 +2980,7 @@ describe('agent-spawn timeout behavior', () => {
       testGroup,
       {
         ...testInput,
-        allowedTools: ['Browser'],
+        toolPolicyRules: ['Browser'],
       },
       () => {},
     );

--- a/apps/core/test/unit/runtime/configured-agent-tools.test.ts
+++ b/apps/core/test/unit/runtime/configured-agent-tools.test.ts
@@ -261,7 +261,7 @@ describe('configured agent tools', () => {
         agentId: 'agent:one',
       }),
     ).resolves.toEqual({
-      allowedTools: [
+      toolPolicyRules: [
         'capability:skill.linkedin-posting.publish',
         'RunCommand(skills/linkedin-posting/post.py *)',
       ],
@@ -388,7 +388,7 @@ describe('configured agent tools', () => {
         agentId: 'agent:one',
       }),
     ).resolves.toEqual({
-      allowedTools: [
+      toolPolicyRules: [
         'capability:acme.invoices.read',
         'RunCommand(/usr/local/bin/acme invoices read *)',
       ],

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -8,6 +8,7 @@ import {
 import type { AgentOutput } from '@core/runtime/agent-spawn-types.js';
 import type { GroupProcessingDeps } from '@core/runtime/group-processing-types.js';
 import { PartialMessageDeliveryError } from '@core/domain/messages/partial-delivery.js';
+import { createAgentExecutionAdapterRegistry } from '@core/application/agent-execution/agent-execution-adapter-registry.js';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -206,6 +207,8 @@ function makeDeps(
     collectSessionMemory: vi.fn().mockResolvedValue({ saved: 0 }),
     executionAdapter: {
       id: 'anthropic:claude-agent-sdk',
+      isMissingProviderSessionError: (error: string | undefined) =>
+        /\bNo conversation found with session ID\b/i.test(error ?? ''),
       prepare: vi.fn(),
     },
     runnerSandboxProvider: {
@@ -1090,6 +1093,66 @@ describe('createGroupProcessor', () => {
           expectedAgentSessionId: 'agent-session:1',
         }),
       );
+    });
+
+    it('uses the selected execution adapter to classify missing provider sessions', async () => {
+      const group = makeGroup({ requiresTrigger: false });
+      const otherAdapter = {
+        id: 'test:other-agent-sdk',
+        isMissingProviderSessionError: vi.fn(() => false),
+        prepare: vi.fn(),
+      };
+      const selectedAdapter = {
+        id: 'anthropic:claude-agent-sdk',
+        isMissingProviderSessionError: vi.fn((error: string | undefined) =>
+          /\bNo conversation found with session ID\b/i.test(error ?? ''),
+        ),
+        prepare: vi.fn(),
+      };
+      const { deps } = setupHappyPath({ group });
+      deps.executionAdapter = undefined;
+      deps.executionAdapters = createAgentExecutionAdapterRegistry([
+        otherAdapter,
+        selectedAdapter,
+      ]);
+      (deps.opsRepository as any).getAgentTurnContext = vi
+        .fn()
+        .mockResolvedValue({
+          appId: 'app:test',
+          agentId: 'agent:test',
+          agentSessionId: 'agent-session:1',
+          providerSessionId: 'provider-session:1',
+          externalSessionId: 'claude-session-stale',
+        });
+      (deps.opsRepository as any).createSessionAgentRun = vi
+        .fn()
+        .mockResolvedValue('agent-run:message-1');
+
+      mockSpawnAgent.mockImplementationOnce(async () => ({
+        status: 'error',
+        result: null,
+        error: 'No conversation found with session ID: stale',
+      }));
+      mockSpawnAgent.mockImplementationOnce(async () => ({
+        status: 'success',
+        result: 'fresh reply',
+        newSessionId: 'claude-session-fresh',
+      }));
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await expect(processGroupMessages('group1@g.us')).resolves.toBe(true);
+
+      expect(
+        selectedAdapter.isMissingProviderSessionError,
+      ).toHaveBeenCalledWith('No conversation found with session ID: stale');
+      expect(otherAdapter.isMissingProviderSessionError).not.toHaveBeenCalled();
+      expect(mockSpawnAgent).toHaveBeenCalledTimes(2);
+      expect(deps.opsRepository.expireProviderSession).toHaveBeenCalledWith({
+        providerSessionId: 'provider-session:1',
+        agentSessionId: 'agent-session:1',
+        provider: 'anthropic:claude-agent-sdk',
+        externalSessionId: 'claude-session-stale',
+      });
     });
 
     it('persists SDK session ids from final agent output for the next turn', async () => {
@@ -2223,6 +2286,31 @@ describe('createGroupProcessor', () => {
         progressCalls.find((call) => call[1] === 'Done in 0s.')?.[2]
           ?.replaceOnly,
       ).toBeUndefined();
+    });
+
+    it('reports requested stops without marking progress as failed', async () => {
+      const streamingChannel = makeChannel({
+        sendStreamingChunk: vi.fn().mockResolvedValue(true),
+        sendProgressUpdate: vi.fn().mockResolvedValue(undefined),
+      });
+      const { deps } = setupHappyPath();
+      deps.channelRuntime = streamingChannel;
+
+      mockSpawnAgent.mockResolvedValue({
+        status: 'error',
+        result: null,
+        error: 'Host agent stopped by request',
+      } satisfies AgentOutput);
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      const result = await processGroupMessages('group1@g.us');
+
+      expect(result).toBe(true);
+      const progressTexts = (
+        streamingChannel.sendProgressUpdate as ReturnType<typeof vi.fn>
+      ).mock.calls.map((call) => call[1]);
+      expect(progressTexts).toContain('Stopped after 0s.');
+      expect(progressTexts).not.toContain('Failed after 0s.');
     });
 
     it('does not treat compact boundary markers as turn completion', async () => {

--- a/apps/core/test/unit/session/session-commands.test.ts
+++ b/apps/core/test/unit/session/session-commands.test.ts
@@ -689,6 +689,26 @@ describe('handleSessionCommand', () => {
     );
   });
 
+  it('returns success:false on stopped pre-compact processing', async () => {
+    const deps = makeDeps({ runAgent: vi.fn().mockResolvedValue('stopped') });
+    const msgs = [
+      makeMsg('summarize this', { timestamp: '99' }),
+      makeMsg('/compact', { timestamp: '100' }),
+    ];
+    const result = await handleSessionCommand({
+      missedMessages: msgs,
+      groupName: 'test',
+      triggerPattern: trigger,
+      timezone: 'UTC',
+      deps,
+    });
+    expect(result).toEqual({ handled: true, success: false });
+    expect(deps.archiveCurrentSession).not.toHaveBeenCalled();
+    expect(deps.sendMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to process'),
+    );
+  });
+
   it('clears session for /new without processing stale pre-command messages', async () => {
     const deps = makeDeps({ runAgent: vi.fn().mockResolvedValue('error') });
     const msgs = [
@@ -1273,6 +1293,23 @@ describe('handleSessionCommand', () => {
   it('reports /compact failure when SDK compact fails', async () => {
     const deps = makeDeps({
       runAgent: vi.fn().mockResolvedValue('error'),
+    });
+    const result = await handleSessionCommand({
+      missedMessages: [makeMsg('/compact')],
+      groupName: 'test',
+      triggerPattern: trigger,
+      timezone: 'UTC',
+      deps,
+    });
+    expect(result).toEqual({ handled: true, success: false });
+    expect(deps.archiveCurrentSession).not.toHaveBeenCalled();
+    expect(deps.sendMessage).toHaveBeenCalledWith('/compact failed.');
+    expect(deps.advanceCursor).not.toHaveBeenCalled();
+  });
+
+  it('reports /compact failure when SDK compact is stopped', async () => {
+    const deps = makeDeps({
+      runAgent: vi.fn().mockResolvedValue('stopped'),
     });
     const result = await handleSessionCommand({
       missedMessages: [makeMsg('/compact')],

--- a/docs/architecture/deepagents-decoupling-goal-prompt.md
+++ b/docs/architecture/deepagents-decoupling-goal-prompt.md
@@ -1,0 +1,220 @@
+# DeepAgents Decoupling Goal Prompt
+
+Use this prompt after the citation-backed harness plan has been reviewed. It is
+for the implementation phase that makes Gantry's current Anthropic SDK runtime
+neutral enough to add DeepAgents as another harness.
+
+```text
+/goal Decouple Gantry's active agent execution runtime from Anthropic Claude Agent SDK assumptions so DeepAgents/LangChain can be added next as `deepagents:langchain` without leaking DeepAgents, Claude, Anthropic SDK, provider-native tools, provider sessions, or raw filesystem/shell authority into Gantry's public contracts.
+
+This is an implementation goal. Make code, test, and docs changes as needed, but do not enable DeepAgents as a runnable production harness in this goal unless every decoupling acceptance criterion below is already satisfied and verified. The primary outcome is a clean provider-neutral harness boundary with the existing `anthropic:claude-agent-sdk` lane still working.
+
+Current architectural decision:
+- Gantry remains authoritative for tools, permissions, capabilities, MCP bindings, skills, browser, sandbox, sessions, jobs, settings, audit, memory, and dreaming.
+- `anthropic:claude-agent-sdk` remains the native Claude OAuth/subscription lane.
+- `deepagents:langchain` is the intended default API-key harness lane for OpenAI API keys, Anthropic API keys, and future LangChain-compatible providers.
+- Harness-specific tool names, callback types, settings files, skill formats, MCP config shapes, session ids, and backend tools are adapter-private runtime projections.
+- Model/harness selection stays alias-resolved through catalog fields such as `modelAlias`, `responseFamily`, diagnostic `modelRoute`, resolver-owned `executionProviderId`, and `credentialProfileRef`. Do not add public `job.harness`, job-level `executionProviderId`, or raw provider model IDs at public boundaries.
+
+Mandatory process:
+1. Start by rereading the current repo truth:
+   - `README.md`
+   - `WORKFLOW.md`
+   - `docs/FACTORY.md`
+   - `docs/QUALITY.md`
+   - `docs/decisions/0001-agent-runtime-platform.md`
+   - `docs/architecture/codebase-refactor-principles.md`
+   - `docs/architecture/capability-management.md`
+   - `docs/architecture/credential-management.md`
+   - `docs/architecture/current-verification-commands.md`
+   - `docs/architecture/deepagents-harness-goal-prompt.md`
+   - `docs/security/single-host-hardening-plan.md`
+2. Browse and cite current official docs before making DeepAgents, LangChain, Anthropic SDK, Claude Agent SDK, or OpenAI behavior claims:
+   - DeepAgents overview, tools, subagents, async subagents, streaming, context engineering, filesystem, backends, sandboxes, permissions, human-in-the-loop, MCP, and harness docs.
+   - Claude Agent SDK TypeScript docs, secure deployment docs, sandboxing docs, sessions/resume docs, allowed-tools/MCP/permission docs, and skills docs.
+   - LangChain model docs for OpenAI and Anthropic only where they affect the intended `deepagents:langchain` route.
+3. Convert this goal into acceptance criteria and a capability-driven task decomposition before editing. Do not improvise the task graph inline.
+4. Use parallel read-only analysis agents for at least these scopes before making broad edits:
+   - runtime/session/model catalog and credential projection,
+   - memory/dreaming/session continuity,
+   - permissions/capabilities/MCP/skills/browser/sandbox,
+   - CLI/control API/contracts/docs/tests.
+5. After each agent reports, reconcile conflicts, tighten the task graph, and only then edit.
+6. Keep changes clean-cut. Do not add compatibility shims, legacy fallbacks, placeholder DeepAgents code, speculative wrappers, dead files, empty directories, or broad `common`/`utils` buckets.
+
+Bounded write scope:
+- Allowed: provider-neutral harness contracts, runtime projection modules, adapter boundary code, existing Anthropic adapter updates, model catalog/provider route plumbing, memory LLM port wiring, permission bridge extraction, skill/MCP/browser projection extraction, sandbox/egress provider-neutral naming, focused docs, focused tests.
+- Allowed only if required by real behavior: Postgres provider-session metadata fields or runtime event shape changes. Prefer existing neutral tables and JSON metadata where sufficient.
+- Not allowed in this goal: enabling a production DeepAgents runtime lane, adding public harness selectors, adding raw DeepAgents `.mcp.json` authority, adding raw `LocalShellBackend` or raw `execute` authority, adding DeepAgents skill names as durable skill identity, or moving Claude OAuth/subscription onto DeepAgents without official support.
+
+Acceptance criteria:
+1. Execution adapter boundary:
+   - `AgentExecutionAdapter` remains the only path from Gantry runtime into a harness-specific child runner.
+   - Multiple execution providers can be registered without Anthropic-specific defaults in shared runtime code.
+   - Shared runtime code does not import Claude Agent SDK, Anthropic SDK, or DeepAgents SDK types.
+   - Existing Anthropic adapter still implements the boundary and keeps `anthropic:claude-agent-sdk` behavior working.
+
+2. Model catalog and credentials:
+   - Public model selection remains alias-first.
+   - Catalog entries resolve to `executionProviderId` through provider-neutral code.
+   - OpenAI API-key routing can be represented as an executable model route for a future `deepagents:langchain` adapter without accepting raw provider model IDs at public boundaries.
+   - Claude OAuth/subscription models remain on `anthropic:claude-agent-sdk`.
+   - Model credential env stays inside model-runtime projection only; approved tool subprocesses receive only provider-neutral `toolNetworkEnv`.
+   - Raw provider credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and Claude OAuth tokens are never accepted from Gantry `.env` or process env as runtime authority.
+
+3. Sessions and resume:
+   - `AgentSession` remains canonical Gantry continuity state.
+   - `ProviderSession` remains adapter metadata with `provider`, `externalSessionId`, `providerRef`, and metadata.
+   - Shared runtime consumes a neutral provider-session output/event contract, not Claude SDK `session_id` message shapes.
+   - Missing/expired provider-session handling is adapter-neutral and preserves the existing retry-without-resume behavior for the Anthropic SDK lane.
+   - Provider transcript/archive and redaction logic stays provider-neutral or explicitly adapter-local.
+
+4. Memory and dreaming:
+   - Memory extraction, dreaming, consolidation, and continuity hydration depend on `MemoryLlmClient` or another provider-neutral port, not direct Claude SDK calls.
+   - Anthropic memory LLM code becomes an adapter implementation, not the default shared memory runtime.
+   - Memory model slots remain settings/catalog-backed and can target a future DeepAgents/OpenAI route.
+   - Provider-specific names such as `llm-haiku` are renamed or contained so user-facing memory status is provider-neutral.
+   - Dreaming automatic promotion/update behavior and memory review tools do not change meaning.
+
+5. Permissions and capabilities:
+   - `ToolExecutionPolicyService` or an equivalent provider-neutral service remains the only authority for risky tool decisions.
+   - Claude `CanUseTool` becomes one adapter bridge over a neutral permission decision contract.
+   - A future DeepAgents tool/HITL/permission bridge can map shell, file, MCP, browser, and custom tool attempts into the same neutral `ToolExecutionRequest` shape.
+   - `SandboxNetworkAccess` remains Anthropic SDK-internal transient defense-in-depth, never durable authority.
+   - Durable access accepts only reviewed semantic capabilities, canonical `Browser`, exact Gantry facade/admin tools, and scoped `RunCommand(...)` rules. Bare `Bash`, broad `RunCommand(*)`, provider-native tool names, and leading wildcard MCP/tool rules are rejected.
+
+6. Skills:
+   - Durable skill ids, sources, reviewed artifacts, and selected capabilities stay Gantry-owned.
+   - Skill source inventory is provider-neutral.
+   - Claude skill materialization becomes an Anthropic adapter renderer over the shared skill inventory.
+   - A future DeepAgents skill renderer can use the same reviewed skill inventory without treating DeepAgents skill names as durable Gantry authority.
+   - Runtime skill directories remain scratch projections and are not durable source of truth.
+
+7. MCP and browser:
+   - Gantry MCP tools remain the product contract.
+   - Third-party MCP definitions, versions, bindings, credentials, and audit events remain Gantry/Postgres authority.
+   - Claude `mcpServers` and any future DeepAgents MCP config are per-run adapter projections only.
+   - Browser durable authority remains canonical `Browser`, projected into Gantry-owned browser tools; per-action backend tool names are not persisted or exposed as durable authority.
+
+8. Sandbox and egress:
+   - Runner sandbox selection remains provider-neutral.
+   - Claude-specific temp/config allowances are either adapter-provided or clearly contained so DeepAgents can supply its own runtime paths.
+   - Approved outbound tool traffic continues through Gantry `toolNetworkEnv` and egress gateway; model provider calls continue through the Gantry model gateway.
+   - Future DeepAgents `execute` is not enabled as raw authority. It must either be disabled, mapped to Gantry policy, or wrapped by an enforcing Gantry sandbox/egress boundary before exposure.
+   - Do not double-jail with conflicting DeepAgents and Gantry sandbox layers; document the selected owner for each mode.
+
+9. CLI, control API, SDK/contracts, and docs:
+   - CLI and control API expose provider-neutral model readiness and route diagnostics through existing model vocabulary.
+   - No public `job.harness`, job-level `executionProviderId`, provider-native tool names, DeepAgents backend ids, or Claude settings paths are added to public contracts.
+   - Docs state what is durable authority, what is runtime projection, and what is adapter-private.
+   - Any changed API/contract schemas include tests and docs.
+
+10. Tests and no-legacy cleanup:
+   - Add or update focused tests for every changed boundary.
+   - Existing Anthropic SDK lane regression tests continue to pass.
+   - Provider-boundary checks fail if new Anthropic/Claude SDK tokens leak outside approved adapter paths.
+   - Cleanup searches prove no raw DeepAgents authority, public provider-native tool names, stale Anthropic defaults, or compatibility shims were introduced.
+
+Capability-driven task decomposition:
+1. Harness contract extraction:
+   - Identify the smallest shared contract for prepared runner input, runner output, provider session events, usage/context events, permission attempts, and runtime projection metadata.
+   - Move only reusable contract code out of `apps/core/src/adapters/llm/anthropic-claude-agent/**`.
+   - Keep Anthropic SDK imports inside the Anthropic adapter.
+
+2. Shared capability/tool projection:
+   - Extract Gantry-owned allowed tool, MCP, browser, and semantic capability projection into a provider-neutral module.
+   - Keep provider renderers responsible for translating the neutral projection into Claude SDK or future DeepAgents shapes.
+   - Preserve current Gantry MCP defaults and browser gating.
+
+3. Permission bridge extraction:
+   - Introduce a neutral permission bridge API consumed by adapter-specific hooks.
+   - Reimplement Claude `CanUseTool` as a renderer/adapter of that neutral bridge.
+   - Preserve live approval, timed approval, durable approval, scheduler denial, protected capability guard, YOLO denylist, and audit behavior.
+
+4. Skill projection extraction:
+   - Split provider-neutral skill source inventory from Claude-specific skill directory materialization.
+   - Keep Claude native reserved-name handling adapter-local.
+   - Preserve reviewed artifact and runtime Browser skill behavior.
+
+5. Session/resume normalization:
+   - Replace any shared runtime dependence on Claude SDK message fields with neutral provider-session output handling.
+   - Preserve live provider-session persistence as soon as the runner streams or reports it.
+   - Preserve retry-without-resume for missing/expired provider sessions.
+
+6. Memory/dreaming neutralization:
+   - Replace direct shared default memory dependence on Claude SDK query with a provider-neutral memory LLM client registry or route-aware implementation.
+   - Keep Anthropic query code adapter-local.
+   - Preserve memory model slots, dreaming decisions, review tools, and embedding behavior.
+
+7. Model route preparation:
+   - Prepare catalog/provider definitions so a future `deepagents:langchain` adapter can own OpenAI API-key and Anthropic API-key model routes.
+   - Keep Claude OAuth/subscription on `anthropic:claude-agent-sdk`.
+   - Do not make DeepAgents default until the adapter exists and tests prove it.
+
+8. Sandbox/egress cleanup:
+   - Move Claude-specific temp/config allowances behind adapter-provided runtime materialization where practical.
+   - Keep sandbox provider and egress gateway provider-neutral.
+   - Add explicit tests or cleanup evidence for raw `execute`, `.mcp.json`, and provider token leakage.
+
+9. CLI/control/docs/contracts:
+   - Update only surfaces affected by the decoupling.
+   - Keep model/harness diagnostics alias-resolved and provider-neutral.
+   - Document current state and future DeepAgents handoff without promising behavior not implemented in this goal.
+
+Surface Impact Matrix requirement:
+- Runtime behavior: classify as Changed and list exact affected runner/session/projection paths.
+- `settings.yaml`: classify based on actual changes; if unchanged, explain that model defaults remain alias-owned.
+- Postgres/runtime projection: classify based on actual changes; if unchanged, explain that existing `provider_sessions` metadata is sufficient.
+- Control API: classify based on actual schema or diagnostic changes.
+- SDK/contracts: classify based on exact package schema changes.
+- CLI: classify based on exact command output/setup/doctor changes.
+- Gantry MCP tools/admin skill: classify based on tool list or projection changes.
+- Channel/provider adapters: usually Unchanged by design; explain that channels see canonical runtime messages only.
+- Docs/prompts: Changed; name each doc updated.
+- Audit/events: classify based on event shape or payload changes.
+- Tests/verification: Changed; name tests added/updated and commands run.
+
+Required cleanup searches before final handoff:
+- Anthropic/Claude leakage outside adapter paths:
+  - `rg -n "@anthropic-ai/claude-agent-sdk|@anthropic-ai/sdk|CLAUDE_CONFIG_DIR|CanUseTool|SandboxNetworkAccess|ANTHROPIC_|anthropic:claude-agent-sdk|Claude|claude" apps/core/src packages/contracts/src docs/architecture docs/security --glob '!apps/core/src/adapters/llm/anthropic-claude-agent/**'`
+- Raw DeepAgents authority leakage:
+  - `rg -n "deepagents|DeepAgents|LocalShellBackend|BackendProtocol|execute\\b|\\.mcp\\.json|filesystem permissions|interrupt_on" apps/core/src packages/contracts/src docs --glob '!docs/architecture/deepagents-*'`
+- Public harness selector leakage:
+  - `rg -n "job\\.harness|harness\\s*:|executionProviderId.*job|job.*executionProviderId" apps/core/src packages/contracts/src docs`
+- Raw provider-native tool public contracts:
+  - `rg -n "mcpServers|allowedTools|disallowedTools|permissionMode|CanUseTool|Bash\\(|RunCommand\\(\\*\\)|SandboxNetworkAccess" apps/core/src packages/contracts/src docs --glob '!apps/core/src/adapters/llm/anthropic-claude-agent/**'`
+- Compatibility/dead-path cleanup:
+  - `rg -n "legacy|compat|shim|TODO: remove|remove after refactor|old path|fallback branch|temporary bridge" apps/core/src apps/core/test docs -S`
+
+Required focused verification:
+- Run the smallest relevant checks after each slice.
+- For provider-session and redaction changes:
+  - `npm run test:unit -- apps/core/test/unit/session/provider-transcript-archive.test.ts apps/core/test/unit/adapters/postgres-provider-artifact-store.test.ts apps/core/test/unit/application/sessions/session-interaction-module.test.ts apps/core/test/unit/runner/claude-logging.test.ts`
+- For tool/capability/permission/MCP/runtime projection changes:
+  - `npm run test:unit -- apps/core/test/unit/shared/tool-execution-policy-service.test.ts apps/core/test/unit/bootstrap/channel-wiring.test.ts apps/core/test/unit/runner/protected-capability-hook.test.ts apps/core/test/unit/runner/protected-capability-guard.test.ts apps/core/test/unit/runner/mcp/scheduler-tools.test.ts apps/core/test/unit/runner/agent-capabilities.test.ts apps/core/test/unit/runner/agent-runner-ipc.test.ts apps/core/test/unit/runtime/agent-spawn.test.ts`
+  - `npm run test:integration -- apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts apps/core/test/integration/permission-approval-ipc.integration.test.ts`
+- For memory/dreaming changes:
+  - run the focused memory/dreaming unit tests discovered with `rg -n "memory.*dream|dreaming|MemoryLlmClient|memory-llm" apps/core/test`
+- Always run:
+  - `python3 .codex/scripts/check_architecture.py`
+  - `python3 .codex/scripts/check_task_completion.py`
+- End-of-goal gates unless explicitly blocked and documented:
+  - `npm run build`
+  - `npm test`
+  - `python3 .codex/scripts/verify.py --print-only`
+
+Final handoff must include:
+- Architecture decision actually implemented.
+- Files changed grouped by surface.
+- Acceptance criteria status, including any intentionally deferred criteria.
+- Surface Impact Matrix.
+- Cleanup search results and interpretation.
+- Verification commands run, results, and any commands not run with reason.
+- Remaining work required before adding the actual DeepAgents adapter.
+
+Definition of done:
+- The Anthropic SDK lane still works and remains adapter-local.
+- Shared runtime/application/domain/contracts do not know Claude SDK callback shapes or DeepAgents backend details.
+- Gantry-owned permissions, skills, MCP, browser, memory, sandbox, sessions, jobs, settings, and audit remain the only durable authority.
+- A future `deepagents:langchain` adapter can be implemented by adding an adapter/runner and catalog routes, not by rewriting shared runtime contracts again.
+```

--- a/docs/architecture/runtime-components.md
+++ b/docs/architecture/runtime-components.md
@@ -102,6 +102,9 @@ sequenceDiagram
 `agent-spawn.ts` launches a provider-neutral `AgentExecutionAdapter`. The
 adapter prepares provider-specific child runner files, SDK environment, model
 projection, runtime materialization, protected filesystem paths, and cleanup.
+Shared runtime passes Gantry-owned `toolPolicyRules` and neutral provider
+session output; adapter-owned renderers translate those into provider-native
+shapes such as Claude SDK `allowedTools` and stale-session error handling.
 The Anthropic adapter is the only production path that calls
 `@anthropic-ai/claude-agent-sdk`.
 The final child process spawn always goes through `RunnerSandboxProvider`.
@@ -121,7 +124,9 @@ Key runner inputs:
 
 `apps/core/src/adapters/llm/anthropic-claude-agent/runner/query-loop.ts` creates a `MessageStream` and passes it to `query()`. The stream lets the host add follow-up user messages to an already-running agent when the queue decides continuation is safe. The same `query()` call receives:
 
-- `allowedTools` from `apps/core/src/adapters/llm/anthropic-claude-agent/agent-capabilities.ts`, backed by the Gantry MCP surface in `apps/core/src/runner/gantry-mcp-tool-surface.ts`
+- `allowedTools` rendered by the Anthropic adapter from Gantry
+  `toolPolicyRules`, backed by the Gantry MCP surface in
+  `apps/core/src/runner/gantry-mcp-tool-surface.ts`
 - Gantry MCP server config from `apps/core/src/runner/mcp/server.ts`
 - provider-session projection: live interactive turns may pass adapter resume
   metadata from `ProviderSession`; scheduled jobs keep provider persistence


### PR DESCRIPTION
## Summary
- Decouple runtime execution/provider session plumbing needed by the DeepAgents preparation work.
- Fix memory LLM timeout handling so empty or timed-out extraction results do not block session reset paths.
- Treat user-requested agent stops as stopped instead of generic failures, so topic /new resets no longer report Failed after ... for intentional cancellations.
- Keep Anthropic SDK runtime environment details generic and visible in permission prompts without flooding the command body.

## Root Cause
A Telegram topic /new reset stopped an active host run, but Host agent stopped by request flowed through the same path as runner errors. The progress renderer therefore sent a failed terminal message even though the stop was intentional. The same investigation also exposed noisy Anthropic SDK runtime env projection in permission prompts and brittle injected-runner fallback handling in scheduler paths.

## User Impact
- Topic resets should now report stopped runs as stopped rather than failed.
- Permission prompts remain auditable while compacting provider-runtime env boilerplate.
- Scheduler and dead-letter injected-runner paths keep provider-neutral fallback resolution.

## Validation
- npm run build
- npm run typecheck
- focused Vitest suite for session commands, permission interaction, group processing, and job execution
- python3 .codex/scripts/check_task_completion.py
- autoreview clean: no accepted/actionable findings
- launchd com.gantry restarted successfully from rebuilt dist/index.js
