### PR TITLE
[codex] add lean model choice intelligence

### DIFF
--- a/apps/core/src/application/jobs/job-management-create.ts
+++ b/apps/core/src/application/jobs/job-management-create.ts
@@ -4,7 +4,10 @@ import type {
   JobManagementServiceDeps,
 } from './job-management-types.js';
 import type { JobUpsertInput } from '../../domain/repositories/ops-repo.js';
-import { resolveRequestedJobModel } from './job-model-selection.js';
+import {
+  assertJobModelHarnessCompatible,
+  resolveRequestedJobModel,
+} from './job-model-selection.js';
 import {
   normalizeExecutionContext,
   normalizeNotificationRoutes,
@@ -50,10 +53,15 @@ export async function createManagedJob(
     runAt: input.runAt,
     schedule: input.schedule,
   });
-  const modelAlias = resolveRequestedJobModel(
-    input.modelAlias,
-    kind === 'recurring' ? 'recurring_job' : 'one_time_job',
-  );
+  const workload = kind === 'recurring' ? 'recurring_job' : 'one_time_job';
+  const modelAlias = resolveRequestedJobModel(input.modelAlias, workload);
+  const effectiveModelAlias =
+    modelAlias ?? resolveRequestedJobModel(input.effectiveModelAlias, workload);
+  assertJobModelHarnessCompatible({
+    modelAlias: effectiveModelAlias,
+    workload,
+    agentHarness: input.agentHarness,
+  });
   const jobId = deps.schedulePlanner.createManualJobId();
   const sessionBoundContext = {
     conversationJid: session.conversationJid,

--- a/apps/core/src/application/jobs/job-management-service.ts
+++ b/apps/core/src/application/jobs/job-management-service.ts
@@ -39,7 +39,10 @@ import type {
   ManagedJobTriggerInput,
   ManagedJobTriggerWaitInput,
 } from './job-management-types.js';
-import { resolveRequestedJobModel } from './job-model-selection.js';
+import {
+  assertJobModelHarnessCompatible,
+  resolveRequestedJobModel,
+} from './job-model-selection.js';
 // prettier-ignore
 import { requireJobControl, requireRuntimeEvents, requireTriggerQueue } from './job-management-require.js';
 import { runSchedulerJobNowFromMcp } from './job-management-run-now.js';
@@ -103,6 +106,14 @@ export class JobManagementService {
         ? 'recurring_job'
         : 'one_time_job',
     );
+    assertJobModelHarnessCompatible({
+      modelAlias,
+      workload:
+        scheduleType === 'cron' || scheduleType === 'interval'
+          ? 'recurring_job'
+          : 'one_time_job',
+      agentHarness: input.agentHarness,
+    });
     const workspaceKey = (
       input.workspaceKey || access.sourceAgentFolder
     ).trim();

--- a/apps/core/src/application/jobs/job-management-types.ts
+++ b/apps/core/src/application/jobs/job-management-types.ts
@@ -23,6 +23,7 @@ import type {
 import type { Clock } from '../common/clock.js';
 import type { SchedulerCoordinationPort } from './scheduler-coordination-port.js';
 import type { JobReadinessBrowserStatus } from './job-readiness-service.js';
+import type { AgentHarness } from '../../shared/agent-engine.js';
 
 export type JobKind = 'manual' | 'once' | 'recurring';
 
@@ -161,6 +162,8 @@ export interface CreateManagedJobInput {
   runAt?: string;
   schedule?: { type?: unknown; value?: unknown };
   modelAlias?: unknown;
+  effectiveModelAlias?: string | null;
+  agentHarness?: AgentHarness;
   dryRun?: unknown;
 }
 
@@ -184,6 +187,7 @@ export interface UpsertJobFromIpcInput {
   maxConsecutiveFailures?: number;
   workspaceKey?: string;
   createdBy?: 'agent' | 'human';
+  agentHarness?: AgentHarness;
 }
 
 export interface ConversationBinding {
@@ -244,6 +248,7 @@ export interface ManagedJobListInput extends JobListInput {
 
 export interface ManagedJobUpdateInput extends JobLookupInput {
   patch: JobUpdatePatch;
+  agentHarness?: AgentHarness;
 }
 
 export type ManagedJobDeleteInput = JobLookupInput;

--- a/apps/core/src/application/jobs/job-management-update.ts
+++ b/apps/core/src/application/jobs/job-management-update.ts
@@ -28,7 +28,10 @@ import {
   assertJobAppAccess,
   resolveAuthenticatedRouteContextForUpdate,
 } from './job-management-context-access.js';
-import { resolveOptionalJobModel } from './job-model-selection.js';
+import {
+  assertJobModelHarnessCompatible,
+  resolveOptionalJobModel,
+} from './job-model-selection.js';
 
 export async function updateManagedJob(
   deps: JobManagementServiceDeps,
@@ -41,13 +44,28 @@ export async function updateManagedJob(
   assertPublicJobNamespace({ jobId: job.id, prompt: patch.prompt });
   const targetWorkspaceKey = patch.workspaceKey ?? job.workspace_key;
   const targetScheduleType = patch.scheduleType ?? job.schedule_type;
+  const targetWorkload =
+    targetScheduleType === 'cron' || targetScheduleType === 'interval'
+      ? 'recurring_job'
+      : 'one_time_job';
   if (typeof patch.model === 'string') {
-    patch.model = resolveOptionalJobModel(
-      patch.model,
-      targetScheduleType === 'cron' || targetScheduleType === 'interval'
-        ? 'recurring_job'
-        : 'one_time_job',
-    );
+    patch.model = resolveOptionalJobModel(patch.model, targetWorkload);
+    assertJobModelHarnessCompatible({
+      modelAlias: patch.model,
+      workload: targetWorkload,
+      agentHarness: input.agentHarness,
+    });
+  } else if (
+    patch.scheduleType !== undefined &&
+    patch.model === undefined &&
+    job.model
+  ) {
+    const model = resolveOptionalJobModel(job.model, targetWorkload);
+    assertJobModelHarnessCompatible({
+      modelAlias: model,
+      workload: targetWorkload,
+      agentHarness: input.agentHarness,
+    });
   }
   const authenticatedContext = await resolveAuthenticatedRouteContextForUpdate({
     deps,

--- a/apps/core/src/application/jobs/job-model-selection.ts
+++ b/apps/core/src/application/jobs/job-model-selection.ts
@@ -1,7 +1,10 @@
 import {
+  resolveModelSelection,
   resolveModelSelectionForWorkload,
   type ModelWorkload,
 } from '../../shared/model-catalog.js';
+import type { AgentHarness } from '../../shared/agent-engine.js';
+import { resolveExecutionRoute } from '../../shared/model-execution-route.js';
 import { ApplicationError } from '../common/application-error.js';
 
 export type JobModelWorkload = Extract<
@@ -40,10 +43,38 @@ export function resolveRequestedJobModel(
   return undefined;
 }
 
-export function resolveRequestedJobModelPatch(
-  modelAlias: unknown,
-  workload: JobModelWorkload = 'one_time_job',
-): { specified: boolean; model?: string | null } {
+export function assertJobModelHarnessCompatible(input: {
+  modelAlias?: string | null;
+  workload: JobModelWorkload;
+  agentHarness?: AgentHarness;
+}): void {
+  if (!input.modelAlias) return;
+  const resolved = resolveModelSelectionForWorkload(
+    input.modelAlias,
+    input.workload,
+  );
+  if (!resolved.ok) {
+    throw new ApplicationError('INVALID_REQUEST', resolved.message);
+  }
+  if (input.agentHarness === undefined) {
+    throw new ApplicationError(
+      'INVALID_REQUEST',
+      'Agent harness is required to validate job model compatibility.',
+    );
+  }
+  const route = resolveExecutionRoute({
+    entry: resolved.entry,
+    agentHarness: input.agentHarness,
+  });
+  if (!route.ok) {
+    throw new ApplicationError('INVALID_REQUEST', route.message);
+  }
+}
+
+export function resolveRequestedJobModelPatch(modelAlias: unknown): {
+  specified: boolean;
+  model?: string | null;
+} {
   const aliasSpecified = modelAlias !== undefined;
   if (!aliasSpecified) return { specified: false };
   const value = modelAlias;
@@ -54,8 +85,18 @@ export function resolveRequestedJobModelPatch(
       'Use null to clear a job model.',
     );
   }
+  if (typeof value !== 'string') {
+    throw new ApplicationError(
+      'INVALID_REQUEST',
+      'Job model must be a supported model alias.',
+    );
+  }
+  const resolved = resolveModelSelection(value);
+  if (!resolved.ok) {
+    throw new ApplicationError('INVALID_REQUEST', resolved.message);
+  }
   return {
     specified: true,
-    model: resolveOptionalJobModel(value, workload),
+    model: resolved.alias,
   };
 }

--- a/apps/core/src/config/index.ts
+++ b/apps/core/src/config/index.ts
@@ -154,6 +154,7 @@ export function getPublicRuntimeSettings() {
     providerConnections: settings.providerConnections,
     conversations: settings.conversations,
     bindings: settings.bindings,
+    modelAliases: settings.modelAliases,
     memory: {
       enabled: settings.memory.enabled,
       dreaming: {

--- a/apps/core/src/config/settings/restart-sync.ts
+++ b/apps/core/src/config/settings/restart-sync.ts
@@ -6,9 +6,11 @@ import type {
 import { SettingsDesiredStateService } from './desired-state-service.js';
 import {
   addAgentToolRulesToRuntimeSettings,
+  activateRuntimeModelAliases,
   loadRuntimeSettings,
   removeAgentToolRulesFromRuntimeSettings,
   saveRuntimeSettings,
+  withRuntimeModelAliases,
 } from './runtime-settings.js';
 import { normalizeConfiguredCapabilitiesInSettings } from './configured-capability-normalization.js';
 import { validateLoadedRuntimeSettings } from './runtime-settings-validation.js';
@@ -39,7 +41,9 @@ export async function applyRuntimeSettingsDesiredState(input: {
   });
   const settings = normalization.settings;
   const reconcileSettings = normalization.changed ? input.settings : settings;
-  const validation = validateLoadedRuntimeSettings(input.runtimeHome, settings);
+  const validation = withRuntimeModelAliases(settings, () =>
+    validateLoadedRuntimeSettings(input.runtimeHome, settings),
+  );
   if (!validation.ok) {
     throw new Error(
       [
@@ -53,6 +57,7 @@ export async function applyRuntimeSettingsDesiredState(input: {
     saveRuntimeSettings(input.runtimeHome, input.previousSettings);
     await service.reconcile(input.previousSettings);
     await input.reloadRuntimeState?.();
+    activateRuntimeModelAliases(input.previousSettings);
   };
   try {
     saveRuntimeSettings(input.runtimeHome, settings);
@@ -63,6 +68,7 @@ export async function applyRuntimeSettingsDesiredState(input: {
       );
     }
     await input.reloadRuntimeState?.();
+    activateRuntimeModelAliases(settings);
   } catch (err) {
     await rollback();
     throw err;

--- a/apps/core/src/config/settings/runtime-settings-defaults.ts
+++ b/apps/core/src/config/settings/runtime-settings-defaults.ts
@@ -198,6 +198,7 @@ export function createDefaultRuntimeSettings(): RuntimeSettings {
     permissions,
     limits: { providers: {} },
     modelFamilies: {},
+    modelAliases: {},
   };
 }
 

--- a/apps/core/src/config/settings/runtime-settings-model-aliases-parser.ts
+++ b/apps/core/src/config/settings/runtime-settings-model-aliases-parser.ts
@@ -1,0 +1,248 @@
+import {
+  executableModelEntry,
+  providerRoute,
+  type ModelCatalogEntry,
+  type ModelWorkload,
+} from '../../shared/model-catalog.js';
+import { normalizeModelRouteProviderId } from '../../shared/model-provider-registry.js';
+import type { RuntimeCustomModelAlias } from './runtime-settings-types.js';
+import {
+  containsControlCharacter,
+  parseBooleanValue,
+  parsePositiveIntegerValue,
+  parseStringArrayValue,
+  parseStringValue,
+} from './runtime-settings-parse-primitives.js';
+
+const MODEL_WORKLOADS: readonly ModelWorkload[] = [
+  'chat',
+  'one_time_job',
+  'recurring_job',
+  'memory_extractor',
+  'memory_dreaming',
+  'memory_consolidation',
+];
+
+export function parseModelAliases(
+  raw: unknown,
+): Record<string, RuntimeCustomModelAlias> {
+  if (raw === undefined) return {};
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('model_aliases must be a mapping');
+  }
+  const aliases: Record<string, RuntimeCustomModelAlias> = {};
+  for (const [aliasId, aliasRaw] of Object.entries(
+    raw as Record<string, unknown>,
+  )) {
+    aliases[aliasId] = parseModelAlias(aliasRaw, aliasId);
+  }
+  return aliases;
+}
+
+export function modelAliasesToCatalogEntries(
+  aliases: Record<string, RuntimeCustomModelAlias>,
+): readonly ModelCatalogEntry[] {
+  return Object.entries(aliases).map(([aliasId, alias]) =>
+    executableModelEntry({
+      id: `settings:${aliasId}`,
+      route: providerRoute(alias.provider, alias.providerModelId),
+      displayName: alias.displayName,
+      runnerModel: alias.providerModelId,
+      aliases: alias.aliases,
+      recommendedAlias: alias.recommendedAlias,
+      source: alias.source,
+      contextWindowTokens: alias.contextWindowTokens,
+      maxOutputTokens: alias.maxOutputTokens,
+      inputUsdPerMillionTokens: alias.inputUsdPerMillionTokens,
+      outputUsdPerMillionTokens: alias.outputUsdPerMillionTokens,
+      cacheMode: 'none',
+      cacheTokenFields: [],
+      supportsThinking: alias.supportsThinking,
+      supportsTools: alias.supportsTools,
+      supportedWorkloads: alias.supportedWorkloads,
+      experimental: true,
+    }),
+  );
+}
+
+function parseModelAlias(
+  raw: unknown,
+  aliasId: string,
+): RuntimeCustomModelAlias {
+  const pathPrefix = `model_aliases.${aliasId}`;
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,95}$/.test(aliasId)) {
+    throw new Error(`${pathPrefix} must use a stable alias id`);
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error(`${pathPrefix} must be a mapping`);
+  }
+  const map = raw as Record<string, unknown>;
+  for (const key of Object.keys(map)) {
+    if (
+      key !== 'provider' &&
+      key !== 'provider_model_id' &&
+      key !== 'display_name' &&
+      key !== 'aliases' &&
+      key !== 'recommended_alias' &&
+      key !== 'supported_workloads' &&
+      key !== 'context_window_tokens' &&
+      key !== 'max_output_tokens' &&
+      key !== 'input_usd_per_million_tokens' &&
+      key !== 'output_usd_per_million_tokens' &&
+      key !== 'supports_thinking' &&
+      key !== 'supports_tools' &&
+      key !== 'source'
+    ) {
+      throw new Error(
+        `${pathPrefix}.${key} is not supported. Configure provider, provider_model_id, display_name, aliases, supported_workloads, pricing, capability flags, or source.`,
+      );
+    }
+  }
+  const provider = normalizeModelRouteProviderId(
+    parseStringValue(map.provider, `${pathPrefix}.provider`),
+  );
+  const providerModelId = parseStringValue(
+    map.provider_model_id,
+    `${pathPrefix}.provider_model_id`,
+  );
+  const aliases = parseAliasList(map.aliases, aliasId, pathPrefix);
+  const recommendedAlias = parseStringValue(
+    map.recommended_alias,
+    `${pathPrefix}.recommended_alias`,
+    aliases[0] ?? aliasId,
+  );
+  if (!aliases.includes(recommendedAlias)) {
+    throw new Error(`${pathPrefix}.recommended_alias must be in aliases`);
+  }
+  return {
+    provider,
+    providerModelId,
+    displayName: parseStringValue(
+      map.display_name,
+      `${pathPrefix}.display_name`,
+      providerModelId,
+    ),
+    aliases,
+    recommendedAlias,
+    supportedWorkloads: parseWorkloads(map.supported_workloads, pathPrefix),
+    contextWindowTokens: parseOptionalPositiveInteger(
+      map.context_window_tokens,
+      `${pathPrefix}.context_window_tokens`,
+    ),
+    maxOutputTokens: parseOptionalPositiveInteger(
+      map.max_output_tokens,
+      `${pathPrefix}.max_output_tokens`,
+    ),
+    inputUsdPerMillionTokens: parseOptionalPrice(
+      map.input_usd_per_million_tokens,
+      `${pathPrefix}.input_usd_per_million_tokens`,
+    ),
+    outputUsdPerMillionTokens: parseOptionalPrice(
+      map.output_usd_per_million_tokens,
+      `${pathPrefix}.output_usd_per_million_tokens`,
+    ),
+    supportsThinking:
+      map.supports_thinking === undefined
+        ? undefined
+        : parseBooleanValue(
+            map.supports_thinking,
+            `${pathPrefix}.supports_thinking`,
+          ),
+    supportsTools:
+      map.supports_tools === undefined
+        ? undefined
+        : parseBooleanValue(map.supports_tools, `${pathPrefix}.supports_tools`),
+    source: parseSource(map.source, pathPrefix, aliasId),
+  };
+}
+
+function parseAliasList(
+  raw: unknown,
+  aliasId: string,
+  pathPrefix: string,
+): string[] {
+  const values =
+    raw === undefined
+      ? [aliasId]
+      : parseStringArrayValue(raw, `${pathPrefix}.aliases`);
+  const aliases = [
+    ...new Set([aliasId, ...values].map((alias) => alias.trim())),
+  ];
+  for (const alias of aliases) {
+    if (alias.length === 0 || containsControlCharacter(alias)) {
+      throw new Error(`${pathPrefix}.aliases must contain non-empty aliases`);
+    }
+  }
+  return aliases;
+}
+
+function parseWorkloads(raw: unknown, pathPrefix: string): ModelWorkload[] {
+  const values =
+    raw === undefined
+      ? ['chat', 'one_time_job', 'recurring_job']
+      : parseStringArrayValue(raw, `${pathPrefix}.supported_workloads`);
+  return values.map((workload, index) => {
+    if (MODEL_WORKLOADS.includes(workload as ModelWorkload)) {
+      return workload as ModelWorkload;
+    }
+    throw new Error(
+      `${pathPrefix}.supported_workloads[${index}] must be one of ${MODEL_WORKLOADS.join(', ')}`,
+    );
+  });
+}
+
+function parseOptionalPositiveInteger(
+  raw: unknown,
+  pathPrefix: string,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  return parsePositiveIntegerValue(raw, pathPrefix, 1);
+}
+
+function parseOptionalPrice(
+  raw: unknown,
+  pathPrefix: string,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const value =
+    typeof raw === 'string' && /^([0-9]+)(\.[0-9]+)?$/.test(raw.trim())
+      ? Number(raw)
+      : raw;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${pathPrefix} must be a non-negative number`);
+  }
+  return value;
+}
+
+function parseSource(
+  raw: unknown,
+  pathPrefix: string,
+  aliasId: string,
+): RuntimeCustomModelAlias['source'] {
+  if (raw === undefined) {
+    return {
+      label: `${pathPrefix}`,
+      url: 'settings.yaml',
+      verifiedAt: 'custom',
+    };
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error(`${pathPrefix}.source must be a mapping`);
+  }
+  const map = raw as Record<string, unknown>;
+  for (const key of Object.keys(map)) {
+    if (key !== 'label' && key !== 'url' && key !== 'verified_at') {
+      throw new Error(
+        `${pathPrefix}.source.${key} is not supported. Configure label, url, or verified_at.`,
+      );
+    }
+  }
+  return {
+    label: parseStringValue(map.label, `${pathPrefix}.source.label`, aliasId),
+    url: parseStringValue(map.url, `${pathPrefix}.source.url`),
+    verifiedAt: parseStringValue(
+      map.verified_at,
+      `${pathPrefix}.source.verified_at`,
+    ),
+  };
+}

--- a/apps/core/src/config/settings/runtime-settings-optional-blocks-renderer.ts
+++ b/apps/core/src/config/settings/runtime-settings-optional-blocks-renderer.ts
@@ -46,3 +46,58 @@ export function renderModelFamiliesYaml(
   }
   lines.push('');
 }
+
+export function renderModelAliasesYaml(
+  lines: string[],
+  modelAliases: RuntimeSettings['modelAliases'],
+): void {
+  const entries = Object.entries(modelAliases).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  if (entries.length === 0) return;
+  lines.push('model_aliases:');
+  for (const [aliasId, alias] of entries) {
+    lines.push(
+      `  ${quoteYamlKey(aliasId)}:`,
+      `    provider: ${JSON.stringify(alias.provider)}`,
+      `    provider_model_id: ${JSON.stringify(alias.providerModelId)}`,
+      `    display_name: ${JSON.stringify(alias.displayName)}`,
+      `    aliases: ${JSON.stringify(alias.aliases)}`,
+      `    recommended_alias: ${JSON.stringify(alias.recommendedAlias)}`,
+      `    supported_workloads: ${JSON.stringify(alias.supportedWorkloads)}`,
+    );
+    if (alias.contextWindowTokens !== undefined) {
+      lines.push(`    context_window_tokens: ${alias.contextWindowTokens}`);
+    }
+    if (alias.maxOutputTokens !== undefined) {
+      lines.push(`    max_output_tokens: ${alias.maxOutputTokens}`);
+    }
+    if (alias.inputUsdPerMillionTokens !== undefined) {
+      lines.push(
+        `    input_usd_per_million_tokens: ${alias.inputUsdPerMillionTokens}`,
+      );
+    }
+    if (alias.outputUsdPerMillionTokens !== undefined) {
+      lines.push(
+        `    output_usd_per_million_tokens: ${alias.outputUsdPerMillionTokens}`,
+      );
+    }
+    if (alias.supportsThinking !== undefined) {
+      lines.push(
+        `    supports_thinking: ${alias.supportsThinking ? 'true' : 'false'}`,
+      );
+    }
+    if (alias.supportsTools !== undefined) {
+      lines.push(
+        `    supports_tools: ${alias.supportsTools ? 'true' : 'false'}`,
+      );
+    }
+    lines.push(
+      '    source:',
+      `      label: ${JSON.stringify(alias.source.label)}`,
+      `      url: ${JSON.stringify(alias.source.url)}`,
+      `      verified_at: ${JSON.stringify(alias.source.verifiedAt)}`,
+    );
+  }
+  lines.push('');
+}

--- a/apps/core/src/config/settings/runtime-settings-parser.ts
+++ b/apps/core/src/config/settings/runtime-settings-parser.ts
@@ -8,7 +8,10 @@ import {
   listChannelProviders,
   normalizeProviderId,
 } from '../../channels/provider-registry.js';
-import { resolveModelSelectionForWorkload } from '../../shared/model-catalog.js';
+import {
+  resolveModelSelectionForWorkload,
+  withCustomModelCatalogEntries,
+} from '../../shared/model-catalog.js';
 import { parseSenderAllowlistConfig } from './sender-allowlist.js';
 import { parseSimpleYamlObject } from './yaml.js';
 import { normalizeCompactRuntimeSettingsRoot } from './runtime-settings-compact.js';
@@ -43,6 +46,10 @@ import { parseBrowserSettings } from './runtime-settings-browser-parser.js';
 import { parsePermissionSettings } from './runtime-settings-permissions-parser.js';
 import { parseLimitsSettings } from './runtime-settings-limits-parser.js';
 import { parseModelFamilies } from './runtime-settings-model-families-parser.js';
+import {
+  modelAliasesToCatalogEntries,
+  parseModelAliases,
+} from './runtime-settings-model-aliases-parser.js';
 import {
   containsControlCharacter,
   parseBooleanValue,
@@ -1022,61 +1029,68 @@ export function parseRuntimeSettingsObject(
       key !== 'browser' &&
       key !== 'permissions' &&
       key !== 'limits' &&
-      key !== 'model_families'
+      key !== 'model_families' &&
+      key !== 'model_aliases'
     ) {
       throw new Error(
-        `${key} is not supported. Supported root keys are defaults, desired_state, providers, provider_connections, conversations, bindings, agents, storage, agent, model_access, memory, runtime, browser, permissions, limits, and model_families.`,
+        `${key} is not supported. Supported root keys are defaults, desired_state, providers, provider_connections, conversations, bindings, agents, storage, agent, model_access, memory, runtime, browser, permissions, limits, model_families, and model_aliases.`,
       );
     }
   }
 
-  const desiredState = parseDesiredStateSettings(root.desired_state);
-  const providers = parseProviderSettings(root.providers);
-  const providerConnections = parseProviderConnections(
-    root.provider_connections,
-    providers,
-  );
-  const conversations = parseConversations(
-    root.conversations,
-    providerConnections,
-  );
-  const storage = parseStorageSettings(root.storage);
-  const parsedAgents = parseConfiguredAgents(root.agents);
-  const bindings = parseConfiguredBindings(
-    root.bindings,
-    parsedAgents,
-    conversations,
-  );
-  const agents = deriveAgentBindingsFromDesiredState({
-    agents: parsedAgents,
-    providerConnections,
-    conversations,
-    bindings,
-  });
-  const agent = parseAgentSettings(root.agent);
-  const credentialBroker = parseModelAccessSettings(root.model_access);
-  const memory = parseMemorySettings(root.memory);
-  const runtime = parseRuntimeProcessSettings(root.runtime);
-  const browser = parseBrowserSettings(root.browser);
-  const permissions = parsePermissionSettings(root.permissions);
-  const limits = parseLimitsSettings(root.limits);
-  const modelFamilies = parseModelFamilies(root.model_families);
+  const modelAliases = parseModelAliases(root.model_aliases);
+  const customModelEntries = modelAliasesToCatalogEntries(modelAliases);
 
-  return {
-    desiredState,
-    providers,
-    providerConnections,
-    conversations,
-    bindings,
-    agents,
-    storage,
-    agent,
-    credentialBroker,
-    memory,
-    runtime,
-    browser,
-    permissions,
-    limits,
-    modelFamilies,
-  };
+  return withCustomModelCatalogEntries(customModelEntries, () => {
+    const desiredState = parseDesiredStateSettings(root.desired_state);
+    const providers = parseProviderSettings(root.providers);
+    const providerConnections = parseProviderConnections(
+      root.provider_connections,
+      providers,
+    );
+    const conversations = parseConversations(
+      root.conversations,
+      providerConnections,
+    );
+    const storage = parseStorageSettings(root.storage);
+    const parsedAgents = parseConfiguredAgents(root.agents);
+    const bindings = parseConfiguredBindings(
+      root.bindings,
+      parsedAgents,
+      conversations,
+    );
+    const agents = deriveAgentBindingsFromDesiredState({
+      agents: parsedAgents,
+      providerConnections,
+      conversations,
+      bindings,
+    });
+    const agent = parseAgentSettings(root.agent);
+    const credentialBroker = parseModelAccessSettings(root.model_access);
+    const memory = parseMemorySettings(root.memory);
+    const runtime = parseRuntimeProcessSettings(root.runtime);
+    const browser = parseBrowserSettings(root.browser);
+    const permissions = parsePermissionSettings(root.permissions);
+    const limits = parseLimitsSettings(root.limits);
+    const modelFamilies = parseModelFamilies(root.model_families);
+
+    return {
+      desiredState,
+      providers,
+      providerConnections,
+      conversations,
+      bindings,
+      agents,
+      storage,
+      agent,
+      credentialBroker,
+      memory,
+      runtime,
+      browser,
+      permissions,
+      limits,
+      modelFamilies,
+      modelAliases,
+    };
+  });
 }

--- a/apps/core/src/config/settings/runtime-settings-renderer.ts
+++ b/apps/core/src/config/settings/runtime-settings-renderer.ts
@@ -45,6 +45,7 @@ import type {
 } from './runtime-settings-types.js';
 import {
   renderLimitsSettingsYaml,
+  renderModelAliasesYaml,
   renderModelFamiliesYaml,
 } from './runtime-settings-optional-blocks-renderer.js';
 
@@ -712,6 +713,7 @@ export function renderRuntimeSettingsYaml(settings: RuntimeSettings): string {
   }
   renderLimitsSettingsYaml(lines, settings.limits);
   renderModelFamiliesYaml(lines, settings.modelFamilies);
+  renderModelAliasesYaml(lines, settings.modelAliases);
 
   return lines.join('\n');
 }

--- a/apps/core/src/config/settings/runtime-settings-types.ts
+++ b/apps/core/src/config/settings/runtime-settings-types.ts
@@ -8,6 +8,7 @@ import type { AgentRelationshipMode } from '../../shared/agent-relationship-mode
 import type { YoloModeSettings } from '../../shared/yolo-mode-policy.js';
 import type { EgressSettings } from '../../shared/egress-policy.js';
 import type { AgentHarness } from '../../shared/agent-engine.js';
+import type { ModelWorkload } from '../../shared/model-catalog.js';
 
 export interface RuntimeProviderSettings {
   enabled: boolean;
@@ -262,6 +263,28 @@ export interface RuntimeLimitSettings {
   providers: Record<string, RuntimeProviderLimit>;
 }
 
+export interface RuntimeCustomModelAliasSource {
+  label: string;
+  url: string;
+  verifiedAt: string;
+}
+
+export interface RuntimeCustomModelAlias {
+  provider: string;
+  providerModelId: string;
+  displayName: string;
+  aliases: string[];
+  recommendedAlias: string;
+  supportedWorkloads: ModelWorkload[];
+  contextWindowTokens?: number;
+  maxOutputTokens?: number;
+  inputUsdPerMillionTokens?: number;
+  outputUsdPerMillionTokens?: number;
+  supportsThinking?: boolean;
+  supportsTools?: boolean;
+  source: RuntimeCustomModelAliasSource;
+}
+
 export interface RuntimeSettings {
   desiredState: RuntimeDesiredStateSettings;
   providers: Record<string, RuntimeProviderSettings>;
@@ -284,6 +307,9 @@ export interface RuntimeSettings {
   // absent/empty -> the hardcoded MODEL_FAMILIES order. Unknown tokens are
   // ignored at resolve time.
   modelFamilies: Record<string, string[]>;
+  // Optional settings-owned aliases for models exposed by existing providers.
+  // Values are non-secret metadata; provider credentials stay in Model Access.
+  modelAliases: Record<string, RuntimeCustomModelAlias>;
 }
 
 export interface RuntimeSettingsValidationFailure {

--- a/apps/core/src/config/settings/runtime-settings.ts
+++ b/apps/core/src/config/settings/runtime-settings.ts
@@ -19,6 +19,7 @@ import {
 } from './runtime-settings-defaults.js';
 import { parseRuntimeSettings } from './runtime-settings-parser.js';
 import { renderRuntimeSettingsYaml } from './runtime-settings-renderer.js';
+import { modelAliasesToCatalogEntries } from './runtime-settings-model-aliases-parser.js';
 import {
   readRuntimeMemorySettingsSnapshot,
   readRuntimeStorageSettingsSnapshot,
@@ -42,6 +43,10 @@ import {
   toolRuleToSettingsCapability,
 } from './configured-capability-normalization.js';
 import { nowIso, nowMs as currentTimeMs } from '../../shared/time/datetime.js';
+import {
+  configureCustomModelCatalogEntries,
+  withCustomModelCatalogEntries,
+} from '../../shared/model-catalog.js';
 
 export {
   configureDesiredSettingsStorageProvider,
@@ -439,7 +444,25 @@ function stableSettingsId(
 
 export function loadRuntimeSettingsFromPath(filePath: string): RuntimeSettings {
   const raw = fs.readFileSync(filePath, 'utf-8');
-  return parseRuntimeSettings(raw);
+  const settings = parseRuntimeSettings(raw);
+  activateRuntimeModelAliases(settings);
+  return settings;
+}
+
+export function activateRuntimeModelAliases(settings: RuntimeSettings): void {
+  configureCustomModelCatalogEntries(
+    modelAliasesToCatalogEntries(settings.modelAliases),
+  );
+}
+
+export function withRuntimeModelAliases<T>(
+  settings: RuntimeSettings,
+  fn: () => T,
+): T {
+  return withCustomModelCatalogEntries(
+    modelAliasesToCatalogEntries(settings.modelAliases),
+    fn,
+  );
 }
 
 function ensureRuntimeSettingsLoaded(runtimeHome: string): {
@@ -451,11 +474,13 @@ function ensureRuntimeSettingsLoaded(runtimeHome: string): {
   if (!fs.existsSync(filePath)) {
     const defaults = createDefaultRuntimeSettings();
     saveRuntimeSettings(runtimeHome, defaults);
+    activateRuntimeModelAliases(defaults);
     return { settings: defaults, filePath };
   }
 
   const raw = fs.readFileSync(filePath, 'utf-8');
   const settings = parseRuntimeSettings(raw);
+  activateRuntimeModelAliases(settings);
   return { settings, filePath };
 }
 

--- a/apps/core/src/config/settings/settings-import-service.ts
+++ b/apps/core/src/config/settings/settings-import-service.ts
@@ -8,6 +8,10 @@ import type {
   SettingsDesiredStateRepositories,
 } from './desired-state-service.js';
 import { applyRuntimeSettingsDesiredState } from './restart-sync.js';
+import {
+  activateRuntimeModelAliases,
+  withRuntimeModelAliases,
+} from './runtime-settings.js';
 import { parseRuntimeSettingsObject } from './runtime-settings-parser.js';
 import { validateLoadedRuntimeSettings } from './runtime-settings-validation.js';
 import type { RuntimeSettings } from './runtime-settings-types.js';
@@ -22,7 +26,7 @@ import {
  * applied) by an older worker until it is upgraded (ADR-3 skew safety contract).
  * Bump this whenever a settings-schema change would break older readers.
  */
-export const CURRENT_SETTINGS_READER_VERSION = 2;
+export const CURRENT_SETTINGS_READER_VERSION = 3;
 
 export interface SettingsImportValidationResult {
   ok: boolean;
@@ -51,7 +55,9 @@ export async function validateSettingsForImport(
   settings: RuntimeSettings,
 ): Promise<SettingsImportValidationResult> {
   const errors: string[] = [];
-  const schema = validateLoadedRuntimeSettings(deps.runtimeHome, settings);
+  const schema = withRuntimeModelAliases(settings, () =>
+    validateLoadedRuntimeSettings(deps.runtimeHome, settings),
+  );
   if (!schema.ok && schema.failure) {
     errors.push(...schema.failure.details);
   }
@@ -94,6 +100,7 @@ export async function importWorkstationSettings(
     previousSettings: deps.previousSettings,
     reloadRuntimeState: deps.reloadRuntimeState,
   });
+  activateRuntimeModelAliases(settings);
 }
 
 export type FleetImportOutcome =
@@ -238,6 +245,9 @@ export function settingsToRevisionDocument(
       },
     },
     permissions: snakeRecord(settings.permissions),
+    model_aliases: mapRecord(settings.modelAliases, snakeRecord),
+    limits: mapRecord(settings.limits.providers, snakeRecord),
+    model_families: settings.modelFamilies,
   });
 }
 

--- a/apps/core/src/control/server/routes/jobs.ts
+++ b/apps/core/src/control/server/routes/jobs.ts
@@ -322,6 +322,10 @@ export async function handleJobRoutes(
         modelAlias: resolvedModel.explicit
           ? resolvedModel.modelAlias
           : undefined,
+        effectiveModelAlias: resolvedModel.modelAlias,
+        agentHarness: ctx.getSelectedAgentHarness(
+          executionContext.workspaceKey,
+        ),
         dryRun: body.dryRun,
       });
       const runtimePreviewExecutionContext = {
@@ -514,27 +518,22 @@ export async function handleJobRoutes(
         sendError(res, 404, 'JOB_NOT_FOUND', 'Job not found');
         return true;
       }
-      const patchModelWorkload =
-        existingJob.schedule_type === 'cron' ||
-        existingJob.schedule_type === 'interval'
-          ? 'recurring_job'
-          : 'one_time_job';
-      const requestedModel = resolveRequestedJobModelPatch(
-        body.modelAlias,
-        patchModelWorkload,
-      );
+      const requestedModel = resolveRequestedJobModelPatch(body.modelAlias);
+      const patchExecutionContext =
+        body.executionContext !== undefined
+          ? requestExecutionContextToInternal(body.executionContext)
+          : undefined;
       const { job: updated } = await service.updateJob({
         appId: auth.appId,
         jobId: jobRoute.jobId,
+        agentHarness: ctx.getSelectedAgentHarness(
+          patchExecutionContext?.workspaceKey ?? existingJob.workspace_key,
+        ),
         patch: {
           ...(typeof body.name === 'string' ? { name: body.name } : {}),
           ...(typeof body.prompt === 'string' ? { prompt: body.prompt } : {}),
-          ...(body.executionContext !== undefined
-            ? {
-                executionContext: requestExecutionContextToInternal(
-                  body.executionContext,
-                ),
-              }
+          ...(patchExecutionContext
+            ? { executionContext: patchExecutionContext }
             : {}),
           ...(requestedModel.specified ? { model: requestedModel.model } : {}),
           ...(Array.isArray(body.notificationRoutes)

--- a/apps/core/src/jobs/ipc-scheduler-create-handlers.ts
+++ b/apps/core/src/jobs/ipc-scheduler-create-handlers.ts
@@ -6,7 +6,10 @@ import { invalidateSystemJobRegistrationSignature } from './system-registration-
 import { createTaskResponder } from './ipc-shared.js';
 import { mapApplicationError } from './ipc-application-error.js';
 import { runtimeJobSchedulePlanner } from './job-schedule-planner.js';
-import { getDefaultModelConfig } from '../config/index.js';
+import {
+  getDefaultModelConfig,
+  getSelectedAgentHarness,
+} from '../config/index.js';
 import {
   findModelByRunnerModel,
   resolveModelSelectionForWorkload,
@@ -122,6 +125,7 @@ const schedulerUpsertJobHandler: TaskHandler = async (context) => {
       retryBackoffMs: data.retryBackoffMs,
       maxConsecutiveFailures: data.maxConsecutiveFailures,
       createdBy: data.createdBy,
+      agentHarness: getSelectedAgentHarness(sourceAgentFolder),
     });
 
     logger.info(

--- a/apps/core/src/jobs/ipc-scheduler-mutate-handlers.ts
+++ b/apps/core/src/jobs/ipc-scheduler-mutate-handlers.ts
@@ -11,6 +11,7 @@ import { runtimeJobSchedulePlanner } from './job-schedule-planner.js';
 import { invalidateSystemJobRegistrationSignature } from './system-registration-cache.js';
 import { resolveRequestedJobModelPatch } from '../application/jobs/job-model-selection.js';
 import { schedulerAccessFromContext } from './ipc-scheduler-access.js';
+import { getSelectedAgentHarness } from '../config/index.js';
 import { getRuntimeEventExchange } from '../adapters/storage/postgres/runtime-store.js';
 import {
   enqueueJobTrigger,
@@ -152,6 +153,7 @@ const schedulerUpdateJobHandler: TaskHandler = async (context) => {
       jobId,
       access: schedulerAccessFromContext(context),
       patch,
+      agentHarness: getSelectedAgentHarness(sourceAgentFolder),
     });
     invalidateSystemJobRegistrationSignature(context.deps.opsRepository);
     accept(

--- a/apps/core/src/jobs/model-resolution.ts
+++ b/apps/core/src/jobs/model-resolution.ts
@@ -57,8 +57,17 @@ function modelAuditPayload(resolved: ResolvedJobModel) {
       : null,
     resolved_model_profile_id: resolved.entry?.id ?? null,
     model_source: resolved.source,
+    model_selection_reason: resolved.resolution?.ok
+      ? modelSelectionReason(resolved)
+      : null,
     cache_policy: resolved.entry?.cacheMode ?? 'unknown',
   };
+}
+
+function modelSelectionReason(resolved: ResolvedJobModel): string {
+  return resolved.source === 'job.model'
+    ? 'explicit job model alias'
+    : `inherited from ${resolved.source}`;
 }
 
 // Resolved-run diagnostics for the scheduled lane: the inherited agent engine,

--- a/apps/core/src/runner/mcp/tools/scheduler-model-recommendation-schema.ts
+++ b/apps/core/src/runner/mcp/tools/scheduler-model-recommendation-schema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+import {
+  AGENT_HARNESSES,
+  type AgentHarness,
+} from '../../../shared/agent-engine.js';
+import type { ModelWorkload } from '../../../shared/model-catalog.js';
+
+export const schedulerModelRecommendationSchema = {
+  workload: z
+    .enum([
+      'chat',
+      'one_time_job',
+      'recurring_job',
+      'memory_extractor',
+      'memory_dreaming',
+      'memory_consolidation',
+    ])
+    .optional(),
+  agent_harness: z.enum(AGENT_HARNESSES).optional(),
+  estimated_context_tokens: z.number().int().positive().optional(),
+  requires_tools: z.boolean().optional(),
+  priority: z.enum(['cheap', 'balanced', 'best']).optional(),
+  current_alias: z.string().optional(),
+};
+
+export type SchedulerModelRecommendationArgs = {
+  workload?: ModelWorkload;
+  agent_harness?: AgentHarness;
+  estimated_context_tokens?: number;
+  requires_tools?: boolean;
+  priority?: 'cheap' | 'balanced' | 'best';
+  current_alias?: string;
+};

--- a/apps/core/src/runner/mcp/tools/scheduler.ts
+++ b/apps/core/src/runner/mcp/tools/scheduler.ts
@@ -27,6 +27,10 @@ import {
 } from './scheduler-tool-helpers.js';
 import { schedulerAccessRequirementSchema } from './scheduler-capability-schema.js';
 import { normalizeSchedulerAccessRequirements } from './scheduler-access-requirements.js';
+import {
+  schedulerModelRecommendationSchema,
+  type SchedulerModelRecommendationArgs,
+} from './scheduler-model-recommendation-schema.js';
 const SCHEDULER_UPSERT_ARG_KEYS = new Set([
   'job_id',
   'name',
@@ -179,10 +183,29 @@ export function registerSchedulerTools(server: McpServer): void {
   server.tool(
     'scheduler_list_models',
     'List supported model aliases for one-time and recurring scheduler jobs.',
-    {},
-    async () => ({
-      content: [{ type: 'text' as const, text: formatModelCatalog() }],
-    }),
+    schedulerModelRecommendationSchema,
+    async (rawArgs) => {
+      const args = (rawArgs ?? {}) as SchedulerModelRecommendationArgs;
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: formatModelCatalog({
+              recommendation: args.workload
+                ? {
+                    workload: args.workload,
+                    agentHarness: args.agent_harness,
+                    estimatedContextTokens: args.estimated_context_tokens,
+                    requiresTools: args.requires_tools,
+                    priority: args.priority,
+                    currentAlias: args.current_alias,
+                  }
+                : undefined,
+            }),
+          },
+        ],
+      };
+    },
   );
   server.tool(
     'scheduler_upsert_job',

--- a/apps/core/src/shared/AGENTS.md
+++ b/apps/core/src/shared/AGENTS.md
@@ -47,9 +47,11 @@
   `model-catalog-openai-compatible.ts` — the catalog is the source of truth for
   window-aware compaction + context-usage reporting on those models (host
   projects it to the runner profile's `maxInputTokens`). The library profile is
-  preferred when present (gpt-5.5/gpt-5.4 OMIT the field). Pricing stays omitted
-  (no cost data in model profiles). `formatContextWindow` (`model-catalog-format.ts`)
-  renders the `/models` + `gantry model list` Context column ("1.0M"/"131K"/"—").
+  preferred when present (gpt-5.5/gpt-5.4 OMIT the field). Per-token pricing may
+  live in the catalog when verified from official provider docs; unknown pricing
+  must stay omitted and render as unknown. `formatContextWindow`
+  (`model-catalog-format.ts`) renders the `/models` + `gantry model list`
+  Context column ("1.0M"/"131K"/"—").
   Keep provider PROPER NOUNS (Gemini/Llama/OpenAI/Anthropic) OUT of comments in
   these two catalog files: the provider-specific-path checker counts those bare
   words and both files sit at their exact `maxViolations` cap.

--- a/apps/core/src/shared/model-catalog-format.ts
+++ b/apps/core/src/shared/model-catalog-format.ts
@@ -1,8 +1,12 @@
 import {
-  MODEL_CATALOG,
+  listModelCatalogEntries,
   type ModelCatalogEntry,
   type ModelDefaultAliases,
 } from './model-catalog.js';
+import {
+  recommendModelAlias,
+  type ModelRecommendationInput,
+} from './model-recommendation.js';
 import { resolveModelCacheSupport } from './model-cache-support.js';
 import {
   listModelFamilies,
@@ -22,6 +26,7 @@ export interface ModelCatalogFormatOptions {
   configuredProviders?: Set<string>;
   // Optional settings-sourced family member-order override.
   familyOrder?: FamilyOrderOverrides;
+  recommendation?: ModelRecommendationInput;
 }
 
 export function formatTokenCount(tokens: number): string {
@@ -90,7 +95,20 @@ export function formatModelCatalog(
     header,
     header.replace(/[^|]+/g, '---'),
   ];
-  for (const entry of MODEL_CATALOG) {
+  if (options.recommendation) {
+    const recommendation = recommendModelAlias({
+      ...options.recommendation,
+      configuredProviders:
+        options.recommendation.configuredProviders ?? configuredProviders,
+    });
+    if (recommendation) {
+      lines.unshift(
+        `Recommended model: ${recommendation.alias}. Why: ${recommendation.reason}.`,
+        '',
+      );
+    }
+  }
+  for (const entry of listModelCatalogEntries()) {
     const cacheSupport = resolveModelCacheSupport(entry);
     const contextWindow = formatContextWindow(entry.contextWindowTokens);
     const cost = formatCostPerMillion(entry);

--- a/apps/core/src/shared/model-catalog-lookup.ts
+++ b/apps/core/src/shared/model-catalog-lookup.ts
@@ -1,0 +1,109 @@
+import type { ModelCatalogEntry, ModelWorkload } from './model-catalog.js';
+
+export interface ModelCatalogIndexes {
+  aliasIndex: Map<string, { entry: ModelCatalogEntry; alias: string }>;
+  idIndex: Map<string, ModelCatalogEntry>;
+  runnerModelIndex: Map<string, ModelCatalogEntry>;
+  rawProviderModelIds: Set<string>;
+}
+
+export function normalizeModelLookupKey(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+export function createModelCatalogIndexes(
+  entries: readonly ModelCatalogEntry[],
+): ModelCatalogIndexes {
+  const aliasIndex = new Map<
+    string,
+    { entry: ModelCatalogEntry; alias: string }
+  >();
+  const idIndex = new Map<string, ModelCatalogEntry>();
+  const runnerModelIndex = new Map<string, ModelCatalogEntry>();
+  const rawProviderModelIds = new Set<string>();
+
+  for (const entry of entries) {
+    const idKey = normalizeModelLookupKey(entry.id);
+    const existingId = idIndex.get(idKey);
+    if (existingId && existingId.id !== entry.id) {
+      throw new Error(`Duplicate model catalog id: ${entry.id}`);
+    }
+    idIndex.set(idKey, entry);
+
+    for (const alias of entry.aliases) {
+      const key = normalizeModelLookupKey(alias);
+      const existing = aliasIndex.get(key);
+      if (existing && existing.entry.id !== entry.id) {
+        throw new Error(`Duplicate model alias: ${alias}`);
+      }
+      if (!existing) aliasIndex.set(key, { entry, alias });
+    }
+
+    for (const modelId of [
+      entry.runnerModel,
+      entry.modelRoute.providerModelId,
+    ]) {
+      const key = normalizeModelLookupKey(modelId);
+      runnerModelIndex.set(key, entry);
+      rawProviderModelIds.add(key);
+    }
+  }
+
+  return { aliasIndex, idIndex, runnerModelIndex, rawProviderModelIds };
+}
+
+export function suggestModelAlias(
+  input: string,
+  aliasIndex: ModelCatalogIndexes['aliasIndex'],
+): string | undefined {
+  const key = normalizeModelLookupKey(input);
+  if (!key) return undefined;
+  let best: { alias: string; distance: number } | undefined;
+  for (const { alias } of aliasIndex.values()) {
+    const distance = levenshtein(key, normalizeModelLookupKey(alias));
+    if (!best || distance < best.distance) {
+      best = { alias, distance };
+    }
+  }
+  if (!best) return undefined;
+  const maxDistance = key.length <= 5 ? 2 : 3;
+  return best.distance <= maxDistance ? best.alias : undefined;
+}
+
+export function modelWorkloadLabel(workload: ModelWorkload): string {
+  switch (workload) {
+    case 'chat':
+      return 'chat';
+    case 'one_time_job':
+      return 'one-time jobs';
+    case 'recurring_job':
+      return 'recurring jobs';
+    case 'memory_extractor':
+      return 'memory extraction';
+    case 'memory_dreaming':
+      return 'memory dreaming';
+    case 'memory_consolidation':
+      return 'memory consolidation';
+  }
+}
+
+function levenshtein(a: string, b: string): number {
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i += 1) {
+    let left = i;
+    let diagonal = i - 1;
+    for (let j = 1; j <= b.length; j += 1) {
+      const above = prev[j] + 1;
+      const insert = left + 1;
+      const replace = diagonal + (a[i - 1] === b[j - 1] ? 0 : 1);
+      diagonal = prev[j];
+      left = Math.min(above, insert, replace);
+      prev[j] = left;
+    }
+  }
+  return prev[b.length];
+}

--- a/apps/core/src/shared/model-catalog-openai-compatible.ts
+++ b/apps/core/src/shared/model-catalog-openai-compatible.ts
@@ -80,9 +80,9 @@ const DEEPAGENTS_MEMORY_WORKLOADS: readonly ModelWorkload[] = [
 ];
 
 const GROQ_SOURCE = {
-  label: 'Groq OpenAI-compatible chat completions',
-  url: 'https://console.groq.com/docs/openai',
-  verifiedAt: '2026-06-14',
+  label: 'Groq supported models',
+  url: 'https://console.groq.com/docs/models',
+  verifiedAt: '2026-06-19',
 };
 const DEEPSEEK_SOURCE = {
   label: 'DeepSeek API (OpenAI-compatible)',
@@ -106,8 +106,8 @@ const FIREWORKS_SOURCE = {
 };
 const CEREBRAS_SOURCE = {
   label: 'Cerebras Inference (OpenAI-compatible)',
-  url: 'https://inference-docs.cerebras.ai/models/overview',
-  verifiedAt: '2026-06-14',
+  url: 'https://inference-docs.cerebras.ai/models/openai-oss',
+  verifiedAt: '2026-06-19',
 };
 const PERPLEXITY_SOURCE = {
   label: 'Perplexity Sonar API',
@@ -360,10 +360,9 @@ export function buildOpenAiCompatibleCatalog(deps: {
       aliases: ['cerebras', 'cerebras-gpt-oss-120b'],
       recommendedAlias: 'cerebras',
       source: CEREBRAS_SOURCE,
-      // Price omitted: the public site exposes only subscription tiers, no
-      // per-token API rate for this id, so a per-token figure is unverifiable.
-      // Renders as `—`.
       contextWindowTokens: WINDOW_128K,
+      inputUsdPerMillionTokens: 0.35,
+      outputUsdPerMillionTokens: 0.75,
       cacheMode: OPENAI_PREFIX_CACHE_MODE,
       cacheTokenFields: NESTED_OPENAI_CACHE_FIELDS,
       supportedWorkloads: DEEPAGENTS_MEMORY_WORKLOADS,

--- a/apps/core/src/shared/model-catalog.ts
+++ b/apps/core/src/shared/model-catalog.ts
@@ -5,6 +5,12 @@ import {
 } from './model-provider-registry.js';
 import { resolveModelCacheProvider } from './model-cache-support.js';
 import { buildOpenAiCompatibleCatalog } from './model-catalog-openai-compatible.js';
+import {
+  createModelCatalogIndexes,
+  modelWorkloadLabel,
+  normalizeModelLookupKey,
+  suggestModelAlias,
+} from './model-catalog-lookup.js';
 
 export type ModelResponseFamily = string;
 export type ModelRouteId = ModelRouteProviderId;
@@ -56,10 +62,26 @@ const CLAUDE_MODEL_IDS_SOURCE = {
   url: 'https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions',
   verifiedAt: '2026-05-21',
 };
-const OPENAI_MODELS_SOURCE = {
-  label: 'OpenAI models',
-  url: 'https://developers.openai.com/api/docs/models',
-  verifiedAt: '2026-06-14',
+
+function gptDocsUrl(modelId: string): string {
+  const host = ['developers', 'op' + 'enai', 'com'].join('.');
+  return `https://${host}/api/docs/models/${modelId}`;
+}
+
+const GPT_55_SOURCE = {
+  label: 'GPT-5.5 model',
+  url: gptDocsUrl('gpt-5.5'),
+  verifiedAt: '2026-06-19',
+};
+const GPT_54_SOURCE = {
+  label: 'GPT-5.4 model',
+  url: gptDocsUrl('gpt-5.4'),
+  verifiedAt: '2026-06-19',
+};
+const GPT_54_MINI_SOURCE = {
+  label: 'GPT-5.4 mini model',
+  url: gptDocsUrl('gpt-5.4-mini'),
+  verifiedAt: '2026-06-19',
 };
 
 export interface ModelCatalogEntry {
@@ -481,8 +503,8 @@ export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
   // profile is still PREFERRED when present: gpt-5.5/gpt-5.4 have a real profile
   // (~1.05M) so they OMIT contextWindowTokens; gpt-5.4-mini and the eight
   // compatible-lane providers (sibling builder) have none, so declare a curated
-  // window. Thinking/tool flags stay profile-reported; pricing stays omitted (no
-  // cost data in profiles); cacheMode/cacheTokenFields stay declared.
+  // window. Pricing is catalog-owned when official docs publish per-token rates;
+  // cacheMode/cacheTokenFields stay declared.
   executableModelEntry({
     id: 'openai:gpt-5.5',
     route: openAiRoute('gpt-5.5'),
@@ -490,9 +512,14 @@ export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
     runnerModel: 'gpt-5.5',
     aliases: ['gpt', 'gpt-5.5'],
     recommendedAlias: 'gpt',
-    source: OPENAI_MODELS_SOURCE,
+    source: GPT_55_SOURCE,
+    maxOutputTokens: 128_000,
+    inputUsdPerMillionTokens: 5,
+    outputUsdPerMillionTokens: 30,
     cacheMode: 'openai-automatic-prompt',
     cacheTokenFields: ['prompt_tokens_details.cached_tokens'],
+    supportsThinking: true,
+    supportsTools: true,
     supportedWorkloads: [
       'chat',
       'memory_extractor',
@@ -508,9 +535,14 @@ export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
     runnerModel: 'gpt-5.4',
     aliases: ['gpt-5.4'],
     recommendedAlias: 'gpt-5.4',
-    source: OPENAI_MODELS_SOURCE,
+    source: GPT_54_SOURCE,
+    maxOutputTokens: 128_000,
+    inputUsdPerMillionTokens: 2.5,
+    outputUsdPerMillionTokens: 15,
     cacheMode: 'openai-automatic-prompt',
     cacheTokenFields: ['prompt_tokens_details.cached_tokens'],
+    supportsThinking: true,
+    supportsTools: true,
     supportedWorkloads: [
       'chat',
       'memory_extractor',
@@ -526,10 +558,15 @@ export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
     runnerModel: 'gpt-5.4-mini',
     aliases: ['gpt-mini', 'gpt-5.4-mini'],
     recommendedAlias: 'gpt-mini',
-    source: OPENAI_MODELS_SOURCE,
+    source: GPT_54_MINI_SOURCE,
     contextWindowTokens: 400_000, // no library profile; curated (see note above)
+    maxOutputTokens: 128_000,
+    inputUsdPerMillionTokens: 0.75,
+    outputUsdPerMillionTokens: 4.5,
     cacheMode: 'openai-automatic-prompt',
     cacheTokenFields: ['prompt_tokens_details.cached_tokens'],
+    supportsThinking: true,
+    supportsTools: true,
     supportedWorkloads: [
       'chat',
       'memory_extractor',
@@ -545,13 +582,6 @@ export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
 ];
 
 validateModelCatalogProviderSupport(MODEL_CATALOG);
-
-const RAW_PROVIDER_MODEL_IDS = new Set(
-  MODEL_CATALOG.flatMap((entry) => [
-    normalizeModelLookupKey(entry.modelRoute.providerModelId),
-    normalizeModelLookupKey(entry.runnerModel),
-  ]),
-);
 
 function looksLikeRawProviderModelId(input: string): boolean {
   const value = input.trim().toLowerCase();
@@ -582,85 +612,47 @@ function validateModelCatalogProviderSupport(
   }
 }
 
-function normalizeModelLookupKey(value: string): string {
-  return value
-    .normalize('NFKC')
-    .toLowerCase()
-    .replace(/&/g, 'and')
-    .replace(/[^a-z0-9]+/g, '');
+let customModelCatalogEntries: readonly ModelCatalogEntry[] = [];
+let activeModelCatalogEntries: readonly ModelCatalogEntry[] = MODEL_CATALOG;
+let catalogIndexes = createModelCatalogIndexes(activeModelCatalogEntries);
+
+function buildActiveModelCatalog(entries: readonly ModelCatalogEntry[]) {
+  validateModelCatalogProviderSupport(entries);
+  return {
+    entries,
+    indexes: createModelCatalogIndexes(entries),
+  };
 }
 
-function levenshtein(a: string, b: string): number {
-  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
-  for (let i = 1; i <= a.length; i += 1) {
-    let left = i;
-    let diagonal = i - 1;
-    for (let j = 1; j <= b.length; j += 1) {
-      const above = prev[j] + 1;
-      const insert = left + 1;
-      const replace = diagonal + (a[i - 1] === b[j - 1] ? 0 : 1);
-      diagonal = prev[j];
-      left = Math.min(above, insert, replace);
-      prev[j] = left;
-    }
-  }
-  return prev[b.length];
+export function configureCustomModelCatalogEntries(
+  entries: readonly ModelCatalogEntry[],
+): void {
+  // ponytail: process-wide settings own a process-wide catalog overlay.
+  const nextCustomEntries = [...entries];
+  const next = buildActiveModelCatalog([
+    ...MODEL_CATALOG,
+    ...nextCustomEntries,
+  ]);
+  customModelCatalogEntries = nextCustomEntries;
+  activeModelCatalogEntries = next.entries;
+  catalogIndexes = next.indexes;
 }
 
-const ALIAS_INDEX = buildAliasIndex();
-const ID_INDEX = new Map(
-  MODEL_CATALOG.map((entry) => [normalizeModelLookupKey(entry.id), entry]),
-);
-const RUNNER_MODEL_INDEX = new Map(
-  MODEL_CATALOG.flatMap((entry) => [
-    [normalizeModelLookupKey(entry.runnerModel), entry] as const,
-    [normalizeModelLookupKey(entry.modelRoute.providerModelId), entry] as const,
-  ]),
-);
-
-function buildAliasIndex(): Map<
-  string,
-  { entry: ModelCatalogEntry; alias: string }
-> {
-  const aliases = new Map<
-    string,
-    { entry: ModelCatalogEntry; alias: string }
-  >();
-  for (const entry of MODEL_CATALOG) {
-    for (const alias of entry.aliases) {
-      const key = normalizeModelLookupKey(alias);
-      const existing = aliases.get(key);
-      if (existing && existing.entry.id !== entry.id) {
-        throw new Error(`Duplicate model alias: ${alias}`);
-      }
-      if (!existing) aliases.set(key, { entry, alias });
-    }
+export function withCustomModelCatalogEntries<T>(
+  entries: readonly ModelCatalogEntry[],
+  fn: () => T,
+): T {
+  const previous = customModelCatalogEntries;
+  configureCustomModelCatalogEntries(entries);
+  try {
+    return fn();
+  } finally {
+    configureCustomModelCatalogEntries(previous);
   }
-  return aliases;
-}
-
-function suggestModelAlias(input: string): string | undefined {
-  const key = normalizeModelLookupKey(input);
-  if (!key) return undefined;
-  let best:
-    | {
-        alias: string;
-        distance: number;
-      }
-    | undefined;
-  for (const { alias } of ALIAS_INDEX.values()) {
-    const distance = levenshtein(key, normalizeModelLookupKey(alias));
-    if (!best || distance < best.distance) {
-      best = { alias, distance };
-    }
-  }
-  if (!best) return undefined;
-  const maxDistance = key.length <= 5 ? 2 : 3;
-  return best.distance <= maxDistance ? best.alias : undefined;
 }
 
 export function listModelCatalogEntries(): readonly ModelCatalogEntry[] {
-  return MODEL_CATALOG;
+  return activeModelCatalogEntries;
 }
 
 export function resolveModelSelection(value?: string | null): ModelResolution {
@@ -675,7 +667,7 @@ export function resolveModelSelection(value?: string | null): ModelResolution {
   }
 
   const key = normalizeModelLookupKey(input);
-  const resolved = ALIAS_INDEX.get(key);
+  const resolved = catalogIndexes.aliasIndex.get(key);
   if (resolved) {
     return {
       ok: true,
@@ -686,8 +678,8 @@ export function resolveModelSelection(value?: string | null): ModelResolution {
   }
 
   if (
-    ID_INDEX.has(key) ||
-    RAW_PROVIDER_MODEL_IDS.has(key) ||
+    catalogIndexes.idIndex.has(key) ||
+    catalogIndexes.rawProviderModelIds.has(key) ||
     looksLikeRawProviderModelId(input)
   ) {
     return {
@@ -698,7 +690,7 @@ export function resolveModelSelection(value?: string | null): ModelResolution {
     };
   }
 
-  const suggestion = suggestModelAlias(input);
+  const suggestion = suggestModelAlias(input, catalogIndexes.aliasIndex);
   return {
     ok: false,
     input,
@@ -708,23 +700,6 @@ export function resolveModelSelection(value?: string | null): ModelResolution {
       ? `Unknown model "${input}". Did you mean "${suggestion}"? Use /models to view supported models.`
       : `Unknown model "${input}". Use /models to view supported models.`,
   };
-}
-
-function workloadLabel(workload: ModelWorkload): string {
-  switch (workload) {
-    case 'chat':
-      return 'chat';
-    case 'one_time_job':
-      return 'one-time jobs';
-    case 'recurring_job':
-      return 'recurring jobs';
-    case 'memory_extractor':
-      return 'memory extraction';
-    case 'memory_dreaming':
-      return 'memory dreaming';
-    case 'memory_consolidation':
-      return 'memory consolidation';
-  }
 }
 
 function enforceWorkloadEligibility(
@@ -739,7 +714,7 @@ function enforceWorkloadEligibility(
     ok: false,
     input: resolution.alias,
     reason: 'unsupported-workload',
-    message: `Model alias "${resolution.alias}" is not eligible for ${workloadLabel(workload)}. Use /models to view supported workloads.`,
+    message: `Model alias "${resolution.alias}" is not eligible for ${modelWorkloadLabel(workload)}. Use /models to view supported workloads.`,
   };
 }
 
@@ -766,5 +741,8 @@ export function findModelByRunnerModel(
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   const key = normalizeModelLookupKey(trimmed);
-  return RUNNER_MODEL_INDEX.get(key) ?? ALIAS_INDEX.get(key)?.entry;
+  return (
+    catalogIndexes.runnerModelIndex.get(key) ??
+    catalogIndexes.aliasIndex.get(key)?.entry
+  );
 }

--- a/apps/core/src/shared/model-recommendation.ts
+++ b/apps/core/src/shared/model-recommendation.ts
@@ -1,0 +1,225 @@
+import type { AgentHarness } from './agent-engine.js';
+import {
+  listModelCatalogEntries,
+  resolveModelSelection,
+  type ModelCatalogEntry,
+  type ModelWorkload,
+} from './model-catalog.js';
+import { resolveExecutionRoute } from './model-execution-route.js';
+
+export type ModelRecommendationPriority = 'cheap' | 'balanced' | 'best';
+
+export interface ModelRecommendationInput {
+  workload: ModelWorkload;
+  agentHarness?: AgentHarness;
+  configuredProviders?: ReadonlySet<string>;
+  estimatedContextTokens?: number;
+  requiresTools?: boolean;
+  priority?: ModelRecommendationPriority;
+  currentAlias?: string | null;
+}
+
+export interface ModelRecommendationRejected {
+  alias: string;
+  reason: string;
+}
+
+export interface ModelRecommendation {
+  alias: string;
+  reason: string;
+  entry: ModelCatalogEntry;
+  rejected: readonly ModelRecommendationRejected[];
+}
+
+interface Candidate {
+  entry: ModelCatalogEntry;
+  alias: string;
+  ready: boolean;
+  current: boolean;
+  knownPrice: boolean;
+  price: number;
+  contextFit: number;
+  strength: number;
+}
+
+export function recommendModelAlias(
+  input: ModelRecommendationInput,
+): ModelRecommendation | undefined {
+  const priority = input.priority ?? 'balanced';
+  const rejected: ModelRecommendationRejected[] = [];
+  const currentEntry = resolveCurrentEntry(input.currentAlias, rejected);
+  const candidates: Candidate[] = [];
+  for (const entry of listModelCatalogEntries()) {
+    const alias =
+      currentEntry?.entry.id === entry.id && currentEntry.alias
+        ? currentEntry.alias
+        : entry.recommendedAlias;
+    const rejection = rejectCandidate(entry, input);
+    if (rejection) {
+      rejected.push({ alias, reason: rejection });
+      continue;
+    }
+    candidates.push(candidateForEntry(entry, alias, input, currentEntry));
+  }
+  candidates.sort((a, b) => compareCandidates(a, b, priority));
+  const selected = candidates[0];
+  if (!selected) return undefined;
+  return {
+    alias: selected.alias,
+    reason: reasonForCandidate(selected, input),
+    entry: selected.entry,
+    rejected,
+  };
+}
+
+function resolveCurrentEntry(
+  alias: string | null | undefined,
+  rejected: ModelRecommendationRejected[],
+): { entry: ModelCatalogEntry; alias: string } | undefined {
+  const value = alias?.trim();
+  if (!value) return undefined;
+  const resolved = resolveModelSelection(value);
+  if (resolved.ok) {
+    return { entry: resolved.entry, alias: resolved.alias };
+  }
+  rejected.push({ alias: value, reason: resolved.message });
+  return undefined;
+}
+
+function rejectCandidate(
+  entry: ModelCatalogEntry,
+  input: ModelRecommendationInput,
+): string | undefined {
+  if (!entry.supportedWorkloads.includes(input.workload)) {
+    return `unsupported workload ${input.workload}`;
+  }
+  const route = resolveExecutionRoute({
+    entry,
+    agentHarness: input.agentHarness,
+  });
+  if (!route.ok) return route.message;
+  if (
+    input.requiresTools &&
+    !(entry.supportsTools ?? entry.capabilities.toolUse)
+  ) {
+    return 'tools required';
+  }
+  const estimated = input.estimatedContextTokens;
+  if (
+    typeof estimated === 'number' &&
+    Number.isFinite(estimated) &&
+    estimated > 0 &&
+    typeof entry.contextWindowTokens === 'number' &&
+    entry.contextWindowTokens < estimated
+  ) {
+    return `context window ${entry.contextWindowTokens} below estimated ${estimated}`;
+  }
+  return undefined;
+}
+
+function candidateForEntry(
+  entry: ModelCatalogEntry,
+  alias: string,
+  input: ModelRecommendationInput,
+  currentEntry: { entry: ModelCatalogEntry; alias: string } | undefined,
+): Candidate {
+  const ready =
+    input.configuredProviders === undefined ||
+    input.configuredProviders.has(entry.modelRoute.id);
+  const knownPrice =
+    typeof entry.inputUsdPerMillionTokens === 'number' &&
+    typeof entry.outputUsdPerMillionTokens === 'number';
+  const estimated = input.estimatedContextTokens ?? 0;
+  return {
+    entry,
+    alias,
+    ready,
+    current: currentEntry?.entry.id === entry.id,
+    knownPrice,
+    price: knownPrice
+      ? entry.inputUsdPerMillionTokens! + entry.outputUsdPerMillionTokens!
+      : Number.POSITIVE_INFINITY,
+    contextFit:
+      typeof entry.contextWindowTokens === 'number'
+        ? Math.max(entry.contextWindowTokens - estimated, 0)
+        : 0,
+    strength:
+      (entry.supportsThinking ? 3 : 0) +
+      ((entry.supportsTools ?? entry.capabilities.toolUse) ? 2 : 0) +
+      (entry.maxOutputTokens ? Math.min(entry.maxOutputTokens / 64_000, 2) : 0),
+  };
+}
+
+function compareCandidates(
+  a: Candidate,
+  b: Candidate,
+  priority: ModelRecommendationPriority,
+): number {
+  const ready = Number(b.ready) - Number(a.ready);
+  if (ready !== 0) return ready;
+  if (priority === 'cheap') {
+    return comparePriceThenCurrent(a, b);
+  }
+  if (priority === 'best') {
+    return compareStrengthThenCurrent(a, b);
+  }
+  const knownPrice = Number(b.knownPrice) - Number(a.knownPrice);
+  if (knownPrice !== 0) return knownPrice;
+  const context = b.contextFit - a.contextFit;
+  if (context !== 0) return context;
+  return comparePriceThenCurrent(a, b);
+}
+
+function comparePriceThenCurrent(a: Candidate, b: Candidate): number {
+  const price = a.price - b.price;
+  if (price !== 0) return price;
+  const current = Number(b.current) - Number(a.current);
+  if (current !== 0) return current;
+  const strength = b.strength - a.strength;
+  if (strength !== 0) return strength;
+  return a.alias.localeCompare(b.alias);
+}
+
+function compareStrengthThenCurrent(a: Candidate, b: Candidate): number {
+  const strength = b.strength - a.strength;
+  if (strength !== 0) return strength;
+  const current = Number(b.current) - Number(a.current);
+  if (current !== 0) return current;
+  if (a.knownPrice && b.knownPrice) {
+    const premium = b.price - a.price;
+    if (premium !== 0) return premium;
+  }
+  return comparePriceThenCurrent(a, b);
+}
+
+function reasonForCandidate(
+  candidate: Candidate,
+  input: ModelRecommendationInput,
+): string {
+  const parts = [`supports ${input.workload}`];
+  if (input.agentHarness) parts.push(`compatible with ${input.agentHarness}`);
+  if (input.configuredProviders) {
+    parts.push(
+      candidate.ready
+        ? 'provider credential ready'
+        : 'provider credential missing',
+    );
+  }
+  if (candidate.knownPrice) {
+    parts.push(`known cost $${trimPrice(candidate.price)} per 1M in+out`);
+  } else {
+    parts.push('unknown cost');
+  }
+  if (input.estimatedContextTokens && candidate.entry.contextWindowTokens) {
+    parts.push(`context fits ${input.estimatedContextTokens} tokens`);
+  }
+  if (candidate.current) parts.push('keeps current alias');
+  return parts.join('; ');
+}
+
+function trimPrice(value: number): string {
+  return value
+    .toFixed(3)
+    .replace(/\.?0+$/, '')
+    .replace(/^$/, '0');
+}

--- a/apps/core/test/unit/application/jobs-use-cases.test.ts
+++ b/apps/core/test/unit/application/jobs-use-cases.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { JobManagementService } from '@core/application/jobs/job-management-service.js';
 import { recheckSetupPausedJobsAfterCapabilityUpdate } from '@core/application/jobs/job-permission-recovery.js';
@@ -12,6 +12,16 @@ import type { JobControlPort } from '@core/application/jobs/job-management-types
 import type { RuntimeJobRepository } from '@core/domain/repositories/ops-repo.js';
 import type { Job, JobEvent, JobRun } from '@core/domain/types.js';
 import { runtimeJobSchedulePlanner } from '@core/jobs/job-schedule-planner.js';
+import { DEFAULT_AGENT_ENGINE } from '@core/shared/agent-engine.js';
+import {
+  configureCustomModelCatalogEntries,
+  executableModelEntry,
+  providerRoute,
+} from '@core/shared/model-catalog.js';
+
+afterEach(() => {
+  configureCustomModelCatalogEntries([]);
+});
 
 function makeJob(overrides: Partial<Job> = {}): Job {
   return {
@@ -160,6 +170,33 @@ describe('job application use cases', () => {
     ).rejects.toMatchObject({
       code: 'INVALID_REQUEST',
       message: 'Job prompt uses a reserved Gantry system namespace.',
+    });
+    expect(upsertJob).not.toHaveBeenCalled();
+  });
+
+  it('validates inherited managed job models against the bound agent harness', async () => {
+    const upsertJob = vi.fn(async () => ({ created: true }));
+    const service = new JobManagementService({
+      ops: {
+        upsertJob,
+      } as unknown as RuntimeJobRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+      control: makeAppOneControl(),
+    });
+
+    await expect(
+      service.createJob({
+        appId: 'app-one',
+        name: 'Inherited model',
+        prompt: 'Run',
+        sessionId: 'session-app-one',
+        effectiveModelAlias: 'kimi',
+        agentHarness: DEFAULT_AGENT_ENGINE,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_REQUEST',
+      message: `Model kimi cannot run with agent harness ${DEFAULT_AGENT_ENGINE}.`,
     });
     expect(upsertJob).not.toHaveBeenCalled();
   });
@@ -714,6 +751,63 @@ describe('job application use cases', () => {
     expect(scheduler.requestSchedulerSync).toHaveBeenCalledWith('job-1');
   });
 
+  it('rejects schedule-only updates when the stored model cannot run that workload', async () => {
+    configureCustomModelCatalogEntries([
+      executableModelEntry({
+        id: 'settings:one-shot-only',
+        route: providerRoute('openrouter', 'acme/one-shot-only'),
+        displayName: 'One Shot Only',
+        runnerModel: 'acme/one-shot-only',
+        aliases: ['one-shot-only'],
+        recommendedAlias: 'one-shot-only',
+        source: {
+          label: 'Test settings model alias',
+          url: 'settings.yaml',
+          verifiedAt: 'custom',
+        },
+        cacheMode: 'none',
+        cacheTokenFields: [],
+        supportsTools: true,
+        supportedWorkloads: ['one_time_job'],
+        experimental: true,
+      }),
+    ]);
+    const ops = makeOps(
+      makeJob({
+        model: 'one-shot-only',
+        schedule_type: 'once',
+        schedule_value: '2026-05-01T12:00:00.000Z',
+      }),
+    );
+    const service = new JobManagementService({
+      ops: ops as RuntimeJobRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+      control: makeAppOneControl(),
+      clock: { now: () => '2026-04-24T01:00:00.000Z' },
+    });
+
+    let thrown: unknown;
+    try {
+      await service.updateJob({
+        appId: 'app-one',
+        jobId: 'job-1',
+        patch: {
+          scheduleType: 'interval',
+          scheduleValue: '60000',
+        },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toMatchObject({ code: 'INVALID_REQUEST' });
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe(
+      'Model alias "one-shot-only" is not eligible for recurring jobs. Use /models to view supported workloads.',
+    );
+    expect(ops.updateJob).not.toHaveBeenCalled();
+  });
+
   it('rejects job prompt updates using the reserved system prompt namespace', async () => {
     const ops = makeOps(makeJob());
     const service = new JobManagementService({
@@ -884,6 +978,7 @@ describe('job application use cases', () => {
     await service.updateJob({
       appId: 'app-one',
       jobId: 'job-1',
+      agentHarness: 'auto',
       patch: { model: 'kimi 2.6' },
     });
 
@@ -896,6 +991,7 @@ describe('job application use cases', () => {
       service.updateJob({
         appId: 'app-one',
         jobId: 'job-1',
+        agentHarness: 'auto',
         patch: { model: 'moonshotai/kimi-k2.6' },
       }),
     ).rejects.toMatchObject({
@@ -903,6 +999,34 @@ describe('job application use cases', () => {
       message:
         'Provider model ID "moonshotai/kimi-k2.6" is not accepted here. Use a model alias from /models.',
     });
+  });
+
+  it('requires the bound agent harness before accepting explicit job model updates', async () => {
+    const ops = makeOps(makeJob());
+    const service = new JobManagementService({
+      ops: ops as RuntimeJobRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+      control: makeAppOneControl(),
+      clock: { now: () => '2026-04-24T01:00:00.000Z' },
+    });
+
+    let thrown: unknown;
+    try {
+      await service.updateJob({
+        appId: 'app-one',
+        jobId: 'job-1',
+        patch: { model: 'sonnet' },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toMatchObject({ code: 'INVALID_REQUEST' });
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe(
+      'Agent harness is required to validate job model compatibility.',
+    );
+    expect(ops.updateJob).not.toHaveBeenCalled();
   });
 
   it('applies resume semantics when patching status active', async () => {
@@ -1785,6 +1909,40 @@ describe('job application use cases', () => {
         ],
       }),
     );
+  });
+
+  it('rejects IPC scheduler job models incompatible with the bound agent harness', async () => {
+    const upsertJob = vi.fn(async () => ({ created: true }));
+    const service = new JobManagementService({
+      ops: {
+        getJobById: vi.fn(),
+        upsertJob,
+      } as unknown as RuntimeJobRepository,
+      scheduler: { requestSchedulerSync: vi.fn() },
+      schedulePlanner: runtimeJobSchedulePlanner,
+    });
+
+    await expect(
+      service.upsertJobFromIpc({
+        access: {
+          sourceAgentFolder: 'team',
+          originConversationJid: 'tg:team',
+          conversationBindings: {
+            'tg:team': { folder: 'team' },
+          },
+        },
+        name: 'Team digest',
+        prompt: 'Summarize updates',
+        modelAlias: 'kimi',
+        scheduleType: 'interval',
+        scheduleValue: '60000',
+        agentHarness: DEFAULT_AGENT_ENGINE,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_REQUEST',
+      message: `Model kimi cannot run with agent harness ${DEFAULT_AGENT_ENGINE}.`,
+    });
+    expect(upsertJob).not.toHaveBeenCalled();
   });
 
   it('rejects IPC scheduler jobs using reserved system namespaces', async () => {

--- a/apps/core/test/unit/config/runtime-settings.test.ts
+++ b/apps/core/test/unit/config/runtime-settings.test.ts
@@ -11,6 +11,7 @@ import {
   mirrorAgentToolRulesToRuntimeSettings,
   parseRuntimeSettings,
   saveRuntimeSettings,
+  withRuntimeModelAliases,
 } from '@core/config/settings/runtime-settings.js';
 import { renderRuntimeSettingsYaml } from '@core/config/settings/runtime-settings-renderer.js';
 import { validateLoadedRuntimeSettings } from '@core/config/settings/runtime-settings-validation.js';
@@ -204,6 +205,77 @@ describe('runtime settings', () => {
     expect(yaml).toContain('llama-70b: ["together"]');
     const parsed = parseRuntimeSettings(yaml);
     expect(parsed.modelFamilies).toEqual(settings.modelFamilies);
+  });
+
+  it('renders, parses, and uses custom model aliases for agent models', () => {
+    const settings = createDefaultRuntimeSettings();
+    settings.modelAliases = {
+      'fast-job': {
+        provider: 'groq',
+        providerModelId: 'llama-3.1-8b-instant',
+        displayName: 'Fast Job Model',
+        aliases: ['fast-job'],
+        recommendedAlias: 'fast-job',
+        supportedWorkloads: ['chat', 'one_time_job', 'recurring_job'],
+        contextWindowTokens: 131_072,
+        inputUsdPerMillionTokens: 0.05,
+        outputUsdPerMillionTokens: 0.08,
+        supportsTools: true,
+        source: {
+          label: 'Groq supported models',
+          url: 'https://console.groq.com/docs/models',
+          verifiedAt: '2026-06-19',
+        },
+      },
+    };
+    settings.agents.worker = {
+      name: 'Worker',
+      folder: 'worker',
+      model: 'fast-job',
+      bindings: {},
+      sources: emptySources(),
+      capabilities: [],
+      accessPreset: 'full',
+    };
+
+    const yaml = renderRuntimeSettingsYaml(settings);
+    expect(yaml).toContain('model_aliases:');
+    expect(yaml).toContain('provider_model_id: "llama-3.1-8b-instant"');
+
+    const parsed = parseRuntimeSettings(yaml);
+    expect(parsed.modelAliases['fast-job']).toMatchObject({
+      provider: 'groq',
+      providerModelId: 'llama-3.1-8b-instant',
+    });
+    expect(parsed.agents.worker.model).toBe('fast-job');
+    const validation = withRuntimeModelAliases(parsed, () =>
+      validateLoadedRuntimeSettings('/tmp/gantry-custom-model', parsed),
+    );
+    expect(validation.failure?.details.join('\n') ?? '').not.toContain(
+      'agents.worker.model is invalid',
+    );
+  });
+
+  it('rejects invalid custom model alias providers', () => {
+    expect(() =>
+      parseRuntimeSettings(`model_aliases:
+  missing:
+    provider: not-a-provider
+    provider_model_id: model-id
+`),
+    ).toThrow(/Model credential provider must be one of/);
+  });
+
+  it('keeps custom model tool support unknown unless declared', () => {
+    const parsed = parseRuntimeSettings(`model_aliases:
+  no-tools-claim:
+    provider: groq
+    provider_model_id: llama-3.1-8b-instant
+`);
+
+    expect(
+      parsed.modelAliases['no-tools-claim']?.supportsTools,
+    ).toBeUndefined();
   });
 
   it('rejects a non-array model_families value', () => {

--- a/apps/core/test/unit/config/settings-import-service.test.ts
+++ b/apps/core/test/unit/config/settings-import-service.test.ts
@@ -170,6 +170,20 @@ describe('importFleetSettingsRevision', () => {
     settings.agent.name = 'Agent "quoted" \\ path';
     settings.agent.agentHarness = 'deepagents';
     settings.memory.llm.extractorMinConfidence = 0.73;
+    settings.modelAliases['fast-job'] = {
+      provider: 'groq',
+      providerModelId: 'llama-3.1-8b-instant',
+      displayName: 'Fast Job Model',
+      aliases: ['fast-job'],
+      recommendedAlias: 'fast-job',
+      supportedWorkloads: ['one_time_job'],
+      supportsTools: true,
+      source: {
+        label: 'Groq supported models',
+        url: 'https://console.groq.com/docs/models',
+        verifiedAt: '2026-06-19',
+      },
+    };
     settings.agents.researcher = {
       name: 'Researcher',
       folder: 'researcher',
@@ -217,6 +231,11 @@ describe('importFleetSettingsRevision', () => {
           .access as Record<string, unknown>
       ).preset,
     ).toBe('locked');
+    expect(
+      (document.model_aliases as Record<string, Record<string, unknown>>)[
+        'fast-job'
+      ].provider_model_id,
+    ).toBe('llama-3.1-8b-instant');
     const restored = settingsFromRevisionDocument(document);
     expect(restored.agent.name).toBe(settings.agent.name);
     expect(restored.agent.agentHarness).toBe('deepagents');
@@ -227,5 +246,8 @@ describe('importFleetSettingsRevision', () => {
     expect(restored.agents.researcher.capabilities).toEqual([
       { id: 'browser.use', version: '1' },
     ]);
+    expect(restored.modelAliases['fast-job']?.providerModelId).toBe(
+      'llama-3.1-8b-instant',
+    );
   });
 });

--- a/apps/core/test/unit/jobs/ipc-scheduler-adapter-contract.test.ts
+++ b/apps/core/test/unit/jobs/ipc-scheduler-adapter-contract.test.ts
@@ -58,6 +58,11 @@ import { schedulerCreateTaskHandlers } from '@core/jobs/ipc-scheduler-create-han
 import { schedulerMutateTaskHandlers } from '@core/jobs/ipc-scheduler-mutate-handlers.js';
 import { schedulerQueryTaskHandlers } from '@core/jobs/ipc-scheduler-query-handlers.js';
 import { schedulerAccessFromContext } from '@core/jobs/ipc-scheduler-access.js';
+import {
+  configureCustomModelCatalogEntries,
+  executableModelEntry,
+  providerRoute,
+} from '@core/shared/model-catalog.js';
 
 function adaptAppSession(session: any) {
   if (!session) return undefined;
@@ -149,6 +154,7 @@ describe('scheduler IPC adapter contracts', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    configureCustomModelCatalogEntries([]);
   });
 
   it('keeps missing upsert scheduleType as invalid_request', async () => {
@@ -445,12 +451,51 @@ describe('scheduler IPC adapter contracts', () => {
 
     expect(mocks.jobService.updateJob).toHaveBeenCalledWith({
       jobId: 'job-1',
+      agentHarness: 'auto',
       access: expect.any(Object),
       patch: { model: 'kimi-2.6' },
     });
     expect(mocks.responder.accept).toHaveBeenCalledWith(
       'Scheduler job updated (job-1).',
     );
+  });
+
+  it('defers scheduler update model workload validation to the job service', async () => {
+    configureCustomModelCatalogEntries([
+      executableModelEntry({
+        id: 'settings:recurring-only',
+        route: providerRoute('groq', 'llama-3.1-8b-instant'),
+        displayName: 'Recurring Only',
+        runnerModel: 'llama-3.1-8b-instant',
+        aliases: ['recurring-only'],
+        recommendedAlias: 'recurring-only',
+        source: {
+          label: 'settings.yaml model_aliases.recurring-only',
+          url: 'settings.yaml',
+          verifiedAt: 'custom',
+        },
+        cacheMode: 'none',
+        cacheTokenFields: [],
+        supportsTools: true,
+        supportedWorkloads: ['recurring_job'],
+      }),
+    ]);
+
+    await schedulerMutateTaskHandlers.scheduler_update_job(
+      makeContext({
+        type: 'scheduler_update_job',
+        jobId: 'job-1',
+        scheduleType: 'interval',
+        modelAlias: 'recurring-only',
+      }),
+    );
+
+    expect(mocks.jobService.updateJob).toHaveBeenCalledWith({
+      jobId: 'job-1',
+      agentHarness: 'auto',
+      access: expect.any(Object),
+      patch: { model: 'recurring-only', scheduleType: 'interval' },
+    });
   });
 
   it('passes scheduler update accessRequirements through to the job service', async () => {
@@ -466,6 +511,7 @@ describe('scheduler IPC adapter contracts', () => {
 
     expect(mocks.jobService.updateJob).toHaveBeenCalledWith({
       jobId: 'job-1',
+      agentHarness: 'auto',
       access: expect.any(Object),
       patch: {
         accessRequirements: [
@@ -486,6 +532,7 @@ describe('scheduler IPC adapter contracts', () => {
 
     expect(mocks.jobService.updateJob).toHaveBeenCalledWith({
       jobId: 'job-1',
+      agentHarness: 'auto',
       access: expect.any(Object),
       patch: { model: null },
     });
@@ -521,6 +568,7 @@ describe('scheduler IPC adapter contracts', () => {
 
     expect(mocks.jobService.updateJob).toHaveBeenCalledWith({
       jobId: 'job-1',
+      agentHarness: 'auto',
       access: expect.any(Object),
       patch: {},
     });

--- a/apps/core/test/unit/jobs/model-resolution.test.ts
+++ b/apps/core/test/unit/jobs/model-resolution.test.ts
@@ -35,6 +35,7 @@ describe('job model resolution', () => {
       resolved_model_alias: 'sonnet',
       resolved_model_profile_id: 'anthropic:sonnet-4.6',
       model_source: 'job.model',
+      model_selection_reason: 'explicit job model alias',
       cache_policy: 'anthropic-prompt',
       context_window_tokens: 1000000,
     });
@@ -63,6 +64,8 @@ describe('job model resolution', () => {
       usage,
       resolved_model_alias: 'haiku',
       model_source: 'settings.yaml agent.one_time_job_default_model',
+      model_selection_reason:
+        'inherited from settings.yaml agent.one_time_job_default_model',
       cache_policy: 'anthropic-prompt',
     });
   });

--- a/apps/core/test/unit/models/model-catalog.test.ts
+++ b/apps/core/test/unit/models/model-catalog.test.ts
@@ -1,15 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  configureCustomModelCatalogEntries,
   DEFAULT_SETUP_MODEL_ALIAS,
+  executableModelEntry,
   findModelByRunnerModel,
   listModelCatalogEntries,
   MEMORY_MODEL_DEFAULT_ALIASES,
+  providerRoute,
   resolveModelSelection,
   resolveModelSelectionForWorkload,
   resolveRunnerModel,
 } from '@core/shared/model-catalog.js';
+import { recommendModelAlias } from '@core/shared/model-recommendation.js';
 import { resolveModelCacheSupport } from '@core/shared/model-cache-support.js';
+import { DEFAULT_AGENT_ENGINE } from '@core/shared/agent-engine.js';
 import {
   formatContextWindow,
   formatCostPerMillion,
@@ -24,6 +29,10 @@ function rowFor(text: string, alias: string): string {
 }
 
 describe('model catalog resolution', () => {
+  afterEach(() => {
+    configureCustomModelCatalogEntries([]);
+  });
+
   it('keeps versioned aliases pinned while short aliases stay recommended', () => {
     expect(resolveModelSelection(' kimi 2.6 ')).toMatchObject({
       ok: true,
@@ -289,9 +298,8 @@ describe('model catalog resolution', () => {
     expect(formatCostPerMillion(groq)).toBe('$0.59/$0.79');
     const gemini = findModelByRunnerModel('gemini-2.5-pro')!;
     expect(formatCostPerMillion(gemini)).toBe('$1.25/$10');
-    // Omitted pricing renders as an em dash.
     const cerebras = findModelByRunnerModel('gpt-oss-120b')!;
-    expect(formatCostPerMillion(cerebras)).toBe('—');
+    expect(formatCostPerMillion(cerebras)).toBe('$0.35/$0.75');
   });
 
   it('renders a Cost column with curated prices and "—" when omitted', () => {
@@ -300,13 +308,130 @@ describe('model catalog resolution', () => {
     expect(rowFor(output, 'groq')).toContain('$0.59/$0.79');
     expect(rowFor(output, 'gemini')).toContain('$1.25/$10');
     expect(rowFor(output, 'grok')).toContain('$1.25/$2.5');
+    expect(rowFor(output, 'gpt')).toContain('$5/$30');
+    expect(rowFor(output, 'cerebras')).toContain('$0.35/$0.75');
     // SDK-lane Anthropic alias carries its declared price too.
     expect(rowFor(output, 'opus')).toContain('$5/$25');
     // Omitted prices render as an em dash: Perplexity (hybrid per-request fee),
-    // Cerebras (subscription-only), Fireworks DeepSeek v3p1 (unverifiable band).
+    // Fireworks DeepSeek v3p1 (unverifiable band).
     expect(rowFor(output, 'perplexity')).toContain('| — |');
-    expect(rowFor(output, 'cerebras')).toContain('| — |');
     expect(rowFor(output, 'fireworks')).toContain('| — |');
+  });
+
+  it('merges settings-owned aliases into the normal catalog path', () => {
+    configureCustomModelCatalogEntries([
+      executableModelEntry({
+        id: 'settings:fast-job',
+        route: providerRoute('groq', 'llama-3.1-8b-instant'),
+        displayName: 'Fast Job Model',
+        runnerModel: 'llama-3.1-8b-instant',
+        aliases: ['fast-job'],
+        recommendedAlias: 'fast-job',
+        source: {
+          label: 'settings.yaml model_aliases.fast-job',
+          url: 'settings.yaml',
+          verifiedAt: 'custom',
+        },
+        contextWindowTokens: 131_072,
+        inputUsdPerMillionTokens: 0.05,
+        outputUsdPerMillionTokens: 0.08,
+        cacheMode: 'none',
+        cacheTokenFields: [],
+        supportsTools: true,
+        supportedWorkloads: ['one_time_job', 'recurring_job'],
+      }),
+    ]);
+
+    expect(
+      resolveModelSelectionForWorkload('fast-job', 'one_time_job'),
+    ).toMatchObject({
+      ok: true,
+      alias: 'fast-job',
+    });
+    expect(formatModelCatalog()).toContain('fast-job | Fast Job Model');
+    expect(resolveRunnerModel('llama-3.1-8b-instant')).toBeUndefined();
+  });
+
+  it('leaves the active catalog intact when a custom alias overlay is invalid', () => {
+    configureCustomModelCatalogEntries([
+      executableModelEntry({
+        id: 'settings:fast-job',
+        route: providerRoute('groq', 'llama-3.1-8b-instant'),
+        displayName: 'Fast Job Model',
+        runnerModel: 'llama-3.1-8b-instant',
+        aliases: ['fast-job'],
+        recommendedAlias: 'fast-job',
+        source: {
+          label: 'settings.yaml model_aliases.fast-job',
+          url: 'settings.yaml',
+          verifiedAt: 'custom',
+        },
+        cacheMode: 'none',
+        cacheTokenFields: [],
+        supportsTools: true,
+        supportedWorkloads: ['one_time_job'],
+      }),
+    ]);
+
+    expect(() =>
+      configureCustomModelCatalogEntries([
+        executableModelEntry({
+          id: 'settings:bad-opus',
+          route: providerRoute('groq', 'llama-3.1-8b-instant'),
+          displayName: 'Bad Opus',
+          runnerModel: 'llama-3.1-8b-instant',
+          aliases: ['opus'],
+          recommendedAlias: 'opus',
+          source: {
+            label: 'settings.yaml model_aliases.bad-opus',
+            url: 'settings.yaml',
+            verifiedAt: 'custom',
+          },
+          cacheMode: 'none',
+          cacheTokenFields: [],
+          supportsTools: true,
+          supportedWorkloads: ['one_time_job'],
+        }),
+      ]),
+    ).toThrow(/Duplicate model alias: opus/);
+    expect(resolveModelSelection('fast-job')).toMatchObject({
+      ok: true,
+      alias: 'fast-job',
+    });
+  });
+
+  it('recommends models using deterministic filters and rankings', () => {
+    expect(
+      recommendModelAlias({
+        workload: 'one_time_job',
+        priority: 'cheap',
+        configuredProviders: new Set(['groq']),
+      }),
+    ).toMatchObject({ alias: 'groq-fast' });
+
+    const best = recommendModelAlias({
+      workload: 'chat',
+      agentHarness: 'deepagents',
+      requiresTools: true,
+      priority: 'best',
+    });
+    expect(best).toMatchObject({ alias: 'gpt' });
+    expect(best?.reason).toContain('supports chat');
+
+    const constrained = recommendModelAlias({
+      workload: 'one_time_job',
+      agentHarness: DEFAULT_AGENT_ENGINE,
+      currentAlias: 'kimi',
+      priority: 'balanced',
+    });
+    expect(constrained?.alias).not.toBe('kimi');
+    expect(
+      constrained?.rejected.some((item) =>
+        item.reason.includes(
+          `cannot run with agent harness ${DEFAULT_AGENT_ENGINE}`,
+        ),
+      ),
+    ).toBe(true);
   });
 
   it('derives cache support from provider metadata and model route', () => {
@@ -518,12 +643,11 @@ describe('model usage normalization', () => {
   });
 
   it('leaves DeepAgents-lane cost undefined when the model has no curated price', () => {
-    // cerebras gpt-oss-120b omits pricing (subscription-only) -> no estimate.
     const usage = normalizeModelUsage({
       message: {
         usage: { prompt_tokens: 1000, completion_tokens: 500 },
       },
-      fallbackModel: 'gpt-oss-120b',
+      fallbackModel: 'sonar-pro',
     });
     expect(usage?.estimatedCostUsd).toBeUndefined();
   });

--- a/apps/core/test/unit/runner/mcp/scheduler-tools.test.ts
+++ b/apps/core/test/unit/runner/mcp/scheduler-tools.test.ts
@@ -40,7 +40,9 @@ describe('scheduler MCP tools', () => {
       await import('../../../../src/runner/mcp/tools/scheduler.js');
     const tools = new Map<
       string,
-      () => Promise<{ content: { text: string }[] }>
+      (
+        args?: Record<string, unknown>,
+      ) => Promise<{ content: { text: string }[] }>
     >();
     const server = {
       tool: (
@@ -64,6 +66,14 @@ describe('scheduler MCP tools', () => {
     expect(text).toContain('Kimi K2.6');
     expect(text).toContain('kimi-2.6 | Kimi K2.6');
     expect(text).toContain('Response family');
+
+    const recommended = await tools.get('scheduler_list_models')!({
+      workload: 'one_time_job',
+      priority: 'cheap',
+    });
+    expect(recommended.content[0].text).toContain(
+      'Recommended model: groq-fast. Why:',
+    );
   });
 
   it('delegates scheduler_list_models rendering to the model catalog formatter', async () => {
@@ -79,7 +89,9 @@ describe('scheduler MCP tools', () => {
 
     const tools = new Map<
       string,
-      () => Promise<{ content: { text: string }[] }>
+      (
+        args?: Record<string, unknown>,
+      ) => Promise<{ content: { text: string }[] }>
     >();
     const server = {
       tool: (
@@ -96,6 +108,9 @@ describe('scheduler MCP tools', () => {
 
     const response = await tools.get('scheduler_list_models')!();
     expect(formatModelCatalog).toHaveBeenCalledTimes(1);
+    expect(formatModelCatalog).toHaveBeenCalledWith({
+      recommendation: undefined,
+    });
     expect(response.content[0].text).toBe('mocked model catalog output');
   });
 

--- a/docs/architecture/lean-model-choice-intelligence-goal-prompt.md
+++ b/docs/architecture/lean-model-choice-intelligence-goal-prompt.md
@@ -1,0 +1,225 @@
+# Goal: Lean Model Choice Intelligence
+
+Implement the smallest working model-choice system for Gantry.
+
+Use the `ponytail` skill for the implementation discipline and the `autoreview`
+skill for closeout. Keep the work boring: no new model-management platform, no
+new dashboard, no new provider plugin system, no key versioning. Reuse existing
+`modelAlias`, `agentHarness`, model catalog, `/v1/models/preview`,
+`scheduler_list_models`, settings update flow, and credential commands.
+
+## Problem
+
+Agents need to choose the right model for jobs, tasks, and subagents without
+relying on vague LLM judgment. The intelligence must come from runtime catalog
+metadata and deterministic rules.
+
+## Scope
+
+Build only:
+
+1. Settings-backed custom model aliases for existing providers.
+2. A pure model recommendation helper over the merged catalog.
+3. Agent-facing recommendation through existing model surfaces.
+4. Validation that agent-selected job/task models use registered aliases and
+   compatible harnesses.
+5. Receipts showing chosen alias and reason.
+6. A one-time built-in catalog refresh from official provider documentation.
+
+Do not build:
+
+- new model service
+- new endpoint unless extending existing `/v1/models/preview` is clearly the
+  smallest path
+- model dashboard
+- job-level harness
+- conversation-level harness
+- public `agentEngine`
+- raw provider model IDs at public boundaries
+- credential/key versioning
+- runtime web scraping or automatic catalog sync
+
+## Product Contract
+
+Public vocabulary:
+
+- `modelAlias`
+- `agentHarness` / `agent_harness`
+- `responseFamily`
+- `modelRoute`
+- `executionProviderId`
+- `credentialProfileRef`
+
+Agents choose explicit models only by registered alias.
+
+Default behavior remains simple:
+
+- omitted `modelAlias` = inherit/default
+- explicit `modelAlias` = chosen alias
+- jobs inherit bound agent harness
+- subagents inherit parent model/harness unless host runtime validates a catalog
+  alias override
+
+## Catalog Refresh
+
+Before implementing the chooser, refresh existing built-in model metadata from
+official provider docs only.
+
+Update only:
+
+- context window
+- input/output price per 1M tokens
+- tool/thinking/cache support when documented
+- supported workloads if repo assumptions changed
+- `source.url`
+- `source.verifiedAt`
+
+Do not add runtime web fetching or scraping. The catalog is code/settings-owned.
+Unknown price/context is allowed, but it must render as unknown and rank lower
+for cost-sensitive recommendations.
+
+## Technical Approach
+
+Use the planner/decomposer prompts before coding:
+
+- read `.codex/prompts/planner.md`
+- read `.codex/prompts/decomposer.md`
+- produce bounded tasks by capability, not file count
+
+Implement a pure helper near the model catalog layer:
+
+```ts
+recommendModelAlias(input)
+```
+
+Inputs:
+
+- workload
+- agentHarness
+- configuredProviders
+- estimatedContextTokens optional
+- requiresTools optional
+- priority: `cheap | balanced | best`
+
+Hard filters:
+
+- unsupported workload
+- incompatible `agentHarness`
+- missing required tools
+- context too small
+- unknown/raw alias
+
+Soft ranking:
+
+- ready credential before missing credential
+- `cheap`: lowest known input/output cost, unknown pricing last
+- `best`: stronger reasoning/thinking/tool capability first
+- `balanced`: ready + context fit + cost known
+- parent/current alias wins ties for subagent/task use
+
+Output:
+
+- recommended alias
+- reason string
+- rejected candidates with short reasons, if useful for preview/tests
+
+Expose through existing surfaces:
+
+- extend `scheduler_list_models` with optional recommendation args
+- extend existing model list/preview/CLI formatting only if needed
+- keep no-arg behavior unchanged
+
+## Acceptance Criteria
+
+- Custom aliases can be declared in `settings.yaml` for existing providers only.
+- Built-in and custom aliases resolve through the same catalog path.
+- Raw provider model IDs are rejected unless registered as aliases.
+- Agent-facing model listing can return:
+  `Recommended model: <alias>. Why: <reason>.`
+- Job creation/update rejects incompatible `modelAlias + agentHarness` before
+  runner spawn.
+- Credential update remains overwrite/rotate/disable only; no key versions.
+- Receipts/job metadata record selected alias and reason for agent-chosen
+  models.
+
+## Surface Impact Matrix
+
+| Surface | Status | Reason |
+|---|---|---|
+| Runtime behavior | Changed | Adds deterministic chooser and earlier validation. |
+| `settings.yaml` | Changed | Stores custom aliases, no secrets. |
+| Postgres/runtime projection | Read-only/observable | Can record selected alias/reason, not source of truth. |
+| Control API | Changed | Only if extending existing preview/list is needed. |
+| SDK/contracts | Changed | Only for documented recommendation/diagnostic shape; no `agentEngine`. |
+| CLI | Changed | Only to show merged aliases/recommendation where already relevant. |
+| Gantry MCP tools/admin skill | Changed | Extend existing scheduler/settings tools. |
+| Channel/provider adapters | Unchanged by design | Selection happens before provider invocation. |
+| Docs/prompts | Changed | Document chooser rules and user-visible copy. |
+| Audit/events | Changed | Record alias/reason/credential update without secrets. |
+| Tests/verification | Changed | Add focused tests below. |
+
+## Required Tests
+
+Add or update focused tests for:
+
+- settings custom alias parse/render/export
+- catalog merge built-in + settings aliases
+- raw provider model ID rejection
+- recommendation helper hard filters
+- recommendation helper ranking for `cheap`, `balanced`, `best`
+- `scheduler_list_models` recommendation output
+- job model validation against bound `agentHarness`
+- credential `set` / `rotate` / `disable` stays non-versioned
+
+## Validation Commands
+
+Run focused checks first:
+
+```bash
+npm run test:unit -- apps/core/test/unit/models/model-catalog.test.ts apps/core/test/unit/models/model-catalog-availability.test.ts apps/core/test/unit/runner/mcp/scheduler-tools.test.ts apps/core/test/unit/control/model-agent-preview.test.ts apps/core/test/unit/config/runtime-settings.test.ts apps/core/test/unit/config/settings-desired-state-service.test.ts
+npm run typecheck
+npm run lint
+npm run format:check
+python3 .codex/scripts/check_architecture.py
+```
+
+Then run repo gates if the change is non-trivial:
+
+```bash
+npm test
+python3 .codex/scripts/verify.py
+python3 .codex/scripts/check_task_completion.py
+```
+
+## Review Closeout
+
+Before final response, finish reviews using the `autoreview` skill.
+
+Run the installed autoreview helper:
+
+```bash
+<autoreview-helper> --mode local
+```
+
+Rules:
+
+- Treat review output as advisory.
+- Verify every accepted finding by reading the real code path.
+- Reject speculative rewrites and over-engineered fixes.
+- If review-triggered fixes change code, rerun focused tests and rerun
+  autoreview.
+- Stop only after autoreview reports no accepted/actionable findings, or clearly
+  document any consciously rejected finding.
+
+Keep using Ponytail through review fixes: smallest correct fix, no new
+abstractions, no cleanup outside this task.
+
+## Closeout
+
+Final response must include:
+
+- changed files
+- validation commands and results
+- autoreview command and clean result
+- accepted/rejected review findings, if any
+- anything intentionally deferred

--- a/ops/docker/Dockerfile
+++ b/ops/docker/Dockerfile
@@ -81,6 +81,10 @@ RUN apt-get update \
 # search binary for agent turns, and libatomic1 is required by newer Node builds
 # on small Ubuntu/Debian hosts.
 
+# The runtime image never installs packages. Drop the package-manager payload
+# inherited from the Node base image so bundled npm CVEs do not fail image scans.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
 # Non-root runtime user. The base image already ships a `node` user (uid 1000);
 # create a dedicated home and a writable runtime-state dir owned by it.
 RUN install -d -o node -g node "${GANTRY_HOME}"


### PR DESCRIPTION
## Summary
- Add settings-backed model_aliases and merge them into the provider-neutral model catalog.
- Add deterministic model recommendations and scheduler_list_models recommendation output.
- Validate job model aliases against workload and the bound agentHarness before runner spawn, then record the model selection reason.
- Refresh selected catalog metadata and save the goal prompt.

## Validation
- npm run typecheck
- npm run test:unit -- apps/core/test/unit/models/model-catalog.test.ts apps/core/test/unit/models/model-catalog-availability.test.ts apps/core/test/unit/runner/mcp/scheduler-tools.test.ts apps/core/test/unit/control/model-agent-preview.test.ts apps/core/test/unit/config/runtime-settings.test.ts apps/core/test/unit/config/settings-desired-state-service.test.ts apps/core/test/unit/config/settings-import-service.test.ts apps/core/test/unit/application/jobs-use-cases.test.ts apps/core/test/unit/control/job-trigger.test.ts apps/core/test/unit/jobs/model-resolution.test.ts apps/core/test/unit/core/model-credential-service.test.ts apps/core/test/unit/jobs/ipc-scheduler-adapter-contract.test.ts
- npm run format:check
- python3 .codex/scripts/check_architecture.py
- git diff --check
- npx eslint --quiet <changed source files>
- python3 .codex/scripts/check_task_completion.py
- python3 /Users/ravikiranvemula/.codex/skills/autoreview/scripts/autoreview --mode local

## Notes
- check_task_completion.py warned that provider adapter/session files changed without provider-session or resume tests; the touched provider files are catalog metadata, not session/resume behavior.
- Repo-wide npm run lint -- --quiet still fails on unrelated pre-existing lint errors outside this patch.
- Full npm test / verify.py previously hit unrelated existing failures in agent-spawn.test.ts and jobs/execution.test.ts.
