### PR TITLE
[codex] Add async subagent task status bridge

### DIFF
--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/agent-delegation-async-bridge.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/agent-delegation-async-bridge.ts
@@ -1,0 +1,83 @@
+import {
+  DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE,
+  evaluateDeepAgentsAsyncSubagentSentinel,
+} from './async-subagent-sentinel.js';
+
+export interface AgentDelegationAsyncIntent {
+  toolName: 'AgentDelegation';
+  task: string;
+}
+
+export interface AgentDelegationAsyncBridgeInput {
+  intent: AgentDelegationAsyncIntent;
+  packageVersion: string;
+  providerModule: Record<string, unknown>;
+  asyncTaskToolsEnabled: boolean;
+  sandboxReady: boolean;
+  agentDelegationAuthorized: boolean;
+  transportReady: boolean;
+}
+
+export type AgentDelegationAsyncBridgeUnavailableReason =
+  | 'async_task_tools_disabled'
+  | 'sandbox_unavailable'
+  | 'agent_delegation_unauthorized'
+  | 'transport_unavailable'
+  | 'provider_async_bridge_unavailable';
+
+export type AgentDelegationAsyncBridgeResult =
+  | {
+      status: 'ready';
+      intent: AgentDelegationAsyncIntent;
+      packageVersion: string;
+      apiCompatible: true;
+    }
+  | {
+      status: 'unavailable';
+      reason: AgentDelegationAsyncBridgeUnavailableReason;
+      message: typeof DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE;
+    };
+
+export function evaluateAgentDelegationAsyncBridge(
+  input: AgentDelegationAsyncBridgeInput,
+): AgentDelegationAsyncBridgeResult {
+  if (!input.asyncTaskToolsEnabled) {
+    return unavailable('async_task_tools_disabled');
+  }
+  if (!input.sandboxReady) {
+    return unavailable('sandbox_unavailable');
+  }
+  if (!input.agentDelegationAuthorized) {
+    return unavailable('agent_delegation_unauthorized');
+  }
+  if (!input.transportReady) {
+    return unavailable('transport_unavailable');
+  }
+
+  const sentinel = evaluateDeepAgentsAsyncSubagentSentinel({
+    packageVersion: input.packageVersion,
+    deepagentsModule: input.providerModule,
+    gantryAgentProtocolTransportReady: true,
+  });
+
+  if (!sentinel.ok) {
+    return unavailable('provider_async_bridge_unavailable');
+  }
+
+  return {
+    status: 'ready',
+    intent: input.intent,
+    packageVersion: sentinel.packageVersion,
+    apiCompatible: true,
+  };
+}
+
+function unavailable(
+  reason: AgentDelegationAsyncBridgeUnavailableReason,
+): AgentDelegationAsyncBridgeResult {
+  return {
+    status: 'unavailable',
+    reason,
+    message: DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE,
+  };
+}

--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-facade-tools.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-facade-tools.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 
 import { tool } from '@langchain/core/tools';
 import type { StructuredToolInterface } from '@langchain/core/tools';
+import * as deepagentsProvider from 'deepagents';
+import deepagentsPackageJson from 'deepagents/package.json' with { type: 'json' };
 
 import {
   GANTRY_FACADE_EXACT_TOOL_NAMES,
@@ -32,11 +34,11 @@ import {
   writeFileNoFollow,
 } from './gantry-facade-file-safety.js';
 import type { ThirdPartyMcpGateConfig } from './third-party-mcp-gate.js';
+import { evaluateAgentDelegationAsyncBridge } from './agent-delegation-async-bridge.js';
+import { DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE } from './async-subagent-sentinel.js';
 
 export const DEEPAGENTS_GANTRY_FACADE_TOOL_NAMES =
-  GANTRY_FACADE_EXACT_TOOL_NAMES.filter(
-    (name) => name !== 'AgentDelegation',
-  ) as Exclude<GantryFacadeExactToolName, 'AgentDelegation'>[];
+  GANTRY_FACADE_EXACT_TOOL_NAMES;
 
 type DeepAgentsFacadeToolName =
   (typeof DEEPAGENTS_GANTRY_FACADE_TOOL_NAMES)[number];
@@ -57,6 +59,8 @@ export interface GantryFacadeToolsConfig {
   permissionEnv: PermissionIpcRuntimeEnv;
   lockedAccessPreset: boolean;
   filesystemToolsEnabled: boolean;
+  asyncTaskToolsEnabled?: boolean;
+  delegateTaskTool?: StructuredToolInterface;
   cwd?: string;
 }
 
@@ -73,8 +77,10 @@ export function createGantryFacadeTools(
   const policy = new ToolExecutionPolicyService();
   return DEEPAGENTS_GANTRY_FACADE_TOOL_NAMES.filter(
     (toolName) =>
-      config.filesystemToolsEnabled ||
-      !DEEPAGENTS_FILESYSTEM_FACADE_TOOL_NAMES.has(toolName),
+      (toolName !== 'AgentDelegation' ||
+        (config.asyncTaskToolsEnabled === true && config.delegateTaskTool)) &&
+      (config.filesystemToolsEnabled ||
+        !DEEPAGENTS_FILESYSTEM_FACADE_TOOL_NAMES.has(toolName)),
   ).map((toolName) =>
     createOneFacadeTool(toolName, config, classifier, policy),
   );
@@ -171,6 +177,8 @@ function policyToolRequest(
         toolName: 'Write',
         toolInput: { file_path: record.path, content: record.content },
       };
+    case 'AgentDelegation':
+      return { toolName: 'AgentDelegation', toolInput: input };
   }
 }
 
@@ -197,7 +205,40 @@ async function executeFacadeTool(
       return fileEdit(String(record.path), String(record.patch), config);
     case 'FileWrite':
       return fileWrite(String(record.path), String(record.content), config);
+    case 'AgentDelegation':
+      return agentDelegation(record, config);
   }
+}
+
+async function agentDelegation(
+  input: Record<string, unknown>,
+  config: GantryFacadeToolsConfig,
+): Promise<string> {
+  const bridge = evaluateAgentDelegationAsyncBridge({
+    intent: {
+      toolName: 'AgentDelegation',
+      task: String(input.task),
+    },
+    packageVersion: installedDeepAgentsVersion(),
+    providerModule: deepagentsProvider,
+    asyncTaskToolsEnabled: config.asyncTaskToolsEnabled === true,
+    sandboxReady: true,
+    agentDelegationAuthorized: true,
+    transportReady: Boolean(config.delegateTaskTool),
+  });
+  if (bridge.status !== 'ready' || !config.delegateTaskTool) {
+    return DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE;
+  }
+  const result = await config.delegateTaskTool.invoke({
+    objective: String(input.task),
+    ...(typeof input.context === 'string' ? { context: input.context } : {}),
+  } as never);
+  return typeof result === 'string' ? result : JSON.stringify(result);
+}
+
+function installedDeepAgentsVersion(): string {
+  const version = (deepagentsPackageJson as { version?: unknown }).version;
+  return typeof version === 'string' ? version : '';
 }
 
 async function webSearch(
@@ -632,5 +673,7 @@ function facadeDescription(toolName: DeepAgentsFacadeToolName): string {
       return 'Edit one approved host workspace file. Patch must be JSON {"oldText":"...","newText":"..."}.';
     case 'FileWrite':
       return 'Write one approved host workspace file by exact safe relative path.';
+    case 'AgentDelegation':
+      return 'Start a durable Gantry child agent task and inspect it with task_get/task_list.';
   }
 }

--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-mcp-env.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-mcp-env.ts
@@ -34,6 +34,7 @@ export interface GantryMcpProjection {
   // True only when the host enabled browser IPC for this run (browser gateway
   // tools must not be reachable otherwise).
   browserIpcEnabled: boolean;
+  asyncTaskToolsEnabled: boolean;
 }
 
 export function buildGantryMcpProjection(
@@ -45,13 +46,14 @@ export function buildGantryMcpProjection(
   const browserIpcEnabled =
     Boolean(env.GANTRY_BROWSER_IPC_AUTH_TOKEN?.trim()) &&
     input.configuredAllowedTools.some(isCanonicalBrowserCapabilityRule);
+  const asyncTaskToolsEnabled = env.GANTRY_ASYNC_TASK_TOOLS_ENABLED === '1';
 
   const selectedToolNamesBase = selectedGantryMcpToolNames(
     input.configuredAllowedTools,
     {
       excludeAuthorityTools: input.hideAuthorityTools,
       memoryReviewerIsControlApprover,
-      asyncTaskToolsEnabled: env.GANTRY_ASYNC_TASK_TOOLS_ENABLED === '1',
+      asyncTaskToolsEnabled,
     },
   );
   // Browser gateway tools (browser_*) are reachable only when the host enabled
@@ -127,6 +129,7 @@ export function buildGantryMcpProjection(
     env: serverEnv,
     selectedToolNames,
     browserIpcEnabled,
+    asyncTaskToolsEnabled,
   };
 }
 

--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/mcp-tools.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/mcp-tools.ts
@@ -123,6 +123,9 @@ export async function connectGantryAndThirdPartyMcpTools(
   const gantryTools = (serverTools[GANTRY_SERVER_NAME] ?? []).filter((tool) =>
     selectedGantrySet.has(tool.name),
   );
+  const delegateTaskTool = gantryTools.find(
+    (tool) => tool.name === 'delegate_task',
+  );
   const facadeTools = createGantryFacadeTools({
     workspaceFolder: input.gate.workspaceFolder,
     memoryBlock: input.gate.memoryBlock,
@@ -131,6 +134,8 @@ export async function connectGantryAndThirdPartyMcpTools(
     gateContext: input.gate.gateContext,
     permissionEnv: input.gate.permissionEnv,
     lockedAccessPreset: input.gate.lockedAccessPreset,
+    asyncTaskToolsEnabled: projection.asyncTaskToolsEnabled,
+    delegateTaskTool,
     filesystemToolsEnabled: shouldProjectGantryFilesystemTools({
       filesystemEnabledEnv: process.env.GANTRY_DEEPAGENTS_FILESYSTEM_ENABLED,
     }),

--- a/apps/core/src/domain/ports/async-tasks.ts
+++ b/apps/core/src/domain/ports/async-tasks.ts
@@ -58,6 +58,10 @@ export interface PublicAsyncTaskDto {
   blocker?: string | null;
   pendingSteeringCount?: number;
   consumedSteeringCount?: number;
+  heartbeatAt?: string | null;
+  elapsedMs?: number | null;
+  stdoutTail?: string | null;
+  stderrTail?: string | null;
   receiptLines: string[];
   allowedActions: Array<'get' | 'list' | 'cancel'>;
   createdAt: string;
@@ -168,6 +172,7 @@ export function toPublicAsyncTaskDto(
     outputSummary: task.outputSummary,
     errorSummary: task.errorSummary,
     ...publicProgress(task),
+    ...publicInspection(task),
     receiptLines: receiptLines(task.receiptJson),
     allowedActions: isAsyncTaskTerminal(task.status)
       ? ['get', 'list']
@@ -231,6 +236,38 @@ function publicProgress(
     consumedSteeringCount: steering.filter(
       (entry) => record(entry).status === 'consumed',
     ).length,
+  };
+}
+
+function publicInspection(
+  task: AsyncTaskRecord,
+): Pick<
+  PublicAsyncTaskDto,
+  'heartbeatAt' | 'elapsedMs' | 'stdoutTail' | 'stderrTail'
+> {
+  if (task.kind !== 'async_command' || task.status !== 'running') {
+    return {
+      heartbeatAt: null,
+      elapsedMs: null,
+      stdoutTail: null,
+      stderrTail: null,
+    };
+  }
+  const progress = record(task.privateCorrelationJson.progress);
+  const startedAt = task.startedAt ?? task.createdAt;
+  const startedMs = Date.parse(startedAt);
+  const endMs =
+    Date.parse(task.terminalAt ?? '') ||
+    Date.parse(task.heartbeatAt ?? '') ||
+    Date.parse(task.updatedAt) ||
+    Date.now();
+  const fallbackElapsedMs =
+    Number.isFinite(startedMs) && endMs >= startedMs ? endMs - startedMs : null;
+  return {
+    heartbeatAt: task.heartbeatAt ?? null,
+    elapsedMs: fallbackElapsedMs,
+    stdoutTail: stringValue(progress.stdoutTail),
+    stderrTail: stringValue(progress.stderrTail),
   };
 }
 

--- a/apps/core/src/jobs/async-command-sandbox-runner.ts
+++ b/apps/core/src/jobs/async-command-sandbox-runner.ts
@@ -13,6 +13,7 @@ import type {
   AsyncCommandLaunchControl,
   AsyncCommandProcessHandle,
 } from './async-command-task-service.js';
+import type { AsyncCommandOutputSnapshot } from './async-command-task-helpers.js';
 
 const ASYNC_COMMAND_ENV_KEYS = [
   'HTTP_PROXY',
@@ -41,6 +42,7 @@ const ASYNC_COMMAND_ENV_KEYS = [
 ] as const;
 
 export const DEFAULT_ASYNC_COMMAND_TIMEOUT_MS = 120_000;
+const OUTPUT_SNAPSHOT_INTERVAL_MS = 1_000;
 export const DEFAULT_ASYNC_RESOURCE_LIMITS: RunnerSandboxResourceLimits = {
   cpuSeconds: 300,
   memoryMb: 1024,
@@ -70,6 +72,7 @@ export async function runSandboxedAsyncCommand(
     onProcessStarted?: (
       handle: AsyncCommandProcessHandle,
     ) => Promise<void> | void;
+    onOutputSnapshot?: (snapshot: AsyncCommandOutputSnapshot) => unknown;
     launchControl?: AsyncCommandLaunchControl;
   },
 ): Promise<{ outputSummary?: string; errorSummary?: string }> {
@@ -158,6 +161,7 @@ export async function runSandboxedAsyncCommand(
       settled = true;
       if (timer) clearTimeout(timer);
       if (forceKillTimer) clearTimeout(forceKillTimer);
+      if (outputSnapshotTimer) clearTimeout(outputSnapshotTimer);
       input.signal.removeEventListener('abort', onAbort);
       fs.rmSync(configFilePath, { force: true });
       fn();
@@ -166,11 +170,38 @@ export async function runSandboxedAsyncCommand(
       timedOut = true;
       terminate();
     }, input.timeoutMs);
+    let outputSnapshotTimer: ReturnType<typeof setTimeout> | undefined;
+    let outputSnapshotInFlight = false;
+    let outputSnapshotPending = false;
+    const emitOutputSnapshot = () => {
+      outputSnapshotPending = false;
+      outputSnapshotInFlight = true;
+      Promise.resolve(
+        input.onOutputSnapshot?.({ stdoutTail: stdout, stderrTail: stderr }),
+      )
+        .catch(() => undefined)
+        .finally(() => {
+          outputSnapshotInFlight = false;
+          if (outputSnapshotPending && !settled) scheduleOutputSnapshot();
+        });
+    };
+    const scheduleOutputSnapshot = () => {
+      if (!input.onOutputSnapshot) return;
+      outputSnapshotPending = true;
+      if (outputSnapshotInFlight || outputSnapshotTimer) return;
+      outputSnapshotTimer = setTimeout(() => {
+        outputSnapshotTimer = undefined;
+        emitOutputSnapshot();
+      }, OUTPUT_SNAPSHOT_INTERVAL_MS);
+      outputSnapshotTimer.unref?.();
+    };
     child.stdout.on('data', (chunk) => {
       stdout = `${stdout}${String(chunk)}`.slice(-input.outputMaxBytes);
+      scheduleOutputSnapshot();
     });
     child.stderr.on('data', (chunk) => {
       stderr = `${stderr}${String(chunk)}`.slice(-input.outputMaxBytes);
+      scheduleOutputSnapshot();
     });
     child.on('error', (err) => settle(() => reject(err)));
     child.on('close', (code, signal) => {

--- a/apps/core/src/jobs/async-command-task-helpers.ts
+++ b/apps/core/src/jobs/async-command-task-helpers.ts
@@ -13,6 +13,8 @@ import type {
   AsyncCommandProcessHandle,
   StartAsyncCommandTaskResult,
 } from './async-command-task-service.js';
+import { sanitizeOutboundLlmText } from '../shared/sensitive-material.js';
+import { nowIso } from '../shared/time/datetime.js';
 
 const OUTPUT_LIMIT = 1_000;
 const localAdmissionLocks = new WeakMap<AsyncTaskRepository, Promise<void>>();
@@ -144,6 +146,93 @@ export function commandSummary(command: string): string {
 
 export function truncate(value: string, limit = OUTPUT_LIMIT): string {
   return value.length <= limit ? value : `${value.slice(0, limit)}...`;
+}
+
+function outputTail(value: string, limit = OUTPUT_LIMIT): string {
+  return value.length <= limit ? value : `...${value.slice(-limit)}`;
+}
+
+export interface AsyncCommandOutputSnapshot {
+  stdoutTail?: string;
+  stderrTail?: string;
+}
+
+export async function persistProcessHandle(input: {
+  repository: AsyncTaskRepository;
+  task: AsyncTaskRecord;
+  handle: AsyncCommandProcessHandle;
+}): Promise<void> {
+  const latest = (await input.repository.getTask(input.task.id)) ?? input.task;
+  if (
+    latest.leaseToken !== input.task.leaseToken ||
+    latest.fencingVersion !== input.task.fencingVersion
+  ) {
+    throw new Error('Async command process owner is stale.');
+  }
+  const updated = await input.repository.transitionTask({
+    taskId: input.task.id,
+    leaseToken: input.task.leaseToken,
+    fencingVersion: input.task.fencingVersion,
+    status: 'running',
+    now: nowIso(),
+    heartbeatAt: nowIso(),
+    privateCorrelationJson: {
+      ...(isRecord(latest.privateCorrelationJson)
+        ? latest.privateCorrelationJson
+        : {}),
+      process: input.handle,
+    },
+  });
+  if (!updated) {
+    throw new Error('Failed to persist async command process handle.');
+  }
+}
+
+export async function persistInspectionSnapshot(input: {
+  repository: AsyncTaskRepository;
+  task: AsyncTaskRecord;
+  snapshot: AsyncCommandOutputSnapshot;
+}): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const latest = await input.repository.getTask(input.task.id);
+    if (
+      !latest ||
+      latest.status !== 'running' ||
+      latest.leaseToken !== input.task.leaseToken ||
+      latest.fencingVersion !== input.task.fencingVersion
+    ) {
+      return;
+    }
+    const now = nowIso();
+    const progress = isRecord(latest.privateCorrelationJson.progress)
+      ? latest.privateCorrelationJson.progress
+      : {};
+    const updated = await input.repository.transitionTask({
+      taskId: input.task.id,
+      leaseToken: input.task.leaseToken,
+      fencingVersion: input.task.fencingVersion,
+      status: 'running',
+      now,
+      heartbeatAt: now,
+      expectedPrivateCorrelationJson: latest.privateCorrelationJson,
+      privateCorrelationJson: {
+        ...(isRecord(latest.privateCorrelationJson)
+          ? latest.privateCorrelationJson
+          : {}),
+        progress: {
+          ...progress,
+          phase: 'running',
+          stdoutTail: outputTail(
+            sanitizeOutboundLlmText(input.snapshot.stdoutTail ?? '').text,
+          ),
+          stderrTail: outputTail(
+            sanitizeOutboundLlmText(input.snapshot.stderrTail ?? '').text,
+          ),
+        },
+      },
+    });
+    if (updated) return;
+  }
 }
 
 export function errorMessage(err: unknown): string {

--- a/apps/core/src/jobs/async-command-task-service.ts
+++ b/apps/core/src/jobs/async-command-task-service.ts
@@ -29,14 +29,16 @@ import {
   cleanupLaunchControl,
   commandSummary,
   errorMessage,
-  isRecord,
   isTimeoutError,
+  persistInspectionSnapshot,
+  persistProcessHandle,
   readPersistedProcessHandle,
   taskInScope,
   taskTimestampMs,
   terminateProcessHandle,
   truncate,
   withLocalAdmissionLock,
+  type AsyncCommandOutputSnapshot,
 } from './async-command-task-helpers.js';
 import {
   cancelledReceipt,
@@ -97,6 +99,7 @@ export interface AsyncCommandRunner {
     onProcessStarted?: (
       handle: AsyncCommandProcessHandle,
     ) => Promise<void> | void;
+    onOutputSnapshot?: (snapshot: AsyncCommandOutputSnapshot) => unknown;
     launchControl?: AsyncCommandLaunchControl;
   }): Promise<AsyncCommandRunnerResult>;
 }
@@ -611,25 +614,14 @@ export class AsyncCommandTaskService {
         resourceLimits: input.resourceLimits,
         signal: controller.signal,
         launchControl,
-        onProcessStarted: async (handle) => {
-          const updated = await this.repository.transitionTask({
-            taskId: task.id,
-            leaseToken: task.leaseToken,
-            fencingVersion: task.fencingVersion,
-            status: 'running',
-            now: nowIso(),
-            heartbeatAt: nowIso(),
-            privateCorrelationJson: {
-              ...(isRecord(task.privateCorrelationJson)
-                ? task.privateCorrelationJson
-                : {}),
-              process: handle,
-            },
-          });
-          if (!updated) {
-            throw new Error('Failed to persist async command process handle.');
-          }
-        },
+        onOutputSnapshot: (snapshot) =>
+          persistInspectionSnapshot({
+            repository: this.repository,
+            task,
+            snapshot,
+          }),
+        onProcessStarted: (handle) =>
+          persistProcessHandle({ repository: this.repository, task, handle }),
         appId: task.appId,
         agentId: task.agentId,
         conversationId: task.conversationId ?? '',

--- a/apps/core/test/unit/adapters/deepagents-gantry-facade-tools.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-gantry-facade-tools.test.ts
@@ -54,6 +54,7 @@ function makeTools(
   rules: string[] = [],
   toolNetworkEnv?: Record<string, string>,
   filesystemToolsEnabled = true,
+  extra: Partial<Parameters<typeof createGantryFacadeTools>[0]> = {},
 ) {
   return createGantryFacadeTools({
     workspaceFolder: 'main_agent',
@@ -65,6 +66,7 @@ function makeTools(
     lockedAccessPreset: false,
     filesystemToolsEnabled,
     cwd: root,
+    ...extra,
   });
 }
 
@@ -115,7 +117,10 @@ describe('Gantry DeepAgents facade tools', () => {
 
   it('projects Gantry public facade names and no raw DeepAgents filesystem tools', () => {
     const root = makeRoot();
-    const names = makeTools(root)
+    const names = makeTools(root, [], undefined, true, {
+      asyncTaskToolsEnabled: true,
+      delegateTaskTool: { name: 'delegate_task', invoke: vi.fn() } as never,
+    })
       .map((item) => item.name)
       .sort();
     expect(names).toEqual([...DEEPAGENTS_GANTRY_FACADE_TOOL_NAMES].sort());
@@ -228,6 +233,36 @@ describe('Gantry DeepAgents facade tools', () => {
       });
     },
   );
+
+  it('bridges AgentDelegation to Gantry delegate_task when authorized', async () => {
+    const root = makeRoot();
+    const delegateTaskTool = {
+      name: 'delegate_task',
+      invoke: vi.fn(async () => 'task task-1 started'),
+    };
+
+    const result = await invoke(
+      makeTools(root, ['AgentDelegation'], undefined, true, {
+        asyncTaskToolsEnabled: true,
+        delegateTaskTool: delegateTaskTool as never,
+      }),
+      'AgentDelegation',
+      { task: 'research accounts', context: 'from lead list' },
+    );
+
+    expect(result).toBe('task task-1 started');
+    expect(delegateTaskTool.invoke).toHaveBeenCalledWith({
+      objective: 'research accounts',
+      context: 'from lead list',
+    });
+  });
+
+  it('does not expose AgentDelegation until the Gantry delegate transport is mounted', () => {
+    const root = makeRoot();
+    expect(makeTools(root).map((item) => item.name)).not.toContain(
+      'AgentDelegation',
+    );
+  });
 
   it('writes and edits files through Gantry facade authority', async () => {
     const root = makeRoot();

--- a/apps/core/test/unit/adapters/deepagents-provider-async-bridge.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-provider-async-bridge.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { evaluateAgentDelegationAsyncBridge } from '@core/adapters/llm/deepagents-langchain/runner/agent-delegation-async-bridge.js';
+import {
+  DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE,
+  EXPECTED_DEEPAGENTS_ASYNC_TOOL_NAMES,
+  EXPECTED_DEEPAGENTS_ASYNC_TOOL_SCHEMAS,
+  SUPPORTED_DEEPAGENTS_ASYNC_SUBAGENT_VERSION,
+} from '@core/adapters/llm/deepagents-langchain/runner/async-subagent-sentinel.js';
+
+function fakeBridgeProviderModule() {
+  return {
+    isAsyncSubAgent: vi.fn((subagent: unknown) =>
+      Boolean(
+        subagent && typeof subagent === 'object' && 'graphId' in subagent,
+      ),
+    ),
+    createAsyncSubAgentMiddleware: vi.fn(() => ({
+      name: 'asyncSubAgentMiddleware',
+      tools: EXPECTED_DEEPAGENTS_ASYNC_TOOL_NAMES.map((name) => ({
+        name,
+        schema: {
+          shape: Object.fromEntries(
+            EXPECTED_DEEPAGENTS_ASYNC_TOOL_SCHEMAS[
+              name as keyof typeof EXPECTED_DEEPAGENTS_ASYNC_TOOL_SCHEMAS
+            ].map((key) => [key, {}]),
+          ),
+        },
+      })),
+    })),
+  };
+}
+
+describe('DeepAgents provider async bridge gate', () => {
+  it('denies before raw DeepAgents async middleware can spawn work', () => {
+    const withoutDelegationProvider = fakeBridgeProviderModule();
+    const withoutDelegation = evaluateAgentDelegationAsyncBridge({
+      intent: { toolName: 'AgentDelegation', task: 'research accounts' },
+      packageVersion: SUPPORTED_DEEPAGENTS_ASYNC_SUBAGENT_VERSION,
+      providerModule: withoutDelegationProvider,
+      asyncTaskToolsEnabled: true,
+      sandboxReady: true,
+      agentDelegationAuthorized: false,
+      transportReady: true,
+    });
+
+    expect(withoutDelegation).toEqual({
+      status: 'unavailable',
+      reason: 'agent_delegation_unauthorized',
+      message: DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE,
+    });
+    expect(
+      withoutDelegationProvider.createAsyncSubAgentMiddleware,
+    ).not.toHaveBeenCalled();
+
+    const withoutTransportProvider = fakeBridgeProviderModule();
+    const withoutTransport = evaluateAgentDelegationAsyncBridge({
+      intent: { toolName: 'AgentDelegation', task: 'research accounts' },
+      packageVersion: SUPPORTED_DEEPAGENTS_ASYNC_SUBAGENT_VERSION,
+      providerModule: withoutTransportProvider,
+      asyncTaskToolsEnabled: true,
+      sandboxReady: true,
+      agentDelegationAuthorized: true,
+      transportReady: false,
+    });
+
+    expect(withoutTransport).toEqual({
+      status: 'unavailable',
+      reason: 'transport_unavailable',
+      message: DEEPAGENTS_ASYNC_DELEGATION_UNAVAILABLE_MESSAGE,
+    });
+    expect(
+      withoutTransportProvider.createAsyncSubAgentMiddleware,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/test/unit/domain/async-tasks.test.ts
+++ b/apps/core/test/unit/domain/async-tasks.test.ts
@@ -5,7 +5,10 @@ import {
   type AsyncTaskRecord,
 } from '../../../src/domain/ports/async-tasks.js';
 
-function task(receiptJson: AsyncTaskRecord['receiptJson']): AsyncTaskRecord {
+function task(
+  receiptJson: AsyncTaskRecord['receiptJson'],
+  overrides: Partial<AsyncTaskRecord> = {},
+): AsyncTaskRecord {
   return {
     id: 'task-1',
     appId: 'app-1',
@@ -22,6 +25,7 @@ function task(receiptJson: AsyncTaskRecord['receiptJson']): AsyncTaskRecord {
     updatedAt: '2026-06-22T00:00:00.000Z',
     terminalAt: '2026-06-22T00:00:00.000Z',
     receiptJson,
+    ...overrides,
   };
 }
 
@@ -58,5 +62,55 @@ describe('toPublicAsyncTaskDto', () => {
       'Delegated: no',
       'Needs attention: none',
     ]);
+  });
+
+  it('exposes only bounded public progress for running async commands', () => {
+    const dto = toPublicAsyncTaskDto(
+      task(null, {
+        status: 'running',
+        heartbeatAt: '2026-06-22T00:00:03.000Z',
+        terminalAt: null,
+        privateCorrelationJson: {
+          process: {
+            pid: 12345,
+            processGroupId: 12345,
+            detached: true,
+            platform: process.platform,
+            ownerPid: process.pid,
+            startedAt: '2026-06-22T00:00:00.000Z',
+          },
+          progress: {
+            phase: 'running',
+            stdoutTail: 'safe stdout tail',
+            stderrTail: 'safe stderr tail',
+            stdout: 'unbounded stdout must stay private',
+            stderr: 'unbounded stderr must stay private',
+            privateCorrelationJson: { nested: true },
+            leaseToken: 'nested-lease',
+            fencingVersion: 7,
+          },
+        },
+      }),
+    );
+
+    expect(dto).toMatchObject({
+      id: 'task-1',
+      kind: 'async_command',
+      status: 'running',
+      currentPhase: 'running',
+      heartbeatAt: '2026-06-22T00:00:03.000Z',
+      elapsedMs: expect.any(Number),
+      stdoutTail: 'safe stdout tail',
+      stderrTail: 'safe stderr tail',
+      allowedActions: ['get', 'list', 'cancel'],
+    });
+    expect(dto.elapsedMs).toBeGreaterThanOrEqual(0);
+    const publicJson = JSON.stringify(dto);
+    expect(publicJson).not.toContain('privateCorrelationJson');
+    expect(publicJson).not.toContain('process');
+    expect(publicJson).not.toContain('leaseToken');
+    expect(publicJson).not.toContain('fencingVersion');
+    expect(publicJson).not.toContain('unbounded stdout');
+    expect(publicJson).not.toContain('unbounded stderr');
   });
 });

--- a/apps/core/test/unit/jobs/async-command-sandbox-runner.test.ts
+++ b/apps/core/test/unit/jobs/async-command-sandbox-runner.test.ts
@@ -175,6 +175,36 @@ describe('async command sandbox runner', () => {
     expect(provider.start).toHaveBeenCalledOnce();
   });
 
+  it('emits bounded throttled output snapshots while the child is running', async () => {
+    vi.useFakeTimers();
+    const { provider, child } = makeProvider();
+    const snapshots: Array<{ stdoutTail?: string; stderrTail?: string }> = [];
+
+    const resultPromise = runSandboxedAsyncCommand(provider, {
+      ...baseInput(),
+      outputMaxBytes: 8,
+      onOutputSnapshot: (snapshot) => snapshots.push(snapshot),
+    });
+    await Promise.resolve();
+    child.stdout.write('123456789');
+    child.stderr.write('abcdefghi');
+    expect(snapshots).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(snapshots).toEqual([
+      {
+        stdoutTail: '23456789',
+        stderrTail: 'bcdefghi',
+      },
+    ]);
+    child.emit('close', 0, null);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(resultPromise).resolves.toEqual({
+      outputSummary: '23456789',
+      errorSummary: 'bcdefghi',
+    });
+  });
+
   it('fails closed without an enforcing sandbox and times out active children', async () => {
     await expect(
       runSandboxedAsyncCommand(makeProvider({ enforcing: false }).provider, {

--- a/apps/core/test/unit/jobs/async-command-task-service.test.ts
+++ b/apps/core/test/unit/jobs/async-command-task-service.test.ts
@@ -4,6 +4,7 @@ import {
   AsyncCommandTaskService,
   type AsyncCommandRunner,
 } from '@core/jobs/async-command-task-service.js';
+import { persistInspectionSnapshot } from '@core/jobs/async-command-task-helpers.js';
 import type {
   AsyncTaskCreateInput,
   AsyncTaskListFilter,
@@ -273,6 +274,43 @@ describe('AsyncCommandTaskService', () => {
       message:
         'Async command capacity is full for this agent. Wait for an existing task to finish or cancel one.',
     });
+  });
+
+  it('applies active task backpressure to delegated agents before child spawn', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const runner: AsyncCommandRunner = {
+      run: async () => new Promise(() => undefined),
+    };
+    const service = new AsyncCommandTaskService(repository, runner);
+
+    await expect(service.start(baseInput())).resolves.toMatchObject({
+      ok: true,
+    });
+    await expect(service.start(baseInput())).resolves.toMatchObject({
+      ok: true,
+    });
+    const childSpawn = vi.fn(async () => ({ outputSummary: 'done' }));
+
+    await expect(
+      service.startDelegatedAgent({
+        appId: 'app-1',
+        agentId: 'agent-1',
+        conversationId: 'conversation-1',
+        objective: 'Research accounts',
+        workspaceFolder: 'main_agent',
+        run: childSpawn,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      message:
+        'Async command capacity is full for this agent. Wait for an existing task to finish or cancel one.',
+    });
+
+    expect(childSpawn).not.toHaveBeenCalled();
+    expect([...repository.tasks.values()].map((task) => task.kind)).toEqual([
+      'async_command',
+      'async_command',
+    ]);
   });
 
   it('does not claim cancellation when this process has no active handle', async () => {
@@ -1111,6 +1149,229 @@ describe('AsyncCommandTaskService', () => {
       'cancelled',
     );
     expect(killed).toEqual([45691]);
+  });
+
+  it('persists redacted bounded output snapshots while command is running', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    let releaseRunner!: () => void;
+    let snapshotPersisted!: () => void;
+    const runnerReleased = new Promise<void>((resolve) => {
+      releaseRunner = resolve;
+    });
+    const snapshotWritten = new Promise<void>((resolve) => {
+      snapshotPersisted = resolve;
+    });
+    const secret = `sk-ant-${'a'.repeat(24)}`;
+    const runner: AsyncCommandRunner = {
+      run: async ({ onProcessStarted, onOutputSnapshot }) => {
+        await onProcessStarted?.({
+          pid: 45693,
+          processGroupId: 45693,
+          detached: true,
+          platform: process.platform,
+          ownerPid: process.pid,
+          startedAt: new Date().toISOString(),
+        });
+        await Promise.resolve(
+          onOutputSnapshot?.({
+            stdoutTail: `${'x'.repeat(1_200)} ${secret}`,
+            stderrTail: `failed with ${secret}`,
+          }),
+        );
+        snapshotPersisted();
+        await runnerReleased;
+        return { outputSummary: 'done' };
+      },
+    };
+    const service = new AsyncCommandTaskService(repository, runner);
+
+    const started = await service.start(baseInput());
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+    await waitForStatus(repository, started.task.id, 'running');
+    await snapshotWritten;
+
+    const dto = await service.get(started.task.id);
+
+    expect(dto).toMatchObject({
+      status: 'running',
+      stdoutTail: expect.stringContaining('[REDACTED_SECRET]'),
+      stderrTail: expect.stringContaining('[REDACTED_SECRET]'),
+    });
+    expect(dto?.stdoutTail?.length).toBeLessThanOrEqual(1_003);
+    expect(JSON.stringify(dto)).not.toContain(secret);
+    releaseRunner();
+    await waitForStatus(repository, started.task.id, 'completed');
+  });
+
+  it('preserves early output snapshot when process handle is persisted later', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    let allowProcessStart!: () => void;
+    const processStartAllowed = new Promise<void>((resolve) => {
+      allowProcessStart = resolve;
+    });
+    const runner: AsyncCommandRunner = {
+      run: async ({ onProcessStarted, onOutputSnapshot }) => {
+        const processStarted = Promise.resolve(
+          onProcessStarted?.({
+            pid: 45694,
+            processGroupId: 45694,
+            detached: true,
+            platform: process.platform,
+            ownerPid: process.pid,
+            startedAt: new Date().toISOString(),
+          }),
+        );
+        await Promise.resolve(
+          onOutputSnapshot?.({
+            stdoutTail: 'early stdout',
+            stderrTail: 'early stderr',
+          }),
+        );
+        allowProcessStart();
+        await processStarted;
+        return { outputSummary: 'done' };
+      },
+    };
+    const service = new AsyncCommandTaskService(repository, runner);
+    const originalGetTask = repository.getTask.bind(repository);
+    let delayProcessMerge = true;
+    repository.getTask = async (taskId) => {
+      if (delayProcessMerge) {
+        delayProcessMerge = false;
+        await processStartAllowed;
+      }
+      return originalGetTask(taskId);
+    };
+
+    const started = await service.start(baseInput());
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+
+    await waitForStatus(repository, started.task.id, 'completed');
+    const correlation =
+      repository.tasks.get(started.task.id)?.privateCorrelationJson ?? {};
+    expect(correlation.progress).toMatchObject({
+      stdoutTail: 'early stdout',
+      stderrTail: 'early stderr',
+    });
+    expect(correlation.process).toMatchObject({ pid: 45694 });
+  });
+
+  it('drops inspection snapshots from stale task owners', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const task = await repository.createTask({
+      id: 'task-stale-snapshot',
+      appId: 'app-1',
+      agentId: 'agent-1',
+      conversationId: 'conversation-1',
+      kind: 'async_command',
+      status: 'running',
+      admissionClass: 'agent',
+      authoritySnapshotJson: {},
+      privateCorrelationJson: {},
+      leaseToken: 'old-token',
+      fencingVersion: 1,
+      now: new Date().toISOString(),
+    });
+    repository.tasks.set(task.id, {
+      ...task,
+      leaseToken: 'new-token',
+      fencingVersion: 2,
+    });
+
+    await persistInspectionSnapshot({
+      repository,
+      task,
+      snapshot: { stdoutTail: 'stale output' },
+    });
+
+    expect(
+      repository.tasks.get(task.id)?.privateCorrelationJson.progress,
+    ).toBeUndefined();
+  });
+
+  it('retries inspection snapshot writes that race process handle persistence', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const task = await repository.createTask({
+      id: 'task-snapshot-process-race',
+      appId: 'app-1',
+      agentId: 'agent-1',
+      conversationId: 'conversation-1',
+      kind: 'async_command',
+      status: 'running',
+      admissionClass: 'agent',
+      authoritySnapshotJson: {},
+      privateCorrelationJson: {},
+      leaseToken: 'token',
+      fencingVersion: 1,
+      now: new Date().toISOString(),
+    });
+    const originalTransition = repository.transitionTask.bind(repository);
+    let raced = false;
+    repository.transitionTask = async (input) => {
+      if (!raced && input.privateCorrelationJson?.progress) {
+        raced = true;
+        const current = repository.tasks.get(task.id);
+        if (current) {
+          repository.tasks.set(task.id, {
+            ...current,
+            privateCorrelationJson: {
+              ...current.privateCorrelationJson,
+              process: { pid: 45696 },
+            },
+          });
+        }
+      }
+      return originalTransition(input);
+    };
+
+    await persistInspectionSnapshot({
+      repository,
+      task,
+      snapshot: { stdoutTail: 'latest output' },
+    });
+
+    expect(repository.tasks.get(task.id)?.privateCorrelationJson).toMatchObject(
+      {
+        process: { pid: 45696 },
+        progress: { stdoutTail: 'latest output' },
+      },
+    );
+  });
+
+  it('drops process handles from stale task owners', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const runner: AsyncCommandRunner = {
+      run: async ({ onProcessStarted }) => {
+        await onProcessStarted?.({
+          pid: 45695,
+          processGroupId: 45695,
+          detached: true,
+          platform: process.platform,
+          ownerPid: process.pid,
+          startedAt: new Date().toISOString(),
+        });
+        return { outputSummary: 'done' };
+      },
+    };
+    const service = new AsyncCommandTaskService(repository, runner);
+    const originalGetTask = repository.getTask.bind(repository);
+    repository.getTask = async (taskId) => {
+      const latest = await originalGetTask(taskId);
+      return latest
+        ? { ...latest, leaseToken: 'new-token', fencingVersion: 2 }
+        : latest;
+    };
+
+    const started = await service.start(baseInput());
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+
+    await waitForStatus(repository, started.task.id, 'failed');
+    expect(
+      repository.tasks.get(started.task.id)?.privateCorrelationJson.process,
+    ).toBeUndefined();
   });
 
   it('rejects steering for async command and terminal tasks', async () => {

--- a/apps/core/test/unit/jobs/ipc-agent-task-lifecycle-handlers.test.ts
+++ b/apps/core/test/unit/jobs/ipc-agent-task-lifecycle-handlers.test.ts
@@ -404,6 +404,28 @@ describe('agent task lifecycle IPC handlers', () => {
     );
 
     const taskId = await waitForStatus(repository, 'running');
+    const runningTask = repository.tasks.get(taskId);
+    expect(runningTask).toBeTruthy();
+    if (!runningTask) return;
+    repository.tasks.set(taskId, {
+      ...runningTask,
+      heartbeatAt: '2026-06-22T00:00:05.000Z',
+      startedAt: '2026-06-22T00:00:00.000Z',
+      privateCorrelationJson: {
+        ...runningTask.privateCorrelationJson,
+        progress: {
+          phase: 'running',
+          elapsedMs: 5_000,
+          stdoutTail: 'ipc stdout tail',
+          stderrTail: 'ipc stderr tail',
+          stdout: 'ipc private full stdout',
+          stderr: 'ipc private full stderr',
+          privateCorrelationJson: { nested: true },
+          leaseToken: 'nested-lease',
+          fencingVersion: 3,
+        },
+      },
+    });
     expect(readResponse(runtimeHome, 'async-start')).toMatchObject({
       ok: true,
       message: 'Started: echo ok',
@@ -432,8 +454,28 @@ describe('agent task lifecycle IPC handlers', () => {
     );
     expect(readResponse(runtimeHome, 'async-get')).toMatchObject({
       ok: true,
-      data: { id: taskId, status: 'running' },
+      data: {
+        id: taskId,
+        status: 'running',
+        kind: 'async_command',
+        currentPhase: 'running',
+        heartbeatAt: '2026-06-22T00:00:05.000Z',
+        elapsedMs: expect.any(Number),
+        stdoutTail: 'ipc stdout tail',
+        stderrTail: 'ipc stderr tail',
+        allowedActions: ['get', 'list', 'cancel'],
+      },
     });
+    expect(
+      readResponse(runtimeHome, 'async-get').data.elapsedMs,
+    ).toBeGreaterThanOrEqual(0);
+    const getJson = JSON.stringify(readResponse(runtimeHome, 'async-get'));
+    expect(getJson).not.toContain('privateCorrelationJson');
+    expect(getJson).not.toContain('process');
+    expect(getJson).not.toContain('leaseToken');
+    expect(getJson).not.toContain('fencingVersion');
+    expect(getJson).not.toContain('ipc private full stdout');
+    expect(getJson).not.toContain('ipc private full stderr');
 
     await agentTaskLifecycleHandlers.task_list(
       contextFor({

--- a/apps/core/test/unit/runner/locked-tool-surface.test.ts
+++ b/apps/core/test/unit/runner/locked-tool-surface.test.ts
@@ -7,10 +7,20 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
   DEFAULT_GANTRY_MCP_TOOL_NAMES,
+  ASYNC_TASK_GANTRY_MCP_TOOL_NAMES,
+  DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
   parseEnabledGantryMcpToolNames,
   selectedGantryMcpToolNames,
 } from '@core/runner/gantry-mcp-tool-surface.js';
 import { ADMIN_MCP_TOOL_NAMES } from '@core/shared/admin-mcp-tools.js';
+
+const RAW_DEEPAGENTS_ASYNC_TOOL_NAMES = [
+  'start_async_task',
+  'check_async_task',
+  'update_async_task',
+  'cancel_async_task',
+  'list_async_tasks',
+] as const;
 
 // server.js transitively requires GANTRY_IPC_DIR at import time, so the env
 // must be set before the dynamic import resolves.
@@ -38,6 +48,13 @@ function hasAnyAuthorityOrAdminTool(names: Iterable<string>): boolean {
       set.has(toolName),
     ) || ADMIN_MCP_TOOL_NAMES.some((toolName) => set.has(toolName))
   );
+}
+
+function expectNoRawDeepAgentsAsyncTools(names: Iterable<string>): void {
+  const set = new Set(names);
+  for (const toolName of RAW_DEEPAGENTS_ASYNC_TOOL_NAMES) {
+    expect(set.has(toolName)).toBe(false);
+  }
 }
 
 describe('locked tool surface mounting', () => {
@@ -159,6 +176,45 @@ describe('locked tool surface mounting', () => {
     expect(lockedNames).not.toContain('task_cancel');
     expect(lockedNames).not.toContain('delegate_task');
     expect(lockedNames).not.toContain('task_message');
+  });
+
+  it('registers only Gantry task tools and ignores raw DeepAgents async names', () => {
+    const publicTaskToolNames = [
+      ...ASYNC_TASK_GANTRY_MCP_TOOL_NAMES,
+      ...DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
+    ];
+    expect(publicTaskToolNames.sort()).toEqual([
+      'async_run_command',
+      'delegate_task',
+      'task_cancel',
+      'task_get',
+      'task_list',
+      'task_message',
+    ]);
+    expectNoRawDeepAgentsAsyncTools(publicTaskToolNames);
+
+    const selectedNames = selectedGantryMcpToolNames(['AgentDelegation'], {
+      asyncTaskToolsEnabled: true,
+    });
+    for (const toolName of publicTaskToolNames) {
+      expect(selectedNames).toContain(toolName);
+    }
+    expectNoRawDeepAgentsAsyncTools(selectedNames);
+
+    const envNames = effectiveEnabledMcpToolNames(
+      JSON.stringify([
+        ...publicTaskToolNames,
+        ...RAW_DEEPAGENTS_ASYNC_TOOL_NAMES,
+      ]),
+      undefined,
+      undefined,
+      false,
+      '1',
+    );
+    for (const toolName of publicTaskToolNames) {
+      expect(envNames.has(toolName)).toBe(true);
+    }
+    expectNoRawDeepAgentsAsyncTools(envNames);
   });
 });
 

--- a/docs/architecture/async-subagents-gap-closure-goal-prompt.md
+++ b/docs/architecture/async-subagents-gap-closure-goal-prompt.md
@@ -1,0 +1,151 @@
+# Async Subagents Gap Closure Goal Prompt
+
+Use this prompt to implement provider-neutral async subagent parity in Gantry
+without exposing raw Anthropic or DeepAgents task authority.
+
+```text
+/goal Implement Gantry-owned async subagent parity across Anthropic SDK and DeepAgents.
+
+Product contract:
+Gantry agents can start delegated async work, inspect status, steer it, cancel
+it, inspect async Bash progress while it is still running, recover it after
+restart, and receive one durable receipt, using Gantry task ids and Gantry
+permission/sandbox policy only.
+
+Current repo truth:
+- `todo_update` is the baseline visible planning tool.
+- `async_run_command`, `task_get`, `task_list`, and `task_cancel` are mounted
+  only when async task tools are enabled.
+- `delegate_task` and `task_message` are mounted only when async task tools are
+  enabled and `AgentDelegation` is selected.
+- `agent_async_tasks` is the durable task store for `async_command` and
+  `delegated_agent`.
+- Async Bash status includes task-state, heartbeat/elapsed metadata, and
+  bounded redacted mid-run stdout/stderr tails through `task_get`.
+- Anthropic native `Agent`/`Task` calls must be forced to background mode and
+  normalized into Gantry runtime events.
+- DeepAgents raw `task`, `write_todos`, filesystem tools, and async tools
+  (`start_async_task`, `check_async_task`, `update_async_task`,
+  `cancel_async_task`, `list_async_tasks`) must stay hidden unless a
+  Gantry-owned wrapper maps them into durable task lifecycle.
+
+External docs to verify before implementation:
+- Anthropic Claude Code subagents: https://code.claude.com/docs/en/sub-agents
+- Anthropic TypeScript Agent SDK: https://code.claude.com/docs/en/agent-sdk/typescript
+- DeepAgents async subagents: https://docs.langchain.com/oss/javascript/deepagents/async-subagents
+- DeepAgents frontend/task stream model: https://docs.langchain.com/oss/javascript/deepagents/frontend/overview
+
+Locked scope:
+- Reuse `agent_async_tasks`; do not create a parallel task model.
+- Keep public tool names provider-neutral: `delegate_task`, `task_message`,
+  `task_get`, `task_list`, `task_cancel`, `todo_update`.
+- Do not expose raw Anthropic `Agent`/`Task`, DeepAgents `task`,
+  `write_todos`, or DeepAgents async tool names as durable authority.
+- Do not add `task_update`.
+- Do not add dashboard or mission-control UI.
+- Do not add new `settings.yaml` keys unless implementation proves existing
+  gates cannot express the feature.
+- Do not use `.claude/agents/`, DeepAgents subagent specs, provider task ids,
+  LangGraph thread ids, child pids, lease tokens, or fencing versions as
+  public/user-facing identifiers.
+- Do not let async Bash status inspection become arbitrary host log access.
+  Mid-run output must come from bounded Gantry-owned capture, not from agent
+  chosen file paths.
+
+Implementation requirements:
+1. Keep DeepAgents raw async subagent API fail-closed until
+   `async-subagent-sentinel` proves package/schema compatibility and a
+   Gantry-owned Agent Protocol transport is available.
+2. Add the smallest Gantry-owned DeepAgents bridge that maps async subagent
+   lifecycle into `agent_async_tasks`, returning only a Gantry task id.
+3. Preserve Anthropic SDK normalization: native `Agent`/`Task` attempts route
+   through `AgentDelegation`, run in background, and emit sanitized task
+   lifecycle runtime events.
+4. Ensure `task_get`, `task_list`, `task_message`, and `task_cancel` work from
+   Gantry task ids after compaction and after host restart.
+5. Add mid-run async Bash inspection: while an `async_command` is `running`,
+   `task_get` returns current status, last heartbeat/update time, elapsed time,
+   and bounded redacted stdout/stderr tails captured by Gantry. This must not
+   expose raw protected paths, arbitrary log files, process internals, or
+   unbounded output.
+6. Add subagent fan-out/backpressure accounting so delegated child work cannot
+   silently exceed runtime capacity.
+7. Host-enforce delegated task terminal receipts:
+   - `Completed: <short outcome>`
+   - `Used: <tools/capabilities or none>`
+   - `Changed: <files/accounts/channels or none>`
+   - `Delegated: yes/no`
+   - `Subtasks: <n completed, n failed, n cancelled>` when delegated
+   - `Needs attention: <blocker or none>`
+
+Exact UX copy:
+- Start accepted: `Started: <short task summary>`
+- Status loaded: `Task loaded.`
+- Running async command status: `Task is running.`
+- List loaded: `Listed <n> async task(s).`
+- Steering accepted: `Message sent to delegated task.`
+- Cancel success: `Task was cancelled. Nothing else changed.`
+- Missing delegation authority: `delegate_task requires AgentDelegation access.`
+- Terminal steering: `Task is already finished and cannot receive messages.`
+- Provider-private detail requested: `Provider task details are internal. Use the Gantry task id to check status or cancel.`
+- DeepAgents unavailable: `Async delegation is unavailable for this DeepAgents version. Gantry did not start delegated work.`
+
+Acceptance criteria:
+1. DeepAgents async delegation starts only when package API, Gantry transport,
+   async task tools, sandbox policy, and `AgentDelegation` authority are all
+   valid.
+2. Denied DeepAgents delegation never invokes raw DeepAgents `task` or async
+   middleware.
+3. Public DTOs never expose raw provider task ids, LangGraph thread ids, pids,
+   lease tokens, fencing versions, output files, or provider session ids.
+4. Anthropic and DeepAgents lanes produce the same public task states and
+   receipt shape.
+5. Delegated task steering is persisted before delivery and marked consumed only
+   after delivery.
+6. `task_get` on a running async Bash task returns status plus bounded redacted
+   stdout/stderr tails without granting arbitrary file or host log reads.
+7. Restart recovery preserves `task_get`/`task_cancel` semantics or fails closed
+   with durable evidence.
+8. Subagent fan-out capacity is enforced before child spawn.
+9. Cleanup searches prove no raw provider async task names entered public API,
+   CLI, settings, MCP/admin docs, or durable config.
+
+Required tests:
+- Extend `apps/core/test/unit/adapters/deepagents-async-subagent-sentinel.test.ts`.
+- Add DeepAgents wrapper tests for allowed and denied `AgentDelegation`.
+- Extend task lifecycle tests for restart/recovery, steering, cancellation, and
+  receipt shape.
+- Add async Bash mid-run inspection tests proving running `task_get` returns
+  status, heartbeat/elapsed data, and bounded redacted output tails.
+- Add run-slot/backpressure tests for delegated child fan-out.
+- Keep existing Anthropic native `Agent`/`Task` boundary tests green.
+
+Verification:
+- `npm run test:unit -- apps/core/test/unit/adapters/deepagents-async-subagent-sentinel.test.ts apps/core/test/unit/jobs/ipc-agent-task-lifecycle-handlers.test.ts apps/core/test/unit/jobs/async-command-task-service.test.ts`
+- `npm run test:integration -- apps/core/test/integration/deepagents-langchain-boundary.integration.test.ts apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts`
+- `npm run typecheck`
+- `npm run build`
+- `python3 .codex/scripts/verify.py`
+- `python3 .codex/scripts/validate_artifacts.py --allow-missing-run`
+- `python3 .codex/scripts/check_task_completion.py`
+
+Closeout reviews:
+- Run local autoreview after implementation and focused tests. Use
+  `/Users/ravikiranvemula/.codex/skills/autoreview/scripts/autoreview --mode local`
+  while the implementation is still dirty; use `--mode branch --base origin/main`
+  after committing or when reviewing a branch diff.
+- Run ponytail review on the final diff and remove any complexity findings that
+  do not weaken safety, validation, or the requested feature.
+- Rerun focused tests and autoreview if either review causes code changes.
+
+Runtime smoke after green tests/reviews:
+1. Build from this checkout: `npm run build`.
+2. Restart the local runtime from the fresh build:
+   `launchctl kickstart -k gui/$(id -u)/com.gantry`.
+3. Confirm the running service: `gantry status`.
+4. Find the scheduler job named `Knacklabs lead gen` with `scheduler_list_jobs`.
+5. Queue it with `scheduler_run_now` using the discovered job id.
+6. Inspect completion with `scheduler_list_runs`, `scheduler_list_events`, or
+   `scheduler_wait_for_events`; do not use sleep/poll loops or Bash-only job
+   monitoring.
+```


### PR DESCRIPTION
## Summary

- Add a DeepAgents async bridge so delegated subagent/task calls can start through Gantry-owned async task execution.
- Add task status/log result fields so async bash/task execution can be checked mid-run and surfaced through existing facades.
- Add the async subagents gap-closure `/goal` prompt and focused tests for facade, runner, task service, IPC lifecycle, and locked tool surface behavior.

## Validation

- `npm run build`
- `npm run test:unit -- apps/core/test/unit/adapters/deepagents-gantry-facade-tools.test.ts apps/core/test/unit/adapters/deepagents-provider-async-bridge.test.ts apps/core/test/unit/domain/async-tasks.test.ts apps/core/test/unit/jobs/async-command-sandbox-runner.test.ts apps/core/test/unit/jobs/async-command-task-service.test.ts apps/core/test/unit/jobs/ipc-agent-task-lifecycle-handlers.test.ts apps/core/test/unit/runner/locked-tool-surface.test.ts`
- `git diff --check`
- `python3 .codex/scripts/check_task_completion.py`

## Notes

- `python3 .codex/scripts/verify.py` passed format, build, architecture, runtime-truth, factory Python tests, and typecheck, then sat silent in full `npm test` for several minutes. I interrupted it and cleaned up its leftover child processes; the focused changed-surface unit suite passed.