### PR TITLE
fix slack setup bootstrap recovery

### DIFF
--- a/apps/core/src/adapters/artifacts/files/local-file-artifact-bytes.ts
+++ b/apps/core/src/adapters/artifacts/files/local-file-artifact-bytes.ts
@@ -3,7 +3,10 @@ import { constants } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import type { FileArtifactId } from '../../../domain/file-artifacts/file-artifact.js';
+import {
+  FileArtifactNotFoundError,
+  type FileArtifactId,
+} from '../../../domain/file-artifacts/file-artifact.js';
 
 export interface StoredFileArtifactBytes {
   storageRef: string;
@@ -61,7 +64,15 @@ export class LocalFileArtifactBytes {
     storageRef: string,
     expected: { hash: string; sizeBytes: number },
   ): Promise<Buffer> {
-    const content = await fs.readFile(this.resolve(storageRef));
+    let content: Buffer;
+    try {
+      content = await fs.readFile(this.resolve(storageRef));
+    } catch (err) {
+      if (isNodeErrnoException(err) && err.code === 'ENOENT') {
+        throw new FileArtifactNotFoundError();
+      }
+      throw err;
+    }
     const actualHash = hashFileArtifactBytes(content);
     if (actualHash !== expected.hash) {
       throw new Error(
@@ -93,6 +104,10 @@ export class LocalFileArtifactBytes {
     }
     return target;
   }
+}
+
+function isNodeErrnoException(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && 'code' in value;
 }
 
 function normalizeStorageRef(value: string): string {

--- a/apps/core/src/application/agents/prompt-profile-service.ts
+++ b/apps/core/src/application/agents/prompt-profile-service.ts
@@ -469,8 +469,8 @@ export class PromptProfileService {
       limit: 1,
     });
     if (existing.length > 0) {
-      await this.reseedMirrorIfMissing(store, input);
-      return;
+      const recovered = await this.reseedMirrorIfMissing(store, input);
+      if (recovered) return;
     }
     await store.writeFileArtifact({
       appId: input.appId,
@@ -503,13 +503,13 @@ export class PromptProfileService {
       fileName: string;
       virtualPath: string;
     },
-  ): Promise<void> {
-    if (!this.mirrorProfileFile || !this.mirrorFileExists) return;
+  ): Promise<boolean> {
+    if (!this.mirrorProfileFile || !this.mirrorFileExists) return true;
     const present = await this.mirrorFileExists({
       agentFolder: input.agentFolder,
       fileName: input.fileName,
     });
-    if (present) return;
+    if (present) return true;
     try {
       const current = await store.readFileArtifact({
         appId: input.appId,
@@ -526,8 +526,9 @@ export class PromptProfileService {
         fileName: input.fileName,
         content,
       });
+      return true;
     } catch (err) {
-      if (err instanceof FileArtifactNotFoundError) return;
+      if (err instanceof FileArtifactNotFoundError) return false;
       throw err;
     }
   }

--- a/apps/core/src/application/agents/prompt-profile-service.ts
+++ b/apps/core/src/application/agents/prompt-profile-service.ts
@@ -468,9 +468,11 @@ export class PromptProfileService {
       virtualPath: input.virtualPath,
       limit: 1,
     });
+    let shouldWriteMirror = true;
     if (existing.length > 0) {
-      const recovered = await this.reseedMirrorIfMissing(store, input);
-      if (recovered) return;
+      const recovery = await this.reseedMirrorIfMissing(store, input);
+      if (recovery.recovered) return;
+      shouldWriteMirror = !recovery.mirrorPresent;
     }
     await store.writeFileArtifact({
       appId: input.appId,
@@ -482,7 +484,7 @@ export class PromptProfileService {
       createdBy: input.createdBy,
       metadata: input.metadata,
     });
-    if (this.mirrorProfileFile) {
+    if (this.mirrorProfileFile && shouldWriteMirror) {
       await this.mirrorProfileFile({
         agentFolder: input.agentFolder,
         fileName: input.fileName,
@@ -503,13 +505,14 @@ export class PromptProfileService {
       fileName: string;
       virtualPath: string;
     },
-  ): Promise<boolean> {
-    if (!this.mirrorProfileFile || !this.mirrorFileExists) return true;
+  ): Promise<{ recovered: boolean; mirrorPresent: boolean }> {
+    if (!this.mirrorProfileFile || !this.mirrorFileExists) {
+      return { recovered: true, mirrorPresent: true };
+    }
     const present = await this.mirrorFileExists({
       agentFolder: input.agentFolder,
       fileName: input.fileName,
     });
-    if (present) return true;
     try {
       const current = await store.readFileArtifact({
         appId: input.appId,
@@ -517,6 +520,7 @@ export class PromptProfileService {
         virtualScope: PROMPT_PROFILE_SCOPE,
         virtualPath: input.virtualPath,
       });
+      if (present) return { recovered: true, mirrorPresent: true };
       const content =
         typeof current.content === 'string'
           ? current.content
@@ -526,9 +530,12 @@ export class PromptProfileService {
         fileName: input.fileName,
         content,
       });
-      return true;
+      return { recovered: true, mirrorPresent: present };
     } catch (err) {
-      if (err instanceof FileArtifactNotFoundError) return false;
+      if (err instanceof FileArtifactNotFoundError) {
+        if (present) throw err;
+        return { recovered: false, mirrorPresent: present };
+      }
       throw err;
     }
   }

--- a/apps/core/src/cli/main-agent.ts
+++ b/apps/core/src/cli/main-agent.ts
@@ -22,7 +22,11 @@ export function allocateDefaultAgentFolder(
   runtimeHome: string,
   existing: Record<string, { folder: string }>,
 ): string {
-  const used = new Set(Object.values(existing).map((group) => group.folder));
+  const used = new Set(
+    Object.entries(existing)
+      .filter(([jid, group]) => !isSeededDefaultPlaceholderRoute(jid, group))
+      .map(([, group]) => group.folder),
+  );
   const hasOnDiskFolder = (folder: string): boolean =>
     fs.existsSync(path.join(runtimeHome, 'agents', folder));
 
@@ -37,6 +41,13 @@ export function allocateDefaultAgentFolder(
     if (!used.has(candidate) && !hasOnDiskFolder(candidate)) return candidate;
   }
   return `${DEFAULT_AGENT_FOLDER}_${currentTimeMs()}`;
+}
+
+function isSeededDefaultPlaceholderRoute(
+  jid: string,
+  group: { folder: string },
+): boolean {
+  return jid === 'app:default' && group.folder === DEFAULT_AGENT_FOLDER;
 }
 
 export function displayAgentName(

--- a/apps/core/src/cli/main-agent.ts
+++ b/apps/core/src/cli/main-agent.ts
@@ -22,6 +22,9 @@ export function allocateDefaultAgentFolder(
   runtimeHome: string,
   existing: Record<string, { folder: string }>,
 ): string {
+  const hasSeededDefaultPlaceholder = Object.entries(existing).some(
+    ([jid, group]) => isSeededDefaultPlaceholderRoute(jid, group),
+  );
   const used = new Set(
     Object.entries(existing)
       .filter(([jid, group]) => !isSeededDefaultPlaceholderRoute(jid, group))
@@ -32,7 +35,7 @@ export function allocateDefaultAgentFolder(
 
   if (
     !used.has(DEFAULT_AGENT_FOLDER) &&
-    !hasOnDiskFolder(DEFAULT_AGENT_FOLDER)
+    (!hasOnDiskFolder(DEFAULT_AGENT_FOLDER) || hasSeededDefaultPlaceholder)
   ) {
     return DEFAULT_AGENT_FOLDER;
   }

--- a/apps/core/src/cli/setup-flow-final-steps.ts
+++ b/apps/core/src/cli/setup-flow-final-steps.ts
@@ -119,10 +119,13 @@ export async function runGroupStep(draft: SetupDraft): Promise<FlowAction> {
   try {
     if (draft.primaryProvider === 'slack') {
       const conversationLabel = draft.slackDisplayName || draft.slackChatJid;
+      const approverIds = parseApproverIds(draft.slackPermissionApproverIds);
       const result = await registerSlackMainGroup({
         runtimeHome: draft.runtimeHome,
         chatJid: draft.slackChatJid,
         displayName: draft.agentName,
+        conversationDisplayName: conversationLabel,
+        approverIds,
       });
       const settings = loadRuntimeSettings(draft.runtimeHome);
       ensureConfiguredConversationBinding(settings, {
@@ -133,7 +136,7 @@ export async function runGroupStep(draft: SetupDraft): Promise<FlowAction> {
         displayName: conversationLabel,
         trigger: `@${result.groupName}`,
         requiresTrigger: false,
-        approverIds: parseApproverIds(draft.slackPermissionApproverIds),
+        approverIds,
       });
       saveRuntimeSettings(draft.runtimeHome, settings);
       draft.workspaceKey = result.folder;

--- a/apps/core/src/cli/setup-flow-final-steps.ts
+++ b/apps/core/src/cli/setup-flow-final-steps.ts
@@ -127,18 +127,6 @@ export async function runGroupStep(draft: SetupDraft): Promise<FlowAction> {
         conversationDisplayName: conversationLabel,
         approverIds,
       });
-      const settings = loadRuntimeSettings(draft.runtimeHome);
-      ensureConfiguredConversationBinding(settings, {
-        agentId: result.folder,
-        agentName: result.groupName,
-        agentFolder: result.folder,
-        jid: draft.slackChatJid,
-        displayName: conversationLabel,
-        trigger: `@${result.groupName}`,
-        requiresTrigger: false,
-        approverIds,
-      });
-      saveRuntimeSettings(draft.runtimeHome, settings);
       draft.workspaceKey = result.folder;
       draft.conversationLabel = conversationLabel;
       spinner.stop(`Registered ${result.groupName} (${result.folder})`);

--- a/apps/core/src/cli/slack.ts
+++ b/apps/core/src/cli/slack.ts
@@ -366,6 +366,8 @@ export async function registerSlackMainGroup(options: {
   runtimeHome: string;
   chatJid: string;
   displayName: string;
+  conversationDisplayName?: string;
+  approverIds?: string[];
 }): Promise<{ folder: string; groupName: string }> {
   ensureRuntimeLayout(options.runtimeHome);
   const db = await openRuntimeGroupDb(options.runtimeHome);
@@ -378,12 +380,6 @@ export async function registerSlackMainGroup(options: {
 
     const groupName = normalizeDefaultAgentName(options.displayName);
 
-    await new PromptProfileService({
-      fileArtifactStore: () => db.getFileArtifactStore(),
-      mirrorProfileFile: createProfileFileMirrorWriter(options.runtimeHome),
-      mirrorFileExists: createProfileFileMirrorExists(options.runtimeHome),
-    }).ensureAgentDefaults({ agentFolder: folder, agentName: groupName });
-
     const route = {
       name: groupName,
       folder,
@@ -393,6 +389,12 @@ export async function registerSlackMainGroup(options: {
       agentConfig: existingGroup?.agentConfig,
     };
     await db.setConversationRoute(options.chatJid, route);
+    await new PromptProfileService({
+      fileArtifactStore: () => db.getFileArtifactStore(),
+      mirrorProfileFile: createProfileFileMirrorWriter(options.runtimeHome),
+      mirrorFileExists: createProfileFileMirrorExists(options.runtimeHome),
+    }).ensureAgentDefaults({ agentFolder: folder, agentName: groupName });
+
     const settings = loadRuntimeSettings(options.runtimeHome);
     const previousSettings = structuredClone(settings);
     ensureConfiguredConversationBinding(settings, {
@@ -400,9 +402,10 @@ export async function registerSlackMainGroup(options: {
       agentName: groupName,
       agentFolder: folder,
       jid: options.chatJid,
-      displayName: options.displayName,
+      displayName: options.conversationDisplayName || options.displayName,
       trigger: route.trigger,
       requiresTrigger: false,
+      approverIds: options.approverIds,
     });
     await writeDesiredRuntimeSettings({
       runtimeHome: options.runtimeHome,
@@ -532,6 +535,7 @@ export async function runSlackConnectCommand(
       runtimeHome,
       chatJid: normalizedChatJid,
       displayName: loadRuntimeSettings(runtimeHome).agent.name,
+      approverIds,
     });
     registeredFolder = registered.folder;
     conversationRouteName = registered.groupName;

--- a/apps/core/src/cli/slack.ts
+++ b/apps/core/src/cli/slack.ts
@@ -389,11 +389,6 @@ export async function registerSlackMainGroup(options: {
       agentConfig: existingGroup?.agentConfig,
     };
     await db.setConversationRoute(options.chatJid, route);
-    await new PromptProfileService({
-      fileArtifactStore: () => db.getFileArtifactStore(),
-      mirrorProfileFile: createProfileFileMirrorWriter(options.runtimeHome),
-      mirrorFileExists: createProfileFileMirrorExists(options.runtimeHome),
-    }).ensureAgentDefaults({ agentFolder: folder, agentName: groupName });
 
     const settings = loadRuntimeSettings(options.runtimeHome);
     const previousSettings = structuredClone(settings);
@@ -412,6 +407,12 @@ export async function registerSlackMainGroup(options: {
       settings,
       previousSettings,
     });
+
+    await new PromptProfileService({
+      fileArtifactStore: () => db.getFileArtifactStore(),
+      mirrorProfileFile: createProfileFileMirrorWriter(options.runtimeHome),
+      mirrorFileExists: createProfileFileMirrorExists(options.runtimeHome),
+    }).ensureAgentDefaults({ agentFolder: folder, agentName: groupName });
 
     return { folder, groupName };
   } finally {
@@ -518,6 +519,7 @@ export async function runSlackConnectCommand(
   const approverIds = parseSlackApproverIds(approverInput || '');
   let registeredFolder = '';
   let conversationRouteName = '';
+  let conversationDisplayName = '';
 
   if (normalizedChatJid) {
     const access = await verifySlackChatAccess({
@@ -530,11 +532,13 @@ export async function runSlackConnectCommand(
       if (access.nextAction) p.log.info(access.nextAction);
       return 1;
     }
+    conversationDisplayName = access.chatTitle || normalizedChatJid;
 
     const registered = await registerSlackMainGroup({
       runtimeHome,
       chatJid: normalizedChatJid,
       displayName: loadRuntimeSettings(runtimeHome).agent.name,
+      conversationDisplayName,
       approverIds,
     });
     registeredFolder = registered.folder;
@@ -558,7 +562,8 @@ export async function runSlackConnectCommand(
       agentName: conversationRouteName || settings.agent.name,
       agentFolder: registeredFolder,
       jid: normalizedChatJid,
-      displayName: conversationRouteName || settings.agent.name,
+      displayName:
+        conversationDisplayName || conversationRouteName || settings.agent.name,
       trigger: `@${conversationRouteName || settings.agent.name}`,
       requiresTrigger: false,
       approverIds,

--- a/apps/core/src/config/settings/desired-state-service.ts
+++ b/apps/core/src/config/settings/desired-state-service.ts
@@ -161,7 +161,7 @@ export class SettingsDesiredStateService {
         const conversation = binding.conversation;
         configuredJids.add(binding.jid);
         await this.deps.ops.setConversationRoute(binding.jid, {
-          name: binding.name ?? agent.name,
+          name: agent.name,
           folder,
           trigger: binding.trigger,
           added_at: binding.addedAt,

--- a/apps/core/test/unit/cli/main-agent.test.ts
+++ b/apps/core/test/unit/cli/main-agent.test.ts
@@ -61,6 +61,15 @@ describe('default-agent helpers', () => {
     ).toBe(`${DEFAULT_AGENT_FOLDER}_2`);
   });
 
+  it('does not treat the seeded default app route as a real main_agent collision', () => {
+    const runtimeHome = makeRuntimeHome();
+    expect(
+      allocateDefaultAgentFolder(runtimeHome, {
+        'app:default': { folder: DEFAULT_AGENT_FOLDER },
+      }),
+    ).toBe(DEFAULT_AGENT_FOLDER);
+  });
+
   it('treats on-disk folders as collisions when allocating', () => {
     const runtimeHome = makeRuntimeHome();
     fs.mkdirSync(path.join(runtimeHome, 'agents', DEFAULT_AGENT_FOLDER), {

--- a/apps/core/test/unit/cli/main-agent.test.ts
+++ b/apps/core/test/unit/cli/main-agent.test.ts
@@ -70,6 +70,19 @@ describe('default-agent helpers', () => {
     ).toBe(DEFAULT_AGENT_FOLDER);
   });
 
+  it('reuses the seeded default app route folder when it exists on disk', () => {
+    const runtimeHome = makeRuntimeHome();
+    fs.mkdirSync(path.join(runtimeHome, 'agents', DEFAULT_AGENT_FOLDER), {
+      recursive: true,
+    });
+
+    expect(
+      allocateDefaultAgentFolder(runtimeHome, {
+        'app:default': { folder: DEFAULT_AGENT_FOLDER },
+      }),
+    ).toBe(DEFAULT_AGENT_FOLDER);
+  });
+
   it('treats on-disk folders as collisions when allocating', () => {
     const runtimeHome = makeRuntimeHome();
     fs.mkdirSync(path.join(runtimeHome, 'agents', DEFAULT_AGENT_FOLDER), {

--- a/apps/core/test/unit/cli/setup-flow-simplified.test.ts
+++ b/apps/core/test/unit/cli/setup-flow-simplified.test.ts
@@ -263,6 +263,10 @@ async function loadGroupStep() {
   const settings = {};
   const spinner = { start: vi.fn(), stop: vi.fn() };
   const ensureConfiguredConversationBinding = vi.fn();
+  const registerSlackMainGroup = vi.fn(async () => ({
+    folder: 'main_agent',
+    groupName: 'Gantry',
+  }));
   vi.doMock('@clack/prompts', () => ({
     isCancel: () => false,
     note: vi.fn(),
@@ -282,10 +286,7 @@ async function loadGroupStep() {
     persistOnboardingConfig: vi.fn(),
   }));
   vi.doMock('@core/cli/slack.js', () => ({
-    registerSlackMainGroup: vi.fn(async () => ({
-      folder: 'main_agent',
-      groupName: 'Gantry',
-    })),
+    registerSlackMainGroup,
   }));
   vi.doMock('@core/cli/telegram.js', () => ({
     registerTelegramMainGroup: vi.fn(async () => ({
@@ -299,13 +300,20 @@ async function loadGroupStep() {
     ensureConfiguredConversationBinding,
   }));
   const { runGroupStep } = await import('@core/cli/setup-flow-final-steps.js');
-  return { runGroupStep, ensureConfiguredConversationBinding };
+  return {
+    runGroupStep,
+    ensureConfiguredConversationBinding,
+    registerSlackMainGroup,
+  };
 }
 
 describe('conversation binding labels', () => {
   it('uses the selected Slack conversation label in the ready draft', async () => {
-    const { runGroupStep, ensureConfiguredConversationBinding } =
-      await loadGroupStep();
+    const {
+      runGroupStep,
+      ensureConfiguredConversationBinding,
+      registerSlackMainGroup,
+    } = await loadGroupStep();
     const draft = {
       primaryProvider: 'slack',
       runtimeHome: '/tmp/gantry-group-labels',
@@ -325,6 +333,15 @@ describe('conversation binding labels', () => {
         agentName: 'Gantry',
         jid: 'sl:C0123456789',
         displayName: 'ops-room',
+        approverIds: ['U123'],
+      }),
+    );
+    expect(registerSlackMainGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatJid: 'sl:C0123456789',
+        displayName: 'Gantry',
+        conversationDisplayName: 'ops-room',
+        approverIds: ['U123'],
       }),
     );
     expect(draft).toEqual(

--- a/apps/core/test/unit/cli/setup-flow-simplified.test.ts
+++ b/apps/core/test/unit/cli/setup-flow-simplified.test.ts
@@ -263,6 +263,7 @@ async function loadGroupStep() {
   const settings = {};
   const spinner = { start: vi.fn(), stop: vi.fn() };
   const ensureConfiguredConversationBinding = vi.fn();
+  const saveRuntimeSettings = vi.fn();
   const registerSlackMainGroup = vi.fn(async () => ({
     folder: 'main_agent',
     groupName: 'Gantry',
@@ -296,7 +297,7 @@ async function loadGroupStep() {
   }));
   vi.doMock('@core/config/settings/runtime-settings.js', () => ({
     loadRuntimeSettings: vi.fn(() => settings),
-    saveRuntimeSettings: vi.fn(),
+    saveRuntimeSettings,
     ensureConfiguredConversationBinding,
   }));
   const { runGroupStep } = await import('@core/cli/setup-flow-final-steps.js');
@@ -304,6 +305,7 @@ async function loadGroupStep() {
     runGroupStep,
     ensureConfiguredConversationBinding,
     registerSlackMainGroup,
+    saveRuntimeSettings,
   };
 }
 
@@ -313,6 +315,7 @@ describe('conversation binding labels', () => {
       runGroupStep,
       ensureConfiguredConversationBinding,
       registerSlackMainGroup,
+      saveRuntimeSettings,
     } = await loadGroupStep();
     const draft = {
       primaryProvider: 'slack',
@@ -327,15 +330,8 @@ describe('conversation binding labels', () => {
       type: 'next',
     });
 
-    expect(ensureConfiguredConversationBinding).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        agentName: 'Gantry',
-        jid: 'sl:C0123456789',
-        displayName: 'ops-room',
-        approverIds: ['U123'],
-      }),
-    );
+    expect(ensureConfiguredConversationBinding).not.toHaveBeenCalled();
+    expect(saveRuntimeSettings).not.toHaveBeenCalled();
     expect(registerSlackMainGroup).toHaveBeenCalledWith(
       expect.objectContaining({
         chatJid: 'sl:C0123456789',

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -45,6 +45,13 @@ const fileArtifactStore = vi.hoisted(() => ({
   },
   async writeFileArtifact(input: any) {
     const key = `${input.appId}:${input.agentId}:${input.virtualScope}:${input.virtualPath}`;
+    const agentFolder = String(input.agentId).replace(/^agent:/, '');
+    const hasConversationRoute = Array.from(groupsStore.values()).some(
+      (group) => group.folder === agentFolder,
+    );
+    if (!hasConversationRoute) {
+      throw new Error(`missing conversation route for ${input.agentId}`);
+    }
     fileArtifacts.set(key, String(input.content));
     return {
       id: `file-artifact:test:${fileArtifacts.size}`,
@@ -512,6 +519,8 @@ describe('cli slack helpers', () => {
       runtimeHome,
       chatJid: 'sl:C0123456789',
       displayName: 'Kai Slack',
+      conversationDisplayName: 'recruiting-demo',
+      approverIds: ['U123'],
     });
 
     const claude =
@@ -525,6 +534,26 @@ describe('cli slack helpers', () => {
 
     expect(result.groupName).toBe('Kai Slack');
     expect(result.folder).toBe('main_agent');
+    expect(groupsStore.get('sl:C0123456789')).toEqual(
+      expect.objectContaining({
+        name: 'Kai Slack',
+        folder: 'main_agent',
+      }),
+    );
+    const settings = loadRuntimeSettings(runtimeHome);
+    expect(settings.conversations?.slack_default_c0123456789).toEqual(
+      expect.objectContaining({
+        displayName: 'recruiting-demo',
+        providerConnection: 'slack_default',
+        externalId: 'C0123456789',
+        controlApprovers: ['U123'],
+      }),
+    );
+    expect(settings.providerConnections?.slack_default).toEqual(
+      expect.objectContaining({
+        provider: 'slack',
+      }),
+    );
     expect(
       fs.existsSync(
         path.join(runtimeHome, 'agents', result.folder, 'CLAUDE.md'),

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -21,6 +21,7 @@ import { listSlackRecentChats } from '@core/cli/slack-chat-discovery.js';
 
 const groupsStore = vi.hoisted(() => new Map<string, any>());
 const fileArtifacts = vi.hoisted(() => new Map<string, string>());
+const fileArtifactState = vi.hoisted(() => ({ failWrites: false }));
 const fileArtifactStore = vi.hoisted(() => ({
   async listFileArtifacts(input: any) {
     return [...fileArtifacts.keys()]
@@ -51,6 +52,9 @@ const fileArtifactStore = vi.hoisted(() => ({
     );
     if (!hasConversationRoute) {
       throw new Error(`missing conversation route for ${input.agentId}`);
+    }
+    if (fileArtifactState.failWrites) {
+      throw new Error('profile seed failed');
     }
     fileArtifacts.set(key, String(input.content));
     return {
@@ -113,6 +117,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   groupsStore.clear();
   fileArtifacts.clear();
+  fileArtifactState.failWrites = false;
   while (runtimeHomes.length > 0) {
     const runtimeHome = runtimeHomes.pop();
     if (runtimeHome) fs.rmSync(runtimeHome, { recursive: true, force: true });
@@ -512,6 +517,88 @@ describe('cli slack helpers', () => {
     expect(outro).toHaveBeenCalledWith('Slack connect cancelled.');
   });
 
+  it('slack connect preserves the verified conversation display name and approvers', async () => {
+    vi.resetModules();
+    const runtimeHome = makeRuntimeHome();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            team: 'My Workspace',
+            team_id: 'T123',
+            user_id: 'U123',
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            url: 'wss://example.slack.test/socket',
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            channel: { id: 'C0123456789', name: 'ops-room' },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchSpy);
+    vi.doMock('@clack/prompts', () => ({
+      isCancel: () => false,
+      note: vi.fn(),
+      password: vi
+        .fn()
+        .mockResolvedValueOnce('xoxb-valid-token')
+        .mockResolvedValueOnce('xapp-valid-token'),
+      text: vi.fn().mockResolvedValueOnce('U123'),
+      outro: vi.fn(),
+      log: {
+        success: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+    }));
+    vi.doMock('@core/cli/slack-connect-chat-picker.js', () => ({
+      chooseSlackChatForConnect: vi.fn(async () => ({
+        type: 'selected',
+        chatJid: 'sl:C0123456789',
+      })),
+    }));
+
+    const { runSlackConnectCommand } = await import('@core/cli/slack.js');
+    const code = await runSlackConnectCommand(runtimeHome);
+
+    expect(code).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const settings = loadRuntimeSettings(runtimeHome);
+    expect(settings.conversations?.slack_default_c0123456789).toEqual(
+      expect.objectContaining({
+        displayName: 'ops-room',
+        providerConnection: 'slack_default',
+        externalId: 'C0123456789',
+        controlApprovers: ['U123'],
+      }),
+    );
+  });
+
   it('seeds AGENTS.md and SOUL.md FileArtifacts when registering the main group', async () => {
     const runtimeHome = makeRuntimeHome();
 
@@ -578,5 +665,36 @@ describe('cli slack helpers', () => {
     expect(soul).toContain('# Soul - Who You Are');
     expect(soul).toContain('- **Name:** Kai Slack');
     expect(soul).toContain('## Continuity Boundary');
+  });
+
+  it('keeps desired Slack settings when prompt profile seeding fails', async () => {
+    const runtimeHome = makeRuntimeHome();
+    fileArtifactState.failWrites = true;
+
+    await expect(
+      registerSlackMainGroup({
+        runtimeHome,
+        chatJid: 'sl:C0123456789',
+        displayName: 'Kai Slack',
+        conversationDisplayName: 'recruiting-demo',
+        approverIds: ['U123'],
+      }),
+    ).rejects.toThrow('profile seed failed');
+
+    expect(groupsStore.get('sl:C0123456789')).toEqual(
+      expect.objectContaining({
+        name: 'Kai Slack',
+        folder: 'main_agent',
+      }),
+    );
+    const settings = loadRuntimeSettings(runtimeHome);
+    expect(settings.conversations?.slack_default_c0123456789).toEqual(
+      expect.objectContaining({
+        displayName: 'recruiting-demo',
+        providerConnection: 'slack_default',
+        externalId: 'C0123456789',
+        controlApprovers: ['U123'],
+      }),
+    );
   });
 });

--- a/apps/core/test/unit/config/settings-desired-state-service.test.ts
+++ b/apps/core/test/unit/config/settings-desired-state-service.test.ts
@@ -957,7 +957,7 @@ describe('SettingsDesiredStateService', () => {
     expect(ops.setConversationRoute).toHaveBeenCalledWith(
       'sl:C123',
       expect.objectContaining({
-        name: 'Sales Slack',
+        name: 'Main',
         folder: 'main_agent',
         trigger: '@main',
       }),

--- a/apps/core/test/unit/runtime/prompt-profile.test.ts
+++ b/apps/core/test/unit/runtime/prompt-profile.test.ts
@@ -141,6 +141,16 @@ class MemoryFileArtifactStore implements FileArtifactStore {
   async promoteScratch(): Promise<FileArtifact> {
     throw new Error('not used');
   }
+
+  removeStoredContentForPath(input: {
+    appId: string;
+    agentId: string;
+    virtualScope: string;
+    virtualPath: string;
+  }): void {
+    const artifact = this.artifacts.get(artifactKey(input));
+    if (artifact) this.contents.delete(artifact.id);
+  }
 }
 
 function createService(store = new MemoryFileArtifactStore()): {
@@ -274,6 +284,51 @@ describe('PromptProfileService', () => {
       virtualPath: 'team/SOUL.md',
     });
     expect(soul.content).toBe('existing soul');
+  });
+
+  it('recreates default prompt artifacts when metadata exists but bytes are missing', async () => {
+    const store = new MemoryFileArtifactStore();
+    const mirrored: Array<{ fileName: string; content: string }> = [];
+    const service = new PromptProfileService({
+      fileArtifactStore: () => store,
+      mirrorFileExists: async () => false,
+      mirrorProfileFile: (input) => {
+        mirrored.push({ fileName: input.fileName, content: input.content });
+      },
+    });
+
+    await service.ensureAgentDefaults({
+      agentFolder: 'team',
+      agentName: 'Kai',
+    });
+    store.removeStoredContentForPath({
+      appId: 'default',
+      agentId: 'agent:team',
+      virtualScope: 'prompt-profile',
+      virtualPath: 'team/AGENTS.md',
+    });
+
+    await service.ensureAgentDefaults({
+      agentFolder: 'team',
+      agentName: 'Kai',
+    });
+
+    const artifacts = await store.listFileArtifacts({
+      appId: 'default',
+      agentId: 'agent:team',
+      virtualScope: 'prompt-profile',
+      virtualPath: 'team/AGENTS.md',
+    });
+    const agentInstructions = await store.readFileArtifact({
+      appId: 'default',
+      agentId: 'agent:team',
+      virtualScope: 'prompt-profile',
+      virtualPath: 'team/AGENTS.md',
+    });
+
+    expect(artifacts[0]?.version).toBe(2);
+    expect(agentInstructions.content).toContain('Diagnose the real blocker');
+    expect(mirrored.map((entry) => entry.fileName)).toContain('AGENTS.md');
   });
 
   it('compiles deterministic order without shared context projection', async () => {

--- a/apps/core/test/unit/runtime/prompt-profile.test.ts
+++ b/apps/core/test/unit/runtime/prompt-profile.test.ts
@@ -331,6 +331,47 @@ describe('PromptProfileService', () => {
     expect(mirrored.map((entry) => entry.fileName)).toContain('AGENTS.md');
   });
 
+  it('does not recreate default prompt artifacts when bytes are missing but the mirror exists', async () => {
+    const store = new MemoryFileArtifactStore();
+    const mirrored: Array<{ fileName: string; content: string }> = [];
+    const service = new PromptProfileService({
+      fileArtifactStore: () => store,
+      mirrorFileExists: async () => true,
+      mirrorProfileFile: (input) => {
+        mirrored.push({ fileName: input.fileName, content: input.content });
+      },
+    });
+
+    await service.ensureAgentDefaults({
+      agentFolder: 'team',
+      agentName: 'Kai',
+    });
+    store.removeStoredContentForPath({
+      appId: 'default',
+      agentId: 'agent:team',
+      virtualScope: 'prompt-profile',
+      virtualPath: 'team/AGENTS.md',
+    });
+    const mirrorWritesBeforeRepair = mirrored.length;
+
+    await expect(
+      service.ensureAgentDefaults({
+        agentFolder: 'team',
+        agentName: 'Kai',
+      }),
+    ).rejects.toThrow('File artifact not found');
+
+    const artifacts = await store.listFileArtifacts({
+      appId: 'default',
+      agentId: 'agent:team',
+      virtualScope: 'prompt-profile',
+      virtualPath: 'team/AGENTS.md',
+    });
+
+    expect(artifacts[0]?.version).toBe(1);
+    expect(mirrored).toHaveLength(mirrorWritesBeforeRepair);
+  });
+
   it('compiles deterministic order without shared context projection', async () => {
     const { store, service } = createService();
     await writePromptArtifact(store, 'team/SOUL.md', '# Soul\nBe direct.');


### PR DESCRIPTION
Fix the ECS/Slack setup path that could fail after runtime settings bootstrap and schema reset.

The seeded app:default placeholder route is no longer treated as a real main_agent collision, so first real Slack setup keeps using main_agent instead of allocating main_agent_2.

Slack setup now persists the conversation route before prompt profile artifacts are created, ensuring the agent projection exists before file_artifacts rows are inserted. The initial Slack settings write also carries the selected conversation display name and approver ids, preventing invalid settings.yaml states with missing control_approvers or provider_connection during setup retries.

Prompt profile recovery now treats missing local artifact bytes as FileArtifactNotFoundError and recreates default profile artifacts when Postgres metadata exists but the local artifact file is gone, which can happen across ECS/EBS/container churn.

Tests cover placeholder-route allocation, Slack setup route/settings ordering, setup-flow approver propagation, and missing prompt artifact byte recovery.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
