### PR TITLE
Fix follow-up progress send ordering

### DIFF
--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -403,7 +403,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       sentAnyTurnDoneProgress = true;
       await sendDoneProgress(state);
     };
-    const startUserVisibleTurn = () => {
+    const startUserVisibleTurn = async () => {
       progressGeneration = streamGeneration = streamingGenerationCounter += 1;
       activeGenerationHasOutput = false;
       resetActiveElapsed();
@@ -414,7 +414,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         .catch((err) =>
           logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
         );
-      void sendRunningProgress();
+      await sendRunningProgress();
     };
     const sendWaitingForUserResponseProgress = async () => {
       if (!supportsProgress) return;
@@ -455,7 +455,9 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
     });
     ({ typingHeartbeatTimer, progressTimer } = progressHeartbeat);
     const unregisterContinuationHandler =
-      deps.queue.registerContinuationHandler?.(queueJid, startUserVisibleTurn);
+      deps.queue.registerContinuationHandler?.(queueJid, () => {
+        void startUserVisibleTurn();
+      });
     const cancelTurnUiTimers = () => {
       if (typingHeartbeatTimer) {
         clearInterval(typingHeartbeatTimer);
@@ -624,8 +626,9 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
           !typingActive &&
           sentAnyTurnDoneProgress &&
           !activeGenerationHasOutput
-        )
-          startUserVisibleTurn();
+        ) {
+          await startUserVisibleTurn();
+        }
         if (!typingActive) {
           await setTypingState(true);
         }

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -392,6 +392,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
     let activeGenerationHasOutput = false;
     let sentAnyTurnDoneProgress = false;
     let sentTurnDoneProgressGeneration: number | null = null;
+    let userVisibleTurnProgressReady: Promise<void> | null = null;
     const sendTurnDoneProgress = async (state: FinalProgressState) => {
       if (
         !activeGenerationHasOutput ||
@@ -414,7 +415,13 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         .catch((err) =>
           logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
         );
-      await sendRunningProgress();
+      const progressReady = sendRunningProgress().finally(() => {
+        if (userVisibleTurnProgressReady === progressReady) {
+          userVisibleTurnProgressReady = null;
+        }
+      });
+      userVisibleTurnProgressReady = progressReady;
+      await progressReady;
     };
     const sendWaitingForUserResponseProgress = async () => {
       if (!supportsProgress) return;
@@ -628,6 +635,8 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
           !activeGenerationHasOutput
         ) {
           await startUserVisibleTurn();
+        } else if (sentAnyTurnDoneProgress && !activeGenerationHasOutput) {
+          await userVisibleTurnProgressReady;
         }
         if (!typingActive) {
           await setTypingState(true);

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -2584,6 +2584,74 @@ describe('createGroupProcessor', () => {
       expect(deps.queue.notifyIdle).toHaveBeenCalledTimes(2);
     });
 
+    it('sends follow-up working progress before follow-up stream output', async () => {
+      const followUpWorkingStarted = deferred();
+      const followUpWorkingSent = deferred();
+      let holdFollowUpWorking = false;
+      const streamingChannel = makeChannel({
+        sendStreamingChunk: vi.fn().mockResolvedValue(true),
+        sendProgressUpdate: vi.fn(async (_jid: string, text: string) => {
+          if (holdFollowUpWorking && text === '⏳ Working') {
+            followUpWorkingStarted.resolve();
+            await followUpWorkingSent.promise;
+          }
+        }),
+      });
+      const { deps } = setupHappyPath();
+      deps.channelRuntime = streamingChannel;
+
+      mockSpawnAgent.mockImplementation(
+        async (
+          _group: ConversationRoute,
+          _input: unknown,
+          _onProc: unknown,
+          onOutput?: (output: AgentOutput) => Promise<void>,
+        ) => {
+          await onOutput?.({ status: 'success', result: 'first turn' });
+          await onOutput?.({ status: 'success', result: null });
+          (
+            streamingChannel.sendStreamingChunk as ReturnType<typeof vi.fn>
+          ).mockClear();
+
+          holdFollowUpWorking = true;
+          const followUpOutput = onOutput?.({
+            status: 'success',
+            result: 'follow-up turn',
+          });
+          await followUpWorkingStarted.promise;
+          try {
+            expect(streamingChannel.sendProgressUpdate).toHaveBeenCalledWith(
+              'group1@g.us',
+              '⏳ Working',
+              expect.objectContaining({
+                actionAffordances: expect.arrayContaining([
+                  expect.objectContaining({
+                    kind: 'live_turn_stop',
+                    label: 'Stop',
+                  }),
+                ]),
+              }),
+            );
+            expect(streamingChannel.sendStreamingChunk).not.toHaveBeenCalled();
+          } finally {
+            followUpWorkingSent.resolve();
+          }
+          await followUpOutput;
+          expect(streamingChannel.sendStreamingChunk).toHaveBeenCalledWith(
+            'group1@g.us',
+            'follow-up turn',
+            expect.objectContaining({ done: false }),
+          );
+
+          await onOutput?.({ status: 'success', result: null });
+          return { status: 'success', result: null } as AgentOutput;
+        },
+      );
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await processGroupMessages('group1@g.us');
+    });
+
     it('keeps buffered follow-up work in one progress lifecycle', async () => {
       const streamingChannel = makeChannel({
         sendStreamingChunk: vi.fn().mockResolvedValue(true),

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -2652,6 +2652,75 @@ describe('createGroupProcessor', () => {
       await processGroupMessages('group1@g.us');
     });
 
+    it('waits for continuation-triggered follow-up progress before stream output', async () => {
+      let continuationHandler: (() => void) | undefined;
+      const followUpWorkingStarted = deferred();
+      const followUpWorkingSent = deferred();
+      let holdFollowUpWorking = false;
+      const streamingChannel = makeChannel({
+        sendStreamingChunk: vi.fn().mockResolvedValue(true),
+        sendProgressUpdate: vi.fn(async (_jid: string, text: string) => {
+          if (holdFollowUpWorking && text === '⏳ Working') {
+            followUpWorkingStarted.resolve();
+            await followUpWorkingSent.promise;
+          }
+        }),
+      });
+      const { deps } = setupHappyPath();
+      deps.channelRuntime = streamingChannel;
+      deps.queue = {
+        ...deps.queue,
+        registerContinuationHandler: vi.fn((_queueJid, handler) => {
+          continuationHandler = handler;
+          return () => {
+            if (continuationHandler === handler)
+              continuationHandler = undefined;
+          };
+        }),
+      };
+
+      mockSpawnAgent.mockImplementation(
+        async (
+          _group: ConversationRoute,
+          _input: unknown,
+          _onProc: unknown,
+          onOutput?: (output: AgentOutput) => Promise<void>,
+        ) => {
+          await onOutput?.({ status: 'success', result: 'first turn' });
+          await onOutput?.({ status: 'success', result: null });
+          (
+            streamingChannel.sendStreamingChunk as ReturnType<typeof vi.fn>
+          ).mockClear();
+
+          holdFollowUpWorking = true;
+          continuationHandler?.();
+          await followUpWorkingStarted.promise;
+          const followUpOutput = onOutput?.({
+            status: 'success',
+            result: 'follow-up turn',
+          });
+          await Promise.resolve();
+          try {
+            expect(streamingChannel.sendStreamingChunk).not.toHaveBeenCalled();
+          } finally {
+            followUpWorkingSent.resolve();
+          }
+          await followUpOutput;
+          expect(streamingChannel.sendStreamingChunk).toHaveBeenCalledWith(
+            'group1@g.us',
+            'follow-up turn',
+            expect.objectContaining({ done: false }),
+          );
+
+          await onOutput?.({ status: 'success', result: null });
+          return { status: 'success', result: null } as AgentOutput;
+        },
+      );
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await processGroupMessages('group1@g.us');
+    });
+
     it('keeps buffered follow-up work in one progress lifecycle', async () => {
       const streamingChannel = makeChannel({
         sendStreamingChunk: vi.fn().mockResolvedValue(true),


### PR DESCRIPTION
Summary: await the fresh follow-up Working progress send before emitting the first follow-up stream output, with a focused regression test. Tests: npm run test:unit -- apps/core/test/unit/runtime/group-processing.test.ts; npm run build. Runtime smoke: launchctl kickstart -k gui/501/com.gantry; gantry status Runtime Ready pid 79118. Previous PR #161 is merged, so this is the follow-up PR on top of main.