### PR TITLE
fix deploy task sandbox options

### DIFF
--- a/.github/workflows/gantry_dev_deployment.yml
+++ b/.github/workflows/gantry_dev_deployment.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - develop
-    paths-ignore:
-      - '.github/**'
 
 env:
   AWS_REGION: ap-south-1
@@ -52,6 +50,20 @@ jobs:
       - name: Download task definition
         run: aws ecs describe-task-definition --task-definition ${{ env.TASK_NAME }} --query taskDefinition > task-definition.json
 
+      - name: Normalize task definition for sandbox runtime
+        run: |
+          jq --arg container "${{ env.CONTAINER_NAME }}" '
+            .containerDefinitions |= map(
+              if .name == $container then
+                .dockerSecurityOptions = (((.dockerSecurityOptions // []) + ["seccomp=unconfined"]) | unique)
+                | .linuxParameters = ((.linuxParameters // {}) + { initProcessEnabled: true })
+              else
+                .
+              end
+            )
+          ' task-definition.json > task-definition.normalized.json
+          mv task-definition.normalized.json task-definition.json
+
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -59,6 +71,15 @@ jobs:
             task-definition: task-definition.json
             container-name: ${{ env.CONTAINER_NAME }}
             image: ${{ steps.build-image.outputs.image }}
+
+      - name: Verify sandbox runtime task options
+        run: |
+          jq -e --arg container "${{ env.CONTAINER_NAME }}" '
+            .containerDefinitions[]
+            | select(.name == $container)
+            | (.dockerSecurityOptions // [])
+            | index("seccomp=unconfined")
+          ' "${{ steps.task-def.outputs.task-definition }}" >/dev/null
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2


### PR DESCRIPTION
<!-- contributing-guide: v1 -->

## Summary

Fixes the Gantry dev ECS deployment workflow so ReAgent tasks keep the sandbox runtime options required by `bubblewrap`.

The deployed ECS task definition was missing `dockerSecurityOptions: ["seccomp=unconfined"]`, causing Slack runs to fail when the sandboxed agent runner started:

```text
bwrap: No permissions to create new namespace

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
