### PR TITLE
fix deepagents sandbox gateway alias

### DIFF
--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/model-factory.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/model-factory.ts
@@ -48,6 +48,11 @@ const INIT_CHAT_MODEL_PROVIDERS = new Set<string>([
   'vertex',
 ]);
 
+// In sandbox_runtime, the host rewrites loopback model gateway URLs to this
+// private alias and installs a Gantry-owned egress mapping back to loopback.
+// Keep the runner allowlist exact so raw private/provider URLs remain rejected.
+const SANDBOX_RUNTIME_MODEL_GATEWAY_HOST = 'model-gateway.gantry.internal';
+
 export interface ResolvedRunnerModel {
   model: BaseChatModel;
   endpointFamily: ModelEndpointFamily;
@@ -168,9 +173,11 @@ function assertLoopbackGatewayUrl(value: string, label: string): void {
       hostname === 'localhost' ||
       hostname === '::1' ||
       hostname === '[::1]');
-  if (!loopback) {
+  const sandboxGatewayAlias =
+    url.protocol === 'http:' && hostname === SANDBOX_RUNTIME_MODEL_GATEWAY_HOST;
+  if (!loopback && !sandboxGatewayAlias) {
     throw new Error(
-      `DeepAgents runner ${label} must be a loopback Gantry gateway URL.`,
+      `DeepAgents runner ${label} must be a loopback or sandbox-private Gantry gateway URL.`,
     );
   }
 }

--- a/apps/core/test/unit/adapters/deepagents-model-factory.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-model-factory.test.ts
@@ -10,6 +10,8 @@ import { buildRunnerModel } from '@core/adapters/llm/deepagents-langchain/runner
 
 const loopbackBaseUrl = 'http://127.0.0.1:4567/openai';
 const openrouterBaseUrl = 'http://127.0.0.1:4567/openrouter';
+const sandboxOpenrouterBaseUrl =
+  'http://model-gateway.gantry.internal:4567/openrouter';
 const gatewayToken = 'gtw_token';
 
 describe('deepagents model factory', () => {
@@ -113,6 +115,22 @@ describe('deepagents model factory', () => {
     expect(resolved.modelId).toBe('moonshotai/kimi-k2.6');
   });
 
+  it('accepts the sandbox-runtime private gateway alias', async () => {
+    const resolved = await buildRunnerModel({
+      provider: 'openrouter',
+      modelId: 'moonshotai/kimi-k2.6',
+      gatewayBaseUrl: sandboxOpenrouterBaseUrl,
+      gatewayToken,
+    });
+
+    const model = resolved.model as unknown as {
+      baseURL: string;
+      apiKey?: string;
+    };
+    expect(model.baseURL).toBe(`${sandboxOpenrouterBaseUrl}/v1`);
+    expect(model.apiKey).toBe(gatewayToken);
+  });
+
   it('threads the durable session id into ChatOpenRouter for sticky cache routing', async () => {
     const resolved = await buildRunnerModel({
       provider: 'openrouter',
@@ -204,7 +222,22 @@ describe('deepagents model factory', () => {
         gatewayBaseUrl: 'https://api.openai.com',
         gatewayToken,
       }),
-    ).rejects.toThrow('must be a loopback Gantry gateway URL');
+    ).rejects.toThrow(
+      'must be a loopback or sandbox-private Gantry gateway URL',
+    );
+  });
+
+  it('rejects arbitrary private gateway-looking hosts', async () => {
+    await expect(
+      buildRunnerModel({
+        provider: 'openai',
+        modelId: 'gpt-5.5',
+        gatewayBaseUrl: 'http://model-gateway.internal:4567/openai',
+        gatewayToken,
+      }),
+    ).rejects.toThrow(
+      'must be a loopback or sandbox-private Gantry gateway URL',
+    );
   });
 
   it('rejects a non-gateway token', async () => {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Issue

DeepAgents runs in ECS sandbox mode were failing with:

`DeepAgents runner gateway base URL must be a loopback Gantry gateway URL.`

The sandbox runtime rewrites the Gantry model gateway URL to the private alias `model-gateway.gantry.internal`, but the DeepAgents runner only accepted literal loopback hosts. Because of that, valid sandboxed OpenRouter/Kimi runs failed before the model call started.

## Fix

- Allow DeepAgents to accept Gantry’s exact sandbox-private model gateway alias in addition to loopback URLs.
- Keep the allowlist narrow so arbitrary private/provider URLs are still rejected.
- Add regression tests for the sandbox alias and for rejecting gateway-looking private hosts.

## Verification

- `npx vitest run -c vitest.unit.config.ts apps/core/test/unit/adapters/deepagents-model-factory.test.ts`
- `npx vitest run -c vitest.unit.config.ts apps/core/test/unit/runtime/agent-spawn-runtime-policy.test.ts`
- `git diff --check`


## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
