### PR TITLE
fix deepagents sandbox proxy isolation

### DIFF
--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-shell-tool.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-shell-tool.ts
@@ -67,13 +67,13 @@ const COMMAND_TERMINATE_GRACE_MS = 1_000;
 
 // Network/proxy + CA-trust env keys the child must carry so egress stays on the
 // Gantry egress gateway and TLS trust resolves — for EVERY client type, not just
-// node. These are projected onto the runner's process.env by the host
-// (buildToolNetworkEnv in shared/tool-network-env.ts sets the proxy/gRPC/CA keys;
-// agent-spawn-helpers.ts sets GODEBUG=netdns=go for Go's resolver). The child env
-// is an explicit allowlist (NOT inherited process.env) so these carry through
-// while secrets do not. This MUST stay a superset of what buildToolNetworkEnv
-// projects (a test asserts it) — the Claude lane's bash-trust-env.ts carries the
-// same set; missing keys silently break egress for Go/gRPC/curl/git tools.
+// node. These are projected explicitly through toolNetworkEnv (buildToolNetworkEnv
+// in shared/tool-network-env.ts sets the proxy/gRPC/CA keys; agent-spawn-helpers.ts
+// sets GODEBUG=netdns=go for Go's resolver). The child env is an explicit allowlist
+// so these carry through while secrets do not. This MUST stay a superset of what
+// buildToolNetworkEnv projects (a test asserts it) — the Claude lane's
+// bash-trust-env.ts carries the same set; missing keys silently break egress for
+// Go/gRPC/curl/git tools.
 export const SHELL_CHILD_NETWORK_ENV_KEYS = [
   'HTTP_PROXY',
   'HTTPS_PROXY',
@@ -111,12 +111,15 @@ const SHELL_CHILD_POSIX_ENV_KEYS = [
 // live on process.env — a `printenv` would otherwise exfiltrate them and let the
 // model forge IPC messages. Build a fresh env from an explicit allowlist of
 // network/proxy + POSIX keys, copying ONLY set values, and pass that to spawn.
-function buildShellChildEnv(): Record<string, string> {
+function buildShellChildEnv(
+  toolNetworkEnv: Record<string, string> | undefined,
+): Record<string, string> {
   const env: Record<string, string> = {};
-  for (const key of [
-    ...SHELL_CHILD_NETWORK_ENV_KEYS,
-    ...SHELL_CHILD_POSIX_ENV_KEYS,
-  ]) {
+  for (const key of SHELL_CHILD_NETWORK_ENV_KEYS) {
+    const value = toolNetworkEnv?.[key];
+    if (typeof value === 'string') env[key] = value;
+  }
+  for (const key of SHELL_CHILD_POSIX_ENV_KEYS) {
     const value = process.env[key];
     if (typeof value === 'string') env[key] = value;
   }
@@ -136,6 +139,7 @@ export interface GantryShellToolConfig {
   // Optional run-cancellation signal (the live-turn close sentinel aborts the
   // LangGraph stream; commands in flight are killed when it fires).
   signal?: AbortSignal;
+  toolNetworkEnv?: Record<string, string>;
 }
 
 const shellInputSchema = z.object({
@@ -219,11 +223,11 @@ export function createGantryShellTool(
 // Executes the approved command as a child of the already-sandboxed runner. The
 // child inherits the OS sandbox confinement (protected-path write denies) from
 // being a runner child; its env is a scrubbed allowlist (buildShellChildEnv) so
-// the runner's egress-proxy env carries through — egress stays on the Gantry
-// egress gateway — but the IPC HMAC keys and provider creds do NOT leak to the
-// model-controlled command. Uses a shell so the model can use pipes/globs the
-// policy matched against; the OS sandbox is the enforcement boundary, not argv
-// shape.
+// only explicit toolNetworkEnv proxy/CA keys carry through — egress stays on the
+// Gantry egress gateway — but the IPC HMAC keys, provider creds, and ambient
+// runner proxy vars do NOT leak to the model-controlled command. Uses a shell so
+// the model can use pipes/globs the policy matched against; the OS sandbox is the
+// enforcement boundary, not argv shape.
 async function runShellCommand(
   command: string,
   config: GantryShellToolConfig,
@@ -243,7 +247,7 @@ async function runShellCommand(
     let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
     const child = spawn('/bin/sh', ['-c', command], {
       cwd: config.cwd,
-      env: buildShellChildEnv(),
+      env: buildShellChildEnv(config.toolNetworkEnv),
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: process.platform !== 'win32',
     });

--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/mcp-tools.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/mcp-tools.ts
@@ -243,6 +243,7 @@ function projectGantryShellTool(
       gateContext: input.gate.gateContext,
       permissionEnv: input.gate.permissionEnv,
       lockedAccessPreset: input.gate.lockedAccessPreset,
+      toolNetworkEnv: input.toolNetworkEnv,
       ...(input.shellCwd ? { cwd: input.shellCwd } : {}),
       ...(input.shellSignal ? { signal: input.shellSignal } : {}),
     }),

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -102,6 +102,20 @@ import {
 export { writeGroupsSnapshot } from './agent-spawn-snapshots.js';
 // prettier-ignore
 export type { AvailableGroup, AgentInput, AgentOutput } from './agent-spawn-types.js';
+
+const DEEPAGENTS_SANDBOX_PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'GRPC_PROXY',
+  'grpc_proxy',
+  'NODE_USE_ENV_PROXY',
+  'GANTRY_EGRESS_PROXY_URL',
+] as const;
+
 export async function spawnAgent(
   group: ConversationRoute,
   input: AgentInput,
@@ -574,6 +588,14 @@ export async function spawnAgent(
       pickSafeHostEnv,
       pickPreparedExecutionEnv,
     });
+    if (
+      preparedExecution.providerId === 'deepagents:langchain' &&
+      runnerSandboxProviderId === 'sandbox_runtime'
+    ) {
+      for (const key of DEEPAGENTS_SANDBOX_PROXY_ENV_KEYS) {
+        delete env[key];
+      }
+    }
     if (
       options?.runnerSandboxProvider?.enforcing === true &&
       options.asyncTaskRepositoryAvailable === true

--- a/apps/core/test/unit/adapters/deepagents-gantry-shell-tool.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-gantry-shell-tool.test.ts
@@ -43,6 +43,7 @@ function makeTool(overrides?: {
   rules?: string[];
   lockedAccessPreset?: boolean;
   signal?: AbortSignal;
+  toolNetworkEnv?: Record<string, string>;
 }) {
   return createGantryShellTool({
     workspaceFolder: 'group',
@@ -52,6 +53,7 @@ function makeTool(overrides?: {
     permissionEnv: PERMISSION_ENV,
     lockedAccessPreset: overrides?.lockedAccessPreset ?? false,
     cwd: os.tmpdir(),
+    toolNetworkEnv: overrides?.toolNetworkEnv,
     ...(overrides?.signal ? { signal: overrides.signal } : {}),
   });
 }
@@ -235,12 +237,17 @@ describe('Gantry DeepAgents shell tool', () => {
     expect(missing).toEqual([]);
   });
 
-  it('passes the runner proxy env so egress is proxied (child sees HTTP_PROXY)', async () => {
+  it('passes explicit tool network env so egress is proxied (child sees HTTP_PROXY)', async () => {
     const previous = process.env.HTTP_PROXY;
-    process.env.HTTP_PROXY = 'http://127.0.0.1:18080/';
+    delete process.env.HTTP_PROXY;
     requestPermissionApprovalViaIpc.mockResolvedValue({ approved: true });
     try {
-      const tool = makeTool({ rules: [] });
+      const tool = makeTool({
+        rules: [],
+        toolNetworkEnv: {
+          HTTP_PROXY: 'http://127.0.0.1:18080/',
+        },
+      });
       const result = await invoke(tool, 'printf %s "$HTTP_PROXY"');
       expect(result).toContain('http://127.0.0.1:18080/');
     } finally {

--- a/apps/core/test/unit/runtime/agent-spawn.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn.test.ts
@@ -1892,7 +1892,14 @@ describe('agent-spawn timeout behavior', () => {
     const runnerInput = JSON.parse(String(writeSpy.mock.calls[0]?.[0]));
     expect(startInput.env.HTTP_PROXY).toBeUndefined();
     expect(startInput.env.HTTPS_PROXY).toBeUndefined();
+    expect(startInput.env.http_proxy).toBeUndefined();
+    expect(startInput.env.https_proxy).toBeUndefined();
+    expect(startInput.env.ALL_PROXY).toBeUndefined();
+    expect(startInput.env.all_proxy).toBeUndefined();
+    expect(startInput.env.GRPC_PROXY).toBeUndefined();
+    expect(startInput.env.grpc_proxy).toBeUndefined();
     expect(startInput.env.NODE_USE_ENV_PROXY).toBeUndefined();
+    expect(startInput.env.GANTRY_EGRESS_PROXY_URL).toBeUndefined();
     expect(runnerInput.toolNetworkEnv).toMatchObject({
       HTTP_PROXY: 'http://127.0.0.1:18080/',
       HTTPS_PROXY: 'http://127.0.0.1:18080/',


### PR DESCRIPTION
Prevent sandbox-runtime DeepAgents model calls from inheriting Gantry egress proxy environment, which caused ECS runs to fail with ECONNREFUSED against loopback proxy ports.

Keep approved tool egress working by threading explicit toolNetworkEnv into the DeepAgents RunCommand facade instead of relying on ambient process env. Extend regression coverage for runner env scrubbing and shell tool proxy projection.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
