### PR TITLE
fix(runtime): stop stale live turn retry loops

### DIFF
--- a/apps/core/src/app/bootstrap/live-execution.ts
+++ b/apps/core/src/app/bootstrap/live-execution.ts
@@ -5,6 +5,7 @@ import type {
   LiveTurn,
   LiveTurnScope,
 } from '../../domain/ports/live-turns.js';
+import type { GroupMessageRunContext } from '../../runtime/group-queue-types.js';
 import type { RunLease } from '../../domain/ports/worker-coordination.js';
 import type { RuntimeLease } from '../../domain/ports/runtime-lease.js';
 import type { ExecutionProviderId } from '../../domain/sessions/sessions.js';
@@ -150,6 +151,7 @@ interface AdmissionApp {
       existingRunLeaseToken?: string;
       existingRunLeaseWorkerInstanceId?: string;
       existingRunLeaseFencingVersion?: number;
+      finalRetry?: boolean;
       onRunResult?: (result: 'success' | 'error' | 'stopped' | null) => void;
     },
   ) => Promise<boolean>;
@@ -184,7 +186,7 @@ export function buildLiveAdmissionProcessor(input: {
   enqueueMessageCheck: (queueJid: string) => void;
   warn: WarnLog;
   finalizeBrowserForLiveTurn?: LiveTurnBrowserFinalizer;
-}): (queueJid: string) => Promise<boolean> {
+}): (queueJid: string, context?: GroupMessageRunContext) => Promise<boolean> {
   const {
     liveTurnAuthority,
     app,
@@ -222,9 +224,15 @@ export function buildLiveAdmissionProcessor(input: {
         opsRepository.completeSessionAgentRun?.bind(opsRepository),
     });
 
-  return async (queueJid: string): Promise<boolean> => {
+  return async (
+    queueJid: string,
+    context?: GroupMessageRunContext,
+  ): Promise<boolean> => {
     if (!liveTurnAuthority) {
-      return app.processGroupMessages(queueJid, { queued: true });
+      return app.processGroupMessages(queueJid, {
+        queued: true,
+        finalRetry: context?.finalRetry === true,
+      });
     }
     let liveRunId = liveTurnAuthority.ownedRunId(queueJid) ?? undefined;
     let liveRunFence = liveTurnAuthority.ownedFence(queueJid);
@@ -313,6 +321,7 @@ export function buildLiveAdmissionProcessor(input: {
       let liveRunResult: 'success' | 'error' | 'stopped' | null = null;
       const success = await app.processGroupMessages(queueJid, {
         queued: true,
+        finalRetry: context?.finalRetry === true,
         existingRunId: liveRunId,
         ...(liveRunFence
           ? {

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -101,7 +101,11 @@ import {
   type RunnerAgentInput,
 } from './agent-spawn-helpers.js';
 export { writeGroupsSnapshot } from './agent-spawn-snapshots.js';
-export type { AvailableGroup, AgentInput, AgentOutput } from './agent-spawn-types.js';
+export type {
+  AvailableGroup,
+  AgentInput,
+  AgentOutput,
+} from './agent-spawn-types.js';
 export async function spawnAgent(
   group: ConversationRoute,
   input: AgentInput,
@@ -194,7 +198,6 @@ export async function spawnAgent(
     compiledSystemPrompt,
     yoloMode: effectiveYoloModeSettings(runtimeSettings.permissions.yoloMode),
   };
-
   const hostRuntime = prepareHostRuntimeContext(group);
   ensureWorkspaceIpcLayout(hostRuntime.workspaceIpcDir);
   let executionAdapter: NonNullable<RunAgentOptions['executionAdapter']>;
@@ -279,7 +282,6 @@ export async function spawnAgent(
         `LLM runtime materialization failed: ${errorText}`,
     };
   }
-
   let mcpConfigPath: string | undefined;
   let sandboxConfigPath: string | undefined;
   let runnerTempDir: string | undefined;
@@ -459,9 +461,8 @@ export async function spawnAgent(
     if (runnerInputPatch.semanticCapabilities) {
       runnerInput.semanticCapabilities = runnerInputPatch.semanticCapabilities;
     }
-    if (runnerInputPatch.deepAgentCheckpointer) {
-      runnerInput.deepAgentCheckpointer = runnerInputPatch.deepAgentCheckpointer;
-    }
+    const checkpointer = runnerInputPatch.deepAgentCheckpointer;
+    if (checkpointer) runnerInput.deepAgentCheckpointer = checkpointer;
     runnerInput.deepAgentSkills = runnerInputPatch.deepAgentSkills;
     const localCliCredentialPaths = resolveHomeRelativePaths(
       localCliCredentialPathHintsFromRuntimeAccess(effectiveRuntimeAccess),
@@ -580,7 +581,6 @@ export async function spawnAgent(
     hostStartup.finish('runnerEnvMs', runnerEnvStarted);
     // Job-level model overrides group-level model.
     const effectiveModelSource = input.model ? 'job.model' : modelConfig.source;
-
     const runtimeDetails = buildAndLogRunnerRuntimeDetails({
       logger,
       groupName: group.name,
@@ -600,7 +600,6 @@ export async function spawnAgent(
       effectiveModelSource,
       systemPromptChars: compiledSystemPrompt.length,
     });
-
     const logsDir = path.join(groupDir, 'logs');
     fs.mkdirSync(logsDir, { recursive: true });
     const selectedSkillEnv = await hostStartup.measureAsync(

--- a/apps/core/src/runtime/failover-eligibility.ts
+++ b/apps/core/src/runtime/failover-eligibility.ts
@@ -85,6 +85,13 @@ function matchesAny(error: string, patterns: readonly RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(error));
 }
 
+export function isMissingProviderSessionError(
+  error: string | undefined,
+): boolean {
+  const text = (error ?? '').trim();
+  return text ? matchesAny(text, NON_ELIGIBLE_PATTERNS.slice(1)) : false;
+}
+
 // True when `error` indicates a provider-specific failure that the NEXT
 // configured family provider might survive. Empty/undefined (no error, or a
 // success frame) is never eligible.

--- a/apps/core/src/runtime/group-agent-runner.ts
+++ b/apps/core/src/runtime/group-agent-runner.ts
@@ -48,6 +48,7 @@ import {
   runFamilyFailoverLoop,
   publishRunFailoverEvent,
 } from './failover-candidate-loop.js';
+import { isMissingProviderSessionError } from './failover-eligibility.js';
 import { logger, redactString } from '../infrastructure/logging/logger.js';
 const DEFAULT_ASSISTANT_NAME = 'Gantry';
 const DEFAULT_MODEL_ALIAS = 'opus';
@@ -57,12 +58,6 @@ const WORKSPACE_FOLDER_INPUT_KEY = `workspace${'Folder'}`;
 const memoryReviewApproverCache = new Map<string, [boolean, number]>();
 
 export type GroupAgentRunResult = 'success' | 'error' | 'stopped';
-
-function isMissingProviderSessionError(error: string | undefined): boolean {
-  return /\bprovider session\b.*\b(?:missing|expired|not found)\b/i.test(
-    error ?? '',
-  );
-}
 
 function redactRuntimeError(error: string | undefined): string | undefined {
   return error ? redactString(error) : undefined;
@@ -609,8 +604,12 @@ export function createGroupAgentRunner(input: {
         registry: deps.executionAdapters,
         fallback: deps.executionAdapter,
       });
+      const adapterMissingProviderSession =
+        activeExecutionAdapter?.isMissingProviderSessionError?.(
+          output.error,
+        ) === true;
       const missingProviderSession =
-        activeExecutionAdapter?.isMissingProviderSessionError?.(output.error) ??
+        adapterMissingProviderSession ||
         isMissingProviderSessionError(output.error);
       if (
         output.status === 'error' &&

--- a/apps/core/src/runtime/group-processing-flow.ts
+++ b/apps/core/src/runtime/group-processing-flow.ts
@@ -4,6 +4,7 @@ type GroupTurnRunResult = 'success' | 'error' | 'stopped';
 
 export async function handleFailure(input: {
   outputSentToUser: boolean;
+  acknowledgeFailedTurn?: boolean;
   groupName: string;
   queueJid: string;
   previousCursor: string;
@@ -11,7 +12,6 @@ export async function handleFailure(input: {
     setCursor: (chatJid: string, timestamp: string) => void;
     saveState: () => Promise<void> | void;
   };
-  isShuttingDown?: () => boolean;
   logger: {
     warn(payload: Record<string, unknown>, message: string): void;
   };
@@ -20,6 +20,14 @@ export async function handleFailure(input: {
     input.logger.warn(
       { group: input.groupName },
       'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
+    );
+    return true;
+  }
+  if (input.acknowledgeFailedTurn) {
+    await input.deps.saveState();
+    input.logger.warn(
+      { group: input.groupName },
+      'Agent error on final retry, preserving message cursor to prevent stale replay',
     );
     return true;
   }

--- a/apps/core/src/runtime/group-processing-types.ts
+++ b/apps/core/src/runtime/group-processing-types.ts
@@ -45,6 +45,7 @@ export interface GroupProcessor {
       existingRunLeaseToken?: string;
       existingRunLeaseWorkerInstanceId?: string;
       existingRunLeaseFencingVersion?: number;
+      finalRetry?: boolean;
       onRunResult?: (result: 'success' | 'error' | 'stopped') => void;
     },
   ) => Promise<boolean>;

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -72,6 +72,8 @@ import { collectPendingMessagesSince } from './pending-message-replay.js';
 let streamingGenerationCounter = 0;
 const PERMISSION_BACKGROUND_DEMOTE_MS = 120_000;
 const DEFAULT_TURN_APP_ID = 'default';
+const MISSING_REPOSITORY_MESSAGE =
+  'Group processor requires runtime repositories';
 type ProgressHeartbeat = ReturnType<typeof startGroupProgressHeartbeats>;
 type ActiveTurnUiCleanup = { token: symbol; cancel: () => void };
 const activeTurnUiCleanupByQueue = new Map<string, ActiveTurnUiCleanup>();
@@ -79,11 +81,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
   const collectSessionMemory = deps.collectSessionMemory;
   const ops = () => {
     const repository = deps.opsRepository ?? deps.getRuntimeRepository?.();
-    if (!repository) {
-      throw new Error(
-        'Group processor requires runtime message and session repositories',
-      );
-    }
+    if (!repository) throw new Error(MISSING_REPOSITORY_MESSAGE);
     return repository;
   };
   const runAgent = createGroupAgentRunner({ deps, ops });
@@ -95,7 +93,8 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       existingRunLeaseToken?: string;
       existingRunLeaseWorkerInstanceId?: string;
       existingRunLeaseFencingVersion?: number;
-      onRunResult?: (result: 'success' | 'error' | 'stopped') => void;
+      finalRetry?: boolean;
+      onRunResult?: (result: GroupAgentRunResult) => void;
     } = {},
   ): Promise<boolean> {
     const { chatJid, threadId: queueThreadId } = parseThreadQueueKey(queueJid);
@@ -766,7 +765,8 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         queueJid,
         previousCursor,
         deps,
-        isShuttingDown: deps.queue.isShuttingDown,
+        acknowledgeFailedTurn:
+          options.finalRetry === true && !deps.queue.isShuttingDown?.(),
         logger,
       });
     } else {

--- a/apps/core/src/runtime/group-queue-types.ts
+++ b/apps/core/src/runtime/group-queue-types.ts
@@ -20,6 +20,15 @@ export type ContinuationOptions = {
 
 export type ContinuationHandler = () => void;
 
+export interface GroupMessageRunContext {
+  finalRetry: boolean;
+}
+
+export type ProcessMessagesFn = (
+  groupJid: string,
+  context: GroupMessageRunContext,
+) => Promise<boolean>;
+
 export type ContinuationRunnerControlPort = Pick<
   RunnerControlPort,
   'writeContinuationInput' | 'writeCloseSignal'

--- a/apps/core/src/runtime/group-queue.ts
+++ b/apps/core/src/runtime/group-queue.ts
@@ -1,5 +1,4 @@
 import type { ChildProcess } from 'child_process';
-
 import { logger } from '../infrastructure/logging/logger.js';
 import { stopActiveGroupRun } from './group-queue-stop.js';
 import { normalizeThreadQueueId } from '../shared/thread-queue-key.js';
@@ -16,6 +15,7 @@ import {
   type ContinuationOptions,
   type ContinuationRunnerControlPort,
   type GroupQueueOptions,
+  type ProcessMessagesFn,
   type QueueKind,
   type QueuedTask,
 } from './group-queue-types.js';
@@ -49,8 +49,7 @@ export class GroupQueue {
   private waitingMessageGroups: string[] = [];
   private waitingTaskGroups: string[] = [];
   private continuationSequence = 0;
-  private processMessagesFn: ((groupJid: string) => Promise<boolean>) | null =
-    null;
+  private processMessagesFn: ProcessMessagesFn | null = null;
   private liveTurnRunnerRegistrar:
     | ((
         queueJid: string,
@@ -109,7 +108,7 @@ export class GroupQueue {
     return this.groups.delete(groupJid);
   }
 
-  setProcessMessagesFn(fn: (groupJid: string) => Promise<boolean>): void {
+  setProcessMessagesFn(fn: ProcessMessagesFn): void {
     this.processMessagesFn = fn;
   }
 
@@ -541,12 +540,11 @@ export class GroupQueue {
 
     try {
       if (this.processMessagesFn) {
-        const success = await this.processMessagesFn(groupJid);
-        if (success) {
-          state.retryCount = 0;
-        } else {
-          this.scheduleRetry(groupJid, state);
-        }
+        const success = await this.processMessagesFn(groupJid, {
+          finalRetry: state.retryCount >= this.policy.maxRetries,
+        });
+        if (success) state.retryCount = 0;
+        else this.scheduleRetry(groupJid, state);
       }
     } catch (err) {
       logger.error({ groupJid, err }, 'Error processing messages for group');
@@ -608,7 +606,7 @@ export class GroupQueue {
     if (state.retryCount > this.policy.maxRetries) {
       logger.error(
         { groupJid, retryCount: state.retryCount },
-        'Max retries exceeded, dropping messages (will retry on next incoming message)',
+        'Max retries exceeded, dropping message retry',
       );
       state.retryCount = 0;
       return;

--- a/apps/core/test/unit/runtime/group-processing-flow.test.ts
+++ b/apps/core/test/unit/runtime/group-processing-flow.test.ts
@@ -34,6 +34,21 @@ describe('handleFailure', () => {
     expect(input.deps.saveState).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves the cursor for final retry failures', async () => {
+    const input = makeInput({
+      acknowledgeFailedTurn: true,
+    });
+
+    await expect(handleFailure(input)).resolves.toBe(true);
+
+    expect(input.deps.setCursor).not.toHaveBeenCalled();
+    expect(input.deps.saveState).toHaveBeenCalledTimes(1);
+    expect(input.logger.warn).toHaveBeenCalledWith(
+      { group: 'Main Agent' },
+      'Agent error on final retry, preserving message cursor to prevent stale replay',
+    );
+  });
+
   it('rolls back first thread failures to the empty cursor for retry', async () => {
     const input = makeInput({
       queueJid: 'sl:C1234567890::thread:1711111111.000200',
@@ -54,9 +69,7 @@ describe('handleFailure', () => {
   });
 
   it('rolls back no-output failures during runtime shutdown', async () => {
-    const input = makeInput({
-      isShuttingDown: () => true,
-    });
+    const input = makeInput();
 
     await expect(handleFailure(input)).resolves.toBe(false);
 

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1465,6 +1465,65 @@ describe('createGroupProcessor', () => {
       });
     });
 
+    it('falls back to runtime missing-session patterns when an adapter returns false', async () => {
+      const group = makeGroup({ requiresTrigger: false });
+      const selectedAdapter = {
+        id: 'anthropic:claude-agent-sdk',
+        isMissingProviderSessionError: vi.fn(() => false),
+        prepare: vi.fn(),
+      };
+      const { deps } = setupHappyPath({ group });
+      deps.executionAdapter = undefined;
+      deps.executionAdapters = createAgentExecutionAdapterRegistry([
+        selectedAdapter,
+      ]);
+      (deps.opsRepository as any).getAgentTurnContext = vi
+        .fn()
+        .mockResolvedValue({
+          appId: 'app:test',
+          agentId: 'agent:test',
+          agentSessionId: 'agent-session:1',
+          providerSessionId: 'provider-session:1',
+          externalSessionId: 'deepagents-session-stale',
+          providerSessionAccessFingerprint: EMPTY_ACCESS_FINGERPRINT,
+        });
+      (deps.opsRepository as any).createSessionAgentRun = vi
+        .fn()
+        .mockResolvedValue('agent-run:message-1');
+
+      mockSpawnAgent.mockImplementationOnce(async () => ({
+        status: 'error',
+        result: null,
+        error:
+          'No DeepAgents session found with session ID: deepagents-session-stale',
+      }));
+      mockSpawnAgent.mockImplementationOnce(async () => ({
+        status: 'success',
+        result: 'fresh reply',
+        newSessionId: 'deepagents-session-fresh',
+      }));
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await expect(processGroupMessages('group1@g.us')).resolves.toBe(true);
+
+      expect(
+        selectedAdapter.isMissingProviderSessionError,
+      ).toHaveBeenCalledWith(
+        'No DeepAgents session found with session ID: deepagents-session-stale',
+      );
+      expect(mockSpawnAgent).toHaveBeenCalledTimes(2);
+      expect(mockSpawnAgent.mock.calls[0][1]).toMatchObject({
+        sessionId: 'deepagents-session-stale',
+      });
+      expect(mockSpawnAgent.mock.calls[1][1]).not.toHaveProperty('sessionId');
+      expect(deps.opsRepository.expireProviderSession).toHaveBeenCalledWith({
+        providerSessionId: 'provider-session:1',
+        agentSessionId: 'agent-session:1',
+        provider: 'anthropic:claude-agent-sdk',
+        externalSessionId: 'deepagents-session-stale',
+      });
+    });
+
     it('persists SDK session ids from final agent output for the next turn', async () => {
       const agentOutput: AgentOutput = {
         status: 'success',

--- a/apps/core/test/unit/runtime/group-queue.test.ts
+++ b/apps/core/test/unit/runtime/group-queue.test.ts
@@ -493,6 +493,25 @@ describe('GroupQueue', () => {
     expect(queue.getPolicy()).toMatchObject({ baseRetryMs: 0, maxRetries: 2 });
   });
 
+  it('marks the last configured retry as final for message processing', async () => {
+    queue = new GroupQueue({ baseRetryMs: 0, maxRetries: 2 });
+    const finalRetryValues: boolean[] = [];
+
+    queue.setProcessMessagesFn(async (_groupJid, context) => {
+      finalRetryValues.push(context.finalRetry);
+      return false;
+    });
+
+    queue.enqueueMessageCheck('group1@g.us');
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(finalRetryValues).toEqual([false, false, true]);
+  });
+
   // --- Shutdown prevents new enqueues ---
 
   it('prevents new enqueues after shutdown', async () => {


### PR DESCRIPTION
Recognize DeepAgents missing-session errors as stale provider sessions even when an adapter classifier does not match, then retry the turn once without the stale resume id. Also passes final-retry context from GroupQueue into live message processing so terminal failures preserve the advanced cursor instead of rolling back forever and replaying old Slack messages.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
