### PR TITLE
fix(slack): require trigger for channel setup

### DIFF
--- a/apps/core/src/cli/slack.ts
+++ b/apps/core/src/cli/slack.ts
@@ -387,7 +387,7 @@ export async function registerSlackMainGroup(options: {
       folder,
       trigger: existingGroup?.trigger || defaultTriggerForAgentName(groupName),
       added_at: existingGroup?.added_at || nowIso(),
-      requiresTrigger: false,
+      requiresTrigger: true,
       agentConfig: existingGroup?.agentConfig,
     };
     await db.setConversationRoute(options.chatJid, route);
@@ -401,7 +401,7 @@ export async function registerSlackMainGroup(options: {
       jid: options.chatJid,
       displayName: options.conversationDisplayName || options.displayName,
       trigger: route.trigger,
-      requiresTrigger: false,
+      requiresTrigger: true,
       approverIds: options.approverIds,
     });
     await writeDesiredRuntimeSettings({
@@ -602,7 +602,7 @@ export async function runSlackConnectCommand(
       displayName:
         conversationDisplayName || conversationRouteName || settings.agent.name,
       trigger: `@${conversationRouteName || settings.agent.name}`,
-      requiresTrigger: false,
+      requiresTrigger: true,
       approverIds,
     });
   }

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -627,6 +627,7 @@ describe('cli slack helpers', () => {
         providerConnection: 'slack_default',
         externalId: 'C0123456789',
         controlApprovers: ['U123'],
+        senderPolicy: { allow: '*', mode: 'trigger' },
       }),
     );
   });
@@ -657,6 +658,7 @@ describe('cli slack helpers', () => {
       expect.objectContaining({
         name: 'Kai Slack',
         folder: 'main_agent',
+        requiresTrigger: true,
       }),
     );
     const settings = loadRuntimeSettings(runtimeHome);
@@ -666,6 +668,7 @@ describe('cli slack helpers', () => {
         providerConnection: 'slack_default',
         externalId: 'C0123456789',
         controlApprovers: ['U123'],
+        senderPolicy: { allow: '*', mode: 'trigger' },
       }),
     );
     expect(settings.providerConnections?.slack_default).toEqual(
@@ -717,6 +720,7 @@ describe('cli slack helpers', () => {
       expect.objectContaining({
         name: 'Kai Slack',
         folder: 'main_agent',
+        requiresTrigger: true,
       }),
     );
     const settings = loadRuntimeSettings(runtimeHome);
@@ -726,6 +730,7 @@ describe('cli slack helpers', () => {
         providerConnection: 'slack_default',
         externalId: 'C0123456789',
         controlApprovers: ['U123'],
+        senderPolicy: { allow: '*', mode: 'trigger' },
       }),
     );
   });

--- a/apps/core/test/unit/runtime/message-loop.test.ts
+++ b/apps/core/test/unit/runtime/message-loop.test.ts
@@ -647,6 +647,134 @@ describe('thread queue routing', () => {
     expect(saveState).toHaveBeenCalledOnce();
   });
 
+  it('ignores untagged messages in a new thread when the parent conversation requires a trigger', async () => {
+    const message = {
+      ...makePendingMessage(1),
+      content: 'this thread is for humans',
+      thread_id: 'thread-1',
+    };
+    mockGetMessagesSince.mockReturnValueOnce([message]);
+    const saveState = vi.fn();
+    const deps = makeDeps({
+      saveState,
+      getOrRecoverCursor: (queueJid: string) =>
+        queueJid.includes('::thread:') ? '' : 'root-cursor',
+      getConversationRoutes: () => ({
+        'group@g.us': {
+          name: 'Team',
+          folder: 'team',
+          trigger: '@Andy',
+          added_at: '2024-01-01T00:00:00.000Z',
+          requiresTrigger: true,
+        },
+      }),
+    });
+    const { processLiveAdmissionWorkItem } =
+      await import('@core/runtime/message-loop.js');
+
+    await expect(
+      processLiveAdmissionWorkItem(deps, {
+        id: 'admission-thread-1',
+        appId: 'default',
+        agentId: null,
+        agentSessionId: null,
+        conversationId: 'group@g.us',
+        threadId: 'thread-1',
+        queueJid: 'group@g.us::thread:thread-1',
+        messageId: 'message:group:g:thread-1:1',
+        messageCursor: '2024-01-01T00:00:01.000Z::1',
+        senderUserId: 'user@s.whatsapp.net',
+        senderDisplayName: 'User',
+        idempotencyKey: 'provider:thread-msg-1',
+        state: 'claimed',
+        sourceKind: 'message',
+        triggerDecision: {},
+        claimWorkerInstanceId: 'worker-1',
+        claimToken: 'claim-1',
+        claimExpiresAt: '2024-01-01T00:01:00.000Z',
+        fencingVersion: 1,
+        retryCount: 1,
+        failureCount: 0,
+        deferUntil: null,
+        deferredReason: null,
+        createdAt: '2024-01-01T00:00:01.000Z',
+        updatedAt: '2024-01-01T00:00:01.000Z',
+        claimedAt: '2024-01-01T00:00:01.000Z',
+        endedAt: null,
+      }),
+    ).resolves.toBe('completed');
+
+    expect(deps.sentTo).toHaveLength(0);
+    expect(deps.enqueued).toHaveLength(0);
+    expect(
+      decodeGroupMessageCursor(deps.cursors['group@g.us::thread:thread-1']),
+    ).toEqual({
+      timestamp: '2024-01-01T00:00:01.000Z',
+      id: '1',
+    });
+    expect(saveState).toHaveBeenCalledOnce();
+  });
+
+  it('allows untagged continuation inside a thread that already has a thread cursor', async () => {
+    const message = {
+      ...makePendingMessage(2),
+      content: 'yes, continue with that',
+      thread_id: 'thread-1',
+    };
+    mockGetMessagesSince.mockReturnValueOnce([message]);
+    const deps = makeDeps({
+      getOrRecoverCursor: (queueJid: string) =>
+        queueJid.includes('::thread:')
+          ? '2024-01-01T00:00:01.000Z::1'
+          : 'root-cursor',
+      getConversationRoutes: () => ({
+        'group@g.us': {
+          name: 'Team',
+          folder: 'team',
+          trigger: '@Andy',
+          added_at: '2024-01-01T00:00:00.000Z',
+          requiresTrigger: true,
+        },
+      }),
+    });
+    const { processLiveAdmissionWorkItem } =
+      await import('@core/runtime/message-loop.js');
+
+    await expect(
+      processLiveAdmissionWorkItem(deps, {
+        id: 'admission-thread-2',
+        appId: 'default',
+        agentId: null,
+        agentSessionId: null,
+        conversationId: 'group@g.us',
+        threadId: 'thread-1',
+        queueJid: 'group@g.us::thread:thread-1',
+        messageId: 'message:group:g:thread-1:2',
+        messageCursor: '2024-01-01T00:00:02.000Z::2',
+        senderUserId: 'user@s.whatsapp.net',
+        senderDisplayName: 'User',
+        idempotencyKey: 'provider:thread-msg-2',
+        state: 'claimed',
+        sourceKind: 'message',
+        triggerDecision: {},
+        claimWorkerInstanceId: 'worker-1',
+        claimToken: 'claim-1',
+        claimExpiresAt: '2024-01-01T00:01:00.000Z',
+        fencingVersion: 1,
+        retryCount: 1,
+        failureCount: 0,
+        deferUntil: null,
+        deferredReason: null,
+        createdAt: '2024-01-01T00:00:02.000Z',
+        updatedAt: '2024-01-01T00:00:02.000Z',
+        claimedAt: '2024-01-01T00:00:02.000Z',
+        endedAt: null,
+      }),
+    ).resolves.toBe('completed');
+
+    expect(deps.sentTo).toEqual(['group@g.us::thread:thread-1']);
+  });
+
   it('defers durable live admission when the message queue rejects capacity', async () => {
     const msg = {
       id: 1,


### PR DESCRIPTION
Seed Slack setup and provider-connect routes as trigger-required so channel messages only start runs when the bot is tagged. Preserve natural thread continuation by keeping runtime behavior that allows untagged replies only after the thread already has an agent cursor, and add focused tests for both paths.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
