### PR TITLE
fix(slack): ignore untagged human thread mentions

### DIFF
--- a/apps/core/src/runtime/message-loop.ts
+++ b/apps/core/src/runtime/message-loop.ts
@@ -116,6 +116,38 @@ function saveStateBestEffort(deps: MessageLoopDeps, chatJid: string): void {
   );
 }
 
+async function hasTriggerOwnedThreadRoot(input: {
+  opsRepository: RuntimeMessageRepository &
+    Partial<RuntimeConversationRouteRepository>;
+  chatJid: string;
+  threadId: string;
+  group: ConversationRoute;
+  triggerPattern: RegExp;
+}): Promise<boolean> {
+  const rootCandidates = await input.opsRepository.getMessagesSince(
+    input.chatJid,
+    '',
+    MESSAGE_FETCH_PAGE_SIZE,
+    { threadId: input.threadId },
+  );
+  if (rootCandidates.length === 0) return false;
+
+  const allowlistCfg = loadSenderAllowlist();
+  return rootCandidates.some(
+    (message) =>
+      message.thread_id === input.threadId &&
+      !message.reply_to_message_id &&
+      input.triggerPattern.test(message.content.trim()) &&
+      (message.is_from_me ||
+        isTriggerAllowed(
+          input.chatJid,
+          message.sender,
+          allowlistCfg,
+          input.group.folder,
+        )),
+  );
+}
+
 async function enqueueMessageCheck(
   deps: MessageLoopDeps,
   queueJid: string,
@@ -216,7 +248,15 @@ async function processQueueMessages(
           isTriggerAllowed(chatJid, m.sender, allowlistCfg, group.folder)),
     );
     const isContinuationThread =
-      threadId !== undefined && recoveredCursor.trim().length > 0;
+      threadId !== undefined &&
+      recoveredCursor.trim().length > 0 &&
+      (await hasTriggerOwnedThreadRoot({
+        opsRepository,
+        chatJid,
+        threadId,
+        group,
+        triggerPattern,
+      }));
     if (!hasTrigger && !isContinuationThread) {
       const lastMessage = initialBatch[initialBatch.length - 1];
       const cursorAfter = replay.cursorAfter

--- a/apps/core/test/unit/runtime/message-loop.test.ts
+++ b/apps/core/test/unit/runtime/message-loop.test.ts
@@ -720,8 +720,17 @@ describe('thread queue routing', () => {
       ...makePendingMessage(2),
       content: 'yes, continue with that',
       thread_id: 'thread-1',
+      reply_to_message_id: 'thread-root',
     };
-    mockGetMessagesSince.mockReturnValueOnce([message]);
+    const rootMessage = {
+      ...makePendingMessage(1),
+      content: '@Andy please help with this',
+      thread_id: 'thread-1',
+      message_id: 'thread-root',
+    };
+    mockGetMessagesSince
+      .mockReturnValueOnce([message])
+      .mockReturnValueOnce([rootMessage]);
     const deps = makeDeps({
       getOrRecoverCursor: (queueJid: string) =>
         queueJid.includes('::thread:')
@@ -773,6 +782,84 @@ describe('thread queue routing', () => {
     ).resolves.toBe('completed');
 
     expect(deps.sentTo).toEqual(['group@g.us::thread:thread-1']);
+  });
+
+  it('ignores untagged messages in a cursor-bearing human thread without a trigger-owned root', async () => {
+    const message = {
+      ...makePendingMessage(2),
+      content: '@Arhan can you check this when you get time',
+      thread_id: 'thread-1',
+      reply_to_message_id: 'human-root',
+    };
+    mockGetMessagesSince.mockReturnValueOnce([message]).mockReturnValueOnce([
+      {
+        ...makePendingMessage(1),
+        content: 'human thread root',
+        thread_id: 'thread-1',
+        message_id: 'human-root',
+      },
+    ]);
+    const saveState = vi.fn();
+    const deps = makeDeps({
+      saveState,
+      getOrRecoverCursor: (queueJid: string) =>
+        queueJid.includes('::thread:')
+          ? '2024-01-01T00:00:01.000Z::1'
+          : 'root-cursor',
+      getConversationRoutes: () => ({
+        'group@g.us': {
+          name: 'Team',
+          folder: 'team',
+          trigger: '@Andy',
+          added_at: '2024-01-01T00:00:00.000Z',
+          requiresTrigger: true,
+        },
+      }),
+    });
+    const { processLiveAdmissionWorkItem } =
+      await import('@core/runtime/message-loop.js');
+
+    await expect(
+      processLiveAdmissionWorkItem(deps, {
+        id: 'admission-thread-human',
+        appId: 'default',
+        agentId: null,
+        agentSessionId: null,
+        conversationId: 'group@g.us',
+        threadId: 'thread-1',
+        queueJid: 'group@g.us::thread:thread-1',
+        messageId: 'message:group:g:thread-1:2',
+        messageCursor: '2024-01-01T00:00:02.000Z::2',
+        senderUserId: 'user@s.whatsapp.net',
+        senderDisplayName: 'User',
+        idempotencyKey: 'provider:thread-msg-human',
+        state: 'claimed',
+        sourceKind: 'message',
+        triggerDecision: {},
+        claimWorkerInstanceId: 'worker-1',
+        claimToken: 'claim-1',
+        claimExpiresAt: '2024-01-01T00:01:00.000Z',
+        fencingVersion: 1,
+        retryCount: 1,
+        failureCount: 0,
+        deferUntil: null,
+        deferredReason: null,
+        createdAt: '2024-01-01T00:00:02.000Z',
+        updatedAt: '2024-01-01T00:00:02.000Z',
+        claimedAt: '2024-01-01T00:00:02.000Z',
+        endedAt: null,
+      }),
+    ).resolves.toBe('completed');
+
+    expect(deps.sentTo).toHaveLength(0);
+    expect(deps.enqueued).toHaveLength(0);
+    expect(
+      decodeGroupMessageCursor(deps.cursors['group@g.us::thread:thread-1']),
+    ).toEqual({
+      timestamp: '2024-01-01T00:00:02.000Z',
+      id: '2',
+    });
+    expect(saveState).toHaveBeenCalledOnce();
   });
 
   it('defers durable live admission when the message queue rejects capacity', async () => {


### PR DESCRIPTION
Trigger-required threaded conversations no longer treat any stored thread cursor as permission to continue untagged. Before admitting an untagged thread reply as a continuation, the message loop now verifies that the thread has a trigger-owned root in thread-scoped history. This keeps normal ReAgent-owned thread continuations working while preventing unrelated human mentions, such as @Arhan in a human thread, from waking the agent. Adds regression coverage for cursor-bearing human threads.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
