### PR TITLE
fix(settings): persist trigger policy changes

### DIFF
--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -63,6 +63,27 @@ import { nowIso } from '../shared/time/datetime.js';
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err);
 
+function displayNameForConfiguredConversation(
+  settings: ReturnType<typeof loadRuntimeSettings>,
+  jid: string,
+  fallback: string,
+): string {
+  const provider = providerFromGroupJid(jid);
+  if (!provider) return fallback;
+  const existingConversation = Object.values(settings.conversations).find(
+    (conversation) => {
+      const connection =
+        settings.providerConnections[conversation.providerConnection];
+      return (
+        connection?.provider === provider &&
+        (conversation.externalId === jid ||
+          jid.endsWith(`:${conversation.externalId}`))
+      );
+    },
+  );
+  return existingConversation?.displayName || fallback;
+}
+
 async function runInfo(
   runtimeHome: string,
   rawSelector?: string,
@@ -525,8 +546,8 @@ async function runTrigger(
     }
 
     try {
-      await db.setConversationRoute(found.jid, nextGroup);
-      try {
+      const providerId = providerFromGroupJid(found.jid);
+      if (providerId) {
         const settings = loadRuntimeSettings(runtimeHome);
         const previousSettings = structuredClone(settings);
         ensureConfiguredConversationBinding(settings, {
@@ -534,7 +555,11 @@ async function runTrigger(
           agentName: found.group.name,
           agentFolder: found.group.folder,
           jid: found.jid,
-          displayName: found.group.name,
+          displayName: displayNameForConfiguredConversation(
+            settings,
+            found.jid,
+            found.group.name,
+          ),
           trigger: nextGroup.trigger,
           requiresTrigger: nextGroup.requiresTrigger !== false,
         });
@@ -543,10 +568,8 @@ async function runTrigger(
           settings,
           previousSettings,
         });
-      } catch {
-        // Generic local JIDs are still allowed for file-backed agents; only
-        // known provider JIDs participate in conversation desired state.
       }
+      await db.setConversationRoute(found.jid, nextGroup);
     } catch (err) {
       p.log.error(`Could not update trigger settings: ${errorMessage(err)}`);
       return 1;

--- a/apps/core/src/config/settings/runtime-settings.ts
+++ b/apps/core/src/config/settings/runtime-settings.ts
@@ -370,12 +370,18 @@ export function ensureConfiguredConversationBinding(
     controlApprovers,
   };
 
-  const bindingId = stableSettingsId(
-    `${agentId}_${conversationId}`,
-    settings.bindings,
-    `${agentId}:${conversationId}`,
+  const existingBindingEntry = Object.entries(settings.bindings).find(
+    ([, binding]) =>
+      binding.agent === agentId && binding.conversation === conversationId,
   );
-  const existingBinding = settings.bindings[bindingId];
+  const bindingId =
+    existingBindingEntry?.[0] ??
+    stableSettingsId(
+      `${agentId}_${conversationId}`,
+      settings.bindings,
+      `${agentId}:${conversationId}`,
+    );
+  const existingBinding = existingBindingEntry?.[1];
   settings.bindings[bindingId] = {
     agent: agentId,
     conversation: conversationId,

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -734,4 +734,58 @@ describe('cli slack helpers', () => {
       }),
     );
   });
+
+  it('persists trigger requirement changes into Slack desired settings', async () => {
+    const runtimeHome = makeRuntimeHome();
+
+    const result = await registerSlackMainGroup({
+      runtimeHome,
+      chatJid: 'sl:C0123456789',
+      displayName: 'Kai Slack',
+      conversationDisplayName: 'recruiting-demo',
+      approverIds: ['U123'],
+    });
+
+    groupsStore.set('sl:C0123456789', {
+      ...groupsStore.get('sl:C0123456789'),
+      requiresTrigger: false,
+    });
+    const staleSettings = loadRuntimeSettings(runtimeHome);
+    const bindingId = Object.entries(staleSettings.bindings).find(
+      ([, binding]) => binding.agent === result.folder,
+    )?.[0];
+    expect(bindingId).toBeTruthy();
+    staleSettings.bindings[bindingId!].requiresTrigger = false;
+    staleSettings.agents[result.folder].bindings[bindingId!].requiresTrigger =
+      false;
+    saveRuntimeSettings(runtimeHome, staleSettings);
+
+    const { runAgentCommand } = await import('@core/cli/group.js');
+    const code = await runAgentCommand(runtimeHome, [
+      'trigger',
+      'sl:C0123456789',
+      '@reagent',
+    ]);
+
+    expect(code).toBe(0);
+    expect(groupsStore.get('sl:C0123456789')).toEqual(
+      expect.objectContaining({ requiresTrigger: true }),
+    );
+    const settings = loadRuntimeSettings(runtimeHome);
+    expect(settings.bindings[bindingId!]).toEqual(
+      expect.objectContaining({
+        trigger: '@reagent',
+        requiresTrigger: true,
+      }),
+    );
+    expect(settings.agents[result.folder].bindings[bindingId!]).toEqual(
+      expect.objectContaining({
+        trigger: '@reagent',
+        requiresTrigger: true,
+      }),
+    );
+    expect(settings.conversations.slack_default_c0123456789.displayName).toBe(
+      'recruiting-demo',
+    );
+  });
 });


### PR DESCRIPTION
Ensure provider-backed agent trigger updates write the desired settings revision before updating the live route projection. Reuse the existing configured binding instead of creating a duplicate binding when syncing conversation settings, so compact settings.yaml and settings_revisions remain the redeploy-safe source of truth. Add a Slack regression covering trigger requirement persistence and display-name preservation.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
