### PR TITLE
Add nonblocking async MCP task flow

### DIFF
--- a/apps/core/src/application/agents/prompt-profile-service.ts
+++ b/apps/core/src/application/agents/prompt-profile-service.ts
@@ -191,7 +191,7 @@ const OPERATING_GUIDANCE_HEAD = [
 
 const FULL_TOOL_ACCESS_GUIDANCE = [
   '- Use available actions first. If the action is missing, request the reviewed capability. If setup is missing, request source setup through the Gantry access flow.',
-  '- When capability_status shows an MCP source as ready, use it: inspect with mcp_list_tools, fetch one-tool schema with mcp_describe_tool when needed, and call approved actions with mcp_call_tool instead of requesting the same access again or using command/browser fallback.',
+  '- When capability_status shows an MCP source as ready, use it: inspect with mcp_list_tools, fetch one-tool schema with mcp_describe_tool when needed, call approved immediate actions with mcp_call_tool, and use async_mcp_call for long-running or parallel MCP work instead of requesting the same access again or using command/browser fallback.',
   '- Do not infer a third-party MCP source is unavailable only because its tools are not direct SDK tool names; inspect connected sources the same way before saying it is unavailable.',
   '- Source setup, MCP tool lists, CLI help, skill text, and adapter discovery are inventory only. Durable authority is the reviewed action capability granted to this agent.',
   '- Use request_access target.kind=capability for durable reviewed access.',

--- a/apps/core/src/application/mcp/mcp-reviewed-tool-resolution.ts
+++ b/apps/core/src/application/mcp/mcp-reviewed-tool-resolution.ts
@@ -1,0 +1,51 @@
+import { ApplicationError } from '../common/application-error.js';
+import {
+  isReviewedMcpToolAllowed,
+  type ReviewedMaterializedMcpCapability,
+} from './mcp-tool-authorization.js';
+import type { McpToolAuditResultClass } from './mcp-tool-audit.js';
+
+export async function resolveReviewedMcpTool(input: {
+  capabilities: ReviewedMaterializedMcpCapability[];
+  serverName: string;
+  toolName: string;
+  finalizeDenied: (
+    resultClass: McpToolAuditResultClass,
+    extra?: Record<string, unknown>,
+  ) => Promise<unknown>;
+}): Promise<{
+  capability: ReviewedMaterializedMcpCapability;
+  selectedToolRule: string;
+  selectedCapability: Pick<
+    ReviewedMaterializedMcpCapability,
+    'name' | 'serverId' | 'bindingId' | 'sourceRevision'
+  >;
+}> {
+  const capability = input.capabilities.find(
+    (candidate) => candidate.name === input.serverName,
+  );
+  if (!capability) {
+    const reason = `MCP server is not approved for this agent: ${input.serverName}`;
+    await input.finalizeDenied('denied', { reason });
+    throw new ApplicationError('NOT_FOUND', reason);
+  }
+  const selectedToolRule = `mcp__${capability.name}__${input.toolName}`;
+  const selectedCapability = {
+    name: capability.name,
+    serverId: capability.serverId,
+    bindingId: capability.bindingId,
+    ...(capability.sourceRevision
+      ? { sourceRevision: capability.sourceRevision }
+      : {}),
+  };
+  if (!isReviewedMcpToolAllowed(capability, input.toolName)) {
+    const reason = `MCP tool is not approved for this agent: ${selectedToolRule}`;
+    await input.finalizeDenied('denied', {
+      reason,
+      selectedToolRule,
+      selectedCapability,
+    });
+    throw new ApplicationError('FORBIDDEN', reason);
+  }
+  return { capability, selectedToolRule, selectedCapability };
+}

--- a/apps/core/src/application/mcp/mcp-tool-detail-fetch.ts
+++ b/apps/core/src/application/mcp/mcp-tool-detail-fetch.ts
@@ -23,10 +23,12 @@ export async function fetchAndCacheMcpToolDetail(input: {
   capability: ReviewedMaterializedMcpCapability;
   client: McpToolListClient;
   timeoutMs: number;
+  signal?: AbortSignal;
 }): Promise<CachedMcpToolDetail> {
   const tools = await fetchMcpToolListPages({
     client: input.client,
     timeoutMs: input.timeoutMs,
+    signal: input.signal,
   });
   const tool = tools.tools.find(
     (candidate) => candidate.name === input.request.toolName,
@@ -59,6 +61,7 @@ export async function resolveMcpToolOutputSchema(input: {
   capability: ReviewedMaterializedMcpCapability;
   client: McpToolListClient;
   timeoutMs: number;
+  signal?: AbortSignal;
 }): Promise<unknown | undefined> {
   const cached = readCachedMcpToolDetail(
     input.request,

--- a/apps/core/src/application/mcp/mcp-tool-list-fetch.ts
+++ b/apps/core/src/application/mcp/mcp-tool-list-fetch.ts
@@ -17,7 +17,7 @@ export type McpListedToolMetadata = {
 export type McpToolListClient = {
   listTools(
     params?: { cursor?: string },
-    options?: { timeout?: number },
+    options?: { timeout?: number; signal?: AbortSignal },
   ): Promise<{
     tools: McpListedToolMetadata[];
     nextCursor?: string;
@@ -34,6 +34,7 @@ export type McpToolListPageResult = {
 export async function fetchMcpToolListPages(input: {
   client: McpToolListClient;
   timeoutMs: number;
+  signal?: AbortSignal;
 }): Promise<McpToolListPageResult> {
   const tools: McpListedToolMetadata[] = [];
   const seenCursors = new Set<string>();
@@ -43,6 +44,7 @@ export async function fetchMcpToolListPages(input: {
   for (let page = 0; page < MAX_MCP_REMOTE_LIST_PAGES; page += 1) {
     const response = await input.client.listTools(cursor ? { cursor } : {}, {
       timeout: input.timeoutMs,
+      ...(input.signal ? { signal: input.signal } : {}),
     });
     const remoteTools = Array.isArray(response.tools) ? response.tools : [];
     if (remoteTools.length > MAX_MCP_REMOTE_TOOLS_PER_PAGE) {

--- a/apps/core/src/application/mcp/mcp-tool-output-bounds.ts
+++ b/apps/core/src/application/mcp/mcp-tool-output-bounds.ts
@@ -8,6 +8,7 @@ export function boundMcpToolResultForReturn(result: unknown): unknown {
   if (!serialized.truncated) return result;
   return {
     type: 'mcp_tool_result_truncated',
+    ...(isMcpToolErrorResult(result) ? { isError: true } : {}),
     truncated: true,
     maxChars: MAX_MCP_TOOL_RESULT_CHARS,
     preview: serialized.text,
@@ -43,6 +44,15 @@ function stringifyMcpToolResult(result: unknown): string {
   } catch {
     return '"[Unserializable MCP tool result]"';
   }
+}
+
+function isMcpToolErrorResult(result: unknown): boolean {
+  return (
+    result !== null &&
+    typeof result === 'object' &&
+    !Array.isArray(result) &&
+    (result as { isError?: unknown }).isError === true
+  );
 }
 
 function boundMcpToolResultText(

--- a/apps/core/src/application/mcp/mcp-tool-proxy-capabilities.ts
+++ b/apps/core/src/application/mcp/mcp-tool-proxy-capabilities.ts
@@ -1,0 +1,92 @@
+import type { AgentId } from '../../domain/agent/agent.js';
+import type { AppId } from '../../domain/app/app.js';
+import type {
+  McpServerRepository,
+  SkillCatalogRepository,
+  ToolCatalogRepository,
+} from '../../domain/ports/repositories.js';
+import type { HostnameLookup } from '../../domain/network/public-address-policy.js';
+import { reviewedExternalMcpToolNamesFromRuntimeAccess } from '../../shared/capability-runtime-access.js';
+import { resolveAgentToolRuntimePolicy } from '../agents/agent-tool-runtime-rules.js';
+import { authorizedMcpServerIdsForAgent } from './mcp-authorized-servers.js';
+import type { RemoteMcpDnsValidationCache } from './mcp-server-policy.js';
+import { McpServerService } from './mcp-server-service.js';
+import {
+  exactExternalMcpToolNames,
+  reviewedToolNameAllowedBySourceScope,
+  type ReviewedMaterializedMcpCapability,
+} from './mcp-tool-authorization.js';
+
+interface MaterializeMcpProxyCapabilitiesInput {
+  mcpServers: McpServerRepository;
+  tools: ToolCatalogRepository;
+  skills?: SkillCatalogRepository;
+  credentialEnv?: Record<string, string>;
+  liveToolRules?: readonly string[];
+  sourceServerIds?: readonly string[];
+  lookupHostname?: HostnameLookup;
+  dnsValidationCache?: RemoteMcpDnsValidationCache;
+  appId: AppId;
+  agentId: AgentId;
+}
+
+export async function materializeSourceMcpCapabilities(
+  input: MaterializeMcpProxyCapabilitiesInput,
+): Promise<ReviewedMaterializedMcpCapability[]> {
+  const capabilities = await new McpServerService(input.mcpServers, undefined, {
+    lookupHostname: input.lookupHostname,
+    dnsValidationCache: input.dnsValidationCache,
+    auditMaterialization: false,
+  }).materializeForAgent({
+    appId: input.appId,
+    agentId: input.agentId,
+    serverIds: input.sourceServerIds as never,
+    credentialEnv: input.credentialEnv ?? {},
+  });
+  return capabilities.map((capability) => ({
+    ...capability,
+    reviewedToolNames: capability.allowedToolNames,
+  }));
+}
+
+export async function materializeReviewedMcpCapabilities(
+  input: MaterializeMcpProxyCapabilitiesInput,
+): Promise<ReviewedMaterializedMcpCapability[]> {
+  const policy = await resolveAgentToolRuntimePolicy({
+    repository: input.tools,
+    skillRepository: input.skills,
+    appId: input.appId,
+    agentId: input.agentId,
+    errorSubject: 'Configured agent tool',
+  });
+  const reviewedToolNames = [
+    ...new Set([
+      ...reviewedExternalMcpToolNamesFromRuntimeAccess(policy.runtimeAccess),
+      ...exactExternalMcpToolNames(input.liveToolRules),
+    ]),
+  ];
+  const serverIds = await authorizedMcpServerIdsForAgent({
+    mcpServers: input.mcpServers,
+    tools: input.tools,
+    skills: input.skills,
+    appId: input.appId,
+    agentId: input.agentId,
+    allowedTools: reviewedToolNames,
+  });
+  const capabilities = await new McpServerService(input.mcpServers, undefined, {
+    lookupHostname: input.lookupHostname,
+    dnsValidationCache: input.dnsValidationCache,
+    auditMaterialization: false,
+  }).materializeForAgent({
+    appId: input.appId,
+    agentId: input.agentId,
+    serverIds: serverIds as never,
+    credentialEnv: input.credentialEnv ?? {},
+  });
+  return capabilities.map((capability) => ({
+    ...capability,
+    reviewedToolNames: reviewedToolNames.filter((toolName) =>
+      reviewedToolNameAllowedBySourceScope(capability, toolName),
+    ),
+  }));
+}

--- a/apps/core/src/application/mcp/mcp-tool-proxy-client-cache.ts
+++ b/apps/core/src/application/mcp/mcp-tool-proxy-client-cache.ts
@@ -9,6 +9,8 @@ type CloseableMcpClient = {
 type CachedMcpClient = {
   client: CloseableMcpClient;
   idleTimer: ReturnType<typeof setTimeout>;
+  activeCalls: number;
+  closeAfterRelease: boolean;
 };
 
 const clientCache = new Map<string, CachedMcpClient>();
@@ -29,6 +31,8 @@ export function cacheMcpClient(
   clientCache.set(mcpClientCacheKey(capability), {
     client,
     idleTimer: createClientIdleTimer(capability),
+    activeCalls: 0,
+    closeAfterRelease: false,
   });
 }
 
@@ -38,7 +42,26 @@ export function scheduleMcpClientIdleClose(
   const cached = clientCache.get(mcpClientCacheKey(capability));
   if (!cached) return;
   clearTimeout(cached.idleTimer);
+  if (cached.activeCalls > 0) return;
   cached.idleTimer = createClientIdleTimer(capability);
+}
+
+export function retainMcpClient(capability: MaterializedMcpCapability): void {
+  const cached = clientCache.get(mcpClientCacheKey(capability));
+  if (!cached) return;
+  cached.activeCalls += 1;
+  clearTimeout(cached.idleTimer);
+}
+
+export function releaseMcpClient(capability: MaterializedMcpCapability): void {
+  const cached = clientCache.get(mcpClientCacheKey(capability));
+  if (!cached) return;
+  cached.activeCalls = Math.max(0, cached.activeCalls - 1);
+  if (cached.activeCalls === 0 && cached.closeAfterRelease) {
+    void closeCachedMcpClient(capability);
+    return;
+  }
+  scheduleMcpClientIdleClose(capability);
 }
 
 export async function closeCachedMcpClient(
@@ -47,6 +70,11 @@ export async function closeCachedMcpClient(
   const cacheKey = mcpClientCacheKey(capability);
   const cached = clientCache.get(cacheKey);
   if (!cached) return;
+  if (cached.activeCalls > 0) {
+    cached.closeAfterRelease = true;
+    clearTimeout(cached.idleTimer);
+    return;
+  }
   clientCache.delete(cacheKey);
   clearTimeout(cached.idleTimer);
   await cached.client.close();

--- a/apps/core/src/application/mcp/mcp-tool-proxy.ts
+++ b/apps/core/src/application/mcp/mcp-tool-proxy.ts
@@ -17,8 +17,6 @@ import type {
 import type { HostnameLookup } from '../../domain/network/public-address-policy.js';
 import { nowIso } from '../../shared/time/datetime.js';
 import { ApplicationError } from '../common/application-error.js';
-import { resolveAgentToolRuntimePolicy } from '../agents/agent-tool-runtime-rules.js';
-import { reviewedExternalMcpToolNamesFromRuntimeAccess } from '../../shared/capability-runtime-access.js';
 import {
   RemoteMcpDnsValidationCache,
   assertRemoteMcpDestinationPublic,
@@ -29,17 +27,15 @@ import {
   isLocalLoopbackHttpMcpUrl,
 } from './mcp-tool-proxy-network.js';
 import {
-  exactExternalMcpToolNames,
-  isReviewedMcpToolAllowed,
   isSourceInventoryToolAllowed,
-  reviewedToolNameAllowedBySourceScope,
   type ReviewedMaterializedMcpCapability,
 } from './mcp-tool-authorization.js';
+import { resolveReviewedMcpTool } from './mcp-reviewed-tool-resolution.js';
+import type { MaterializedMcpCapability } from './mcp-server-service.js';
 import {
-  McpServerService,
-  type MaterializedMcpCapability,
-} from './mcp-server-service.js';
-import { authorizedMcpServerIdsForAgent } from './mcp-authorized-servers.js';
+  materializeReviewedMcpCapabilities,
+  materializeSourceMcpCapabilities,
+} from './mcp-tool-proxy-capabilities.js';
 import {
   cacheMcpInventory,
   compareMcpToolSearchResults,
@@ -71,7 +67,9 @@ import { boundMcpToolResultForReturn } from './mcp-tool-output-bounds.js';
 import {
   cacheMcpClient,
   closeCachedMcpClient,
+  releaseMcpClient,
   readCachedMcpClient,
+  retainMcpClient,
   scheduleMcpClientIdleClose,
 } from './mcp-tool-proxy-client-cache.js';
 
@@ -83,6 +81,16 @@ export {
 
 const MCP_PROXY_TIMEOUT_MS = 60_000;
 
+interface McpToolCallInput {
+  appId: AppId;
+  agentId: AgentId;
+  serverName: string;
+  toolName: string;
+  arguments?: Record<string, unknown>;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
 export class McpToolProxy {
   constructor(
     private readonly mcpServers: McpServerRepository,
@@ -91,6 +99,7 @@ export class McpToolProxy {
       skills?: SkillCatalogRepository;
       credentialEnv?: Record<string, string>;
       liveToolRules?: readonly string[];
+      sourceServerIds?: readonly string[];
       lookupHostname?: HostnameLookup;
       dnsValidationCache?: RemoteMcpDnsValidationCache;
       egressDenylist?: readonly string[];
@@ -288,14 +297,9 @@ export class McpToolProxy {
     }
   }
 
-  async callTool(input: {
-    appId: AppId;
-    agentId: AgentId;
-    serverName: string;
-    toolName: string;
-    arguments?: Record<string, unknown>;
-  }): Promise<unknown> {
+  async callTool(input: McpToolCallInput): Promise<unknown> {
     const startedAt = Date.now();
+    const timeoutMs = input.timeoutMs ?? MCP_PROXY_TIMEOUT_MS;
     const argumentSummary = summarizeMcpToolArguments(input.arguments ?? {});
     await this.publishMcpToolActivity({
       input,
@@ -328,37 +332,19 @@ export class McpToolProxy {
     };
     let toolReturned = false;
     try {
-      const capabilities = await this.materializeReviewedCapabilities(input);
-      const capability = capabilities.find(
-        (candidate) => candidate.name === input.serverName,
-      );
-      if (!capability) {
-        const reason = `MCP server is not approved for this agent: ${input.serverName}`;
-        await finalize('denied', { reason });
-        throw new ApplicationError('NOT_FOUND', reason);
-      }
-      const allowedTool = `mcp__${capability.name}__${input.toolName}`;
-      selectedToolRule = allowedTool;
-      selectedCapability = {
-        name: capability.name,
-        serverId: capability.serverId,
-        bindingId: capability.bindingId,
-        ...(capability.sourceRevision
-          ? { sourceRevision: capability.sourceRevision }
-          : {}),
-      };
-      if (!isReviewedMcpToolAllowed(capability, input.toolName)) {
-        const reason = `MCP tool is not approved for this agent: ${allowedTool}`;
-        await finalize('denied', { reason });
-        throw new ApplicationError('FORBIDDEN', reason);
-      }
+      const reviewed = await this.resolveReviewedTool(input, finalize);
+      const { capability } = reviewed;
+      selectedToolRule = reviewed.selectedToolRule;
+      selectedCapability = reviewed.selectedCapability;
       const client = await this.connect(capability);
+      retainMcpClient(capability);
       try {
         const outputSchema = await resolveMcpToolOutputSchema({
           request: input,
           capability,
           client,
           timeoutMs: MCP_PROXY_TIMEOUT_MS,
+          signal: input.signal,
         });
         const resultValidation = prepareMcpToolResultValidation({
           serverName: input.serverName,
@@ -371,7 +357,10 @@ export class McpToolProxy {
             arguments: input.arguments ?? {},
           },
           undefined,
-          { timeout: MCP_PROXY_TIMEOUT_MS },
+          {
+            timeout: timeoutMs,
+            ...(input.signal ? { signal: input.signal } : {}),
+          },
         );
         toolReturned = true;
         const validationAudit = resultValidation.validate(result);
@@ -389,7 +378,7 @@ export class McpToolProxy {
         await closeCachedMcpClient(capability);
         throw err;
       } finally {
-        scheduleMcpClientIdleClose(capability);
+        releaseMcpClient(capability);
       }
     } catch (err) {
       if (!finalized) {
@@ -410,6 +399,20 @@ export class McpToolProxy {
       }
       throw err;
     }
+  }
+
+  async assertToolAllowed(input: McpToolCallInput): Promise<void> {
+    const argumentSummary = summarizeMcpToolArguments(input.arguments ?? {});
+    const startedAt = Date.now();
+    await this.resolveReviewedTool(input, (resultClass, extra = {}) =>
+      this.publishMcpToolActivity({
+        input,
+        resultClass,
+        latencyMs: Date.now() - startedAt,
+        argumentSummary,
+        ...extra,
+      }),
+    );
   }
 
   private async fetchAndCacheInventory(
@@ -533,70 +536,61 @@ export class McpToolProxy {
     appId: AppId;
     agentId: AgentId;
   }): Promise<ReviewedMaterializedMcpCapability[]> {
-    const capabilities = await new McpServerService(
-      this.mcpServers,
-      undefined,
-      {
-        lookupHostname: this.options.lookupHostname,
-        dnsValidationCache: this.options.dnsValidationCache,
-        auditMaterialization: false,
-      },
-    ).materializeForAgent({
+    return materializeSourceMcpCapabilities({
+      mcpServers: this.mcpServers,
+      tools: this.options.tools,
+      skills: this.options.skills,
+      credentialEnv: this.options.credentialEnv,
+      sourceServerIds: this.options.sourceServerIds,
+      lookupHostname: this.options.lookupHostname,
+      dnsValidationCache: this.options.dnsValidationCache,
       appId: input.appId,
       agentId: input.agentId,
-      credentialEnv: this.options.credentialEnv ?? {},
     });
-    return capabilities.map((capability) => ({
-      ...capability,
-      reviewedToolNames: capability.allowedToolNames,
-    }));
   }
 
   private async materializeReviewedCapabilities(input: {
     appId: AppId;
     agentId: AgentId;
   }): Promise<ReviewedMaterializedMcpCapability[]> {
-    const policy = await resolveAgentToolRuntimePolicy({
-      repository: this.options.tools,
-      skillRepository: this.options.skills,
-      appId: input.appId,
-      agentId: input.agentId,
-      errorSubject: 'Configured agent tool',
-    });
-    const reviewedToolNames = [
-      ...new Set([
-        ...reviewedExternalMcpToolNamesFromRuntimeAccess(policy.runtimeAccess),
-        ...exactExternalMcpToolNames(this.options.liveToolRules),
-      ]),
-    ];
-    const serverIds = await authorizedMcpServerIdsForAgent({
+    return materializeReviewedMcpCapabilities({
       mcpServers: this.mcpServers,
       tools: this.options.tools,
       skills: this.options.skills,
+      credentialEnv: this.options.credentialEnv,
+      liveToolRules: this.options.liveToolRules,
+      lookupHostname: this.options.lookupHostname,
+      dnsValidationCache: this.options.dnsValidationCache,
       appId: input.appId,
       agentId: input.agentId,
-      allowedTools: reviewedToolNames,
     });
-    const capabilities = await new McpServerService(
-      this.mcpServers,
-      undefined,
-      {
-        lookupHostname: this.options.lookupHostname,
-        dnsValidationCache: this.options.dnsValidationCache,
-        auditMaterialization: false,
-      },
-    ).materializeForAgent({
-      appId: input.appId,
-      agentId: input.agentId,
-      serverIds: serverIds as never,
-      credentialEnv: this.options.credentialEnv ?? {},
+  }
+
+  private async resolveReviewedTool(
+    input: {
+      appId: AppId;
+      agentId: AgentId;
+      serverName: string;
+      toolName: string;
+    },
+    finalizeDenied: (
+      resultClass: McpToolAuditResultClass,
+      extra?: Record<string, unknown>,
+    ) => Promise<unknown>,
+  ): Promise<{
+    capability: ReviewedMaterializedMcpCapability;
+    selectedToolRule: string;
+    selectedCapability: Pick<
+      ReviewedMaterializedMcpCapability,
+      'name' | 'serverId' | 'bindingId' | 'sourceRevision'
+    >;
+  }> {
+    return resolveReviewedMcpTool({
+      capabilities: await this.materializeReviewedCapabilities(input),
+      serverName: input.serverName,
+      toolName: input.toolName,
+      finalizeDenied,
     });
-    return capabilities.map((capability) => ({
-      ...capability,
-      reviewedToolNames: reviewedToolNames.filter((toolName) =>
-        reviewedToolNameAllowedBySourceScope(capability, toolName),
-      ),
-    }));
   }
 
   private async connect(
@@ -622,6 +616,11 @@ export class McpToolProxy {
     );
     const transport = await this.createTransport(capability);
     await client.connect(transport, { timeout: MCP_PROXY_TIMEOUT_MS });
+    const existing = readCachedMcpClient(capability) as Client | null;
+    if (existing) {
+      await client.close();
+      return existing;
+    }
     cacheMcpClient(capability, client);
     return client;
   }
@@ -660,7 +659,6 @@ export class McpToolProxy {
       'stdio_template MCP servers are approved durable capabilities, but current-session proxy execution is disabled until sandboxed stdio execution is implemented.',
     );
   }
-
   private assertNetworkAllowedForCapability(
     capability: MaterializedMcpCapability,
   ): void {

--- a/apps/core/src/cli/mcp.ts
+++ b/apps/core/src/cli/mcp.ts
@@ -31,7 +31,7 @@ function usage(): string {
     '  gantry mcp connect --name <name> --transport <stdio_template> --template <node-script|npx-package> --sandbox-profile <id> --agent <agentId> [--arg <value>] [--tool <name>] [--credential <name:env:key>] [--network <host:port>]',
     '  gantry mcp list [--status <active|disabled>]',
     '  gantry mcp show <serverId>',
-    '  gantry mcp doctor <serverId> [--by <admin>]',
+    '  gantry mcp doctor <serverId> [--agent <agentId>] [--by <admin>]',
     '  gantry mcp remove <serverId> --agent <agentId>',
     '  gantry mcp disable <serverId> [--reason <text>] [--by <admin>]',
   ].join('\n');
@@ -237,10 +237,14 @@ async function doctorServer(
     return 1;
   }
   const by = flagValue(args, '--by');
+  const agentId = flagValue(args, '--agent');
   const response = await controlApiRequest(runtimeHome, {
     method: 'POST',
     path: `/v1/mcp-servers/${encodeURIComponent(serverId)}/test`,
-    body: { testedBy: by },
+    body: {
+      testedBy: by,
+      ...(agentId ? { agentId: normalizeAgentId(agentId) } : {}),
+    },
   });
   printRecord(response, 'MCP Doctor');
   return 0;

--- a/apps/core/src/config/profiles.ts
+++ b/apps/core/src/config/profiles.ts
@@ -57,6 +57,7 @@ export const LOCKED_DENIED_IPC_TASK_TYPES: ReadonlySet<string> =
       toolName === 'request_access' ? 'request_permission' : toolName,
     ),
     'async_run_command',
+    'async_mcp_call',
     'delegate_task',
     'task_get',
     'task_list',

--- a/apps/core/src/control/server/handler-context.ts
+++ b/apps/core/src/control/server/handler-context.ts
@@ -15,6 +15,7 @@ import type {
   ModelWorkload,
 } from '../../shared/model-catalog.js';
 import type { AgentHarness } from '../../shared/agent-engine.js';
+import type { EgressSettings } from '../../shared/egress-policy.js';
 import { authenticate, type ApiKeyRecord, type Scope } from './auth.js';
 import { sendError } from './http.js';
 import type { RateLimiter } from './rate-limit.js';
@@ -91,6 +92,7 @@ export type ControlRouteContext = {
   triggerRateLimiter: RateLimiter;
   getRuntimeSettings: () => RuntimeSettingsResponse['settings'];
   getInternalRuntimeSettings: () => InternalRuntimeSettings;
+  getEgressSettings?: () => EgressSettings;
   getDefaultModelConfig: (
     kind?: 'interactive' | 'oneTimeJob' | 'recurringJob',
     agentFolder?: string,

--- a/apps/core/src/control/server/index.ts
+++ b/apps/core/src/control/server/index.ts
@@ -326,6 +326,7 @@ export function startControlServer(input: {
     triggerRateLimiter: createRateLimiter(),
     getRuntimeSettings: () => getPublicRuntimeSettings(),
     getInternalRuntimeSettings: () => getRuntimeSettingsForConfig(),
+    getEgressSettings: () => getRuntimeSettingsForConfig().permissions.egress,
     getDefaultModelConfig,
     getModelDefaults: getRuntimeModelDefaults,
     patchModelDefaults: patchRuntimeModelDefaults,

--- a/apps/core/src/control/server/routes/mcp-servers.ts
+++ b/apps/core/src/control/server/routes/mcp-servers.ts
@@ -3,10 +3,14 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   ConnectMcpServerRequestSchema,
   DisableMcpServerRequestSchema,
+  TestMcpServerRequestSchema,
   UpdateAgentMcpServerBindingRequestSchema,
 } from '@gantry/contracts';
 
 import { McpServerService } from '../../../application/mcp/mcp-server-service.js';
+import { McpToolProxy } from '../../../application/mcp/mcp-tool-proxy.js';
+import { resolveAgentToolRuntimePolicy } from '../../../application/agents/agent-tool-runtime-rules.js';
+import { resolveMcpCredentialEnvForAgent } from '../../../application/capability-secrets/mcp-secret-projection.js';
 import { getRuntimeStorage } from '../../../adapters/storage/postgres/runtime-store.js';
 import { defaultHostnameLookup } from '../../../infrastructure/network/hostname-lookup.js';
 import type { AgentId } from '../../../domain/agent/agent.js';
@@ -18,6 +22,7 @@ import type {
   McpServerStatus,
 } from '../../../domain/mcp/mcp-servers.js';
 import { ApplicationError } from '../../../application/common/application-error.js';
+import { reviewedExternalMcpToolNamesFromRuntimeAccess } from '../../../shared/capability-runtime-access.js';
 import {
   authorizeControlRequest,
   type ControlRouteContext,
@@ -165,10 +170,12 @@ export async function handleMcpServerRoutes(
   if (testMatch && req.method === 'POST') {
     const auth = authorizeControlRequest(req, res, ctx.keys, ['mcp:admin']);
     if (!auth) return true;
-    const body = await readJson(req);
-    const appId = readOptionalString(body, 'appId');
-    const testedBy = readOptionalString(body, 'testedBy');
-    if (appId && appId !== auth.appId) {
+    const parsed = TestMcpServerRequestSchema.safeParse(await readJson(req));
+    if (!parsed.success) {
+      sendError(res, 400, 'INVALID_REQUEST', 'Invalid MCP server test request');
+      return true;
+    }
+    if (parsed.data.appId && parsed.data.appId !== auth.appId) {
       sendError(
         res,
         403,
@@ -181,12 +188,21 @@ export async function handleMcpServerRoutes(
       const result = await service().testServer({
         appId: auth.appId as AppId,
         serverId: decodeURIComponent(testMatch[1]) as McpServerId,
-        testedBy,
+        testedBy: parsed.data.testedBy,
       });
+      const diagnostics = parsed.data.agentId
+        ? await mcpCapabilityDriftDiagnostics({
+            appId: auth.appId as AppId,
+            agentId: parsed.data.agentId as AgentId,
+            server: result.server,
+            egressDenylist: ctx.getEgressSettings?.().denylist ?? [],
+          })
+        : undefined;
       sendJson(res, 200, {
         ok: result.ok,
-        message: result.message,
+        message: doctorMessage(result.message, diagnostics),
         server: serverToResponse(result.server),
+        ...(diagnostics ? { diagnostics } : {}),
       });
     } catch (error) {
       sendRouteError(res, error, 'MCP server test failed');
@@ -304,10 +320,92 @@ export async function handleMcpServerRoutes(
   return false;
 }
 
-function readOptionalString(input: unknown, key: string): string | undefined {
-  if (!input || typeof input !== 'object') return undefined;
-  const value = (input as Record<string, unknown>)[key];
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+async function mcpCapabilityDriftDiagnostics(input: {
+  appId: AppId;
+  agentId: AgentId;
+  server: McpServerDefinition;
+  egressDenylist: readonly string[];
+}): Promise<
+  | {
+      agentId: string;
+      serverName: string;
+      visibleTools: string[];
+      approvedTools: string[];
+      blockedByCapabilityReview: string[];
+      inventoryTruncated?: boolean;
+      warning?: string;
+    }
+  | undefined
+> {
+  const storage = getRuntimeStorage();
+  const credentialEnv = await resolveMcpCredentialEnvForAgent({
+    appId: input.appId,
+    agentId: input.agentId,
+    mcpServers: storage.repositories.mcpServers,
+    secrets: storage.repositories.capabilitySecrets,
+    serverIds: [input.server.id],
+  });
+  const proxy = new McpToolProxy(storage.repositories.mcpServers, {
+    tools: storage.repositories.tools,
+    skills: storage.repositories.skills,
+    credentialEnv,
+    sourceServerIds: [input.server.id],
+    lookupHostname: defaultHostnameLookup,
+    egressDenylist: input.egressDenylist,
+  });
+  const [inventory, policy] = await Promise.all([
+    proxy.listTools({
+      appId: input.appId,
+      agentId: input.agentId,
+      serverName: input.server.name,
+      limit: 50,
+    }),
+    resolveAgentToolRuntimePolicy({
+      repository: storage.repositories.tools,
+      skillRepository: storage.repositories.skills,
+      appId: input.appId,
+      agentId: input.agentId,
+      errorSubject: 'Configured agent tool',
+    }),
+  ]);
+  const visibleTools = inventory.servers.flatMap((server) =>
+    server.tools.map((tool) => `mcp__${server.name}__${tool.name}`),
+  );
+  const approvedTools = reviewedExternalMcpToolNamesFromRuntimeAccess(
+    policy.runtimeAccess,
+    { serverNames: [input.server.name] },
+  ).sort();
+  const approved = new Set(approvedTools);
+  const blockedByCapabilityReview = visibleTools
+    .filter((tool) => !approved.has(tool))
+    .sort();
+  return {
+    agentId: input.agentId,
+    serverName: input.server.name,
+    visibleTools: [...visibleTools].sort(),
+    approvedTools,
+    blockedByCapabilityReview,
+    ...(inventory.diagnostics.remoteListTruncated
+      ? { inventoryTruncated: true }
+      : {}),
+    ...(blockedByCapabilityReview.length > 0
+      ? {
+          warning:
+            'MCP source is healthy, but some visible tools are not approved by selected agent capabilities. Review semantic capability implementationBindings before users call them.',
+        }
+      : {}),
+  };
+}
+
+function doctorMessage(
+  message: string,
+  diagnostics:
+    | Awaited<ReturnType<typeof mcpCapabilityDriftDiagnostics>>
+    | undefined,
+): string {
+  const count = diagnostics?.blockedByCapabilityReview.length ?? 0;
+  if (count === 0) return message;
+  return `${message} ${count} visible MCP tool(s) are blocked by missing semantic capability bindings.`;
 }
 
 function parsePage(url: URL): { limit: number; cursor?: string } {

--- a/apps/core/src/domain/ports/async-tasks.ts
+++ b/apps/core/src/domain/ports/async-tasks.ts
@@ -1,4 +1,7 @@
-export type AsyncTaskKind = 'async_command' | 'delegated_agent';
+export type AsyncTaskKind =
+  | 'async_command'
+  | 'delegated_agent'
+  | 'mcp_tool_call';
 
 export type AsyncTaskStatus =
   | 'queued'
@@ -245,7 +248,10 @@ function publicInspection(
   PublicAsyncTaskDto,
   'heartbeatAt' | 'elapsedMs' | 'stdoutTail' | 'stderrTail'
 > {
-  if (task.kind !== 'async_command' || task.status !== 'running') {
+  if (
+    task.status !== 'running' ||
+    (task.kind !== 'async_command' && task.kind !== 'mcp_tool_call')
+  ) {
     return {
       heartbeatAt: null,
       elapsedMs: null,
@@ -266,8 +272,10 @@ function publicInspection(
   return {
     heartbeatAt: task.heartbeatAt ?? null,
     elapsedMs: fallbackElapsedMs,
-    stdoutTail: stringValue(progress.stdoutTail),
-    stderrTail: stringValue(progress.stderrTail),
+    stdoutTail:
+      task.kind === 'async_command' ? stringValue(progress.stdoutTail) : null,
+    stderrTail:
+      task.kind === 'async_command' ? stringValue(progress.stderrTail) : null,
   };
 }
 

--- a/apps/core/src/jobs/async-command-task-receipts.ts
+++ b/apps/core/src/jobs/async-command-task-receipts.ts
@@ -4,6 +4,16 @@ export function cancelledReceipt(
   task: AsyncTaskRecord,
   childCancelledCount = 0,
 ) {
+  if (task.kind === 'mcp_tool_call') {
+    return {
+      completed: 'cancelled',
+      used: mcpToolName(task),
+      changed: 'unknown',
+      delegated: 'no' as const,
+      needsAttention:
+        'remote MCP work may have already run; late results will be ignored',
+    };
+  }
   return task.kind === 'delegated_agent'
     ? {
         completed: 'cancelled',
@@ -23,6 +33,16 @@ export function cancelledReceipt(
 }
 
 export function failedReceipt(task: AsyncTaskRecord, completed: string) {
+  if (task.kind === 'mcp_tool_call') {
+    return {
+      completed,
+      used: mcpToolName(task),
+      changed: 'unknown',
+      delegated: 'no' as const,
+      needsAttention:
+        'check the remote MCP system before retrying; work may have already run',
+    };
+  }
   return task.kind === 'delegated_agent'
     ? {
         completed,
@@ -39,4 +59,10 @@ export function failedReceipt(task: AsyncTaskRecord, completed: string) {
         delegated: 'no' as const,
         needsAttention: 'start this task again if it is still needed',
       };
+}
+
+function mcpToolName(task: AsyncTaskRecord): string {
+  const snapshot = task.authoritySnapshotJson;
+  const tool = snapshot.mcpToolRule;
+  return typeof tool === 'string' && tool ? tool : 'mcp_call_tool';
 }

--- a/apps/core/src/jobs/async-command-task-service.ts
+++ b/apps/core/src/jobs/async-command-task-service.ts
@@ -44,6 +44,7 @@ import {
   cancelledReceipt,
   failedReceipt,
 } from './async-command-task-receipts.js';
+import { cancelAsyncMcpTask } from './async-mcp-tool-task.js';
 import { refreshDelegatedCancellationReceipt } from './async-task-cancellation.js';
 
 const SHELL_POLICY_TOOL_NAME = 'Bash';
@@ -450,6 +451,9 @@ export class AsyncCommandTaskService {
     }
     const controller = this.active.get(taskId);
     if (!controller) {
+      if (task.kind === 'mcp_tool_call') {
+        return cancelAsyncMcpTask(this.repository, task);
+      }
       const handle = readPersistedProcessHandle(task.privateCorrelationJson);
       if (handle) {
         const now = nowIso();

--- a/apps/core/src/jobs/async-mcp-tool-task.ts
+++ b/apps/core/src/jobs/async-mcp-tool-task.ts
@@ -1,0 +1,481 @@
+import { randomUUID } from 'node:crypto';
+
+import type { McpToolProxy } from '../application/mcp/mcp-tool-proxy.js';
+import type {
+  AsyncTaskCreateInput,
+  AsyncTaskRecord,
+  AsyncTaskRepository,
+} from '../domain/ports/async-tasks.js';
+import { sanitizeOutboundLlmText } from '../shared/sensitive-material.js';
+import { nowIso } from '../shared/time/datetime.js';
+import { serializeMcpToolResult } from '../application/mcp/mcp-tool-output-bounds.js';
+import {
+  errorMessage,
+  isRecord,
+  isTimeoutError,
+  taskTimestampMs,
+  truncate,
+  withLocalAdmissionLock,
+} from './async-command-task-helpers.js';
+import { cancelledReceipt } from './async-command-task-receipts.js';
+
+const ACTIVE_ASYNC_MCP_STATUSES = ['queued', 'running'] as const;
+const MAX_ACTIVE_ASYNC_MCP_PER_APP = 4;
+const MAX_ACTIVE_ASYNC_MCP_PER_AGENT = 2;
+const ASYNC_MCP_HEARTBEAT_MS = 15_000;
+const ASYNC_MCP_TIMEOUT_MS = 15 * 60_000;
+const ASYNC_MCP_STALE_AFTER_MS = 60_000;
+const activeAsyncMcpControllers = new Map<
+  string,
+  {
+    controller: AbortController;
+    appId: string;
+    agentId: string;
+    countsAgainstCapacity: boolean;
+  }
+>();
+
+export async function createAsyncMcpTask(input: {
+  repository: AsyncTaskRepository;
+  appId: string;
+  agentId: string;
+  conversationId: string;
+  threadId?: string | null;
+  parentTaskId?: string | null;
+  jobId?: string;
+  runId?: string;
+  serverName: string;
+  toolName: string;
+}): Promise<
+  { ok: true; task: AsyncTaskRecord } | { ok: false; message: string }
+> {
+  const now = nowIso();
+  const createInput: AsyncTaskCreateInput = {
+    id: `task_${randomUUID()}`,
+    appId: input.appId,
+    agentId: input.agentId,
+    conversationId: input.conversationId,
+    threadId: input.threadId ?? null,
+    parentRunId: input.jobId ? null : (input.runId ?? null),
+    parentJobId: input.jobId ?? null,
+    parentJobRunId: input.jobId ? (input.runId ?? null) : null,
+    kind: 'mcp_tool_call',
+    status: 'queued',
+    admissionClass: 'task',
+    authoritySnapshotJson: {
+      toolName: 'async_mcp_call',
+      mcpToolRule: `mcp__${input.serverName}__${input.toolName}`,
+      serverName: input.serverName,
+      mcpToolName: input.toolName,
+    },
+    privateCorrelationJson: {
+      ...(input.parentTaskId ? { parentTaskId: input.parentTaskId } : {}),
+      progress: {
+        phase: 'queued',
+        lastProgress: 'MCP tool queued.',
+        lastToolSummary: `${input.serverName}.${input.toolName}`,
+      },
+    },
+    leaseToken: randomUUID(),
+    fencingVersion: 1,
+    summary: `${input.serverName}.${input.toolName}`,
+    now,
+  };
+  await recoverStaleAsyncMcpTasks(input.repository, input.appId);
+  const activeControllerCounts = activeAsyncMcpControllerCounts(
+    input.appId,
+    input.agentId,
+  );
+  if (activeControllerCounts.app >= MAX_ACTIVE_ASYNC_MCP_PER_APP) {
+    return {
+      ok: false,
+      message:
+        'Async MCP capacity is full for this app. Wait for an existing task to finish or cancel one.',
+    };
+  }
+  if (activeControllerCounts.agent >= MAX_ACTIVE_ASYNC_MCP_PER_AGENT) {
+    return {
+      ok: false,
+      message:
+        'Async MCP capacity is full for this agent. Wait for an existing task to finish or cancel one.',
+    };
+  }
+  const admitted = input.repository.createTaskWithAdmission
+    ? await input.repository.createTaskWithAdmission(createInput, {
+        activeStatuses: [...ACTIVE_ASYNC_MCP_STATUSES],
+        maxActivePerApp: MAX_ACTIVE_ASYNC_MCP_PER_APP,
+        maxActivePerAgent: MAX_ACTIVE_ASYNC_MCP_PER_AGENT,
+      })
+    : await admitWithLocalLock(input.repository, createInput);
+  if (admitted.ok) return admitted;
+  return {
+    ok: false,
+    message:
+      admitted.reason === 'app_capacity'
+        ? 'Async MCP capacity is full for this app. Wait for an existing task to finish or cancel one.'
+        : 'Async MCP capacity is full for this agent. Wait for an existing task to finish or cancel one.',
+  };
+}
+
+async function recoverStaleAsyncMcpTasks(
+  repository: AsyncTaskRepository,
+  appId: string,
+): Promise<void> {
+  const staleBefore = Date.now() - ASYNC_MCP_STALE_AFTER_MS;
+  const tasks = await repository.listTasks({
+    appId,
+    statuses: [...ACTIVE_ASYNC_MCP_STATUSES],
+    limit: 100,
+  });
+  for (const task of tasks) {
+    if (task.kind !== 'mcp_tool_call' || taskTimestampMs(task) > staleBefore) {
+      continue;
+    }
+    const now = nowIso();
+    await repository.transitionTask({
+      taskId: task.id,
+      leaseToken: task.leaseToken,
+      fencingVersion: task.fencingVersion,
+      status: 'failed',
+      now,
+      terminalAt: now,
+      errorSummary:
+        'Async MCP task recovered after its worker stopped heartbeating.',
+      receiptJson: {
+        completed: 'failed after worker heartbeat expired',
+        used: String(
+          task.authoritySnapshotJson.mcpToolRule ?? 'async_mcp_call',
+        ),
+        changed: 'unknown',
+        delegated: 'no',
+        needsAttention:
+          'check the remote MCP system before retrying; work may have already run',
+      },
+    });
+  }
+}
+
+async function admitWithLocalLock(
+  repository: AsyncTaskRepository,
+  createInput: AsyncTaskCreateInput,
+) {
+  return withLocalAdmissionLock(repository, async () => {
+    const [appActive, agentActive] = await Promise.all([
+      repository.listTasks({
+        appId: createInput.appId,
+        statuses: [...ACTIVE_ASYNC_MCP_STATUSES],
+        limit: MAX_ACTIVE_ASYNC_MCP_PER_APP,
+      }),
+      repository.listTasks({
+        appId: createInput.appId,
+        agentId: createInput.agentId,
+        statuses: [...ACTIVE_ASYNC_MCP_STATUSES],
+        limit: MAX_ACTIVE_ASYNC_MCP_PER_AGENT,
+      }),
+    ]);
+    if (appActive.length >= MAX_ACTIVE_ASYNC_MCP_PER_APP) {
+      return { ok: false as const, reason: 'app_capacity' as const };
+    }
+    if (agentActive.length >= MAX_ACTIVE_ASYNC_MCP_PER_AGENT) {
+      return { ok: false as const, reason: 'agent_capacity' as const };
+    }
+    return {
+      ok: true as const,
+      task: await repository.createTask(createInput),
+    };
+  });
+}
+
+export async function executeAsyncMcpTask(input: {
+  repository: AsyncTaskRepository;
+  task: AsyncTaskRecord;
+  proxy: McpToolProxy;
+  appId: string;
+  agentId: string;
+  serverName: string;
+  toolName: string;
+  arguments: Record<string, unknown>;
+}): Promise<void> {
+  const controller = new AbortController();
+  activeAsyncMcpControllers.set(input.task.id, {
+    controller,
+    appId: input.appId,
+    agentId: input.agentId,
+    countsAgainstCapacity: true,
+  });
+  const toolSummary = `${input.serverName}.${input.toolName}`;
+  const running = await input.repository.transitionTask({
+    taskId: input.task.id,
+    leaseToken: input.task.leaseToken,
+    fencingVersion: input.task.fencingVersion,
+    status: 'running',
+    now: nowIso(),
+    heartbeatAt: nowIso(),
+    startedAt: nowIso(),
+    privateCorrelationJson: taskProgress(input.task, {
+      phase: 'running',
+      lastProgress: 'MCP tool running.',
+      lastToolSummary: toolSummary,
+    }),
+  });
+  if (!running) {
+    activeAsyncMcpControllers.delete(input.task.id);
+    return;
+  }
+  const heartbeat = setInterval(() => {
+    void input.repository.transitionTask({
+      taskId: input.task.id,
+      leaseToken: input.task.leaseToken,
+      fencingVersion: input.task.fencingVersion,
+      status: 'running',
+      now: nowIso(),
+      heartbeatAt: nowIso(),
+      privateCorrelationJson: taskProgress(input.task, {
+        phase: 'running',
+        lastProgress: 'MCP tool still running.',
+        lastToolSummary: toolSummary,
+      }),
+    });
+  }, ASYNC_MCP_HEARTBEAT_MS);
+  heartbeat.unref?.();
+  try {
+    const result = await input.proxy.callTool({
+      appId: input.appId as never,
+      agentId: input.agentId as never,
+      serverName: input.serverName,
+      toolName: input.toolName,
+      arguments: input.arguments,
+      timeoutMs: ASYNC_MCP_TIMEOUT_MS,
+      signal: controller.signal,
+    });
+    const outputSummary = summarizeAsyncMcpResult(result);
+    if (controller.signal.aborted) {
+      const now = nowIso();
+      await input.repository.transitionTask({
+        taskId: input.task.id,
+        leaseToken: input.task.leaseToken,
+        fencingVersion: input.task.fencingVersion,
+        status: 'cancelled',
+        now,
+        terminalAt: now,
+        outputSummary: 'MCP tool returned after cancellation; result ignored.',
+        privateCorrelationJson: taskProgress(input.task, {
+          phase: 'cancelled',
+          lastProgress: 'MCP tool returned after cancellation; result ignored.',
+          lastToolSummary: toolSummary,
+        }),
+        receiptJson: cancelledMcpReceipt(input, 'cancelled'),
+      });
+      return;
+    }
+    if (isMcpToolErrorResult(result)) {
+      const now = nowIso();
+      await input.repository.transitionTask({
+        taskId: input.task.id,
+        leaseToken: input.task.leaseToken,
+        fencingVersion: input.task.fencingVersion,
+        status: 'failed',
+        now,
+        terminalAt: now,
+        errorSummary: outputSummary,
+        privateCorrelationJson: taskProgress(input.task, {
+          phase: 'failed',
+          lastProgress: outputSummary,
+          lastToolSummary: toolSummary,
+          blocker: outputSummary,
+        }),
+        receiptJson: {
+          completed: 'failed',
+          used: `mcp__${input.serverName}__${input.toolName}`,
+          changed: 'unknown',
+          delegated: 'no',
+          needsAttention: outputSummary,
+        },
+      });
+      return;
+    }
+    const now = nowIso();
+    await input.repository.transitionTask({
+      taskId: input.task.id,
+      leaseToken: input.task.leaseToken,
+      fencingVersion: input.task.fencingVersion,
+      status: 'completed',
+      now,
+      terminalAt: now,
+      outputSummary,
+      privateCorrelationJson: taskProgress(input.task, {
+        phase: 'completed',
+        lastProgress: outputSummary,
+        lastToolSummary: toolSummary,
+      }),
+      receiptJson: {
+        completed: outputSummary,
+        used: `mcp__${input.serverName}__${input.toolName}`,
+        changed: 'unknown',
+        delegated: 'no',
+        needsAttention: 'none',
+      },
+    });
+  } catch (err) {
+    const aborted = controller.signal.aborted;
+    const timedOut = isTimeoutError(err);
+    const summary = truncate(
+      sanitizeOutboundLlmText(errorMessage(err)).text,
+      500,
+    );
+    const now = nowIso();
+    await input.repository.transitionTask({
+      taskId: input.task.id,
+      leaseToken: input.task.leaseToken,
+      fencingVersion: input.task.fencingVersion,
+      status: aborted ? 'cancelled' : timedOut ? 'timed_out' : 'failed',
+      now,
+      terminalAt: now,
+      errorSummary: summary,
+      privateCorrelationJson: taskProgress(input.task, {
+        phase: aborted ? 'cancelled' : timedOut ? 'timed_out' : 'failed',
+        lastProgress: summary,
+        lastToolSummary: toolSummary,
+        ...(aborted ? {} : { blocker: summary }),
+      }),
+      receiptJson: {
+        completed: aborted ? 'cancelled' : timedOut ? 'timed out' : 'failed',
+        used: `mcp__${input.serverName}__${input.toolName}`,
+        changed: 'unknown',
+        delegated: 'no',
+        needsAttention: aborted
+          ? 'check the remote MCP system before retrying; work may have already run'
+          : summary,
+      },
+    });
+  } finally {
+    clearInterval(heartbeat);
+    activeAsyncMcpControllers.delete(input.task.id);
+  }
+}
+
+function cancelledMcpReceipt(
+  input: {
+    serverName: string;
+    toolName: string;
+  },
+  completed: string,
+) {
+  return {
+    completed,
+    used: `mcp__${input.serverName}__${input.toolName}`,
+    changed: 'unknown',
+    delegated: 'no' as const,
+    needsAttention:
+      'check the remote MCP system before retrying; work may have already run',
+  };
+}
+
+function activeAsyncMcpControllerCounts(appId: string, agentId: string) {
+  let app = 0;
+  let agent = 0;
+  for (const active of activeAsyncMcpControllers.values()) {
+    if (!active.countsAgainstCapacity) continue;
+    if (active.appId !== appId) continue;
+    app += 1;
+    if (active.agentId === agentId) agent += 1;
+  }
+  return { app, agent };
+}
+
+export async function cancelAsyncMcpTask(
+  repository: AsyncTaskRepository,
+  task: AsyncTaskRecord,
+): Promise<{ ok: boolean; message: string }> {
+  const active = activeAsyncMcpControllers.get(task.id);
+  const now = nowIso();
+  if (active) {
+    const cancelled = await repository.transitionTask({
+      taskId: task.id,
+      leaseToken: task.leaseToken,
+      fencingVersion: task.fencingVersion,
+      status: 'cancelled',
+      now,
+      terminalAt: now,
+      privateCorrelationJson: taskProgress(task, {
+        phase: 'cancelled',
+        lastProgress: 'MCP tool cancelled.',
+        lastToolSummary: task.summary ?? task.id,
+      }),
+      receiptJson: cancelledMcpReceipt(
+        {
+          serverName: String(
+            task.authoritySnapshotJson.serverName ?? 'unknown',
+          ),
+          toolName: String(task.authoritySnapshotJson.mcpToolName ?? 'unknown'),
+        },
+        'cancelled',
+      ),
+    });
+    if (!cancelled) {
+      return {
+        ok: false,
+        message: 'Task is already finished and cannot be cancelled.',
+      };
+    }
+    active.countsAgainstCapacity = false;
+    active.controller.abort();
+    return {
+      ok: true,
+      message:
+        'Task was cancelled in Gantry. Remote MCP work may have already run; late results will be ignored.',
+    };
+  }
+  const cancelled = await repository.transitionTask({
+    taskId: task.id,
+    leaseToken: task.leaseToken,
+    fencingVersion: task.fencingVersion,
+    status: 'cancelled',
+    now,
+    terminalAt: now,
+    privateCorrelationJson: taskProgress(task, {
+      phase: 'cancelled',
+      lastProgress: 'MCP tool cancelled.',
+      lastToolSummary: task.summary ?? task.id,
+    }),
+    receiptJson: cancelledReceipt(task),
+  });
+  const message = cancelled
+    ? 'Task was cancelled in Gantry. Remote MCP work may have already run; late results will be ignored.'
+    : 'Task is already finished and cannot be cancelled.';
+  return { ok: Boolean(cancelled), message };
+}
+
+function taskProgress(
+  task: AsyncTaskRecord,
+  progress: {
+    phase: string;
+    lastProgress: string;
+    lastToolSummary: string;
+    blocker?: string;
+  },
+): Record<string, unknown> {
+  return {
+    ...(isRecord(task.privateCorrelationJson)
+      ? task.privateCorrelationJson
+      : {}),
+    progress,
+  };
+}
+
+function summarizeAsyncMcpResult(result: unknown): string {
+  const raw = serializeMcpToolResult(result, 1_000).text;
+  return truncate(
+    sanitizeOutboundLlmText(raw || 'MCP tool completed.').text,
+    1_000,
+  );
+}
+
+function isMcpToolErrorResult(result: unknown): boolean {
+  return (
+    result !== null &&
+    typeof result === 'object' &&
+    !Array.isArray(result) &&
+    (result as { isError?: unknown }).isError === true
+  );
+}

--- a/apps/core/src/jobs/ipc-admin-handlers.ts
+++ b/apps/core/src/jobs/ipc-admin-handlers.ts
@@ -83,8 +83,12 @@ import {
 } from './request-access-job-recovery.js';
 import { requestOnlyCapabilityPendingKey } from './request-only-capability-dedupe.js';
 const pendingRequestOnlyCapabilityReviews = new Set<string>();
-const { mcpCallToolHandler, mcpDescribeToolHandler, mcpListToolsHandler } =
-  createMcpToolHandlers(createMcpProxyForSourceGroup);
+const {
+  asyncMcpCallToolHandler,
+  mcpCallToolHandler,
+  mcpDescribeToolHandler,
+  mcpListToolsHandler,
+} = createMcpToolHandlers(createMcpProxyForSourceGroup);
 configureSkillInstallHandlers({
   getStorage: getRuntimeStorage,
   logInfo: (context, message) => logger.info(context, message),
@@ -395,7 +399,7 @@ const adminPermissionRevokeHandler: TaskHandler = async (context) => {
   }
 };
 // prettier-ignore
-export const adminTaskHandlers: Record<string, TaskHandler> = { refresh_groups: refreshGroupsHandler, register_agent: registerAgentHandler, service_restart: serviceRestartHandler, settings_desired_state: settingsDesiredStateHandler, guided_action_preview: guidedActionPreviewHandler, request_settings_update: requestSettingsUpdateHandler, admin_permission_revoke: adminPermissionRevokeHandler, request_skill_install: requestSkillInstallHandler, request_skill_dependency_install: requestOnlyCapabilityHandler, request_permission: requestOnlyCapabilityHandler, request_skill_proposal: requestSkillProposalHandler, pattern_candidate_decision: patternCandidateDecisionHandler, request_mcp_server: requestMcpServerHandler, mcp_list_tools: mcpListToolsHandler, mcp_describe_tool: mcpDescribeToolHandler, mcp_call_tool: mcpCallToolHandler };
+export const adminTaskHandlers: Record<string, TaskHandler> = { refresh_groups: refreshGroupsHandler, register_agent: registerAgentHandler, service_restart: serviceRestartHandler, settings_desired_state: settingsDesiredStateHandler, guided_action_preview: guidedActionPreviewHandler, request_settings_update: requestSettingsUpdateHandler, admin_permission_revoke: adminPermissionRevokeHandler, request_skill_install: requestSkillInstallHandler, request_skill_dependency_install: requestOnlyCapabilityHandler, request_permission: requestOnlyCapabilityHandler, request_skill_proposal: requestSkillProposalHandler, pattern_candidate_decision: patternCandidateDecisionHandler, request_mcp_server: requestMcpServerHandler, mcp_list_tools: mcpListToolsHandler, mcp_describe_tool: mcpDescribeToolHandler, mcp_call_tool: mcpCallToolHandler, async_mcp_call: asyncMcpCallToolHandler };
 // prettier-ignore
 function validateSameChannelApprovalTarget(input: { data: Parameters<TaskHandler>[0]['data']; sourceAgentFolderJids: string[]; requestKind: string; reject: (error: string, code?: string, details?: string[]) => void }): string | null {
   const requestedTargetJid = toTrimmedString(input.data.chatJid, { maxLen: 512 });

--- a/apps/core/src/jobs/ipc-mcp-tool-handlers.ts
+++ b/apps/core/src/jobs/ipc-mcp-tool-handlers.ts
@@ -3,7 +3,18 @@ import path from 'path';
 import { publishInvalidMcpToolRequestAudit } from '../application/mcp/mcp-tool-audit.js';
 import type { McpToolProxy } from '../application/mcp/mcp-tool-proxy.js';
 import { isActiveRunLeaseForInteraction } from '../application/interactions/pending-interaction-durability.js';
+import {
+  isAsyncTaskTerminal,
+  toPublicAsyncTaskDto,
+  type AsyncTaskRecord,
+  type AsyncTaskRepository,
+} from '../domain/ports/async-tasks.js';
 import { memoryAgentIdForWorkspaceFolder } from '../memory/app-memory-boundaries.js';
+import { readAsyncCommandSandboxPolicy } from '../runtime/async-command-sandbox-policy.js';
+import {
+  createAsyncMcpTask,
+  executeAsyncMcpTask,
+} from './async-mcp-tool-task.js';
 import { createTaskResponder, toTrimmedString } from './ipc-shared.js';
 import { TaskHandler } from './ipc-types.js';
 import {
@@ -27,6 +38,7 @@ export function createMcpToolHandlers(
   mcpListToolsHandler: TaskHandler;
   mcpDescribeToolHandler: TaskHandler;
   mcpCallToolHandler: TaskHandler;
+  asyncMcpCallToolHandler: TaskHandler;
 } {
   return {
     mcpListToolsHandler: mcpListToolsHandler(createMcpProxyForSourceGroup),
@@ -34,6 +46,9 @@ export function createMcpToolHandlers(
       createMcpProxyForSourceGroup,
     ),
     mcpCallToolHandler: mcpCallToolHandler(createMcpProxyForSourceGroup),
+    asyncMcpCallToolHandler: asyncMcpCallToolHandler(
+      createMcpProxyForSourceGroup,
+    ),
   };
 }
 
@@ -229,6 +244,182 @@ function mcpCallToolHandler(
       );
     }
   };
+}
+
+function asyncMcpCallToolHandler(
+  createMcpProxyForSourceGroup: CreateMcpProxyForSourceGroup,
+): TaskHandler {
+  return async (context) => {
+    const { data, deps, sourceAgentFolder, sourceAgentFolderJids } = context;
+    const { acceptData, reject } = createTaskResponder(
+      sourceAgentFolder,
+      data.taskId,
+      data.authThreadId,
+      data.responseKeyId,
+    );
+    if (!data.appId) {
+      reject('Async MCP tool calls require signed app scope.', 'forbidden');
+      return;
+    }
+    const requestedTargetJid = validateSameChannelMcpTarget({
+      data,
+      sourceAgentFolderJids,
+      requestKind: 'Async MCP tool call',
+      reject,
+    });
+    if (!requestedTargetJid) return;
+    try {
+      const callInput = mcpCallToolProxyInput(data.payload || {});
+      if (
+        !callInput.serverName ||
+        !callInput.toolName ||
+        callInput.invalidArguments
+      ) {
+        const reason = callInput.invalidArguments
+          ? 'async_mcp_call arguments must be a JSON object when provided.'
+          : 'Missing required fields: serverName and toolName.';
+        await auditInvalidMcpCallRequest({
+          data,
+          deps,
+          sourceAgentFolder,
+          callInput,
+          reason,
+        });
+        reject(reason, 'invalid_request');
+        return;
+      }
+      const repository = deps.getAsyncTaskRepository?.();
+      if (!repository || deps.runnerSandboxProvider?.enforcing !== true) {
+        reject('Async task runtime is unavailable.', 'unavailable');
+        return;
+      }
+      const parentTask = await validateAsyncMcpParentTask({
+        repository,
+        data,
+        appId: data.appId,
+        agentId: agentIdForMcpTask(data, sourceAgentFolder),
+        conversationId: requestedTargetJid,
+        threadId: data.authThreadId || data.threadId || null,
+      });
+      if (!parentTask.ok) {
+        reject(parentTask.message, 'invalid_request');
+        return;
+      }
+      const activeLease = await isActiveRunLeaseForInteraction({
+        runId: data.runId,
+        runLeaseToken: data.runLeaseToken,
+        runLeaseFencingVersion: data.runLeaseFencingVersion,
+      });
+      if (!activeLease) {
+        reject(
+          'Async MCP tool call rejected because the run lease is no longer active.',
+          'stale_run_lease',
+        );
+        return;
+      }
+      const { serverName, toolName } = callInput;
+      const agentId = agentIdForMcpTask(data, sourceAgentFolder);
+      const sandboxPolicy = readAsyncCommandSandboxPolicy({
+        sourceAgentFolder,
+        runHandle: data.runHandle,
+      });
+      if (
+        !sandboxPolicy ||
+        sandboxPolicy.appId !== data.appId ||
+        (sandboxPolicy.agentId && sandboxPolicy.agentId !== agentId) ||
+        sandboxPolicy.conversationId !== requestedTargetJid ||
+        (sandboxPolicy.threadId ?? null) !==
+          (data.authThreadId || data.threadId || null) ||
+        (sandboxPolicy.runId && sandboxPolicy.runId !== data.runId) ||
+        (sandboxPolicy.jobId && sandboxPolicy.jobId !== data.jobId)
+      ) {
+        reject(
+          'async_mcp_call must target a run where async task tools are mounted.',
+          'forbidden',
+        );
+        return;
+      }
+      const proxy = await createMcpProxyForSourceGroup({
+        appId: data.appId as never,
+        agentId,
+        deps,
+        ipcDir: context.ipcBaseDir
+          ? path.join(context.ipcBaseDir, sourceAgentFolder)
+          : undefined,
+        runHandle: data.runHandle,
+        runId: data.runId,
+      });
+      await proxy.assertToolAllowed({
+        appId: data.appId as never,
+        agentId,
+        serverName,
+        toolName,
+        arguments: callInput.arguments ?? {},
+      });
+      const taskResult = await createAsyncMcpTask({
+        repository,
+        appId: data.appId,
+        agentId,
+        conversationId: requestedTargetJid,
+        threadId: data.authThreadId || data.threadId || null,
+        parentTaskId: parentTask.parentTaskId,
+        jobId: data.jobId,
+        runId: data.runId,
+        serverName,
+        toolName,
+      });
+      if (!taskResult.ok) {
+        reject(taskResult.message, 'capacity_full');
+        return;
+      }
+      void executeAsyncMcpTask({
+        repository,
+        task: taskResult.task,
+        proxy,
+        appId: data.appId,
+        agentId,
+        serverName,
+        toolName,
+        arguments: callInput.arguments ?? {},
+      });
+      acceptData(`Started: ${serverName}.${toolName}`, {
+        task: toPublicAsyncTaskDto(taskResult.task),
+      });
+    } catch (err) {
+      reject(
+        err instanceof Error ? err.message : 'Async MCP tool call failed.',
+        'mcp_proxy_failed',
+      );
+    }
+  };
+}
+
+async function validateAsyncMcpParentTask(input: {
+  repository: AsyncTaskRepository;
+  data: Parameters<TaskHandler>[0]['data'];
+  appId: string;
+  agentId: string;
+  conversationId: string;
+  threadId?: string | null;
+}): Promise<
+  { ok: true; parentTaskId: string | null } | { ok: false; message: string }
+> {
+  const parentTaskId = toTrimmedString(input.data.parentTaskId, {
+    maxLen: 120,
+  });
+  if (!parentTaskId) return { ok: true, parentTaskId: null };
+  const parent = await input.repository.getTask(parentTaskId);
+  const valid =
+    parent &&
+    parent.kind === 'delegated_agent' &&
+    parent.appId === input.appId &&
+    parent.agentId === input.agentId &&
+    parent.conversationId === input.conversationId &&
+    (parent.threadId ?? null) === (input.threadId ?? null) &&
+    !isAsyncTaskTerminal(parent.status);
+  return valid
+    ? { ok: true, parentTaskId }
+    : { ok: false, message: 'async_mcp_call parent task is not active.' };
 }
 
 async function auditInvalidMcpCallRequest(input: {

--- a/apps/core/src/runner/gantry-agent-system-prompt.ts
+++ b/apps/core/src/runner/gantry-agent-system-prompt.ts
@@ -46,9 +46,9 @@ const PUBLIC_CATALOG = [
   'Files: FileSearch, FileRead, FileEdit, FileWrite, file',
   'Memory: memory_search, memory_save, reviewed memory tools',
   'Skills: selected skills and skill request tools',
-  'MCP/apps: mcp_list_tools, mcp_describe_tool, mcp_call_tool, request_mcp_server',
+  'MCP/apps: mcp_list_tools, mcp_describe_tool, mcp_call_tool, async_mcp_call, request_mcp_server',
   'Commands: RunCommand(<argv pattern>)',
-  'Tasks: todo_update; async_run_command/delegate_task/task_get/task_list/task_message/task_cancel only when mounted in this run',
+  'Tasks: todo_update; async_run_command/async_mcp_call/delegate_task/task_get/task_list/task_message/task_cancel only when mounted in this run',
   'Scheduler: scheduler_*',
   'Admin: settings, permission, restart, register-agent tools',
 ];
@@ -149,7 +149,7 @@ function toolingSection(mode: GantryAgentPromptMode): string {
           'Use Ready tools first. If the tool you need is missing, inspect the catalog/source. If it is still missing, request access or setup. If policy blocks the action, say so plainly.',
           'Use WebSearch for discovery and WebRead for exact source reading.',
           'Use FileSearch, FileRead, FileEdit, and FileWrite for approved host file work. Use file only for Gantry FileArtifacts.',
-          'Use MCP tools through mcp_list_tools, mcp_describe_tool, and mcp_call_tool.',
+          'Use MCP tools through mcp_list_tools, mcp_describe_tool, and mcp_call_tool. Use async_mcp_call for long-running or parallel MCP work, then task_get or task_list for status.',
           'Never use raw harness subagents. Gantry delegation tools are unavailable until Gantry mounts a real delegated-task executor.',
           'Do not describe raw provider or harness tool names to users unless the user asks for runtime internals.',
         ];
@@ -189,7 +189,7 @@ function gantryControlSection(): string {
   return [
     '## Gantry Control',
     'Use send_message for channel-visible updates and ask_user_question for decision-blocking questions.',
-    'If Gantry mounts async_run_command, use it for approved long-running commands. If Gantry mounts delegate_task, use task_get/task_list/task_message/task_cancel to inspect, steer, and cancel delegated work.',
+    'If Gantry mounts async_run_command or async_mcp_call, use it for approved long-running work. If Gantry mounts delegate_task, use task_get/task_list/task_message/task_cancel to inspect, steer, and cancel delegated work.',
   ].join('\n');
 }
 

--- a/apps/core/src/runner/gantry-mcp-tool-surface.ts
+++ b/apps/core/src/runner/gantry-mcp-tool-surface.ts
@@ -33,6 +33,7 @@ export const BASELINE_GANTRY_MCP_TOOL_NAMES = [
 
 export const ASYNC_TASK_GANTRY_MCP_TOOL_NAMES = [
   'async_run_command',
+  'async_mcp_call',
   'task_cancel',
   'task_get',
   'task_list',

--- a/apps/core/src/runner/mcp/context.ts
+++ b/apps/core/src/runner/mcp/context.ts
@@ -230,6 +230,7 @@ export function capabilityStatusText(): string {
       toolName === 'send_message' ||
       toolName === 'ask_user_question' ||
       toolName === 'async_run_command' ||
+      toolName === 'async_mcp_call' ||
       toolName === 'delegate_task' ||
       toolName === 'task_cancel' ||
       toolName === 'task_get' ||
@@ -328,13 +329,13 @@ export function capabilityStatusText(): string {
                     `  selected capabilities: ${selectedCapabilities.join(', ')}`,
                   ]
                 : []),
-              `  use: mcp_list_tools with serverName="${sourceName}", mcp_describe_tool for one tool schema if needed, then mcp_call_tool with serverName="${sourceName}"`,
+              `  use: mcp_list_tools with serverName="${sourceName}", mcp_describe_tool for one tool schema if needed, then mcp_call_tool with serverName="${sourceName}" for immediate calls or async_mcp_call for long-running work`,
             ];
           })
       : ['- none connected yet']),
     ...(attachedMcpSourceIds.length > 0
       ? [
-          'MCP source rule: ready sources are already attached. Inspect them with mcp_list_tools, fetch one-tool schema/details with mcp_describe_tool when needed, and call approved actions through mcp_call_tool. Do not request the same MCP capability again unless the tool response says access is missing or denied.',
+          'MCP source rule: ready sources are already attached. Inspect them with mcp_list_tools, fetch one-tool schema/details with mcp_describe_tool when needed, call approved immediate actions through mcp_call_tool, and use async_mcp_call for long-running or parallel work. Do not request the same MCP capability again unless the tool response says access is missing or denied.',
         ]
       : []),
     ...(requestableBrowserTools.length > 0

--- a/apps/core/src/runner/mcp/tools/mcp-proxy-tools.ts
+++ b/apps/core/src/runner/mcp/tools/mcp-proxy-tools.ts
@@ -9,6 +9,7 @@ import {
 import {
   capabilityStatusText,
   chatJid,
+  jobId,
   jobRunId,
   jobRunLeaseFencingVersion,
   jobRunLeaseToken,
@@ -216,6 +217,69 @@ export function registerMcpProxyTools(server: McpServer): void {
           {
             type: 'text' as const,
             text: formatMcpCallToolResponse(response.data),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    'async_mcp_call',
+    lockedAccessPreset
+      ? 'Start a background call to a tool from an MCP server source connected to this agent. Use task_get or task_list for status.'
+      : 'Start a background MCP source tool call only when the requested action is covered by reviewed current-run capability access. Use task_get or task_list for status; do not poll in a tight loop.',
+    {
+      serverName: z.string().describe('Connected MCP server name'),
+      toolName: z
+        .string()
+        .describe('Raw MCP tool name without the mcp__server__ prefix'),
+      arguments: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('JSON object arguments for the MCP tool'),
+    },
+    async (args) => {
+      const taskId = makeIpcId('async-mcp-call');
+      writeIpcFile(TASKS_DIR, {
+        type: 'async_mcp_call',
+        taskId,
+        runHandle: process.env.GANTRY_AGENT_RUN_HANDLE || undefined,
+        ...(jobId ? { jobId } : {}),
+        ...(jobRunId ? { runId: jobRunId } : {}),
+        ...(process.env.GANTRY_PARENT_TASK_ID
+          ? { parentTaskId: process.env.GANTRY_PARENT_TASK_ID }
+          : {}),
+        ...(jobRunLeaseToken ? { runLeaseToken: jobRunLeaseToken } : {}),
+        ...(jobRunLeaseFencingVersion !== undefined
+          ? { runLeaseFencingVersion: Number(jobRunLeaseFencingVersion) }
+          : {}),
+        targetJid: chatJid,
+        chatJid,
+        authThreadId: threadId,
+        payload: {
+          serverName: args.serverName,
+          toolName: args.toolName,
+          arguments: args.arguments ?? {},
+        },
+        timestamp: nowIso(),
+      });
+      const response = await waitForTaskResponse(taskId, MCP_PROXY_WAIT_MS);
+      if (!response?.ok) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: response?.error || 'Async MCP tool call failed.',
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `${response.message || 'Async MCP task started.'}\n${JSON.stringify(response.data)}`,
           },
         ],
       };

--- a/apps/core/src/runner/mcp/tools/service.ts
+++ b/apps/core/src/runner/mcp/tools/service.ts
@@ -236,7 +236,7 @@ export function registerServiceTools(server: McpServer): void {
             text: [
               'RunCommand/Bash permission is not available as a fallback while MCP access is selected for this run.',
               `Selected MCP capabilities: ${selectedMcpCapabilityIds.join(', ')}`,
-              'Use mcp_list_tools to inspect the ready source, then mcp_call_tool to call the approved action.',
+              'Use mcp_list_tools to inspect the ready source, then mcp_call_tool for immediate approved actions or async_mcp_call for long-running work.',
             ].join('\n'),
           },
         ],
@@ -307,7 +307,7 @@ export function registerServiceTools(server: McpServer): void {
                 existingSource.selectedCapabilities.length
                   ? `Selected capabilities: ${existingSource.selectedCapabilities.join(', ')}`
                   : 'A matching MCP source is already attached.',
-                `Use mcp_list_tools with serverName="${existingSource.serverName}", mcp_describe_tool when schema is needed, then mcp_call_tool with serverName="${existingSource.serverName}" for approved actions.`,
+                `Use mcp_list_tools with serverName="${existingSource.serverName}", mcp_describe_tool when schema is needed, then mcp_call_tool with serverName="${existingSource.serverName}" for immediate approved actions or async_mcp_call for long-running work.`,
                 'Do not request the same MCP source setup again unless a tool call reports access is missing or denied.',
               ].join('\n'),
             },

--- a/apps/core/src/runtime/agent-spawn-helpers.ts
+++ b/apps/core/src/runtime/agent-spawn-helpers.ts
@@ -163,7 +163,7 @@ export function buildBaseRunnerEnv(input: {
   };
 }
 type WarnLogger = (metadata: Record<string, unknown>, message: string) => void;
-type SandboxRuntimeGatewayOptions = {
+type SandboxRuntimeNetworkProjection = {
   allowedNetworkHosts?: string[];
   privateNetworkHostMappings?: readonly EgressGatewayPrivateHostMapping[];
 };
@@ -291,16 +291,16 @@ export function sandboxRuntimeToolNetworkEnv(
   };
 }
 
-export function buildSandboxRuntimeGatewayOptions(
+export function buildSandboxRuntimeNetworkProjection(
   providerId: string,
   allowedNetworkHosts: readonly string[],
   modelCredentialEnv: Record<string, string> | undefined,
 ): {
   modelCredentialEnv: Record<string, string> | undefined;
-  gatewayOptions: SandboxRuntimeGatewayOptions;
+  networkProjection: SandboxRuntimeNetworkProjection;
 } {
   if (providerId !== 'sandbox_runtime') {
-    return { modelCredentialEnv, gatewayOptions: {} };
+    return { modelCredentialEnv, networkProjection: {} };
   }
   const projection = projectSandboxRuntimeModelGatewayEnv(modelCredentialEnv);
   const mergedHosts =
@@ -314,7 +314,7 @@ export function buildSandboxRuntimeGatewayOptions(
       : [...allowedNetworkHosts];
   return {
     modelCredentialEnv: projection.modelCredentialEnv,
-    gatewayOptions: {
+    networkProjection: {
       allowedNetworkHosts: mergedHosts,
       ...(projection.privateNetworkHostMappings.length > 0
         ? { privateNetworkHostMappings: projection.privateNetworkHostMappings }

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -85,7 +85,7 @@ import { compileSpawnSystemPrompt } from './agent-spawn-prompt.js';
 import {
   cleanupRunnerMcpConfigFile,
   cleanupRunnerTempDir,
-  buildSandboxRuntimeGatewayOptions,
+  buildSandboxRuntimeNetworkProjection,
   deepAgentsFilesystemEnabledEnv,
   deepAgentsShellEnabledEnv,
   protectedWritePathsForOuterSandbox,
@@ -392,21 +392,14 @@ export async function spawnAgent(
         runtimeProvider: runtimeSandbox.provider,
         measure: hostStartup.measure,
       });
-    const sandboxRuntimeGateway = buildSandboxRuntimeGatewayOptions(
+    const sandboxRuntimeNetwork = buildSandboxRuntimeNetworkProjection(
       runnerSandboxProviderId,
       sandboxAllowedNetworkHosts,
       runnerInput.modelCredentialEnv,
     );
-    runnerInput.modelCredentialEnv = sandboxRuntimeGateway.modelCredentialEnv;
+    runnerInput.modelCredentialEnv = sandboxRuntimeNetwork.modelCredentialEnv;
     runnerInputPatch.modelCredentialEnv =
-      sandboxRuntimeGateway.modelCredentialEnv;
-    const egressAllowedNetworkHosts =
-      runnerSandboxProviderId === 'sandbox_runtime'
-        ? uniqueStrings(
-            sandboxRuntimeGateway.gatewayOptions.allowedNetworkHosts ??
-              sandboxAllowedNetworkHosts,
-          )
-        : sandboxRuntimeGateway.gatewayOptions.allowedNetworkHosts;
+      sandboxRuntimeNetwork.modelCredentialEnv;
     egressGateway = await hostStartup.measureAsync('egressGatewayMs', () =>
       ensureEgressGateway({
         key: `${runnerAppId}:${input.agentId || group.folder}:${processName}`,
@@ -420,9 +413,12 @@ export async function spawnAgent(
           ...(input.jobId ? { jobId: input.jobId } : {}),
         },
         networkAttribution,
-        ...sandboxRuntimeGateway.gatewayOptions,
-        ...(egressAllowedNetworkHosts
-          ? { allowedNetworkHosts: egressAllowedNetworkHosts }
+        ...(sandboxRuntimeNetwork.networkProjection.privateNetworkHostMappings
+          ? {
+              privateNetworkHostMappings:
+                sandboxRuntimeNetwork.networkProjection
+                  .privateNetworkHostMappings,
+            }
           : {}),
         ...(options?.mcpHostnameLookup
           ? { lookupHostname: options.mcpHostnameLookup }
@@ -683,7 +679,7 @@ export async function spawnAgent(
       protectedReadPaths: protectedFilesystemDenyReadPaths,
       protectedWritePaths: protectedFilesystemDenyWritePaths,
       gatewayAllowedNetworkHosts:
-        sandboxRuntimeGateway.gatewayOptions.allowedNetworkHosts,
+        sandboxRuntimeNetwork.networkProjection.allowedNetworkHosts,
       fallbackAllowedNetworkHosts: sandboxAllowedNetworkHosts,
       resourceLimits: runtimeSandbox.resourceLimits,
     });

--- a/apps/core/src/runtime/egress-gateway-access-policy.ts
+++ b/apps/core/src/runtime/egress-gateway-access-policy.ts
@@ -3,7 +3,6 @@ import { declaredNetworkAuthority } from '../shared/network-host-declaration.js'
 import type { EgressNetworkAttribution } from './egress-gateway.js';
 
 export interface EgressAccessPolicyState {
-  allowedNetworkAuthorities?: Set<string>;
   allowedPrivateAuthorities?: Set<string>;
   privateNetworkConnectHosts?: Map<string, string>;
 }
@@ -26,25 +25,6 @@ export function networkAuthoritySet(hosts: readonly string[]): Set<string> {
     if (authority) set.add(authority);
   }
   return set;
-}
-
-export function evaluateEgressAllowlist(
-  state: EgressAccessPolicyState,
-  target: { host: string; port: number; authority: string },
-): { host: string; matchedPattern: string; reason: string } | undefined {
-  if (!state.allowedNetworkAuthorities) return undefined;
-  const authority = declaredNetworkAuthority(authorityWithPort(target));
-  if (authority && state.allowedNetworkAuthorities.has(authority)) {
-    return undefined;
-  }
-  if (authority && state.allowedPrivateAuthorities?.has(authority)) {
-    return undefined;
-  }
-  return {
-    host: normalizeEgressHost(target.host),
-    matchedPattern: 'runtime.sandbox.allowed_network_hosts',
-    reason: 'not_allowed_by_runtime_sandbox',
-  };
 }
 
 export function allowedPrivateEgressTarget(

--- a/apps/core/src/runtime/egress-gateway.ts
+++ b/apps/core/src/runtime/egress-gateway.ts
@@ -23,7 +23,6 @@ import {
 import { lookupHostnameWithDeadline } from '../shared/hostname-lookup-deadline.js';
 import {
   allowedPrivateEgressTarget,
-  evaluateEgressAllowlist,
   networkAttributionMap,
   networkAuthoritySet,
 } from './egress-gateway-access-policy.js';
@@ -63,7 +62,6 @@ interface EgressGatewayState {
   settings: EgressSettings;
   principal: EgressGatewayPrincipal;
   networkAttribution: Map<string, EgressNetworkAttribution>;
-  allowedNetworkAuthorities?: Set<string>;
   allowedPrivateAuthorities?: Set<string>;
   privateNetworkConnectHosts?: Map<string, string>;
   upstreamProxy?: EgressGatewayUpstreamProxy;
@@ -97,7 +95,6 @@ export async function ensureEgressGateway(input: {
   settings: EgressSettings;
   principal: EgressGatewayPrincipal;
   networkAttribution?: readonly EgressNetworkAttribution[];
-  allowedNetworkHosts?: readonly string[];
   allowedPrivateNetworkHosts?: readonly string[];
   privateNetworkHostMappings?: readonly EgressGatewayPrivateHostMapping[];
   upstreamProxy?: EgressGatewayUpstreamProxy;
@@ -112,9 +109,6 @@ export async function ensureEgressGateway(input: {
     existing.networkAttribution = networkAttributionMap(
       input.networkAttribution,
     );
-    existing.allowedNetworkAuthorities = input.allowedNetworkHosts
-      ? networkAuthoritySet(input.allowedNetworkHosts)
-      : undefined;
     existing.allowedPrivateAuthorities = hasPrivateNetworkAuthority(input)
       ? networkAuthoritySet([
           ...(input.allowedPrivateNetworkHosts ?? []),
@@ -159,13 +153,6 @@ export async function ensureEgressGateway(input: {
         principal: input.principal,
         networkAttribution,
         logger,
-        ...(input.allowedNetworkHosts
-          ? {
-              allowedNetworkAuthorities: networkAuthoritySet(
-                input.allowedNetworkHosts,
-              ),
-            }
-          : {}),
         ...(hasPrivateNetworkAuthority(input)
           ? {
               allowedPrivateAuthorities: networkAuthoritySet([
@@ -264,19 +251,6 @@ async function handleConnectRequest(
     clientSocket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
     return;
   }
-  const allowlistDeny = evaluateEgressAllowlist(state, target);
-  if (allowlistDeny) {
-    await auditConnect(state, {
-      host: allowlistDeny.host,
-      port: target.port,
-      allowed: false,
-      denied: true,
-      reason: allowlistDeny.reason,
-      matchedPattern: allowlistDeny.matchedPattern,
-    });
-    writeDeniedConnect(clientSocket, allowlistDeny);
-    return;
-  }
   const deny = evaluateEgressDenylist({
     settings: state.settings,
     host: target.host,
@@ -356,24 +330,6 @@ async function handleHttpProxyRequest(
   if (!target) {
     res.writeHead(400);
     res.end('Bad Request');
-    return;
-  }
-  const allowlistDeny = evaluateEgressAllowlist(state, {
-    host: normalizeEgressHost(target.hostname),
-    port: urlPort(target),
-    authority: target.host,
-  });
-  if (allowlistDeny) {
-    await auditConnect(state, {
-      host: allowlistDeny.host,
-      port: urlPort(target),
-      allowed: false,
-      denied: true,
-      reason: allowlistDeny.reason,
-      matchedPattern: allowlistDeny.matchedPattern,
-    });
-    res.writeHead(403, { 'content-type': 'application/json' });
-    res.end(JSON.stringify(deniedBody(allowlistDeny)));
     return;
   }
   const deny = evaluateEgressDenylist({

--- a/apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
+++ b/apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
@@ -507,6 +507,7 @@ describe('Claude Agent SDK boundary integration', () => {
         'TaskUpdate',
         'TodoWrite',
         'mcp__gantry__async_run_command',
+        'mcp__gantry__async_mcp_call',
         'mcp__gantry__task_get',
         'mcp__gantry__task_list',
         'mcp__gantry__task_cancel',

--- a/apps/core/test/unit/application/mcp-tool-proxy.test.ts
+++ b/apps/core/test/unit/application/mcp-tool-proxy.test.ts
@@ -1229,6 +1229,133 @@ describe('McpToolProxy', () => {
     );
   });
 
+  it('does not idle-close the MCP client while a tool call is active', async () => {
+    vi.useFakeTimers();
+    let finishCall!: () => void;
+    mockCreateIssueToolDetail();
+    mcpSdkMocks.client.callTool.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishCall = () => resolve({ content: [] });
+        }),
+    );
+    const proxy = new McpToolProxy(mcpRepository({ remote: true }), {
+      tools: emptyToolRepository(),
+      liveToolRules: ['mcp__github__create_issue'],
+      lookupHostname: vi.fn(async () => [
+        { address: '93.184.216.34', family: 4 as const },
+      ]),
+    });
+
+    const pending = proxy.callTool({
+      appId: 'app-one' as never,
+      agentId: 'agent-one' as never,
+      serverName: 'github',
+      toolName: 'create_issue',
+      arguments: { title: 'Bug' },
+      timeoutMs: 15 * 60_000,
+    });
+    await vi.waitFor(() => {
+      expect(mcpSdkMocks.client.callTool).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(121_000);
+    expect(mcpSdkMocks.client.close).not.toHaveBeenCalled();
+
+    finishCall();
+    await expect(pending).resolves.toEqual({ content: [] });
+    await vi.advanceTimersByTimeAsync(121_000);
+    expect(mcpSdkMocks.client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps schema discovery on the short proxy timeout for long tool calls', async () => {
+    mockCreateIssueToolDetail();
+    const proxy = new McpToolProxy(mcpRepository({ remote: true }), {
+      tools: emptyToolRepository(),
+      liveToolRules: ['mcp__github__create_issue'],
+      lookupHostname: vi.fn(async () => [
+        { address: '93.184.216.34', family: 4 as const },
+      ]),
+    });
+
+    await expect(
+      proxy.callTool({
+        appId: 'app-one' as never,
+        agentId: 'agent-one' as never,
+        serverName: 'github',
+        toolName: 'create_issue',
+        arguments: { title: 'Bug' },
+        timeoutMs: 15 * 60_000,
+      }),
+    ).resolves.toEqual({ content: [] });
+
+    expect(mcpSdkMocks.client.listTools).toHaveBeenCalledWith(
+      {},
+      { timeout: 60_000 },
+    );
+    expect(mcpSdkMocks.client.callTool).toHaveBeenCalledWith(
+      { name: 'create_issue', arguments: { title: 'Bug' } },
+      undefined,
+      { timeout: 15 * 60_000 },
+    );
+  });
+
+  it('does not close a shared MCP client after one failed call while another call is active', async () => {
+    vi.useFakeTimers();
+    let failFirst!: () => void;
+    let finishSecond!: () => void;
+    mockCreateIssueToolDetail();
+    mockCreateIssueToolDetail();
+    mcpSdkMocks.client.callTool
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            failFirst = () => reject(new Error('remote failed'));
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishSecond = () => resolve({ content: [] });
+          }),
+      );
+    const proxy = new McpToolProxy(mcpRepository({ remote: true }), {
+      tools: emptyToolRepository(),
+      liveToolRules: ['mcp__github__create_issue'],
+      lookupHostname: vi.fn(async () => [
+        { address: '93.184.216.34', family: 4 as const },
+      ]),
+    });
+
+    const first = proxy.callTool({
+      appId: 'app-one' as never,
+      agentId: 'agent-one' as never,
+      serverName: 'github',
+      toolName: 'create_issue',
+      arguments: { title: 'One' },
+      timeoutMs: 15 * 60_000,
+    });
+    const second = proxy.callTool({
+      appId: 'app-one' as never,
+      agentId: 'agent-one' as never,
+      serverName: 'github',
+      toolName: 'create_issue',
+      arguments: { title: 'Two' },
+      timeoutMs: 15 * 60_000,
+    });
+    await vi.waitFor(() => {
+      expect(mcpSdkMocks.client.callTool).toHaveBeenCalledTimes(2);
+    });
+
+    failFirst();
+    await expect(first).rejects.toThrow('remote failed');
+    expect(mcpSdkMocks.client.close).not.toHaveBeenCalled();
+
+    finishSecond();
+    await expect(second).resolves.toEqual({ content: [] });
+    expect(mcpSdkMocks.client.close).toHaveBeenCalledTimes(1);
+  });
+
   it('audits approved stdio MCP sources as denied until sandboxed proxy execution exists', async () => {
     const publishRuntimeEvent = vi.fn(async () => undefined);
     const appendAuditEvent = vi.fn(async () => undefined);
@@ -1336,6 +1463,7 @@ describe('McpToolProxy', () => {
       ]),
     });
     mcpSdkMocks.client.callTool.mockResolvedValueOnce({
+      isError: true,
       content: [
         { type: 'text', text: 'x'.repeat(MAX_MCP_TOOL_RESULT_CHARS + 1) },
       ],
@@ -1350,6 +1478,7 @@ describe('McpToolProxy', () => {
       }),
     ).resolves.toMatchObject({
       type: 'mcp_tool_result_truncated',
+      isError: true,
       truncated: true,
       maxChars: MAX_MCP_TOOL_RESULT_CHARS,
       preview: expect.stringContaining('[truncated MCP tool result]'),

--- a/apps/core/test/unit/cli/mcp.test.ts
+++ b/apps/core/test/unit/cli/mcp.test.ts
@@ -174,4 +174,57 @@ describe('mcp CLI', () => {
     expect(seen).toEqual([{ method: 'GET', url: '/v1/mcp-servers' }]);
     expect(note).toHaveBeenCalledWith('No records found.', 'MCP Servers');
   });
+
+  it('passes agent context to mcp doctor for capability drift diagnostics', async () => {
+    const note = vi.fn();
+    vi.doMock('@clack/prompts', () => ({
+      note,
+      log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), success: vi.fn() },
+    }));
+    const seen: Array<{ method?: string; url?: string; body: unknown }> = [];
+    const port = await listen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf-8');
+        seen.push({
+          method: req.method,
+          url: req.url,
+          body: body ? JSON.parse(body) : undefined,
+        });
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, message: 'ok' }));
+      });
+    });
+    process.env.GANTRY_CONTROL_API_KEYS_JSON = JSON.stringify([
+      {
+        kid: 'cli-test',
+        token: 'test-key',
+        appId: 'default',
+        scopes: ['mcp:admin'],
+      },
+    ]);
+    process.env.GANTRY_CONTROL_PORT = String(port);
+
+    const { runMcpCommand } = await import('@core/cli/mcp.js');
+    const code = await runMcpCommand(makeTempDir(), [
+      'doctor',
+      'mcp:itops',
+      '--agent',
+      'main',
+    ]);
+
+    expect(code).toBe(0);
+    expect(seen).toEqual([
+      {
+        method: 'POST',
+        url: '/v1/mcp-servers/mcp%3Aitops/test',
+        body: { agentId: 'agent:main' },
+      },
+    ]);
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining('"message": "ok"'),
+      'MCP Doctor',
+    );
+  });
 });

--- a/apps/core/test/unit/domain/async-tasks.test.ts
+++ b/apps/core/test/unit/domain/async-tasks.test.ts
@@ -113,4 +113,44 @@ describe('toPublicAsyncTaskDto', () => {
     expect(publicJson).not.toContain('unbounded stdout');
     expect(publicJson).not.toContain('unbounded stderr');
   });
+
+  it('exposes running async MCP heartbeat without process output', () => {
+    const dto = toPublicAsyncTaskDto(
+      task(null, {
+        kind: 'mcp_tool_call',
+        status: 'running',
+        heartbeatAt: '2026-06-22T00:00:03.000Z',
+        terminalAt: null,
+        privateCorrelationJson: {
+          progress: {
+            phase: 'running',
+            lastProgress: 'MCP tool running.',
+            lastToolSummary: 'crm.create_deal',
+            stdoutTail: 'must stay hidden',
+            stderrTail: 'must stay hidden',
+          },
+        },
+      }),
+    );
+
+    expect(dto).toMatchObject({
+      kind: 'mcp_tool_call',
+      status: 'running',
+      currentPhase: 'running',
+      lastProgress: 'MCP tool running.',
+      lastToolSummary: 'crm.create_deal',
+      heartbeatAt: '2026-06-22T00:00:03.000Z',
+      elapsedMs: expect.any(Number),
+      stdoutTail: null,
+      stderrTail: null,
+      allowedActions: ['get', 'list', 'cancel'],
+    });
+  });
+
+  it('hides cancel for terminal tasks', () => {
+    expect(toPublicAsyncTaskDto(task(null)).allowedActions).toEqual([
+      'get',
+      'list',
+    ]);
+  });
 });

--- a/apps/core/test/unit/jobs/async-command-task-service.test.ts
+++ b/apps/core/test/unit/jobs/async-command-task-service.test.ts
@@ -1017,6 +1017,73 @@ describe('AsyncCommandTaskService', () => {
     expect(killed.sort()).toEqual([56789, 56790]);
   });
 
+  it('keeps stale MCP recovery retry guidance side-effect safe', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const stale = new Date(Date.now() - 120_000).toISOString();
+    await repository.createTask({
+      id: 'task-mcp',
+      appId: 'app-1',
+      agentId: 'agent-1',
+      conversationId: 'conversation-1',
+      kind: 'mcp_tool_call',
+      status: 'running',
+      admissionClass: 'task',
+      authoritySnapshotJson: { mcpToolRule: 'mcp__crm__create_deal' },
+      privateCorrelationJson: {},
+      leaseToken: 'lease-mcp',
+      fencingVersion: 1,
+      now: stale,
+    });
+    const service = new AsyncCommandTaskService(repository, {
+      run: async () => ({}),
+    });
+
+    await expect(
+      service.recoverStaleTasks({ appId: 'app-1', staleAfterMs: 1 }),
+    ).resolves.toBe(1);
+    expect(repository.tasks.get('task-mcp')?.receiptJson).toMatchObject({
+      used: 'mcp__crm__create_deal',
+      needsAttention:
+        'check the remote MCP system before retrying; work may have already run',
+    });
+  });
+
+  it('cancels recovered running MCP tasks with a fenced terminal state', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    await repository.createTask({
+      id: 'task-mcp',
+      appId: 'app-1',
+      agentId: 'agent-1',
+      conversationId: 'conversation-1',
+      kind: 'mcp_tool_call',
+      status: 'running',
+      admissionClass: 'task',
+      authoritySnapshotJson: { mcpToolRule: 'mcp__crm__create_deal' },
+      privateCorrelationJson: {},
+      leaseToken: 'lease-mcp',
+      fencingVersion: 1,
+      now: new Date().toISOString(),
+    });
+    const service = new AsyncCommandTaskService(repository, {
+      run: async () => ({}),
+    });
+
+    await expect(service.cancel('task-mcp')).resolves.toEqual({
+      ok: true,
+      message:
+        'Task was cancelled in Gantry. Remote MCP work may have already run; late results will be ignored.',
+    });
+    expect(repository.tasks.get('task-mcp')?.status).toBe('cancelled');
+    expect(
+      repository.tasks.get('task-mcp')?.privateCorrelationJson,
+    ).toMatchObject({
+      progress: {
+        phase: 'cancelled',
+        lastProgress: 'MCP tool cancelled.',
+      },
+    });
+  });
+
   it('starts delegated agent tasks and records steering messages', async () => {
     const repository = new MemoryAsyncTaskRepository();
     let release!: () => void;

--- a/apps/core/test/unit/jobs/ipc-locked-agent-denial.test.ts
+++ b/apps/core/test/unit/jobs/ipc-locked-agent-denial.test.ts
@@ -128,6 +128,7 @@ describe('locked agent parent-side IPC denial', () => {
     'request_mcp_server',
     'request_permission',
     'async_run_command',
+    'async_mcp_call',
     'delegate_task',
     'task_get',
     'task_list',

--- a/apps/core/test/unit/jobs/ipc-mcp-tool-handlers.test.ts
+++ b/apps/core/test/unit/jobs/ipc-mcp-tool-handlers.test.ts
@@ -1,11 +1,151 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { configurePendingInteractionDurability } from '@core/application/interactions/pending-interaction-durability.js';
+import type {
+  AsyncTaskCreateInput,
+  AsyncTaskListFilter,
+  AsyncTaskRecord,
+  AsyncTaskRepository,
+  AsyncTaskStatusCount,
+  AsyncTaskTransitionInput,
+} from '@core/domain/ports/async-tasks.js';
+import { isAsyncTaskTerminal } from '@core/domain/ports/async-tasks.js';
+import { AsyncCommandTaskService } from '@core/jobs/async-command-task-service.js';
 import { createMcpToolHandlers } from '@core/jobs/ipc-mcp-tool-handlers.js';
+import { registerAsyncCommandSandboxPolicy } from '@core/runtime/async-command-sandbox-policy.js';
 
 afterEach(() => {
   configurePendingInteractionDurability(null);
 });
+
+function asyncRuntimeDeps(repository: AsyncTaskRepository) {
+  return {
+    getAsyncTaskRepository: () => repository,
+    runnerSandboxProvider: { enforcing: true },
+  } as never;
+}
+
+class MemoryAsyncTaskRepository implements AsyncTaskRepository {
+  readonly tasks = new Map<string, AsyncTaskRecord>();
+
+  async createTask(input: AsyncTaskCreateInput): Promise<AsyncTaskRecord> {
+    const task: AsyncTaskRecord = {
+      id: input.id,
+      appId: input.appId,
+      agentId: input.agentId,
+      conversationId: input.conversationId ?? null,
+      threadId: input.threadId ?? null,
+      parentRunId: input.parentRunId ?? null,
+      parentJobId: input.parentJobId ?? null,
+      parentJobRunId: input.parentJobRunId ?? null,
+      kind: input.kind,
+      status: input.status,
+      admissionClass: input.admissionClass,
+      authoritySnapshotJson: input.authoritySnapshotJson,
+      privateCorrelationJson: input.privateCorrelationJson ?? {},
+      leaseToken: input.leaseToken,
+      fencingVersion: input.fencingVersion,
+      createdAt: input.now,
+      updatedAt: input.now,
+      summary: input.summary ?? null,
+    };
+    this.tasks.set(task.id, task);
+    return task;
+  }
+
+  async getTask(taskId: string): Promise<AsyncTaskRecord | null> {
+    return this.tasks.get(taskId) ?? null;
+  }
+
+  async listTasks(filter: AsyncTaskListFilter): Promise<AsyncTaskRecord[]> {
+    return [...this.tasks.values()]
+      .filter(
+        (task) =>
+          task.appId === filter.appId &&
+          (!filter.agentId || task.agentId === filter.agentId) &&
+          (!filter.statuses || filter.statuses.includes(task.status)),
+      )
+      .slice(0, filter.limit ?? 50);
+  }
+
+  async countTasksByStatus(
+    filter: Omit<AsyncTaskListFilter, 'limit'>,
+  ): Promise<AsyncTaskStatusCount[]> {
+    const tasks = await this.listTasks({ ...filter, limit: 100 });
+    const counts = new Map<AsyncTaskRecord['status'], number>();
+    for (const task of tasks) {
+      counts.set(task.status, (counts.get(task.status) ?? 0) + 1);
+    }
+    return [...counts.entries()].map(([status, count]) => ({ status, count }));
+  }
+
+  async updateTaskReceipt(
+    taskId: string,
+    receiptJson: AsyncTaskRecord['receiptJson'],
+    now: string,
+  ): Promise<AsyncTaskRecord | null> {
+    const current = this.tasks.get(taskId);
+    if (!current) return null;
+    const next = { ...current, receiptJson, updatedAt: now };
+    this.tasks.set(taskId, next);
+    return next;
+  }
+
+  async transitionTask(
+    input: AsyncTaskTransitionInput,
+  ): Promise<AsyncTaskRecord | null> {
+    const current = this.tasks.get(input.taskId);
+    if (
+      !current ||
+      current.leaseToken !== input.leaseToken ||
+      current.fencingVersion !== input.fencingVersion ||
+      isAsyncTaskTerminal(current.status)
+    ) {
+      return null;
+    }
+    const next: AsyncTaskRecord = {
+      ...current,
+      status: input.status,
+      updatedAt: input.now,
+      heartbeatAt: input.heartbeatAt ?? current.heartbeatAt,
+      startedAt: input.startedAt ?? current.startedAt,
+      terminalAt: input.terminalAt ?? current.terminalAt,
+      privateCorrelationJson:
+        input.privateCorrelationJson ?? current.privateCorrelationJson,
+      outputSummary: input.outputSummary ?? current.outputSummary,
+      errorSummary: input.errorSummary ?? current.errorSummary,
+      receiptJson: input.receiptJson ?? current.receiptJson,
+    };
+    this.tasks.set(next.id, next);
+    return next;
+  }
+}
+
+function registerAsyncTaskPolicy(input: {
+  runHandle: string;
+  appId?: string;
+  agentId?: string;
+  conversationId?: string;
+  runId?: string;
+  jobId?: string;
+}): void {
+  registerAsyncCommandSandboxPolicy({
+    sourceAgentFolder: 'main_agent',
+    runHandle: input.runHandle,
+    policy: {
+      appId: input.appId ?? 'app:test',
+      agentId: input.agentId ?? 'agent:signed',
+      conversationId: input.conversationId ?? 'sl:C123',
+      threadId: null,
+      ...(input.runId ? { runId: input.runId } : {}),
+      ...(input.jobId ? { jobId: input.jobId } : {}),
+      protectedReadPaths: [],
+      protectedWritePaths: [],
+      allowedNetworkHosts: [],
+      resourceLimits: { cpuSeconds: 10, memoryMb: 128, maxProcesses: 8 },
+    },
+  });
+}
 
 describe('MCP IPC tool handlers', () => {
   it('uses the signed runner agent id for MCP tool calls', async () => {
@@ -84,5 +224,351 @@ describe('MCP IPC tool handlers', () => {
     });
 
     expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it('starts async MCP calls as durable tasks before remote execution completes', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    let release!: () => void;
+    const remoteDone = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const callTool = vi.fn(async (input: { signal?: AbortSignal }) => {
+      await remoteDone;
+      input.signal?.throwIfAborted();
+      return { content: [{ type: 'text', text: 'created' }] };
+    });
+    const assertToolAllowed = vi.fn(async () => undefined);
+    const createProxy = vi.fn(async () => ({
+      assertToolAllowed,
+      callTool,
+      describeTool: vi.fn(),
+      listTools: vi.fn(),
+    }));
+    const { asyncMcpCallToolHandler } = createMcpToolHandlers(
+      createProxy as never,
+    );
+    registerAsyncTaskPolicy({ runHandle: 'run-handle-1', runId: 'run-1' });
+    const parent = await repository.createTask({
+      id: 'task_parent',
+      appId: 'app:test',
+      agentId: 'agent:signed',
+      conversationId: 'sl:C123',
+      threadId: null,
+      kind: 'delegated_agent',
+      status: 'running',
+      admissionClass: 'task',
+      authoritySnapshotJson: { toolName: 'delegate_task' },
+      privateCorrelationJson: {},
+      leaseToken: 'parent-lease',
+      fencingVersion: 1,
+      now: '2026-06-25T00:00:00.000Z',
+    });
+    configurePendingInteractionDurability({
+      repository: {
+        getActiveRunLease: vi.fn(async () => ({
+          runId: 'run-1',
+          leaseToken: 'lease-1',
+          fencingVersion: 1,
+        })),
+      } as never,
+    });
+
+    await asyncMcpCallToolHandler({
+      data: {
+        type: 'async_mcp_call',
+        appId: 'app:test',
+        agentId: 'agent:signed',
+        chatJid: 'sl:C123',
+        targetJid: 'sl:C123',
+        runId: 'run-1',
+        runHandle: 'run-handle-1',
+        runLeaseToken: 'lease-1',
+        runLeaseFencingVersion: 1,
+        parentTaskId: parent.id,
+        payload: {
+          serverName: 'crm',
+          toolName: 'create_deal',
+          arguments: { name: 'Acme' },
+        },
+      },
+      sourceAgentFolder: 'main_agent',
+      deps: asyncRuntimeDeps(repository),
+      conversationBindings: {},
+      sourceAgentFolderJids: ['sl:C123'],
+    });
+
+    const task = [...repository.tasks.values()].find(
+      (candidate) => candidate.kind === 'mcp_tool_call',
+    );
+    if (!task) throw new Error('mcp_tool_call task was not created');
+    expect(task).toMatchObject({
+      kind: 'mcp_tool_call',
+      appId: 'app:test',
+      agentId: 'agent:signed',
+      conversationId: 'sl:C123',
+      parentRunId: 'run-1',
+      parentJobId: null,
+      parentJobRunId: null,
+      summary: 'crm.create_deal',
+    });
+    expect(task.privateCorrelationJson.parentTaskId).toBe(parent.id);
+    expect(assertToolAllowed).toHaveBeenCalledWith(
+      expect.objectContaining({ serverName: 'crm', toolName: 'create_deal' }),
+    );
+    expect(callTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent:signed',
+        serverName: 'crm',
+        toolName: 'create_deal',
+        timeoutMs: 15 * 60_000,
+      }),
+    );
+
+    release();
+    await vi.waitFor(() => {
+      expect(repository.tasks.get(task.id)?.status).toBe('completed');
+    });
+    expect(repository.tasks.get(task.id)?.receiptJson).toMatchObject({
+      used: 'mcp__crm__create_deal',
+      delegated: 'no',
+      needsAttention: 'none',
+    });
+  });
+
+  it('cancels running async MCP calls through the request signal', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const callTool = vi.fn(
+      (input: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          input.signal?.addEventListener(
+            'abort',
+            () => reject(new Error('MCP request aborted')),
+            { once: true },
+          );
+        }),
+    );
+    const createProxy = vi.fn(async () => ({
+      assertToolAllowed: vi.fn(async () => undefined),
+      callTool,
+      describeTool: vi.fn(),
+      listTools: vi.fn(),
+    }));
+    const { asyncMcpCallToolHandler } = createMcpToolHandlers(
+      createProxy as never,
+    );
+    configurePendingInteractionDurability({
+      repository: {
+        getActiveRunLease: vi.fn(async () => ({
+          runId: 'run-1',
+          leaseToken: 'lease-1',
+          fencingVersion: 1,
+        })),
+      } as never,
+    });
+    registerAsyncTaskPolicy({ runHandle: 'run-handle-1', runId: 'run-1' });
+
+    await asyncMcpCallToolHandler({
+      data: {
+        type: 'async_mcp_call',
+        appId: 'app:test',
+        agentId: 'agent:signed',
+        chatJid: 'sl:C123',
+        targetJid: 'sl:C123',
+        runId: 'run-1',
+        runHandle: 'run-handle-1',
+        runLeaseToken: 'lease-1',
+        runLeaseFencingVersion: 1,
+        payload: {
+          serverName: 'crm',
+          toolName: 'create_deal',
+          arguments: { name: 'Acme' },
+        },
+      },
+      sourceAgentFolder: 'main_agent',
+      deps: asyncRuntimeDeps(repository),
+      conversationBindings: {},
+      sourceAgentFolderJids: ['sl:C123'],
+    });
+
+    const task = [...repository.tasks.values()].find(
+      (candidate) => candidate.kind === 'mcp_tool_call',
+    );
+    if (!task) throw new Error('mcp_tool_call task was not created');
+    await vi.waitFor(() => {
+      expect(repository.tasks.get(task.id)?.status).toBe('running');
+    });
+    const service = new AsyncCommandTaskService(repository, {
+      run: async () => ({}),
+    });
+
+    await expect(service.cancel(task.id)).resolves.toMatchObject({
+      ok: true,
+    });
+    await vi.waitFor(() => {
+      expect(repository.tasks.get(task.id)?.status).toBe('cancelled');
+    });
+    expect(repository.tasks.get(task.id)?.receiptJson).toMatchObject({
+      needsAttention:
+        'check the remote MCP system before retrying; work may have already run',
+    });
+  });
+
+  it('rejects async MCP calls when async task tools were not mounted', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const createProxy = vi.fn(async () => ({
+      assertToolAllowed: vi.fn(async () => undefined),
+      callTool: vi.fn(async () => ({})),
+      describeTool: vi.fn(),
+      listTools: vi.fn(),
+    }));
+    const { asyncMcpCallToolHandler } = createMcpToolHandlers(
+      createProxy as never,
+    );
+    configurePendingInteractionDurability({
+      repository: {
+        getActiveRunLease: vi.fn(async () => ({
+          runId: 'run-1',
+          leaseToken: 'lease-1',
+          fencingVersion: 1,
+        })),
+      } as never,
+    });
+    registerAsyncTaskPolicy({ runHandle: 'run-handle-1', runId: 'run-1' });
+
+    await asyncMcpCallToolHandler({
+      data: {
+        type: 'async_mcp_call',
+        appId: 'app:test',
+        agentId: 'agent:signed',
+        chatJid: 'sl:C123',
+        targetJid: 'sl:C123',
+        runId: 'run-1',
+        runHandle: 'run-handle-1',
+        runLeaseToken: 'lease-1',
+        runLeaseFencingVersion: 1,
+        payload: {
+          serverName: 'crm',
+          toolName: 'create_deal',
+          arguments: { name: 'Acme' },
+        },
+      },
+      sourceAgentFolder: 'main_agent',
+      deps: { getAsyncTaskRepository: () => repository } as never,
+      conversationBindings: {},
+      sourceAgentFolderJids: ['sl:C123'],
+    });
+
+    expect(repository.tasks.size).toBe(0);
+    expect(createProxy).not.toHaveBeenCalled();
+  });
+
+  it('rejects async MCP calls when the run lease is stale before creating a task', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const callTool = vi.fn(async () => ({}));
+    const createProxy = vi.fn(async () => ({
+      assertToolAllowed: vi.fn(async () => undefined),
+      callTool,
+      describeTool: vi.fn(),
+      listTools: vi.fn(),
+    }));
+    configurePendingInteractionDurability({
+      repository: {
+        getActiveRunLease: vi.fn(async () => ({
+          runId: 'run-1',
+          leaseToken: 'new-lease',
+          fencingVersion: 8,
+        })),
+      } as never,
+    });
+    const { asyncMcpCallToolHandler } = createMcpToolHandlers(
+      createProxy as never,
+    );
+
+    await asyncMcpCallToolHandler({
+      data: {
+        type: 'async_mcp_call',
+        appId: 'app:test',
+        agentId: 'agent:signed',
+        chatJid: 'sl:C123',
+        targetJid: 'sl:C123',
+        runId: 'run-1',
+        runLeaseToken: 'old-lease',
+        runLeaseFencingVersion: 7,
+        payload: {
+          serverName: 'crm',
+          toolName: 'create_deal',
+          arguments: { name: 'Acme' },
+        },
+      },
+      sourceAgentFolder: 'main_agent',
+      deps: asyncRuntimeDeps(repository),
+      conversationBindings: {},
+      sourceAgentFolderJids: ['sl:C123'],
+    });
+
+    expect(repository.tasks.size).toBe(0);
+    expect(createProxy).not.toHaveBeenCalled();
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it('stores scheduled async MCP job metadata outside live parentRunId', async () => {
+    const repository = new MemoryAsyncTaskRepository();
+    const callTool = vi.fn(async () => ({}));
+    const createProxy = vi.fn(async () => ({
+      assertToolAllowed: vi.fn(async () => undefined),
+      callTool,
+      describeTool: vi.fn(),
+      listTools: vi.fn(),
+    }));
+    configurePendingInteractionDurability({
+      repository: {
+        getActiveRunLease: vi.fn(async () => ({
+          runId: 'job-run-1',
+          leaseToken: 'lease-1',
+          fencingVersion: 1,
+        })),
+      } as never,
+    });
+    const { asyncMcpCallToolHandler } = createMcpToolHandlers(
+      createProxy as never,
+    );
+    registerAsyncTaskPolicy({
+      runHandle: 'job-run-handle-1',
+      runId: 'job-run-1',
+      jobId: 'job-1',
+    });
+
+    await asyncMcpCallToolHandler({
+      data: {
+        type: 'async_mcp_call',
+        appId: 'app:test',
+        agentId: 'agent:signed',
+        chatJid: 'sl:C123',
+        targetJid: 'sl:C123',
+        jobId: 'job-1',
+        runId: 'job-run-1',
+        runHandle: 'job-run-handle-1',
+        runLeaseToken: 'lease-1',
+        runLeaseFencingVersion: 1,
+        payload: {
+          serverName: 'crm',
+          toolName: 'create_deal',
+          arguments: { name: 'Acme' },
+        },
+      },
+      sourceAgentFolder: 'main_agent',
+      deps: asyncRuntimeDeps(repository),
+      conversationBindings: {},
+      sourceAgentFolderJids: ['sl:C123'],
+    });
+
+    const task = [...repository.tasks.values()].find(
+      (candidate) => candidate.kind === 'mcp_tool_call',
+    );
+    expect(task).toMatchObject({
+      parentRunId: null,
+      parentJobId: 'job-1',
+      parentJobRunId: 'job-run-1',
+    });
   });
 });

--- a/apps/core/test/unit/runner/locked-tool-surface.test.ts
+++ b/apps/core/test/unit/runner/locked-tool-surface.test.ts
@@ -120,6 +120,7 @@ describe('locked tool surface mounting', () => {
     const defaultNames = selectedGantryMcpToolNames([]);
     expect(defaultNames).toContain('todo_update');
     expect(defaultNames).not.toContain('async_run_command');
+    expect(defaultNames).not.toContain('async_mcp_call');
     expect(defaultNames).not.toContain('task_get');
     expect(defaultNames).not.toContain('task_list');
     expect(defaultNames).not.toContain('task_cancel');
@@ -130,6 +131,7 @@ describe('locked tool surface mounting', () => {
       asyncTaskToolsEnabled: true,
     });
     expect(enabledNames).toContain('async_run_command');
+    expect(enabledNames).toContain('async_mcp_call');
     expect(enabledNames).toContain('task_get');
     expect(enabledNames).toContain('task_list');
     expect(enabledNames).toContain('task_cancel');
@@ -144,11 +146,13 @@ describe('locked tool surface mounting', () => {
 
     const explicitlyConfiguredNames = selectedGantryMcpToolNames([
       'mcp__gantry__delegate_task',
+      'mcp__gantry__async_mcp_call',
       'mcp__gantry__task_get',
       'mcp__gantry__task_cancel',
       'mcp__gantry__task_message',
     ]);
     expect(explicitlyConfiguredNames).not.toContain('delegate_task');
+    expect(explicitlyConfiguredNames).not.toContain('async_mcp_call');
     expect(explicitlyConfiguredNames).not.toContain('task_get');
     expect(explicitlyConfiguredNames).not.toContain('task_cancel');
     expect(explicitlyConfiguredNames).not.toContain('task_message');
@@ -156,12 +160,14 @@ describe('locked tool surface mounting', () => {
     const parsedNames = parseEnabledGantryMcpToolNames(
       JSON.stringify([
         'delegate_task',
+        'async_mcp_call',
         'task_get',
         'task_cancel',
         'task_message',
       ]),
     );
     expect(parsedNames.has('delegate_task')).toBe(true);
+    expect(parsedNames.has('async_mcp_call')).toBe(true);
     expect(parsedNames.has('task_get')).toBe(true);
     expect(parsedNames.has('task_cancel')).toBe(true);
     expect(parsedNames.has('task_message')).toBe(true);
@@ -171,6 +177,7 @@ describe('locked tool surface mounting', () => {
     });
     expect(lockedNames).toContain('todo_update');
     expect(lockedNames).not.toContain('async_run_command');
+    expect(lockedNames).not.toContain('async_mcp_call');
     expect(lockedNames).not.toContain('task_get');
     expect(lockedNames).not.toContain('task_list');
     expect(lockedNames).not.toContain('task_cancel');
@@ -184,6 +191,7 @@ describe('locked tool surface mounting', () => {
       ...DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
     ];
     expect(publicTaskToolNames.sort()).toEqual([
+      'async_mcp_call',
       'async_run_command',
       'delegate_task',
       'task_cancel',

--- a/apps/core/test/unit/runner/mcp/server-registry.test.ts
+++ b/apps/core/test/unit/runner/mcp/server-registry.test.ts
@@ -136,6 +136,7 @@ describe('effective enabled MCP tool projection', () => {
     expect(enabled.has('send_message')).toBe(true);
     expect(enabled.has('ask_user_question')).toBe(true);
     expect(enabled.has('async_run_command')).toBe(false);
+    expect(enabled.has('async_mcp_call')).toBe(false);
     expect(enabled.has('task_get')).toBe(false);
     expect(enabled.has('task_list')).toBe(false);
     expect(enabled.has('task_cancel')).toBe(false);
@@ -154,6 +155,7 @@ describe('effective enabled MCP tool projection', () => {
     const enabled = effectiveEnabledMcpToolNames(
       JSON.stringify([
         'async_run_command',
+        'async_mcp_call',
         'task_get',
         'task_list',
         'task_cancel',
@@ -167,6 +169,7 @@ describe('effective enabled MCP tool projection', () => {
     );
 
     expect(enabled.has('async_run_command')).toBe(true);
+    expect(enabled.has('async_mcp_call')).toBe(true);
     expect(enabled.has('task_get')).toBe(true);
     expect(enabled.has('task_list')).toBe(true);
     expect(enabled.has('task_cancel')).toBe(true);

--- a/apps/core/test/unit/runtime/agent-spawn.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn.test.ts
@@ -1721,9 +1721,11 @@ describe('agent-spawn timeout behavior', () => {
     );
     expect(runnerInput.modelCredentialEnv.HTTP_PROXY).toBeUndefined();
     expect(runnerInput.modelCredentialEnv.HTTPS_PROXY).toBeUndefined();
+    expect(startInput.allowedNetworkHosts).toContain(
+      `${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`,
+    );
     expect(mockEnsureEgressGateway).toHaveBeenCalledWith(
       expect.objectContaining({
-        allowedNetworkHosts: [`${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`],
         privateNetworkHostMappings: [
           {
             authority: `${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`,
@@ -1806,11 +1808,6 @@ describe('agent-spawn timeout behavior', () => {
       schema: 'gantry_deepagents_checkpoints',
     });
     expect(runnerInput.deepAgentCheckpointer.proxyUrl).toBeUndefined();
-    expect(mockEnsureEgressGateway).toHaveBeenCalledWith(
-      expect.objectContaining({
-        allowedNetworkHosts: ['db.internal:6543'],
-      }),
-    );
   });
 
   it('projects the audited egress proxy into sandbox-runtime DeepAgents process env', async () => {
@@ -1910,9 +1907,11 @@ describe('agent-spawn timeout behavior', () => {
     expect(runnerInput.modelCredentialEnv.OPENAI_BASE_URL).toBe(
       `http://${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567/openrouter`,
     );
+    expect(startInput.allowedNetworkHosts).toContain(
+      `${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`,
+    );
     expect(mockEnsureEgressGateway).toHaveBeenCalledWith(
       expect.objectContaining({
-        allowedNetworkHosts: [`${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`],
         privateNetworkHostMappings: [
           {
             authority: `${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`,
@@ -2170,9 +2169,12 @@ describe('agent-spawn timeout behavior', () => {
     expect(runnerInput.modelCredentialEnv[anthropicEnvKey('BASE_URL')]).toBe(
       `http://${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567/anthropic`,
     );
+    const startInput = start.mock.calls[0]?.[0] as RunnerSandboxSpawnInput;
+    expect(startInput.allowedNetworkHosts).toContain(
+      `${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`,
+    );
     expect(mockEnsureEgressGateway).toHaveBeenCalledWith(
       expect.objectContaining({
-        allowedNetworkHosts: [`${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`],
         privateNetworkHostMappings: [
           {
             authority: `${SANDBOX_RUNTIME_MODEL_GATEWAY_HOST}:4567`,

--- a/apps/core/test/unit/runtime/egress-gateway.test.ts
+++ b/apps/core/test/unit/runtime/egress-gateway.test.ts
@@ -153,14 +153,13 @@ describe('egress gateway', () => {
     await upstream.close();
   });
 
-  it('blocks undeclared public hosts when a sandbox allowlist is configured', async () => {
+  it('allows undeclared public hosts when the denylist is empty', async () => {
     const upstream = await startRecordingProxy();
     const publishRuntimeEvent = vi.fn();
     const gateway = await ensureEgressGateway({
       key: 'test:sandbox-allowlist',
       settings: { denylist: [] },
       principal: { appId: 'default', agentId: 'agent:test' },
-      allowedNetworkHosts: ['api.linkedin.com:443'],
       upstreamProxy: {
         provider: 'test-proxy',
         url: `http://127.0.0.1:${upstream.port}/`,
@@ -168,38 +167,34 @@ describe('egress gateway', () => {
       publishRuntimeEvent,
     });
 
-    const denied = await connectThroughGateway({
+    const response = await connectThroughGateway({
       gatewayPort: gateway.port,
       authority: 'example.com:443',
     });
-    const allowed = await connectThroughGateway({
-      gatewayPort: gateway.port,
-      authority: 'api.linkedin.com:443',
-    });
 
-    expect(denied.statusCode).toBe(403);
-    expect(allowed.statusCode).toBe(502);
+    expect(response.statusCode).toBe(502);
     expect(upstream.headers[0]).toContain('CONNECT 93.184.216.34:443 HTTP/1.1');
+    expect(upstream.headers[0]).toContain('Host: example.com:443');
     expect(publishRuntimeEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
           host: 'example.com',
-          denied: true,
-          reason: 'not_allowed_by_runtime_sandbox',
+          allowed: true,
+          denied: false,
+          reason: 'default_allow',
         }),
       }),
     );
     await upstream.close();
   });
 
-  it('keeps model provider hosts out of the sandbox tool allowlist', async () => {
+  it('allows Anthropic public hosts when the denylist is empty', async () => {
     const publishRuntimeEvent = vi.fn();
     const upstream = await startRecordingProxy();
     const gateway = await ensureEgressGateway({
       key: 'test:sandbox-model-provider-allowlist',
       settings: { denylist: [] },
       principal: { appId: 'default', agentId: 'agent:test' },
-      allowedNetworkHosts: ['api.linkedin.com:443'],
       upstreamProxy: {
         provider: 'test-proxy',
         url: `http://127.0.0.1:${upstream.port}/`,
@@ -207,19 +202,21 @@ describe('egress gateway', () => {
       publishRuntimeEvent,
     });
 
-    const denied = await connectThroughGateway({
+    const response = await connectThroughGateway({
       gatewayPort: gateway.port,
       authority: 'api.anthropic.com:443',
     });
 
-    expect(denied.statusCode).toBe(403);
-    expect(upstream.headers).toHaveLength(0);
+    expect(response.statusCode).toBe(502);
+    expect(upstream.headers[0]).toContain('CONNECT 93.184.216.34:443 HTTP/1.1');
+    expect(upstream.headers[0]).toContain('Host: api.anthropic.com:443');
     expect(publishRuntimeEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
           host: 'api.anthropic.com',
-          denied: true,
-          reason: 'not_allowed_by_runtime_sandbox',
+          allowed: true,
+          denied: false,
+          reason: 'default_allow',
         }),
       }),
     );
@@ -232,7 +229,6 @@ describe('egress gateway', () => {
       key: 'test:sandbox-ipv6-model-gateway',
       settings: { denylist: [] },
       principal: { appId: 'default', agentId: 'agent:test' },
-      allowedNetworkHosts: ['api.anthropic.com:443'],
       allowedPrivateNetworkHosts: ['[::1]:18999'],
       publishRuntimeEvent,
     });
@@ -263,7 +259,6 @@ describe('egress gateway', () => {
       key: 'test:sandbox-model-gateway-alias',
       settings: { denylist: [] },
       principal: { appId: 'default', agentId: 'agent:test' },
-      allowedNetworkHosts: [authority],
       privateNetworkHostMappings: [{ authority, connectHost: '127.0.0.1' }],
       publishRuntimeEvent,
     });

--- a/apps/core/test/unit/runtime/prompt-profile.test.ts
+++ b/apps/core/test/unit/runtime/prompt-profile.test.ts
@@ -467,7 +467,7 @@ describe('PromptProfileService', () => {
       'mcp_list_tools and used through mcp_call_tool',
     );
     expect(prompt).toContain(
-      'When capability_status shows an MCP source as ready, use it: inspect with mcp_list_tools, fetch one-tool schema with mcp_describe_tool when needed, and call approved actions with mcp_call_tool instead of requesting the same access again',
+      'When capability_status shows an MCP source as ready, use it: inspect with mcp_list_tools, fetch one-tool schema with mcp_describe_tool when needed, call approved immediate actions with mcp_call_tool, and use async_mcp_call for long-running or parallel MCP work instead of requesting the same access again',
     );
     expect(prompt).toContain(
       'instead of requesting the same access again or using command/browser fallback',

--- a/docs/architecture/nonblocking-tool-ux-goal-prompt.md
+++ b/docs/architecture/nonblocking-tool-ux-goal-prompt.md
@@ -1,0 +1,195 @@
+# Non-Blocking Tool UX Goal Prompt
+
+Use this prompt to implement Gantry-owned async task UX for long-running Bash,
+delegated agent, and MCP work without changing the LLM loop into a fake
+concurrent thinker.
+
+```text
+/goal Implement non-blocking tool UX for Gantry using durable async tasks.
+
+Product contract:
+Gantry agents keep short, result-critical tools synchronous, but start
+long-running or parallelizable work as durable Gantry tasks. Starting async work
+returns a Gantry task id immediately. The user sees one coalesced task-status
+surface per task, can continue talking to the main agent, and can inspect or
+cancel work through Gantry task tools after compaction or restart.
+
+Current repo truth:
+- `async_run_command` already starts approved long-running Bash as
+  `agent_async_tasks.kind = async_command`.
+- `delegate_task` already starts durable child agent work as
+  `agent_async_tasks.kind = delegated_agent`, gated by `AgentDelegation`.
+- `task_get`, `task_list`, `task_cancel`, and `task_message` are the shared task
+  control tools.
+- `mcp_call_tool` is currently synchronous: the runner waits for the MCP result.
+- `agent_async_tasks.kind` is plain text in Postgres, so adding a new task kind
+  should not need a migration unless implementation discovers a missing field.
+- Live channel progress is per visible turn; async task heartbeats must not reset
+  the main turn's progress generation.
+
+Locked scope:
+- Add a new Gantry MCP tool named `async_mcp_call`.
+- Keep `mcp_call_tool` synchronous and behavior-compatible.
+- Add `mcp_tool_call` as an `AsyncTaskKind`.
+- Reuse `agent_async_tasks`; do not create a parallel task table.
+- Reuse the existing task control tools; do not add `async_mcp_get`,
+  `async_mcp_cancel`, or `task_update`.
+- Do not add a dashboard, mission-control UI, recursive delegation, or new
+  `settings.yaml` keys.
+- Do not expose provider task ids, MCP client internals, SDK session ids, child
+  pids, lease tokens, fencing versions, raw correlation JSON, or raw provider
+  async tool names.
+- Do not expose DeepAgents raw async tools (`start_async_task`,
+  `check_async_task`, `update_async_task`, `cancel_async_task`,
+  `list_async_tasks`) or Anthropic raw `Agent`/`Task` as public authority.
+
+Agent behavior contract:
+- Use `mcp_call_tool` only when the result is needed before the next answer.
+- Use `async_mcp_call`, `async_run_command`, or `delegate_task` for long-running,
+  parallelizable, or user-visible background work.
+- After starting async work, return control to the user unless useful independent
+  work remains.
+- Do not immediately poll a task in a loop after starting it.
+- Call `task_get` or `task_list` before reporting task status.
+- Use `task_message` only for delegated agent tasks.
+- The LLM loop remains step-based: think -> tool call(s) -> tool result(s) ->
+  think -> response/tool. Multiple async task starts may be emitted in one model
+  step and run concurrently, but synchronous tools still block that model step.
+
+Implementation requirements:
+1. Extend the task domain with `mcp_tool_call`.
+2. Register `async_mcp_call` only when async task support is mounted.
+3. Implement `async_mcp_call` by validating the same app, agent,
+   conversation/thread, reviewed MCP source/action access, run lease, DNS/egress,
+   and audit rules as `mcp_call_tool`.
+4. Create the durable `agent_async_tasks` row before invoking the remote MCP
+   tool.
+5. Execute the MCP call in the background, persist heartbeat/progress, and write
+   a host-enforced terminal receipt.
+6. Keep MCP task public status bounded and sanitized: server/tool name, short
+   argument summary, phase, blocker, heartbeat/elapsed, bounded result/error
+   summary, and receipt lines only.
+7. Make cancellation honest:
+   - If the MCP client path cleanly supports `AbortSignal`, wire it through.
+   - Otherwise, mark the Gantry task cancelled, close the cached client when
+     possible, and ignore late results through fenced terminal transitions.
+   - Never claim a remote side effect stopped unless Gantry actually aborted it.
+8. Add host-owned task-status rendering keyed by task id. Coalesce running
+   updates, flush `needs_attention` and terminal receipts immediately, and do
+   not turn every heartbeat into a chat message.
+9. Ensure async task status rendering does not reset live-turn progress
+   generation or elapsed timers.
+10. Update agent prompt/docs so agents choose sync vs async tools correctly.
+
+Exact UX copy:
+- Async MCP start accepted: `Started: <server>.<tool>`
+- Status loaded: `Task loaded.`
+- List loaded: `Listed <n> async task(s).`
+- Cancel before remote work or abort success: `Task was cancelled. Nothing else changed.`
+- Cancel after MCP may have started: `Task was cancelled in Gantry. Remote MCP work may have already run; late results will be ignored.`
+- Sync MCP still uses existing `mcp_call_tool` result/failure formatting.
+- Provider-private detail requested: `Provider task details are internal. Use the Gantry task id to check status or cancel.`
+- Terminal receipt lines:
+  - `Completed: <short outcome>`
+  - `Used: <tools/capabilities or none>`
+  - `Changed: <files/accounts/channels or none>`
+  - `Delegated: yes/no`
+  - `Needs attention: <blocker or none>`
+
+Acceptance criteria:
+1. `async_mcp_call` starts a durable `mcp_tool_call` task and returns before the
+   MCP tool completes.
+2. `mcp_call_tool` remains synchronous and behavior-compatible.
+3. `task_get`, `task_list`, and `task_cancel` work for `async_command`,
+   `delegated_agent`, and `mcp_tool_call`.
+4. Running MCP task status exposes only bounded, sanitized public fields.
+5. Cancelled MCP tasks cannot be overwritten by late success or failure results.
+6. Async task heartbeats update durable task state and coalesced task status
+   surfaces without chat spam.
+7. Async task heartbeats do not reset live-turn progress generation.
+8. Agents can start multiple async tasks in one model step and inspect each by
+   task id later.
+9. Raw provider async/subagent names stay out of settings, public API, CLI,
+   MCP/admin docs, and user-facing prompts except denylist tests or historical
+   architecture context.
+10. Plain Codex and ACP/ACPX integrations both work; do not assume ACP is
+    present.
+
+Surface Impact Matrix:
+- Runtime behavior: Changed. Adds direct async MCP task execution and
+  host-rendered task status.
+- `settings.yaml`: Unchanged by design. Existing async task mounting and
+  selected capabilities are enough.
+- Postgres/runtime projection: Changed. Reuses `agent_async_tasks` with new
+  `mcp_tool_call` kind; no migration expected.
+- Control API: Read-only/observable. Existing task/event read paths may observe
+  task state; no new write endpoint in this slice.
+- SDK/contracts: Changed. Adds Gantry MCP tool `async_mcp_call` and extends the
+  public task DTO kind.
+- CLI: Read-only/observable. No CLI task manager in this slice.
+- Gantry MCP tools/admin skill: Changed. Tool surface and prompt guidance update.
+- Channel/provider adapters: Changed. Render coalesced task status; provider
+  internals stay hidden.
+- Docs/prompts: Changed. Document sync-vs-async rules, polling rules, and honest
+  cancellation.
+- Audit/events: Changed. Record async MCP start, progress, terminal, cancel, and
+  late-result-ignore evidence.
+- Tests/verification: Changed. Add focused task, MCP, progress, cancellation,
+  prompt, and cleanup-search coverage.
+
+Capability task decomposition:
+1. Public task contract and tool surface
+   - Write scope: async task domain types, Gantry MCP tool registry/schema,
+     agent prompt/docs.
+   - Acceptance: `async_mcp_call` mounted only with async task support; sync
+     `mcp_call_tool` unchanged.
+   - Verify: locked tool surface, MCP server registry, prompt/profile tests.
+
+2. Async MCP lifecycle
+   - Write scope: MCP IPC handler/service path and task repository usage.
+   - Acceptance: row before remote call, same permission/audit checks as sync
+     MCP, terminal receipt persisted.
+   - Verify: `ipc-mcp-tool-handlers` and MCP proxy tests.
+
+3. Cancellation and late-result fencing
+   - Write scope: task service cancellation path and optional MCP abort wiring.
+   - Acceptance: cancellation is honest; late MCP result cannot overwrite a
+     terminal cancelled task.
+   - Verify: unit tests for abort-supported and cancel-and-ignore paths.
+
+4. Task status UX
+   - Write scope: channel-neutral task-status rendering using existing progress
+     or todo-style surfaces.
+   - Acceptance: coalesced task card updates; no heartbeat chat spam; no
+     live-turn progress-generation reset.
+   - Verify: group-processing/channel progress tests.
+
+5. Cleanup, docs, and review
+   - Write scope: docs/prompts/tests only after runtime behavior is green.
+   - Acceptance: cleanup searches classify or remove stale/raw provider public
+     mentions.
+   - Verify: focused searches, architecture check, full gates, autoreview, PR.
+
+Focused verification:
+- `npm run test:unit -- apps/core/test/unit/jobs/ipc-mcp-tool-handlers.test.ts apps/core/test/unit/jobs/ipc-agent-task-lifecycle-handlers.test.ts apps/core/test/unit/jobs/async-command-task-service.test.ts`
+- `npm run test:unit -- apps/core/test/unit/runner/locked-tool-surface.test.ts apps/core/test/unit/runner/mcp/server-registry.test.ts apps/core/test/unit/runtime/group-processing.test.ts`
+- `npm run test:unit -- apps/core/test/unit/application/mcp-tool-proxy.test.ts`
+- `npm run typecheck`
+- `npm run build`
+- `python3 .codex/scripts/check_architecture.py`
+
+Cleanup searches:
+- `rg -n "background: true|background.*mcp_call_tool|async_mcp_get|async_mcp_cancel|task_update" apps/core/src apps/core/test docs -S`
+- `rg -n "start_async_task|check_async_task|update_async_task|cancel_async_task|list_async_tasks|write_todos|LangGraph thread|provider task id|subagent dashboard|mission-control" apps/core/src apps/core/test docs -S`
+- `rg -n "child pid|lease token|fencing version|privateCorrelationJson" apps/core/src/runner apps/core/src/jobs apps/core/src/channels docs -S`
+
+Full closeout:
+- `npm test`
+- `python3 .codex/scripts/verify.py`
+- `python3 .codex/scripts/validate_artifacts.py --allow-missing-run`
+- `python3 .codex/scripts/check_task_completion.py`
+- Run local autoreview.
+- Run ponytail review and remove any complexity that does not protect safety,
+  trust boundaries, or requested behavior.
+- Create a PR after tests and review are clean.
+```

--- a/packages/contracts/src/mcp-servers/index.ts
+++ b/packages/contracts/src/mcp-servers/index.ts
@@ -101,6 +101,13 @@ export type DisableMcpServerRequest = z.infer<
   typeof DisableMcpServerRequestSchema
 >;
 
+export const TestMcpServerRequestSchema = z.object({
+  appId: z.string().optional(),
+  testedBy: z.string().optional(),
+  agentId: z.string().optional(),
+});
+export type TestMcpServerRequest = z.infer<typeof TestMcpServerRequestSchema>;
+
 export const UpdateAgentMcpServerBindingRequestSchema = z.object({
   appId: z.string().optional(),
   required: z.boolean().optional(),

--- a/packages/sdk/src/mcp-servers.ts
+++ b/packages/sdk/src/mcp-servers.ts
@@ -74,7 +74,7 @@ export function createMcpServersClient(transport: TransportLike) {
       }),
     test: (
       serverId: string,
-      input: { appId?: string; testedBy?: string } = {},
+      input: { appId?: string; testedBy?: string; agentId?: string } = {},
     ) =>
       transport.request<Record<string, unknown>>({
         method: 'POST',


### PR DESCRIPTION
## Summary
- add durable `async_mcp_call` flow using existing async task controls
- keep MCP authorization, sandbox/run policy, egress, cancellation, recovery, and bounded-result behavior intact
- add `gantry mcp doctor --agent` diagnostics for source-visible tools blocked by stale capability bindings

## Verification
- `npm run build`
- `npm test`
- `python3 /Users/ravikiranvemula/.codex/skills/autoreview/scripts/autoreview --mode local`
- `python3 .codex/scripts/verify.py` fails on pre-existing architecture ratchets recorded in `.factory/verify.json`