### PR TITLE
fix(settings): base trigger writes on latest revision

### DIFF
--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -10,6 +10,7 @@ import { envFilePath } from '../config/settings/runtime-home.js';
 import {
   capabilityToToolRule,
   ensureConfiguredConversationBinding,
+  loadDesiredRuntimeSettingsForWrite,
   loadRuntimeSettings,
   writeDesiredRuntimeSettings,
 } from '../config/settings/runtime-settings.js';
@@ -548,7 +549,9 @@ async function runTrigger(
     try {
       const providerId = providerFromGroupJid(found.jid);
       if (providerId) {
-        const settings = loadRuntimeSettings(runtimeHome);
+        const settings = await loadDesiredRuntimeSettingsForWrite({
+          runtimeHome,
+        });
         const previousSettings = structuredClone(settings);
         ensureConfiguredConversationBinding(settings, {
           agentId: found.group.folder,

--- a/apps/core/src/config/settings/desired-settings-writer.ts
+++ b/apps/core/src/config/settings/desired-settings-writer.ts
@@ -6,6 +6,7 @@ import {
 } from './runtime-settings.js';
 import {
   importWorkstationSettings,
+  settingsFromRevisionDocument,
   type SettingsRevisionMirror,
 } from './settings-import-service.js';
 import type {
@@ -96,6 +97,31 @@ export async function writeDesiredRuntimeSettings(input: {
       input.settings,
     );
     return { reconciled: true };
+  } finally {
+    await storage.close?.();
+  }
+}
+
+export async function loadDesiredRuntimeSettingsForWrite(input: {
+  runtimeHome: string;
+  appId?: AppId;
+}): Promise<RuntimeSettings> {
+  const fileSettings = loadRuntimeSettings(input.runtimeHome);
+  if (!storageProvider) return fileSettings;
+
+  const storage = await storageProvider({ settings: fileSettings });
+  if (!storage) {
+    throw new Error(
+      'Settings mutation requires runtime storage so settings_revisions can be durably read.',
+    );
+  }
+  try {
+    if (!storage.settingsRevisions) return fileSettings;
+    const appId = input.appId ?? ('default' as AppId);
+    const latest =
+      await storage.settingsRevisions.getLatestSettingsRevision(appId);
+    if (!latest) return fileSettings;
+    return settingsFromRevisionDocument(latest.settingsDocument);
   } finally {
     await storage.close?.();
   }

--- a/apps/core/src/config/settings/runtime-settings.ts
+++ b/apps/core/src/config/settings/runtime-settings.ts
@@ -51,6 +51,7 @@ import { envRuntimeSecretRef } from '../../domain/ports/runtime-secret-provider.
 
 export {
   configureDesiredSettingsStorageProvider,
+  loadDesiredRuntimeSettingsForWrite,
   writeDesiredRuntimeSettings,
 } from './desired-settings-writer.js';
 

--- a/apps/core/test/unit/config/desired-settings-writer.test.ts
+++ b/apps/core/test/unit/config/desired-settings-writer.test.ts
@@ -183,4 +183,51 @@ describe('writeDesiredRuntimeSettings', () => {
       }),
     ).rejects.toThrow('settings revisions unavailable');
   });
+
+  it('loads latest settings revision as the mutation base when storage is available', async () => {
+    const fileSettings = {
+      runtime: { deploymentMode: 'workstation' },
+      stale: true,
+    };
+    const revisionSettings = {
+      runtime: { deploymentMode: 'workstation' },
+      stale: false,
+      latest: true,
+    };
+    const loadRuntimeSettings = vi.fn(() => fileSettings);
+    const settingsFromRevisionDocument = vi.fn(() => revisionSettings);
+    vi.doMock('@core/config/settings/settings-import-service.js', () => ({
+      importWorkstationSettings: vi.fn(),
+      settingsFromRevisionDocument,
+    }));
+    vi.doMock('@core/config/settings/runtime-settings.js', () => ({
+      loadRuntimeSettings,
+    }));
+
+    const {
+      configureDesiredSettingsStorageProvider,
+      loadDesiredRuntimeSettingsForWrite,
+    } = await import('@core/config/settings/desired-settings-writer.js');
+    const close = vi.fn(async () => {});
+    configureDesiredSettingsStorageProvider(async () => ({
+      ops: {} as never,
+      repositories: {} as never,
+      settingsRevisions: {
+        getLatestSettingsRevision: vi.fn(async () => ({
+          revision: 11,
+          settingsDocument: { latest: true },
+        })),
+      } as never,
+      close,
+    }));
+
+    await expect(
+      loadDesiredRuntimeSettingsForWrite({ runtimeHome: '/tmp/gantry-test' }),
+    ).resolves.toBe(revisionSettings);
+    expect(loadRuntimeSettings).toHaveBeenCalledWith('/tmp/gantry-test');
+    expect(settingsFromRevisionDocument).toHaveBeenCalledWith({
+      latest: true,
+    });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Use the latest settings_revisions document as the mutation base for CLI trigger updates when runtime storage is configured. This prevents agent trigger changes from failing with stale-settings protection after ECS restores settings.yaml from the durable revision authority.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
