### PR TITLE
[codex] Fix setup memory embedding provider flow

### DIFF
--- a/apps/core/src/cli/memory-health.ts
+++ b/apps/core/src/cli/memory-health.ts
@@ -72,7 +72,7 @@ function inspectEmbeddings(input: {
       status: 'fail',
       message: `Unknown embedding provider "${input.embeddingProvider}".`,
       nextAction:
-        'Set memory.embeddings.provider to a registered brokered provider, or disable embeddings.',
+        'Set memory.embeddings.provider to openai, or disable embeddings.',
     };
   }
 

--- a/apps/core/src/cli/memory.ts
+++ b/apps/core/src/cli/memory.ts
@@ -25,7 +25,7 @@ function usage(): string {
   return [
     'Usage:',
     '  gantry memory status [--json]',
-    '  gantry memory embeddings <off|disabled|provider>',
+    '  gantry memory embeddings <off|disabled|openai>',
     '  gantry memory embeddings backfill [--limit N] [--mode auto|inline|provider_batch]',
     '  gantry memory dreaming <on|off>',
     '  gantry model memory',
@@ -118,7 +118,7 @@ async function setEmbeddings(
   } else {
     return {
       ok: false,
-      message: `Unknown embedding provider "${provider}". Register the provider before enabling it, or keep embeddings off.`,
+      message: `Unknown embedding provider "${provider}". Use openai, or keep embeddings off.`,
     };
   }
   settings.memory.embeddings.provider = provider;

--- a/apps/core/src/cli/onboarding-config.ts
+++ b/apps/core/src/cli/onboarding-config.ts
@@ -10,6 +10,7 @@ import {
 } from '../config/settings/runtime-home.js';
 import {
   applyModelPreset,
+  loadDesiredRuntimeSettingsForWrite,
   loadRuntimeSettings,
   writeDesiredRuntimeSettings,
 } from '../config/settings/runtime-settings.js';
@@ -79,17 +80,12 @@ export async function persistOnboardingConfig(
     process.env.SECRET_ENCRYPTION_KEY = credentialSecretEncryptionKey;
   }
 
-  const settings = loadRuntimeSettings(input.runtimeHome);
-  const previousSettings = structuredClone(settings);
-  if (input.agentName?.trim()) {
-    settings.agent.name = input.agentName.trim();
-  }
-  settings.storage.postgres.urlEnv = 'GANTRY_DATABASE_URL';
-  settings.storage.postgres.schema = input.postgresSchema?.trim() || 'gantry';
   const model = resolveOnboardingModel(input.modelAlias);
-  // The preset governs the memory/defaults cascade. A non-preset (DeepAgents-
-  // lane) chat model legitimately pairs with any preset, so only fall back to
-  // the model's provider as the preset when it is itself a preset id.
+  // The preset governs chat plus memory LLM defaults. Embeddings are handled
+  // separately and use the registered OpenAI embedding provider when enabled.
+  // A non-preset (DeepAgents-lane) chat model legitimately pairs with any
+  // preset, so only fall back to the model's provider as the preset when it is
+  // itself a preset id.
   const modelPresetId =
     model.preset && isModelPresetId(model.preset) ? model.preset : undefined;
   const preset = input.modelPreset ?? modelPresetId ?? DEFAULT_MODEL_PRESET_ID;
@@ -100,12 +96,26 @@ export async function persistOnboardingConfig(
       `Selected model alias "${model.alias}" belongs to ${modelPresetId}, not ${preset}.`,
     );
   }
+  const postgresSchema = input.postgresSchema?.trim() || 'gantry';
   if (input.postgresDatabaseUrl?.trim()) {
     await runPostgresMigrations({
       url: input.postgresDatabaseUrl.trim(),
-      schema: settings.storage.postgres.schema,
+      schema: postgresSchema,
     });
   }
+  const settingsSeed = loadRuntimeSettings(input.runtimeHome);
+  settingsSeed.storage.postgres.urlEnv = 'GANTRY_DATABASE_URL';
+  settingsSeed.storage.postgres.schema = postgresSchema;
+  const settings = await loadDesiredRuntimeSettingsForWrite({
+    runtimeHome: input.runtimeHome,
+    settings: settingsSeed,
+  });
+  const previousSettings = structuredClone(settings);
+  if (input.agentName?.trim()) {
+    settings.agent.name = input.agentName.trim();
+  }
+  settings.storage.postgres.urlEnv = 'GANTRY_DATABASE_URL';
+  settings.storage.postgres.schema = postgresSchema;
   let previousSettingsForFinalWrite = previousSettings;
   const storesRuntimeSecrets = Boolean(
     input.telegramBotToken?.trim() ||

--- a/apps/core/src/cli/setup-credentials.ts
+++ b/apps/core/src/cli/setup-credentials.ts
@@ -5,7 +5,9 @@ import type { HostCredentialMode } from '../config/credentials/mode.js';
 import {
   DEFAULT_MODEL_PRESET_ID,
   getModelPreset,
+  resolveModelSelectionForWorkload,
   type ModelPresetId,
+  type ModelWorkload,
 } from '../shared/model-catalog.js';
 import { getModelProviderDefinition } from '../shared/model-provider-registry.js';
 import {
@@ -209,6 +211,77 @@ export function requiredModelCredentialProvidersForSetupDraft(
       },
     },
   });
+}
+
+export interface RequiredModelCredentialProviderReason {
+  providerId: string;
+  reasons: string[];
+}
+
+export function requiredModelCredentialProviderReasonsForSetupDraft(
+  draft: CredentialSetupDraft,
+): RequiredModelCredentialProviderReason[] {
+  const preset = getModelPreset(draft.modelPreset ?? DEFAULT_MODEL_PRESET_ID);
+  const chatModel = draft.selectedModel || preset.chatDefault;
+  const memoryEnabled = draft.memoryEnabled ?? true;
+  const embeddingsEnabled = memoryEnabled && (draft.embeddingsEnabled ?? false);
+  const reasons = new Map<string, Set<string>>();
+  const addReason = (providerId: string, reason: string) => {
+    const set = reasons.get(providerId) ?? new Set<string>();
+    set.add(reason);
+    reasons.set(providerId, set);
+  };
+  const addModelReason = (
+    alias: string,
+    workload: ModelWorkload,
+    reason: string,
+  ) => {
+    const resolved = resolveModelSelectionForWorkload(alias, workload);
+    if (resolved.ok) addReason(resolved.entry.modelRoute.id, reason);
+  };
+
+  addModelReason(chatModel, 'chat', `main model ${chatModel}`);
+  addModelReason(
+    preset.oneTimeJobDefault || chatModel,
+    'one_time_job',
+    preset.oneTimeJobDefault
+      ? `one-time job model ${preset.oneTimeJobDefault}`
+      : 'one-time jobs inherit main model',
+  );
+  addModelReason(
+    preset.recurringJobDefault || chatModel,
+    'recurring_job',
+    preset.recurringJobDefault
+      ? `recurring job model ${preset.recurringJobDefault}`
+      : 'recurring jobs inherit main model',
+  );
+  if (memoryEnabled) {
+    addModelReason(
+      preset.memoryDefaults.extractor,
+      'memory_extractor',
+      `memory LLM extractor ${preset.memoryDefaults.extractor}`,
+    );
+    addModelReason(
+      preset.memoryDefaults.dreaming,
+      'memory_dreaming',
+      `memory LLM dreaming ${preset.memoryDefaults.dreaming}`,
+    );
+    addModelReason(
+      preset.memoryDefaults.consolidation,
+      'memory_consolidation',
+      `memory LLM consolidation ${preset.memoryDefaults.consolidation}`,
+    );
+    if (embeddingsEnabled) {
+      addReason('openai', 'memory embeddings');
+    }
+  }
+
+  return requiredModelCredentialProvidersForSetupDraft(draft).map(
+    (providerId) => ({
+      providerId,
+      reasons: [...(reasons.get(providerId) ?? [])].sort(),
+    }),
+  );
 }
 
 function formatProviderIds(providerIds: readonly string[]): string {

--- a/apps/core/src/cli/setup-flow-core-steps.ts
+++ b/apps/core/src/cli/setup-flow-core-steps.ts
@@ -285,12 +285,12 @@ export async function runModelStep(draft: SetupDraft): Promise<FlowAction> {
   draft.agentName = String(agentName).trim();
 
   const preset = await p.select({
-    message: 'Choose memory/defaults preset',
+    message: 'Choose chat and memory LLM defaults preset',
     options: [
       ...listModelPresets().map((preset) => ({
         value: preset.id,
         label: preset.label,
-        hint: `Chat default ${preset.chatDefault}; memory defaults use ${formatMemoryDefaultAliases(preset.memoryDefaults)}.`,
+        hint: `Chat default ${preset.chatDefault}; memory LLM defaults use ${formatMemoryDefaultAliases(preset.memoryDefaults)}.`,
       })),
       {
         value: 'back',
@@ -363,7 +363,7 @@ export async function runModelStep(draft: SetupDraft): Promise<FlowAction> {
     const providerId = resolvedModel.entry.modelRoute.id;
     if (providerId !== draft.modelPreset) {
       p.note(
-        `${resolvedModel.entry.displayName} runs on the ${resolvedModel.entry.modelRoute.label} provider — configure its credential in the credentials step. Memory will use the ${selectedPreset.label} preset.`,
+        `${resolvedModel.entry.displayName} runs on the ${resolvedModel.entry.modelRoute.label} provider — configure its credential in the credentials step. Memory LLM defaults will use the ${selectedPreset.label} preset. Memory embeddings use OpenAI when enabled.`,
       );
     }
   }

--- a/apps/core/src/cli/setup-flow-final-steps.ts
+++ b/apps/core/src/cli/setup-flow-final-steps.ts
@@ -23,6 +23,7 @@ import { type FlowAction } from './setup-flow-control.js';
 import { chooseProgressAction } from './setup-flow-prompts.js';
 import type { SetupDraft } from './setup-flow-state.js';
 import {
+  requiredModelCredentialProviderReasonsForSetupDraft,
   requiredModelCredentialProvidersForSetupDraft,
   verifyModelAccess,
 } from './setup-credentials.js';
@@ -57,6 +58,7 @@ export async function runConfigStep(draft: SetupDraft): Promise<FlowAction> {
       `Main model: ${draft.selectedModel}`,
       `Agent harness: ${draft.agentHarness} (${resolvedHarnessLabel(draft.selectedModel)})`,
       `Required model providers: ${formatProviderIds(requiredModelCredentialProvidersForSetupDraft(draft))}`,
+      ...formatRequiredProviderReasons(draft),
       ...(draft.primaryProvider === 'slack'
         ? [`Slack approvers: ${draft.slackPermissionApproverIds}`]
         : [`Telegram approvers: ${draft.telegramPermissionApproverIds}`]),
@@ -275,6 +277,13 @@ export async function runVerifyStep(
 
 function formatProviderIds(providerIds: readonly string[]): string {
   return providerIds.length > 0 ? providerIds.join(', ') : 'none';
+}
+
+function formatRequiredProviderReasons(draft: SetupDraft): string[] {
+  return requiredModelCredentialProviderReasonsForSetupDraft(draft).map(
+    ({ providerId, reasons }) =>
+      `  ${providerId}: ${reasons.length ? reasons.join('; ') : 'selected defaults'}`,
+  );
 }
 
 function resolvedHarnessLabel(alias: string): string {

--- a/apps/core/src/cli/setup-ready.ts
+++ b/apps/core/src/cli/setup-ready.ts
@@ -6,7 +6,10 @@ import {
   resolveModelSelectionForWorkload,
   type ModelPresetId,
 } from '../shared/model-catalog.js';
-import { requiredModelCredentialProvidersForSetupDraft } from './setup-credentials.js';
+import {
+  requiredModelCredentialProviderReasonsForSetupDraft,
+  requiredModelCredentialProvidersForSetupDraft,
+} from './setup-credentials.js';
 
 export interface SetupReadyDraft {
   workspaceKey: string;
@@ -36,6 +39,7 @@ export async function runReadyStep(
       `Model: ${draft.selectedModel}`,
       `Resolved model/harness: ${draft.selectedModel} / ${resolvedHarnessLabel(draft.selectedModel)}`,
       `Required model providers: ${formatProviderIds(requiredModelProviders(draft))}`,
+      ...formatRequiredProviderReasons(draft),
       '',
       'Next: Start chatting or run gantry status.',
       'Optional setup: memory, background service, extra providers.',
@@ -84,4 +88,18 @@ function requiredModelProviders(draft: SetupReadyDraft): string[] {
     embeddingsEnabled: draft.embeddingsEnabled,
     dreamingEnabled: draft.dreamingEnabled,
   });
+}
+
+function formatRequiredProviderReasons(draft: SetupReadyDraft): string[] {
+  return requiredModelCredentialProviderReasonsForSetupDraft({
+    credentialMode: 'gantry',
+    modelPreset: draft.modelPreset,
+    selectedModel: draft.selectedModel,
+    memoryEnabled: draft.memoryEnabled,
+    embeddingsEnabled: draft.embeddingsEnabled,
+    dreamingEnabled: draft.dreamingEnabled,
+  }).map(
+    ({ providerId, reasons }) =>
+      `  ${providerId}: ${reasons.length ? reasons.join('; ') : 'selected defaults'}`,
+  );
 }

--- a/apps/core/src/config/settings/desired-settings-writer.ts
+++ b/apps/core/src/config/settings/desired-settings-writer.ts
@@ -105,8 +105,9 @@ export async function writeDesiredRuntimeSettings(input: {
 export async function loadDesiredRuntimeSettingsForWrite(input: {
   runtimeHome: string;
   appId?: AppId;
+  settings?: RuntimeSettings;
 }): Promise<RuntimeSettings> {
-  const fileSettings = loadRuntimeSettings(input.runtimeHome);
+  const fileSettings = input.settings ?? loadRuntimeSettings(input.runtimeHome);
   if (!storageProvider) return fileSettings;
 
   const storage = await storageProvider({ settings: fileSettings });

--- a/apps/core/src/config/settings/runtime-settings-memory-parser.ts
+++ b/apps/core/src/config/settings/runtime-settings-memory-parser.ts
@@ -28,6 +28,7 @@ import type {
   RuntimeMemoryLlmModels,
   RuntimeMemorySettings,
 } from './runtime-settings-types.js';
+import { listEmbeddingModelProviders } from '../../shared/model-provider-registry.js';
 
 const BACKFILL_MODES: ReadonlySet<MemoryBackfillMode> = new Set([
   'auto',
@@ -142,6 +143,15 @@ function parseEmbeddingProvider(
   if (!/^[a-z][a-z0-9_-]{0,62}$/.test(value)) {
     throw new Error(
       `${pathPrefix} must be a lowercase provider id such as disabled or openai`,
+    );
+  }
+  const supported = new Set([
+    'disabled',
+    ...listEmbeddingModelProviders().map((provider) => provider.id),
+  ]);
+  if (!supported.has(value)) {
+    throw new Error(
+      `${pathPrefix} must be one of ${[...supported].sort().join(', ')}.`,
     );
   }
   return value;

--- a/apps/core/src/memory/memory-embeddings.ts
+++ b/apps/core/src/memory/memory-embeddings.ts
@@ -482,7 +482,7 @@ export class DisabledEmbeddingClient implements EmbeddingProvider {
   }
 }
 
-export function registerEmbeddingProvider(
+function registerEmbeddingProvider(
   name: string,
   factory: (options?: EmbeddingProviderOptions) => EmbeddingProvider,
 ): void {
@@ -491,10 +491,6 @@ export function registerEmbeddingProvider(
 
 export function isEmbeddingProviderRegistered(name: string): boolean {
   return embeddingProviderFactories.has(name);
-}
-
-export function listEmbeddingProviderNames(): string[] {
-  return [...embeddingProviderFactories.keys()].sort();
 }
 
 export function createEmbeddingProvider(

--- a/apps/core/test/unit/cli/memory-command.test.ts
+++ b/apps/core/test/unit/cli/memory-command.test.ts
@@ -8,7 +8,6 @@ import {
   loadRuntimeSettings,
   saveRuntimeSettings,
 } from '@core/config/settings/runtime-settings.js';
-import type { EmbeddingProvider } from '@core/memory/memory-embeddings.js';
 
 const runtimeHomes: string[] = [];
 
@@ -59,35 +58,25 @@ describe('memory command', () => {
     expect(settings.memory.embeddings.provider).toBe('disabled');
   });
 
-  it('enables registered providers that validate successfully', async () => {
+  it('enables OpenAI embeddings when the provider validates successfully', async () => {
     const runtimeHome = makeRuntimeHome();
-    const providerName = `ready-provider-${Date.now()}`;
-    const { registerEmbeddingProvider } =
-      await import('@core/memory/memory-embeddings.js');
-    registerEmbeddingProvider(
-      providerName,
-      () =>
-        ({
-          isEnabled: () => true,
-          validateConfiguration: () => undefined,
-          embedMany: async (texts: string[]) => texts.map(() => [0.1, 0.2]),
-          embedOne: async () => [0.1, 0.2],
-        }) satisfies EmbeddingProvider,
-    );
+    vi.doMock('@core/memory/memory-embeddings.js', () => ({
+      isEmbeddingProviderRegistered: vi.fn(
+        (provider: string) => provider === 'openai',
+      ),
+      validateEmbeddingProviderReady: vi.fn(async () => undefined),
+    }));
     saveRuntimeSettings(runtimeHome, loadRuntimeSettings(runtimeHome));
     const { runMemoryCommand, log } = await loadMemoryCommand();
 
-    const code = await runMemoryCommand(runtimeHome, [
-      'embeddings',
-      providerName,
-    ]);
+    const code = await runMemoryCommand(runtimeHome, ['embeddings', 'openai']);
 
     expect(code).toBe(0);
     expect(log.success).toHaveBeenCalledWith(
-      `Memory embeddings set to ${providerName} in settings.yaml.`,
+      'Memory embeddings set to openai in settings.yaml.',
     );
     const settings = loadRuntimeSettings(runtimeHome);
     expect(settings.memory.embeddings.enabled).toBe(true);
-    expect(settings.memory.embeddings.provider).toBe(providerName);
+    expect(settings.memory.embeddings.provider).toBe('openai');
   });
 });

--- a/apps/core/test/unit/cli/memory-health.test.ts
+++ b/apps/core/test/unit/cli/memory-health.test.ts
@@ -6,39 +6,12 @@ import { describe, expect, it } from 'vitest';
 
 import { inspectMemoryHealth } from '@core/cli/memory-health.js';
 import { createDefaultRuntimeSettings } from '@core/config/settings/runtime-settings.js';
-import {
-  type EmbeddingProvider,
-  registerEmbeddingProvider,
-} from '@core/memory/memory-embeddings.js';
 
 function runtimeHome(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'gantry-memory-health-'));
 }
 
 describe('memory health', () => {
-  it('uses the embedding provider registry for custom providers', () => {
-    const providerName = `custom-provider-${Date.now()}`;
-    registerEmbeddingProvider(
-      providerName,
-      () =>
-        ({
-          isEnabled: () => true,
-          validateConfiguration: () => undefined,
-          embedMany: async (texts: string[]) => texts.map(() => [0.1, 0.2]),
-          embedOne: async () => [0.1, 0.2],
-        }) satisfies EmbeddingProvider,
-    );
-    const settings = createDefaultRuntimeSettings();
-    settings.memory.embeddings.enabled = true;
-    settings.memory.embeddings.provider = providerName;
-    settings.memory.embeddings.model = 'custom-embedding-model';
-
-    const health = inspectMemoryHealth(runtimeHome(), settings, {});
-
-    expect(health.embeddingCheck.status).toBe('pass');
-    expect(health.embeddingCheck.message).toContain(providerName);
-  });
-
   it('fails unknown embedding providers before runtime use', () => {
     const settings = createDefaultRuntimeSettings();
     settings.memory.embeddings.enabled = true;

--- a/apps/core/test/unit/cli/onboarding-config.test.ts
+++ b/apps/core/test/unit/cli/onboarding-config.test.ts
@@ -10,6 +10,7 @@ const settingsWrites: Array<{
   telegramBotRef?: string;
   agentHarness: string;
 }> = [];
+const desiredSettings = createDefaultRuntimeSettings();
 
 vi.mock('@core/config/env/file.js', () => ({
   readEnvFile: vi.fn(() => ({})),
@@ -43,6 +44,16 @@ vi.mock('@core/config/settings/runtime-settings.js', async (importOriginal) => {
   return {
     ...actual,
     loadRuntimeSettings: vi.fn(() => createDefaultRuntimeSettings()),
+    loadDesiredRuntimeSettingsForWrite: vi.fn(
+      (input: {
+        settings?: ReturnType<typeof createDefaultRuntimeSettings>;
+      }) => {
+        events.push(
+          `loadDesired:${input.settings?.storage.postgres.schema ?? 'none'}`,
+        );
+        return structuredClone(desiredSettings);
+      },
+    ),
     writeDesiredRuntimeSettings: vi.fn(
       async (input: {
         settings: ReturnType<typeof createDefaultRuntimeSettings>;
@@ -68,6 +79,7 @@ describe('persistOnboardingConfig', () => {
   beforeEach(() => {
     events.length = 0;
     settingsWrites.length = 0;
+    Object.assign(desiredSettings, createDefaultRuntimeSettings());
   });
 
   it('persists the selected storage schema before writing repository runtime secrets', async () => {
@@ -90,6 +102,7 @@ describe('persistOnboardingConfig', () => {
 
     expect(events).toEqual([
       'migrate:custom_schema',
+      'loadDesired:custom_schema',
       'write:custom_schema',
       'secret:TELEGRAM_BOT_TOKEN',
       'write:custom_schema',
@@ -126,5 +139,31 @@ describe('persistOnboardingConfig', () => {
 
     expect(events).toEqual([]);
     expect(settingsWrites).toEqual([]);
+  });
+
+  it('starts from latest desired state before onboarding writes', async () => {
+    desiredSettings.agent.name = 'Latest Desired Agent';
+    desiredSettings.storage.postgres.schema = 'latest_schema';
+    const { persistOnboardingConfig } =
+      await import('@core/cli/onboarding-config.js');
+
+    await persistOnboardingConfig({
+      runtimeHome: '/tmp/gantry',
+      postgresDatabaseUrl:
+        'postgres://user:pass@127.0.0.1:5432/gantry?schema=custom_schema',
+      postgresSchema: 'custom_schema',
+      primaryProvider: 'telegram',
+      agentHarness: 'auto',
+      credentialMode: 'gantry',
+      memoryEnabled: true,
+      embeddingsEnabled: true,
+      dreamingEnabled: true,
+    });
+
+    expect(settingsWrites.at(-1)).toMatchObject({
+      schema: 'custom_schema',
+      previousSchema: 'latest_schema',
+      agentHarness: 'auto',
+    });
   });
 });

--- a/apps/core/test/unit/cli/setup-credentials.test.ts
+++ b/apps/core/test/unit/cli/setup-credentials.test.ts
@@ -165,6 +165,34 @@ describe('setup credentials step', () => {
     );
   });
 
+  it('explains OpenAI separately when only embeddings require it', async () => {
+    const { requiredModelCredentialProviderReasonsForSetupDraft } =
+      await import('@core/cli/setup-credentials.js');
+
+    expect(
+      requiredModelCredentialProviderReasonsForSetupDraft({
+        credentialMode: 'gantry',
+        modelPreset: 'anthropic',
+        selectedModel: 'opus',
+        memoryEnabled: true,
+        embeddingsEnabled: true,
+        dreamingEnabled: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        providerId: 'anthropic',
+        reasons: expect.arrayContaining([
+          'main model opus',
+          'memory LLM extractor haiku',
+        ]),
+      }),
+      {
+        providerId: 'openai',
+        reasons: ['memory embeddings'],
+      },
+    ]);
+  });
+
   it('lets the user go back instead of deferring required credentials', async () => {
     const { runCredentialsStep, password, select, upsertModelCredential } =
       await loadCredentialsStep({

--- a/apps/core/test/unit/cli/setup-flow-model-step.test.ts
+++ b/apps/core/test/unit/cli/setup-flow-model-step.test.ts
@@ -64,7 +64,7 @@ describe('setup model step', () => {
     await runModelStep(makeDraft());
 
     expect(select.mock.calls[0]?.[0]?.message).toBe(
-      'Choose memory/defaults preset',
+      'Choose chat and memory LLM defaults preset',
     );
     expect(select.mock.calls[1]?.[0]?.message).toBe(
       'Choose main model/provider',
@@ -116,7 +116,9 @@ describe('setup model step', () => {
     expect(draft.modelPreset).toBe('anthropic');
     expect(draft.selectedModel).toBe('kimi');
     expect(note).toHaveBeenCalledWith(
-      expect.stringContaining('Memory will use the Anthropic preset.'),
+      expect.stringContaining(
+        'Memory LLM defaults will use the Anthropic preset.',
+      ),
     );
   });
 
@@ -135,7 +137,7 @@ describe('setup model step', () => {
     expect(action).toEqual({ type: 'next' });
     expect(draft.selectedModel).toBe('gpt');
     expect(draft.agentHarness).toBe(AUTO_AGENT_HARNESS);
-    // Non-preset chat model does NOT change the memory/defaults preset.
+    // Non-preset chat model does NOT change the memory LLM/defaults preset.
     expect(draft.modelPreset).toBe('anthropic');
     // The model list now spans providers beyond the selected preset.
     const options = select.mock.calls[1]?.[0]?.options ?? [];

--- a/apps/core/test/unit/cli/setup-flow-simplified.test.ts
+++ b/apps/core/test/unit/cli/setup-flow-simplified.test.ts
@@ -263,6 +263,7 @@ describe('ready screen copy', () => {
         'Model: sonnet',
         'Resolved model/harness: sonnet / Anthropic SDK',
         'Required model providers: anthropic',
+        '  anthropic: main model sonnet; memory LLM consolidation sonnet; memory LLM dreaming sonnet; memory LLM extractor haiku; one-time jobs inherit main model; recurring jobs inherit main model',
         '',
         'Next: Start chatting or run gantry status.',
         'Optional setup: memory, background service, extra providers.',
@@ -311,6 +312,9 @@ async function loadVerifyStep(input: {
     listConnectableChannelProviders: vi.fn(() => [{ id: 'telegram' }]),
   }));
   vi.doMock('@core/cli/setup-credentials.js', () => ({
+    requiredModelCredentialProviderReasonsForSetupDraft: vi.fn(() => [
+      { providerId: 'anthropic', reasons: ['main model opus'] },
+    ]),
     requiredModelCredentialProvidersForSetupDraft: vi.fn(() => ['anthropic']),
     verifyModelAccess: vi.fn(
       async () => input.modelAccess ?? { ok: true, message: 'ok' },

--- a/apps/core/test/unit/config/runtime-settings.test.ts
+++ b/apps/core/test/unit/config/runtime-settings.test.ts
@@ -803,6 +803,18 @@ agents:
     );
   });
 
+  it('rejects non-embedding providers for memory embeddings', () => {
+    expect(() =>
+      parseRuntimeSettings(`memory:
+  enabled: true
+  embeddings:
+    enabled: true
+    provider: anthropic
+    model: text-embedding-3-small
+`),
+    ).toThrow('memory.embeddings.provider must be one of disabled, openai.');
+  });
+
   it('keeps explicit verbose provider connections over compact defaults', () => {
     const parsed = parseRuntimeSettings(`providers:
   telegram:

--- a/apps/core/test/unit/memory/memory-embeddings.test.ts
+++ b/apps/core/test/unit/memory/memory-embeddings.test.ts
@@ -5,9 +5,7 @@ import { MEMORY_EMBED_BATCH_SIZE } from '@core/config/index.js';
 import {
   createEmbeddingProvider,
   DisabledEmbeddingClient,
-  EmbeddingProvider,
   OpenAIEmbeddingClient,
-  registerEmbeddingProvider,
 } from '@core/memory/memory-embeddings.js';
 
 describe('memory embedding providers', () => {
@@ -20,44 +18,6 @@ describe('memory embedding providers', () => {
     expect(() => createEmbeddingProvider('does-not-exist')).toThrow(
       /Unknown memory embedding provider/,
     );
-  });
-
-  it('supports registering additional providers', async () => {
-    const providerName = `test-provider-${Date.now()}`;
-    registerEmbeddingProvider(
-      providerName,
-      () =>
-        ({
-          isEnabled: () => true,
-          validateConfiguration: () => undefined,
-          embedMany: async (texts: string[]) =>
-            texts.map(() => [0.1, 0.2, 0.3, 0.4]),
-          embedOne: async () => [0.1, 0.2, 0.3, 0.4],
-        }) satisfies EmbeddingProvider,
-    );
-
-    const provider = createEmbeddingProvider(providerName);
-    expect(await provider.embedOne('hello')).toEqual([0.1, 0.2, 0.3, 0.4]);
-  });
-
-  it('passes model overrides through provider factory creation', async () => {
-    const providerName = `test-model-override-${Date.now()}`;
-    const seen: Array<{ model?: string }> = [];
-    registerEmbeddingProvider(providerName, (options) => {
-      seen.push({ model: options?.model });
-      return {
-        isEnabled: () => true,
-        validateConfiguration: () => undefined,
-        embedMany: async () => [[0.1, 0.2, 0.3]],
-        embedOne: async () => [0.1, 0.2, 0.3],
-      } satisfies EmbeddingProvider;
-    });
-
-    const provider = createEmbeddingProvider(providerName, {
-      model: 'text-embedding-dream-test',
-    });
-    await provider.embedOne('hello');
-    expect(seen).toEqual([{ model: 'text-embedding-dream-test' }]);
   });
 
   it('does not synthesize zero vectors when disabled', async () => {

--- a/apps/core/test/unit/models/model-catalog.test.ts
+++ b/apps/core/test/unit/models/model-catalog.test.ts
@@ -219,7 +219,7 @@ describe('model catalog resolution', () => {
     });
   });
 
-  it('uses catalog aliases for setup and memory defaults', () => {
+  it('uses catalog aliases for setup and memory LLM defaults', () => {
     expect(DEFAULT_SETUP_MODEL_ALIAS).toBe('opus');
     expect(MEMORY_MODEL_DEFAULT_ALIASES).toEqual({
       extractor: 'haiku',

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -116,11 +116,17 @@ active-item overlap proposals, and keeps every LLM output as untrusted JSON.
 Host validation is the only durable mutation path.
 
 Memory LLM tasks use provider-neutral catalog aliases from `settings.yaml`.
-Setup and `gantry model use-preset` apply preset-managed memory defaults:
+Setup and `gantry model use-preset` apply preset-managed memory LLM defaults:
 
-- Anthropic memory defaults: extractor `haiku`, dreaming `sonnet`,
+- Anthropic memory LLM defaults: extractor `haiku`, dreaming `sonnet`,
   consolidation `sonnet`.
-- OpenRouter memory defaults: extractor, dreaming, and consolidation all `kimi`.
+- OpenRouter memory LLM defaults: extractor, dreaming, and consolidation all
+  `kimi`.
+
+Memory embeddings are configured separately under `memory.embeddings.*`. The
+current embedding provider choices are `disabled` and `openai`; Anthropic,
+OpenRouter, and other chat/model-response providers are not embedding providers
+unless they are explicitly registered as such.
 
 Operators inspect memory model aliases with `gantry model memory` and reapply
 preset-managed defaults with `gantry model reset memory` or

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -352,13 +352,14 @@ Job model precedence is:
 3. `agent.default_model`
 4. system default `opus`
 
-Memory model aliases live under `memory.llm.models` and are preset-managed.
-Provider presets set chat and memory defaults together: `anthropic` uses chat
-`opus`, job defaults inherit chat, and memory uses
+Memory LLM aliases live under `memory.llm.models` and are preset-managed.
+Provider presets set chat and memory LLM defaults together: `anthropic` uses
+chat `opus`, job defaults inherit chat, and memory LLM tasks use
 `haiku`/`sonnet`/`sonnet`; `openrouter` uses chat `kimi`, job defaults inherit
-chat, and memory uses `kimi` for extraction, dreaming, and consolidation. The
-OpenRouter catalog also includes selectable `glm-5.2` without changing preset
-defaults.
+chat, and memory LLM tasks use `kimi` for extraction, dreaming, and
+consolidation. Memory embeddings are separate from these LLM defaults; today
+they support only `openai` or `disabled`. The OpenRouter catalog also includes
+selectable `glm-5.2` without changing preset defaults.
 
 Use `/model` in a group session to switch the live model (`/model`, `/model <alias>`, `/model default`). Use `/models` to list supported aliases and `/status` to inspect the current model, context window usage percentage, cache hit percentage, token usage, cache read/write tokens, cache state, top context contributors when available, and cost when the provider reports it.
 
@@ -594,7 +595,7 @@ continuation state.
 | `model_access.gateway.bind_host`      | `127.0.0.1`              | Loopback bind host for Gantry Model Gateway                     |
 | `memory.enabled`                      | `true`                   | Enables durable memory                                          |
 | `memory.embeddings.enabled`           | `false`                  | Optional embedding toggle                                       |
-| `memory.embeddings.provider`          | `disabled`               | Embedding provider (`disabled` or `openai`)                     |
+| `memory.embeddings.provider`          | `disabled`               | Embedding provider (`disabled` or `openai`; OpenAI only today)  |
 | `memory.embeddings.model`             | `text-embedding-3-small` | Embedding model                                                 |
 | `memory.embeddings.batch_size`        | `16`                     | Texts per embedding API call                                    |
 | `memory.embeddings.daily_limit`       | `500`                    | Daily embedding API call limit                                  |

--- a/docs/decisions/2026-05-01-model-catalog-and-cache-accounting.md
+++ b/docs/decisions/2026-05-01-model-catalog-and-cache-accounting.md
@@ -93,18 +93,23 @@ Job model precedence is:
 3. agent interactive default
 4. system default `opus`
 
-Memory model precedence is runtime-owned and settings-backed:
+Memory LLM model precedence is runtime-owned and settings-backed:
 
 1. memory task default in `memory.llm.models`
 2. preset-managed defaults for the current model route
-3. system memory defaults
+3. system memory LLM defaults
 
 Model presets are:
 
 - `anthropic`: chat `opus`; one-time and recurring jobs inherit chat; memory
-  defaults use extractor `haiku`, dreaming `sonnet`, consolidation `sonnet`.
-- `openrouter`: chat uses `kimi`; jobs inherit chat; extractor, dreaming, and
-  consolidation use `kimi`.
+  LLM defaults use extractor `haiku`, dreaming `sonnet`, consolidation
+  `sonnet`.
+- `openrouter`: chat uses `kimi`; jobs inherit chat; memory LLM extractor,
+  dreaming, and consolidation use `kimi`.
+
+Memory embeddings are not selected by the model preset. They are controlled by
+`memory.embeddings.*`; current supported embedding providers are `disabled` and
+`openai`.
 
 `gantry setup`, `gantry model use-preset`, `gantry model set chat`,
 `gantry model set jobs`, `gantry model reset`, and `PATCH /v1/models/defaults`

--- a/docs/decisions/2026-06-12-agent-engine-selection.md
+++ b/docs/decisions/2026-06-12-agent-engine-selection.md
@@ -49,7 +49,7 @@ provider -> engine); the engine follows the resolved model's provider:
   the `PATCH /v1/agents/:id` `agentEngine` write, and the `AGENT_ENGINE_CHANGED`
   audit event. `memory.engine` and the `MEMORY_ENGINE_CHANGED` audit are retired
   too (the `memory.engine` key is now rejected at settings validation); the memory
-  transport lane derives purely from the memory model's response family
+  LLM transport lane derives purely from the memory LLM model's response family
   (`memoryTransportLaneForResponseFamily`): anthropic -> Claude SDK memory client;
   openai/openrouter -> OpenAI-compatible chat-completions memory client. The
   now-dead Claude-on-DeepAgents memory client (`anthropic-memory-direct`) and the

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -678,7 +678,7 @@ API job creation rejects raw provider model IDs unless they are registered
 catalog aliases.
 
 Use `client.models.defaults.get()` to inspect configured and effective chat,
-job, and memory defaults. Use `client.models.defaults.update()` or
+job, and memory LLM defaults. Use `client.models.defaults.update()` or
 `PATCH /v1/models/defaults` to select a model preset, set chat/job
 aliases, or reset an area back to inheritance/preset-managed defaults:
 


### PR DESCRIPTION
## Summary
- make setup distinguish memory LLM defaults from OpenAI-only memory embeddings
- restrict memory embeddings config/runtime to registered embedding-capable providers, currently OpenAI
- fix resumed setup config writes by reading latest desired state after migrations and against the selected Postgres schema
- update CLI review/ready output, tests, and docs for the memory embedding provider flow

## Root Cause
Setup treated memory embeddings as part of the regular model/preset lane, so provider requirements could look like Anthropic/OpenAI response-family selection instead of a separate OpenAI embedding dependency. The resumed setup save path also read desired state through stale settings/schema state.

## Validation
- npm run test:unit -- apps/core/test/unit/cli/setup-flow-simplified.test.ts apps/core/test/unit/cli/setup-flow-model-step.test.ts apps/core/test/unit/cli/setup-credentials.test.ts apps/core/test/unit/cli/onboarding-config.test.ts apps/core/test/unit/cli/memory-command.test.ts apps/core/test/unit/cli/memory-health.test.ts apps/core/test/unit/config/runtime-settings.test.ts apps/core/test/unit/models/model-catalog.test.ts apps/core/test/unit/memory/memory-embeddings.test.ts
- npm run typecheck
- npm run format:check
- git diff --check
- npx eslint <changed src/test files> (0 errors, existing warnings only)
- python3 .codex/scripts/check_task_completion.py
- python3 /Users/ravikiranvemula/.codex/skills/autoreview/scripts/autoreview --mode local
