### PR TITLE
[codex] Fix memory dreaming and Slack admission

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/agent-capabilities.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/agent-capabilities.ts
@@ -125,15 +125,21 @@ function gantryMcpAllowedTools(input: {
   configuredTools?: readonly string[];
   hideAuthorityTools?: boolean;
   asyncTaskToolsEnabled?: boolean;
+  memoryReviewerIsControlApprover?: boolean;
 }): string[] {
   const selectedNames = new Set(
     selectedGantryMcpToolNames(input.configuredTools ?? [], {
       excludeAuthorityTools: input.hideAuthorityTools === true,
       asyncTaskToolsEnabled: input.asyncTaskToolsEnabled === true,
+      memoryReviewerIsControlApprover:
+        input.memoryReviewerIsControlApprover === true,
     }),
   );
   const defaultAllowedNames = [
     ...BASELINE_GANTRY_MCP_TOOL_NAMES,
+    ...(input.memoryReviewerIsControlApprover === true
+      ? ['memory_review_pending', 'memory_review_decision']
+      : []),
     ...(input.asyncTaskToolsEnabled === true
       ? ASYNC_TASK_GANTRY_MCP_TOOL_NAMES
       : []),
@@ -151,6 +157,7 @@ function defaultAllowedTools(input: {
   configuredTools?: readonly string[];
   hideAuthorityTools?: boolean;
   asyncTaskToolsEnabled?: boolean;
+  memoryReviewerIsControlApprover?: boolean;
 }): string[] {
   return [...SAFE_NATIVE_SDK_TOOLS, ...gantryMcpAllowedTools(input)];
 }
@@ -208,12 +215,16 @@ const sdkToolsProvider: AgentCapabilityProvider = {
                 configuredTools: ctx.configuredAllowedTools,
                 hideAuthorityTools: ctx.hideAuthorityTools,
                 asyncTaskToolsEnabled: ctx.asyncTaskToolsEnabled,
+                memoryReviewerIsControlApprover:
+                  ctx.memoryReviewerIsControlApprover,
               }),
             ]
           : defaultAllowedTools({
               configuredTools: ctx.configuredAllowedTools,
               hideAuthorityTools: ctx.hideAuthorityTools,
               asyncTaskToolsEnabled: ctx.asyncTaskToolsEnabled,
+              memoryReviewerIsControlApprover:
+                ctx.memoryReviewerIsControlApprover,
             }),
       availableTools: baseAvailableTools,
       disallowedTools: UNSUPPORTED_CLAUDE_CODE_BUILTIN_TOOLS,
@@ -285,6 +296,8 @@ const gantryMcpProvider: AgentCapabilityProvider = {
         selectedGantryMcpToolNames(ctx.configuredAllowedTools ?? [], {
           excludeAuthorityTools: ctx.hideAuthorityTools === true,
           asyncTaskToolsEnabled: ctx.asyncTaskToolsEnabled === true,
+          memoryReviewerIsControlApprover:
+            ctx.memoryReviewerIsControlApprover === true,
         }),
       ),
       ...(ctx.asyncTaskToolsEnabled

--- a/apps/core/src/adapters/storage/postgres/repositories/live-admission-work-item-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/live-admission-work-item-repository.postgres.ts
@@ -109,10 +109,12 @@ export async function enqueueLiveAdmissionWorkItem(
     db,
     input.idempotencyKey,
   );
-  if (!existing) {
+  const replayed =
+    existing ?? (await findLiveAdmissionWorkItemById(db, input.id));
+  if (!replayed) {
     throw new Error('Live admission work item conflict was not replayable.');
   }
-  return { outcome: 'replayed', item: existing };
+  return { outcome: 'replayed', item: replayed };
 }
 
 export async function claimLiveAdmissionWorkItems(
@@ -326,6 +328,16 @@ async function findLiveAdmissionWorkItemByIdempotencyKey(
     .from(items)
     .where(eq(items.idempotencyKey, idempotencyKey))
     .limit(1);
+  const row = rows[0];
+  return row ? toLiveAdmissionWorkItem(row) : null;
+}
+
+async function findLiveAdmissionWorkItemById(
+  db: CanonicalExecutor,
+  id: string,
+): Promise<LiveAdmissionWorkItem | null> {
+  const items = pgSchema.liveAdmissionWorkItemsPostgres;
+  const rows = await db.select().from(items).where(eq(items.id, id)).limit(1);
   const row = rows[0];
   return row ? toLiveAdmissionWorkItem(row) : null;
 }

--- a/apps/core/src/channels/slack/channel-message-ingest.ts
+++ b/apps/core/src/channels/slack/channel-message-ingest.ts
@@ -1,12 +1,16 @@
 import type { ChannelOpts } from '../channel-provider.js';
-import type { NewMessage } from '../../domain/types.js';
+import type { ConversationRoute, NewMessage } from '../../domain/types.js';
 import { logger } from '../../infrastructure/logging/logger.js';
 import {
   buildTriggerPattern,
   triggerForRoute,
 } from '../../shared/trigger-pattern.js';
-import { findConversationRoutesForChat } from '../../shared/thread-queue-key.js';
+import {
+  findConversationRoutesForChat,
+  parseAgentThreadQueueKey,
+} from '../../shared/thread-queue-key.js';
 import { nowIso } from '../../shared/time/datetime.js';
+import { agentIdForFolder } from '../../domain/agent/agent-folder-id.js';
 import type { SlackMessageLike } from './channel-state.js';
 import { ingestSlackSlashCommand as ingestSlackSlashCommandEvent } from './slash-command-ingest.js';
 
@@ -22,6 +26,36 @@ type EnrichedSlackMessage = {
   text: string;
   attachments: NonNullable<NewMessage['attachments']>;
 };
+type SlackRouteMatch = [string, ConversationRoute, string | undefined];
+
+function dedupeRouteAliases(matches: SlackRouteMatch[]): SlackRouteMatch[] {
+  const byIdentity = new Map<
+    string,
+    { match: SlackRouteMatch; specificity: number }
+  >();
+  for (const match of matches) {
+    const [key, route, providerAccountId] = match;
+    const parsed = parseAgentThreadQueueKey(key);
+    const agentId =
+      parsed.agentId ?? route.agentId ?? agentIdForFolder(route.folder);
+    const routeProviderAccountId =
+      parsed.providerAccountId ??
+      route.providerAccountId ??
+      providerAccountId ??
+      '';
+    const routeThreadId = parsed.threadId ?? '';
+    const identity = `${agentId}::${routeProviderAccountId}::${routeThreadId}`;
+    const specificity =
+      (parsed.agentId ? 1 : 0) +
+      (parsed.providerAccountId ? 1 : 0) +
+      (parsed.threadId ? 1 : 0);
+    const existing = byIdentity.get(identity);
+    if (!existing || specificity >= existing.specificity) {
+      byIdentity.set(identity, { match, specificity });
+    }
+  }
+  return [...byIdentity.values()].map(({ match }) => match);
+}
 
 export async function ingestSlackSlashCommand(input: {
   command: {
@@ -82,13 +116,15 @@ export async function ingestSlackMessage(input: {
     input.opts.inboundProviderAccountIds?.length && input.opts.providerAccountId
       ? input.opts.inboundProviderAccountIds
       : [input.opts.providerAccountId];
-  const routeMatches = providerAccountIds.flatMap((providerAccountId) =>
-    findConversationRoutesForChat(
-      routes,
-      jid,
-      event.thread_ts,
-      providerAccountId,
-    ).map((match) => [...match, providerAccountId] as const),
+  const routeMatches = dedupeRouteAliases(
+    providerAccountIds.flatMap((providerAccountId) =>
+      findConversationRoutesForChat(
+        routes,
+        jid,
+        event.thread_ts,
+        providerAccountId,
+      ).map((match) => [...match, providerAccountId] as SlackRouteMatch),
+    ),
   );
   const singleRoute =
     routeMatches.length === 1 ? routeMatches[0]?.[1] : undefined;

--- a/apps/core/src/jobs/execution-notifications.ts
+++ b/apps/core/src/jobs/execution-notifications.ts
@@ -223,16 +223,44 @@ function compactMemoryDreamingTerminalMessage(input: {
 }): string | null {
   if (!isMemoryDreamingSystemJob(input.job)) return null;
   if (input.runStatus !== 'completed') return null;
-  if (memoryDreamingSummaryNeedsAttention(input.summary)) return null;
-  return memoryDreamingSummaryAlreadyRunning(input.summary)
-    ? 'Memory job already running.'
+  if (memoryDreamingSummaryAlreadyRunning(input.summary)) {
+    return 'Memory job already running.';
+  }
+  const reviewCount = memoryDreamingReviewCount(input.summary);
+  if (reviewCount) {
+    return `Memory job needs review: ${reviewCount} memory change${reviewCount === 1 ? '' : 's'} waiting.`;
+  }
+  const blockedCount = memoryDreamingBlockedCount(input.summary);
+  if (blockedCount) {
+    return `Memory job needs attention: ${blockedCount} memory change${blockedCount === 1 ? '' : 's'} blocked while creating reviews.`;
+  }
+  return memoryDreamingSummaryNeedsAttention(input.summary)
+    ? null
     : 'Memory job done.';
 }
 
 function memoryDreamingSummaryNeedsAttention(summary: string): boolean {
-  return /\b(needs attention|failed|blocked|sent to review|pending memory reviews?|needs review|deadline exceeded|timed out)\b/i.test(
+  return /\b(needs attention|failed|deadline exceeded|timed out)\b/i.test(
     summary,
   );
+}
+
+function memoryDreamingReviewCount(summary: string): number | null {
+  const match =
+    summary.match(/\b(\d+)\s+sent to review\b/i) ||
+    summary.match(/\b(\d+)\s+(?:pending\s+)?memory reviews?\b/i);
+  return positiveIntegerMatch(match);
+}
+
+function memoryDreamingBlockedCount(summary: string): number | null {
+  const match = summary.match(/\b(\d+)\s+blocked\b/i);
+  return positiveIntegerMatch(match);
+}
+
+function positiveIntegerMatch(match: RegExpMatchArray | null): number | null {
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function memoryDreamingSummaryAlreadyRunning(summary: string): boolean {

--- a/apps/core/src/memory/app-memory-continuity.ts
+++ b/apps/core/src/memory/app-memory-continuity.ts
@@ -3,6 +3,7 @@ import { nowMs as currentTimeMs } from '../shared/time/datetime.js';
 import { normalizeSubject } from './app-memory-boundaries.js';
 import type {
   AppMemoryItem,
+  BlockedDreamDecision,
   MemoryBoundaryContext,
   MemoryReviewRecord,
   MemorySubjectType,
@@ -20,6 +21,14 @@ type ContinuityMemoryPort = {
     input?: Partial<MemoryBoundaryContext> & { limit?: number },
     options?: { signal?: AbortSignal; statementTimeoutMs?: number },
   ): Promise<AppMemoryItem[]>;
+  listRecentBlockedDreamDecisions?(
+    input?: ContinuityInput,
+    options?: {
+      signal?: AbortSignal;
+      statementTimeoutMs?: number;
+      limit?: number;
+    },
+  ): Promise<BlockedDreamDecision[]>;
 };
 type ContinuityInput = Partial<MemoryBoundaryContext> & {
   subjectType?: MemorySubjectType;
@@ -53,37 +62,59 @@ export async function buildAppMemoryContinuitySummary(
 ) {
   const subject = normalizeSubject(input);
   const startedAtMs = input.nowMs ?? currentTimeMs();
-  const [memoriesResult, runsResult, reviewsResult] = await Promise.all([
-    settleContinuitySection(
-      (signal, statementTimeoutMs) =>
-        memory.list({ ...subject, limit: 100 }, { signal, statementTimeoutMs }),
-      input.deadlineAtMs,
-      startedAtMs,
-      input.signal,
-      input.statementTimeoutMs,
-    ),
-    settleContinuitySection(
-      (signal, statementTimeoutMs) =>
-        memory.dreamingStatus(subject, { signal, statementTimeoutMs }),
-      input.deadlineAtMs,
-      startedAtMs,
-      input.signal,
-      input.statementTimeoutMs,
-    ),
-    settleContinuitySection(
-      (signal, statementTimeoutMs) =>
-        memory.listPendingReviews(subject, { signal, statementTimeoutMs }),
-      input.deadlineAtMs,
-      startedAtMs,
-      input.signal,
-      input.statementTimeoutMs,
-    ),
-  ]);
+  const hasBlockedDreamDecisionSection =
+    memory.listRecentBlockedDreamDecisions !== undefined;
+  const [memoriesResult, runsResult, reviewsResult, blockedResult] =
+    await Promise.all([
+      settleContinuitySection(
+        (signal, statementTimeoutMs) =>
+          memory.list(
+            { ...subject, limit: 100 },
+            { signal, statementTimeoutMs },
+          ),
+        input.deadlineAtMs,
+        startedAtMs,
+        input.signal,
+        input.statementTimeoutMs,
+      ),
+      settleContinuitySection(
+        (signal, statementTimeoutMs) =>
+          memory.dreamingStatus(subject, { signal, statementTimeoutMs }),
+        input.deadlineAtMs,
+        startedAtMs,
+        input.signal,
+        input.statementTimeoutMs,
+      ),
+      settleContinuitySection(
+        (signal, statementTimeoutMs) =>
+          memory.listPendingReviews(subject, { signal, statementTimeoutMs }),
+        input.deadlineAtMs,
+        startedAtMs,
+        input.signal,
+        input.statementTimeoutMs,
+      ),
+      hasBlockedDreamDecisionSection
+        ? settleContinuitySection(
+            (signal, statementTimeoutMs) =>
+              memory.listRecentBlockedDreamDecisions?.(subject, {
+                signal,
+                statementTimeoutMs,
+                limit: 10,
+              }) ?? Promise.resolve([]),
+            input.deadlineAtMs,
+            startedAtMs,
+            input.signal,
+            input.statementTimeoutMs,
+          )
+        : Promise.resolve({ status: 'fulfilled' as const, value: [] }),
+    ]);
   const memories =
     memoriesResult.status === 'fulfilled' ? memoriesResult.value : [];
   const runs = runsResult.status === 'fulfilled' ? runsResult.value : [];
   const reviews =
     reviewsResult.status === 'fulfilled' ? reviewsResult.value : [];
+  const blocked =
+    blockedResult.status === 'fulfilled' ? blockedResult.value : [];
   const status = statusFromParts(subject, runs, reviews.length);
   const injected = injectedStatus(subject);
   const recentDecisions = memories
@@ -97,10 +128,16 @@ export async function buildAppMemoryContinuitySummary(
     }));
   const latestDreamSummary = summaryObject(runs[0]?.summary);
   const lastRun = runs[0];
-  const unavailableCount = [memoriesResult, runsResult, reviewsResult].filter(
+  const sectionResults = [
+    memoriesResult,
+    runsResult,
+    reviewsResult,
+    ...(hasBlockedDreamDecisionSection ? [blockedResult] : []),
+  ];
+  const unavailableCount = sectionResults.filter(
     (result) => result.status === 'unavailable',
   ).length;
-  const sectionCount = [memoriesResult, runsResult, reviewsResult].length;
+  const sectionCount = sectionResults.length;
   return {
     overall_status:
       unavailableCount === 0
@@ -151,6 +188,29 @@ export async function buildAppMemoryContinuitySummary(
             ]
           : [],
         runsResult.status === 'unavailable' ? runsResult.reason : undefined,
+      ),
+      blocked_dream_decisions: section(
+        blockedResult.status === 'unavailable'
+          ? 'unavailable'
+          : blocked.length > 0
+            ? 'populated'
+            : 'empty',
+        blocked.map((item) => ({
+          id: item.id,
+          run_id: item.runId,
+          candidate_id: item.candidateId,
+          item_id: item.itemId,
+          subject_type: item.subjectType,
+          subject_id: item.subjectId,
+          kind: item.kind,
+          key: item.key,
+          value: item.value,
+          rationale: item.rationale,
+          created_at: item.createdAt,
+        })),
+        blockedResult.status === 'unavailable'
+          ? blockedResult.reason
+          : undefined,
       ),
       issue_index: section(
         'deferred',

--- a/apps/core/src/memory/app-memory-dreaming.ts
+++ b/apps/core/src/memory/app-memory-dreaming.ts
@@ -12,7 +12,7 @@ import type {
   SaveAppMemoryInput,
 } from './memory-types.js';
 import { embeddingContentHash } from './app-memory-service-helpers.js';
-import { hashText } from './app-memory-canonical-codec.js';
+import { hashText, parseItemSource } from './app-memory-canonical-codec.js';
 import {
   extractMemoryValue,
   parseStagedCandidateMetadata,
@@ -292,6 +292,7 @@ export async function runAppMemoryDreamPass(input: {
       const value =
         typeof payload.value === 'string' ? payload.value.toLowerCase() : '';
       if (/\b(no longer|instead|actually|correction|wrong)\b/.test(value)) {
+        const evidenceIds = parseItemSource(item.row).evidenceIds;
         const action = await routeMemoryProposalToReview({
           db,
           runId,
@@ -299,7 +300,7 @@ export async function runAppMemoryDreamPass(input: {
           dryRun,
           createPendingReview: input.createPendingReview,
           itemId: item.row.id,
-          evidenceIds: [],
+          evidenceIds,
           proposal: {
             action: 'needs_review',
             itemId: item.row.id,
@@ -308,12 +309,14 @@ export async function runAppMemoryDreamPass(input: {
             reason:
               'REM dreaming found correction language; human or admin review should decide whether to rewrite or retire related memory.',
             confidence: item.row.confidence,
-            evidenceIds: [],
+            evidenceIds,
           },
           reviewRationale:
             'REM dreaming routed correction language to memory review',
           blockRationale:
-            'REM dreaming blocked correction-language review because memory review creation failed.',
+            evidenceIds.length > 0
+              ? 'REM dreaming blocked correction-language review because memory review creation failed.'
+              : 'REM dreaming blocked correction-language review because the active memory has no source evidence.',
         });
         decisions.push({ action });
       }

--- a/apps/core/src/memory/app-memory-item-queries.ts
+++ b/apps/core/src/memory/app-memory-item-queries.ts
@@ -23,6 +23,7 @@ import {
 import { hasDreamingStatusSubjectScope } from './app-memory-service-dreaming.js';
 import { toRun } from './app-memory-service-record-mappers.js';
 import type {
+  BlockedDreamDecision,
   DemoteDreamingMemoryInput,
   DeleteAppMemoryInput,
   DreamingRunStatus,
@@ -94,6 +95,135 @@ export async function listDreamingStatuses(
   )) as Array<typeof pgSchema.memoryDreamRunsPostgres.$inferSelect>;
   options.signal?.throwIfAborted();
   return rows.map(toRun);
+}
+
+export async function listRecentBlockedDreamDecisions(
+  db: Db,
+  input: Partial<MemoryBoundaryContext> & {
+    subjectType?: MemorySubjectType;
+    subjectId?: string;
+  } = {},
+  options: {
+    signal?: AbortSignal;
+    statementTimeoutMs?: number;
+    limit?: number;
+  } = {},
+): Promise<BlockedDreamDecision[]> {
+  options.signal?.throwIfAborted();
+  const hasSubjectScope = hasDreamingStatusSubjectScope(input);
+  const subject = normalizeSubject(input);
+  const subjectFilters = hasSubjectScope
+    ? [
+        eq(pgSchema.memoryDreamRunsPostgres.subjectType, subject.subjectType),
+        eq(pgSchema.memoryDreamRunsPostgres.subjectId, subject.subjectId),
+      ]
+    : [];
+  const limit =
+    options.limit && Number.isSafeInteger(options.limit) && options.limit > 0
+      ? Math.min(options.limit, 25)
+      : 10;
+  type BlockedDreamDecisionRow = {
+    id: string;
+    runId: string;
+    itemId: string | null;
+    candidateId: string | null;
+    rationale: string;
+    createdAt: string;
+    subjectType: string;
+    subjectId: string;
+    itemKind: string | null;
+    itemKey: string | null;
+    itemValue: string | null;
+    candidateKind: string | null;
+    candidateKey: string | null;
+    candidateValue: string | null;
+  };
+  const rows = (await withStatementTimeout(
+    db,
+    options.statementTimeoutMs,
+    (timeoutMs) =>
+      sql`select set_config('statement_timeout', ${String(timeoutMs)}, true)`,
+    (queryDb) =>
+      queryDb
+        .select({
+          id: pgSchema.memoryDreamDecisionsPostgres.id,
+          runId: pgSchema.memoryDreamDecisionsPostgres.runId,
+          itemId: pgSchema.memoryDreamDecisionsPostgres.itemId,
+          candidateId: pgSchema.memoryDreamDecisionsPostgres.candidateId,
+          rationale: pgSchema.memoryDreamDecisionsPostgres.rationale,
+          createdAt: pgSchema.memoryDreamDecisionsPostgres.createdAt,
+          subjectType: pgSchema.memoryDreamRunsPostgres.subjectType,
+          subjectId: pgSchema.memoryDreamRunsPostgres.subjectId,
+          itemKind: pgSchema.memoryItemsPostgres.kind,
+          itemKey: pgSchema.memoryItemsPostgres.key,
+          itemValue: sql<
+            string | null
+          >`${pgSchema.memoryItemsPostgres.valueJson}->>'value'`,
+          candidateKind: pgSchema.memoryCandidatesPostgres.kind,
+          candidateKey: pgSchema.memoryCandidatesPostgres.key,
+          candidateValue: pgSchema.memoryCandidatesPostgres.value,
+        })
+        .from(pgSchema.memoryDreamDecisionsPostgres)
+        .innerJoin(
+          pgSchema.memoryDreamRunsPostgres,
+          and(
+            eq(
+              pgSchema.memoryDreamDecisionsPostgres.runId,
+              pgSchema.memoryDreamRunsPostgres.id,
+            ),
+            eq(pgSchema.memoryDreamRunsPostgres.appId, subject.appId),
+            eq(pgSchema.memoryDreamRunsPostgres.agentId, subject.agentId),
+          ),
+        )
+        .leftJoin(
+          pgSchema.memoryCandidatesPostgres,
+          and(
+            eq(
+              pgSchema.memoryDreamDecisionsPostgres.candidateId,
+              pgSchema.memoryCandidatesPostgres.id,
+            ),
+            eq(pgSchema.memoryCandidatesPostgres.appId, subject.appId),
+            eq(pgSchema.memoryCandidatesPostgres.agentId, subject.agentId),
+          ),
+        )
+        .leftJoin(
+          pgSchema.memoryItemsPostgres,
+          and(
+            eq(
+              pgSchema.memoryDreamDecisionsPostgres.itemId,
+              pgSchema.memoryItemsPostgres.id,
+            ),
+            eq(pgSchema.memoryItemsPostgres.appId, subject.appId),
+            eq(pgSchema.memoryItemsPostgres.agentId, subject.agentId),
+          ),
+        )
+        .where(
+          and(
+            eq(pgSchema.memoryDreamDecisionsPostgres.appId, subject.appId),
+            eq(pgSchema.memoryDreamDecisionsPostgres.agentId, subject.agentId),
+            eq(pgSchema.memoryDreamDecisionsPostgres.action, 'blocked'),
+            ...subjectFilters,
+          ),
+        )
+        .orderBy(desc(pgSchema.memoryDreamDecisionsPostgres.createdAt))
+        .limit(limit),
+  )) as BlockedDreamDecisionRow[];
+  options.signal?.throwIfAborted();
+  return rows.map((row) => ({
+    appId: subject.appId,
+    agentId: subject.agentId,
+    subjectType: row.subjectType as MemorySubjectType,
+    subjectId: row.subjectId,
+    id: row.id,
+    runId: row.runId,
+    itemId: row.itemId,
+    candidateId: row.candidateId,
+    rationale: row.rationale,
+    kind: row.candidateKind ?? row.itemKind,
+    key: row.candidateKey ?? row.itemKey,
+    value: row.candidateValue ?? row.itemValue,
+    createdAt: row.createdAt,
+  }));
 }
 
 export async function getOwnedMemoryItem(input: {

--- a/apps/core/src/memory/app-memory-service.ts
+++ b/apps/core/src/memory/app-memory-service.ts
@@ -26,6 +26,7 @@ import type {
   AppMemoryItem,
   AppMemorySearchInput,
   AppMemorySearchResult,
+  BlockedDreamDecision,
   DemoteDreamingMemoryInput,
   DeleteAppMemoryInput,
   DreamingRunStatus,
@@ -62,6 +63,7 @@ import {
   findActiveMemoryByKey,
   getOwnedMemoryItem,
   listDreamingStatuses,
+  listRecentBlockedDreamDecisions,
 } from './app-memory-item-queries.js';
 import {
   buildAppMemoryContinuityStatus,
@@ -520,6 +522,21 @@ export class AppMemoryService {
     });
     options.signal?.throwIfAborted();
     return reviews;
+  }
+
+  async listRecentBlockedDreamDecisions(
+    input: Partial<MemoryBoundaryContext> & {
+      subjectType?: MemorySubjectType;
+      subjectId?: string;
+    } = {},
+    options: {
+      signal?: AbortSignal;
+      statementTimeoutMs?: number;
+      limit?: number;
+    } = {},
+  ): Promise<BlockedDreamDecision[]> {
+    if (!this.isEnabled()) return [];
+    return listRecentBlockedDreamDecisions(this.db, input, options);
   }
 
   async listPendingReviewPage(

--- a/apps/core/src/memory/memory-types.ts
+++ b/apps/core/src/memory/memory-types.ts
@@ -167,6 +167,18 @@ export interface MemoryReviewRecord extends NormalizedMemorySubject {
   decidedAt?: string | null;
 }
 
+export interface BlockedDreamDecision extends NormalizedMemorySubject {
+  id: string;
+  runId: string;
+  itemId?: string | null;
+  candidateId?: string | null;
+  rationale: string;
+  kind?: string | null;
+  key?: string | null;
+  value?: string | null;
+  createdAt: string;
+}
+
 export interface MemoryReviewPage {
   reviews: MemoryReviewRecord[];
   reviewPage?: MemoryReviewDisplayPage;

--- a/apps/core/src/runner/mcp/context.ts
+++ b/apps/core/src/runner/mcp/context.ts
@@ -242,6 +242,8 @@ export function capabilityStatusText(): string {
       toolName === 'memory_search' ||
       toolName === 'memory_save' ||
       toolName === 'continuity_summary' ||
+      toolName === 'memory_review_pending' ||
+      toolName === 'memory_review_decision' ||
       toolName === 'procedure_save' ||
       toolName === 'file' ||
       toolName === 'request_access' ||
@@ -285,6 +287,15 @@ export function capabilityStatusText(): string {
           'Scheduler monitoring:',
           '- Use scheduler_get_job, scheduler_list_runs, scheduler_list_events, and scheduler_wait_for_events to inspect or wait for jobs.',
           '- Never request Bash just to sleep, wait, poll, or monitor scheduler job completion.',
+        ]
+      : []),
+    ...(normalActionToolNames.includes('memory_review_pending')
+      ? [
+          '',
+          'Memory review:',
+          '- When a user asks to inspect, approve, reject, or edit pending memory changes, call memory_review_pending first and show the numbered items.',
+          '- Call memory_review_decision only after explicit numbered approve, reject, or edit instructions from the user.',
+          '- When pending reviews are empty but dreaming reports blocked changes, inspect continuity_summary for blocked dream decision details.',
         ]
       : []),
     ...(lockedAccessPreset

--- a/apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
+++ b/apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
@@ -899,7 +899,13 @@ describe('Claude Agent SDK boundary integration', () => {
     expect(
       sdkState.calls[0]?.options.mcpServers.gantry?.env
         ?.GANTRY_MCP_TOOL_NAMES_JSON,
-    ).toBe(JSON.stringify(selectedGantryMcpToolNames([])));
+    ).toBe(
+      JSON.stringify(
+        selectedGantryMcpToolNames([], {
+          memoryReviewerIsControlApprover: true,
+        }),
+      ),
+    );
     expect(
       sdkState.calls[0]?.options.mcpServers.gantry?.env
         ?.GANTRY_MEMORY_IPC_ACTIONS_JSON,
@@ -910,7 +916,7 @@ describe('Claude Agent SDK boundary integration', () => {
         }),
       ),
     );
-    expect(sdkState.calls[0]?.options.allowedTools).not.toEqual(
+    expect(sdkState.calls[0]?.options.allowedTools).toEqual(
       expect.arrayContaining([
         'mcp__gantry__memory_review_pending',
         'mcp__gantry__memory_review_decision',

--- a/apps/core/test/integration/live-admission-work-items.postgres.integration.test.ts
+++ b/apps/core/test/integration/live-admission-work-items.postgres.integration.test.ts
@@ -61,6 +61,34 @@ maybeDescribe('live admission work items (Postgres)', () => {
     expect(replay.item.id).toBe('admission-1');
   });
 
+  it('deduplicates provider delivery by deterministic work item id', async () => {
+    const first = await liveTurns.enqueueLiveAdmissionWorkItem({
+      id: 'admission-id-replay',
+      ...base,
+      appId: 'app-id-replay',
+      messageId: 'message:tg:live-admission:id-replay',
+      messageCursor: '2026-06-16T00:00:00.500Z::id-replay',
+      idempotencyKey: 'telegram:delivery:id-replay:root',
+      now: toIso(nowMs() - 9_500),
+    });
+    expect(first.outcome).toBe('enqueued');
+
+    const replay = await liveTurns.enqueueLiveAdmissionWorkItem({
+      id: 'admission-id-replay',
+      ...base,
+      appId: 'app-id-replay',
+      messageId: 'message:tg:live-admission:id-replay',
+      messageCursor: '2026-06-16T00:00:00.500Z::id-replay',
+      idempotencyKey: 'telegram:delivery:id-replay:thread',
+    });
+
+    expect(replay.outcome).toBe('replayed');
+    expect(replay.item).toMatchObject({
+      id: 'admission-id-replay',
+      idempotencyKey: 'telegram:delivery:id-replay:root',
+    });
+  });
+
   it('claims due rows in durable FIFO order without prompt text payloads', async () => {
     await liveTurns.enqueueLiveAdmissionWorkItem({
       id: 'admission-2',

--- a/apps/core/test/unit/channels/slack.test.ts
+++ b/apps/core/test/unit/channels/slack.test.ts
@@ -452,6 +452,47 @@ describe('Slack channel', () => {
     );
   });
 
+  it('treats duplicate Slack route aliases for one agent as one route', async () => {
+    const opts = createOpts();
+    const route = {
+      folder: 'slack_ops',
+      name: 'Ops',
+      trigger: '@Ops',
+      providerAccountId: 'slack_default',
+    };
+    opts.conversationRoutes.mockReturnValue({
+      'sl:C123': route,
+      [makeAgentThreadQueueKey('sl:C123', 'agent:slack_ops')]: route,
+      [makeAgentThreadQueueKey(
+        'sl:C123',
+        'agent:slack_ops',
+        null,
+        'slack_default',
+      )]: route,
+    });
+    const channel = new SlackChannel('xoxb-token', 'xapp-token', opts as any);
+    await channel.connect();
+
+    const handlers = appRef.current.eventHandlers.get('app_mention') || [];
+    await handlers[0]({
+      event: {
+        channel: 'C123',
+        ts: '1710000000.000100',
+        user: 'U123',
+        text: '<@U_BOT> list projects',
+      },
+    });
+
+    expect(opts.onMessage).toHaveBeenCalledWith(
+      'sl:C123',
+      expect.objectContaining({
+        content: '@Ops list projects',
+        providerAccountId: 'slack_default',
+        thread_id: '1710000000.000100',
+      }),
+    );
+  });
+
   it('matches shared Slack inbound routes under the target provider account', async () => {
     const opts = {
       ...createOpts(),

--- a/apps/core/test/unit/jobs/execution-notifications.test.ts
+++ b/apps/core/test/unit/jobs/execution-notifications.test.ts
@@ -258,22 +258,12 @@ describe('jobs/execution-notifications', () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
       'tg:scheduler',
-      expect.stringContaining(
-        '**📝 Needs memory review** · Memory Dreaming (main_agent tg:5759865942)',
-      ),
+      'Memory job needs review: 4 memory changes waiting.',
       expect.objectContaining({
         threadId: 'thread-1',
         actionAffordances: [],
       }),
     );
-    const message = String(sendMessage.mock.calls[0]?.[1]);
-    expect(message).toContain(
-      'Memory dreaming needs attention: 4 sent to review.',
-    );
-    expect(message).toContain(
-      'Needs attention: 4 memory changes need your review.',
-    );
-    expect(message).not.toContain('memory_review_pending');
   });
 
   it('keeps pending memory review guidance in lifecycle update summaries', async () => {
@@ -300,21 +290,35 @@ describe('jobs/execution-notifications', () => {
     expect(updateLifecycleNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         runStatus: 'completed',
-        summaryMessage: expect.stringContaining(
-          '**📝 Needs memory review** · Memory Dreaming (main_agent tg:5759865942)',
-        ),
+        summaryMessage: 'Memory job needs review: 7 memory changes waiting.',
       }),
     );
-    const summaryMessage = String(
-      updateLifecycleNotification.mock.calls[0]?.[0].summaryMessage,
+  });
+
+  it('sends compact blocked memory dreaming notifications', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+
+    await notifySchedulerTerminalRunState({
+      job: makeMemoryDreamingJob(),
+      runId: 'run-1',
+      runShortId: 9,
+      runStatus: 'completed',
+      summary: 'Memory dreaming needs attention: 4 blocked.',
+      nextRun: null,
+      retryCount: 0,
+      pauseReason: null,
+      sendMessage,
+      durationMs: 12_000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      'tg:scheduler',
+      'Memory job needs attention: 4 memory changes blocked while creating reviews.',
+      expect.objectContaining({
+        threadId: 'thread-1',
+        actionAffordances: [],
+      }),
     );
-    expect(summaryMessage).toContain(
-      'Memory dreaming needs attention: 7 pending memory reviews need review.',
-    );
-    expect(summaryMessage).toContain(
-      'Needs attention: 7 memory changes need your review.',
-    );
-    expect(summaryMessage).not.toContain('memory_review_pending');
   });
 
   it('hides runner diagnostics from failed job receipts', async () => {

--- a/apps/core/test/unit/memory/app-memory-continuity.test.ts
+++ b/apps/core/test/unit/memory/app-memory-continuity.test.ts
@@ -233,6 +233,71 @@ describe('app memory continuity summary', () => {
     });
   });
 
+  it('includes recent blocked dream decisions in continuity details', async () => {
+    const listRecentBlockedDreamDecisions = vi.fn().mockResolvedValue([
+      {
+        id: 'mdd-1',
+        runId: 'mdr-1',
+        appId: 'default',
+        agentId: 'agent:team',
+        subjectType: 'channel',
+        subjectId: 'conversation:sl:C-target',
+        candidateId: 'memcand-1',
+        itemId: null,
+        kind: 'preference',
+        key: 'preference:telegram-copy',
+        value: 'Keep dreaming notices short.',
+        rationale: 'review creation failed',
+        createdAt: '2026-05-08T02:01:00.000Z',
+      },
+    ]);
+    const memory = {
+      dreamingStatus: vi.fn().mockResolvedValue([
+        {
+          completedAt: '2026-05-08T02:00:00.000Z',
+          status: 'completed',
+          phase: 'rem',
+          summary: { blocked: 1 },
+        },
+      ]),
+      listPendingReviews: vi.fn().mockResolvedValue([]),
+      list: vi.fn().mockResolvedValue([]),
+      listRecentBlockedDreamDecisions,
+    };
+
+    const summary = await buildAppMemoryContinuitySummary(memory, {
+      appId: 'default',
+      agentId: 'agent:team',
+      channelId: 'conversation:sl:C-target',
+    });
+
+    expect(listRecentBlockedDreamDecisions).toHaveBeenCalledWith(
+      {
+        appId: 'default',
+        agentId: 'agent:team',
+        subjectType: 'channel',
+        subjectId: 'conversation:sl:C-target',
+        channelId: 'conversation:sl:C-target',
+      },
+      expect.objectContaining({ limit: 10 }),
+    );
+    expect(summary.sections.blocked_dream_decisions).toMatchObject({
+      status: 'populated',
+      count: 1,
+      items: [
+        {
+          id: 'mdd-1',
+          run_id: 'mdr-1',
+          candidate_id: 'memcand-1',
+          kind: 'preference',
+          key: 'preference:telegram-copy',
+          value: 'Keep dreaming notices short.',
+          rationale: 'review creation failed',
+        },
+      ],
+    });
+  });
+
   it('marks continuity summary partial when one memory section is unavailable', async () => {
     const memory = {
       dreamingStatus: vi.fn().mockResolvedValue([

--- a/apps/core/test/unit/memory/app-memory-dreaming.test.ts
+++ b/apps/core/test/unit/memory/app-memory-dreaming.test.ts
@@ -85,6 +85,7 @@ function activeItemRow(
     key?: string;
     kind?: string;
     value?: string;
+    sourceRefJson?: string;
   } = {},
 ) {
   return {
@@ -99,7 +100,7 @@ function activeItemRow(
     kind: input.kind ?? 'decision',
     key: input.key ?? 'decision:queue-policy',
     valueJson: JSON.stringify({ value: input.value ?? 'old value', why: null }),
-    sourceRefJson: '{}',
+    sourceRefJson: input.sourceRefJson ?? '{}',
     confidence: 0.8,
     status: 'active',
     lastObservedAt: null,
@@ -526,6 +527,56 @@ describe('runAppMemoryDreamPass guardrails', () => {
         candidateId: 'mca-1',
         evidenceIdsJson: '["mev-1"]',
         applied: true,
+      },
+    ]);
+  });
+
+  it('routes REM correction-language items to review with source evidence', async () => {
+    const { db, inserted } = createDb([]);
+    const createPendingReview = vi.fn(async () => 'mrv-correction');
+    const sourceRefJson = JSON.stringify({
+      source: 'dreaming',
+      subject,
+      version: 1,
+      evidenceIds: ['mev-1'],
+    });
+
+    const decisions = await runAppMemoryDreamPass({
+      db: db as never,
+      runId: 'mdr-rem-correction',
+      subject,
+      phase: 'rem',
+      dryRun: false,
+      listItems: vi.fn(async () => [
+        {
+          row: activeItemRow({
+            value: 'Actually use lead finder instead of Mode A.',
+            sourceRefJson,
+          }),
+        },
+      ]),
+      save: vi.fn(),
+      retire: vi.fn(async () => ({ deleted: true })),
+      createPendingReview,
+    });
+
+    expect(decisions).toEqual([{ action: 'needs_review' }]);
+    expect(createPendingReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'needs_review',
+        itemId: 'mem-1',
+        value: 'Actually use lead finder instead of Mode A.',
+        evidenceIds: ['mev-1'],
+      }),
+      db,
+    );
+    expect(decisionValues(inserted)).toMatchObject([
+      {
+        action: 'needs_review',
+        itemId: 'mem-1',
+        evidenceIdsJson: '["mev-1"]',
+        rationale:
+          'REM dreaming routed correction language to memory review: mrv-correction.',
       },
     ]);
   });

--- a/apps/core/test/unit/runner/agent-capabilities.test.ts
+++ b/apps/core/test/unit/runner/agent-capabilities.test.ts
@@ -497,7 +497,7 @@ describe('agent capability composition', () => {
     ]);
   });
 
-  it('keeps memory review tools out of the user-facing runner', () => {
+  it('projects memory review tools for memory control approvers', () => {
     const profile = composeAgentCapabilities({
       mcpServerPath: '/tmp/ipc-mcp-stdio.js',
       chatJid: 'tg:sales',
@@ -506,10 +506,10 @@ describe('agent capability composition', () => {
       memoryReviewerIsControlApprover: true,
     });
 
-    expect(profile.allowedTools).not.toContain(
+    expect(profile.allowedTools).toContain(
       'mcp__gantry__memory_review_pending',
     );
-    expect(profile.allowedTools).not.toContain(
+    expect(profile.allowedTools).toContain(
       'mcp__gantry__memory_review_decision',
     );
     expect(profile.allowedTools).not.toContain('mcp__gantry__memory_patch');
@@ -522,8 +522,8 @@ describe('agent capability composition', () => {
     const projectedToolNames = JSON.parse(
       String(profile.mcpServers.gantry?.env?.GANTRY_MCP_TOOL_NAMES_JSON),
     ) as string[];
-    expect(projectedToolNames).not.toContain('memory_review_pending');
-    expect(projectedToolNames).not.toContain('memory_review_decision');
+    expect(projectedToolNames).toContain('memory_review_pending');
+    expect(projectedToolNames).toContain('memory_review_decision');
     expect(
       JSON.parse(
         String(profile.mcpServers.gantry?.env?.GANTRY_MEMORY_IPC_ACTIONS_JSON),

--- a/apps/core/test/unit/runner/mcp/locked-introspection.test.ts
+++ b/apps/core/test/unit/runner/mcp/locked-introspection.test.ts
@@ -106,6 +106,29 @@ describe('capabilityStatusText access projection', () => {
     expect(text).toContain('Scheduler monitoring:');
   });
 
+  it('shows memory review guidance when review tools are mounted', async () => {
+    setRunnerEnv({
+      GANTRY_AGENT_ACCESS_PRESET: 'full',
+      GANTRY_MCP_TOOL_NAMES_JSON: JSON.stringify([
+        'send_message',
+        'continuity_summary',
+        'memory_review_pending',
+        'memory_review_decision',
+      ]),
+      GANTRY_SELECTED_SKILLS_JSON: JSON.stringify([]),
+      GANTRY_SELECTED_MCP_SERVERS_JSON: JSON.stringify([]),
+    });
+    vi.resetModules();
+    const { capabilityStatusText } =
+      await import('@core/runner/mcp/context.js');
+
+    const text = capabilityStatusText();
+    expect(text).toContain('- available: mcp__gantry__memory_review_pending');
+    expect(text).toContain('- available: mcp__gantry__memory_review_decision');
+    expect(text).toContain('Memory review:');
+    expect(text).toContain('inspect continuity_summary');
+  });
+
   it('does not label requestable MCP capabilities as selected', async () => {
     const semanticCapability = {
       capabilityId: 'mcp.crm.lookup',


### PR DESCRIPTION
## Summary
- shrink memory dreaming scheduler notifications to concise one-line terminal outcomes while preserving counts for reviewed and blocked candidates
- expose blocked dreaming candidates through continuity_summary and authorize reviewer tools/env so agents can list and decide pending memory review items
- keep correction-language memory proposals tied to source evidence ids to avoid false blocked outcomes when evidence exists
- deduplicate Slack route aliases for the same agent/provider/thread and replay live-admission work items by deterministic id across provider delivery variants

## Verification
- npm run test:unit -- apps/core/test/unit/memory/app-memory-dreaming.test.ts apps/core/test/unit/jobs/execution-notifications.test.ts apps/core/test/unit/memory/app-memory-continuity.test.ts apps/core/test/unit/runner/agent-capabilities.test.ts apps/core/test/unit/runner/mcp/locked-introspection.test.ts apps/core/test/unit/jobs/status-formatting.test.ts apps/core/test/unit/runner/mcp-memory-payload.test.ts
- npm run test:integration -- apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
- npm run build
- python3 .codex/scripts/check_task_completion.py
- local launchd restart plus /healthz and /readyz checks passed after build