### PR TITLE
Push agents to route writes between memory and brain deliberately

### DIFF
--- a/apps/core/src/application/agents/prompt-profile-service.ts
+++ b/apps/core/src/application/agents/prompt-profile-service.ts
@@ -163,7 +163,7 @@ const OPERATING_GUIDANCE_HEAD = [
   '- Use injected query-relevant memory when present; absence means no relevant memory was auto-retrieved, not that memory is empty.',
   '- Durable memory works by default through full-text recall; semantic recall is an optional ranking enhancement and is off unless embeddings are configured. Do not describe memory as empty, broken, or unavailable when only semantic recall is off or paused.',
   '- Call memory_search before telling the user, or assuming, that a prior decision, user preference, or continuation context is unknown.',
-  '- Check brain_search/brain_query before calling org-level knowledge unknown; org-level facts go to brain_write (org-visible), personal or conversation context to memory_save. Unsure? memory_save.',
+  '- Check brain_search/brain_query before calling org knowledge unknown. Org facts -> brain_write (org-visible); user-private facts -> memory_save scope user; else memory_save.',
   '- Do not ask the user to configure embeddings or an embedding provider unless they explicitly want better semantic ranking; full-text memory does not require them.',
   '- Save only durable facts, preferences, decisions, corrections, constraints, and reusable procedures.',
   '- Do not save raw chat logs, terminal output, temporary task progress, secrets, credentials, or vague importance scores.',

--- a/apps/core/src/application/agents/prompt-profile-service.ts
+++ b/apps/core/src/application/agents/prompt-profile-service.ts
@@ -163,6 +163,7 @@ const OPERATING_GUIDANCE_HEAD = [
   '- Use injected query-relevant memory when present; absence means no relevant memory was auto-retrieved, not that memory is empty.',
   '- Durable memory works by default through full-text recall; semantic recall is an optional ranking enhancement and is off unless embeddings are configured. Do not describe memory as empty, broken, or unavailable when only semantic recall is off or paused.',
   '- Call memory_search before telling the user, or assuming, that a prior decision, user preference, or continuation context is unknown.',
+  '- Check brain_search/brain_query before calling org-level knowledge unknown; org-level facts go to brain_write (org-visible), personal or conversation context to memory_save. Unsure? memory_save.',
   '- Do not ask the user to configure embeddings or an embedding provider unless they explicitly want better semantic ranking; full-text memory does not require them.',
   '- Save only durable facts, preferences, decisions, corrections, constraints, and reusable procedures.',
   '- Do not save raw chat logs, terminal output, temporary task progress, secrets, credentials, or vague importance scores.',

--- a/apps/core/src/runner/mcp/tools/brain.ts
+++ b/apps/core/src/runner/mcp/tools/brain.ts
@@ -34,7 +34,7 @@ async function brainToolResult(
 export function registerBrainTools(server: McpServer): void {
   server.tool(
     'brain_search',
-    'Search the shared Gantry company brain across agents. Returns app-scoped markdown pages with graph evidence and citations.',
+    'Search the shared Gantry company brain across agents. Returns app-scoped markdown pages with graph evidence and citations. Check it before saying organization-level information is unknown.',
     {
       query: z.string().min(1),
       limit: z.number().int().min(1).max(20).optional(),
@@ -47,7 +47,7 @@ export function registerBrainTools(server: McpServer): void {
 
   server.tool(
     'brain_query',
-    'Answer a question from the shared Gantry company brain with citations and explicit gaps.',
+    'Answer a question from the shared Gantry company brain with citations and explicit gaps. Use it before telling the user organization-level knowledge is unknown.',
     {
       question: z.string().min(1),
       limit: z.number().int().min(1).max(20).optional(),
@@ -60,7 +60,7 @@ export function registerBrainTools(server: McpServer): void {
 
   server.tool(
     'brain_write',
-    'Write or update one markdown page in the shared Gantry company brain. Use stable slugs and cite source details in frontmatter or page body.',
+    'Write or update one markdown page in the shared Gantry company brain. Pages are visible to every agent and user in this org: only write durable organization-level facts (people, companies, projects, decisions). Never write personal or user-private context — that belongs in memory_save. Use stable slugs and cite source details in frontmatter or page body.',
     {
       slug: z.string().min(1),
       markdown: z.string().min(1),

--- a/apps/core/src/runner/mcp/tools/memory.ts
+++ b/apps/core/src/runner/mcp/tools/memory.ts
@@ -106,7 +106,7 @@ export function registerMemoryTools(server: McpServer): void {
 
   server.tool(
     'memory_save',
-    'Save a durable memory statement. Defaults to workspace scope in group/channel conversations and user scope in DMs. Use this for preferences, facts, decisions, corrections, and constraints that should survive future sessions. Do not save raw logs, temporary task progress, secrets, generic summaries, or common/global memory without an approved admin path. For durable organization-level facts every agent should see, use brain_write instead; when unsure, prefer memory_save (memory stays scoped, brain pages are org-visible).',
+    'Save a durable memory statement. Defaults to workspace scope in group/channel conversations and user scope in DMs. Pass scope "user" for user-private facts learned in shared conversations so they never persist workspace-visible. Use this for preferences, facts, decisions, corrections, and constraints that should survive future sessions. Do not save raw logs, temporary task progress, secrets, generic summaries, or common/global memory without an approved admin path. For durable organization-level facts every agent should see, use brain_write instead; when unsure, prefer memory_save (memory stays scoped, brain pages are org-visible).',
     {
       scope: z.enum(['user', 'group', 'global']).optional(),
       workspace_folder: z.string().optional(),

--- a/apps/core/src/runner/mcp/tools/memory.ts
+++ b/apps/core/src/runner/mcp/tools/memory.ts
@@ -106,7 +106,7 @@ export function registerMemoryTools(server: McpServer): void {
 
   server.tool(
     'memory_save',
-    'Save a durable memory statement. Defaults to workspace scope in group/channel conversations and user scope in DMs. Use this for preferences, facts, decisions, corrections, and constraints that should survive future sessions. Do not save raw logs, temporary task progress, secrets, generic summaries, or common/global memory without an approved admin path.',
+    'Save a durable memory statement. Defaults to workspace scope in group/channel conversations and user scope in DMs. Use this for preferences, facts, decisions, corrections, and constraints that should survive future sessions. Do not save raw logs, temporary task progress, secrets, generic summaries, or common/global memory without an approved admin path. For durable organization-level facts every agent should see, use brain_write instead; when unsure, prefer memory_save (memory stays scoped, brain pages are org-visible).',
     {
       scope: z.enum(['user', 'group', 'global']).optional(),
       workspace_folder: z.string().optional(),


### PR DESCRIPTION
## Summary

Follow-up to #196. Agents had no guidance distinguishing `memory_save` from `brain_write` — the system prompt mentioned memory_search three times and the brain zero times, so the behavior gradient pointed at memory for everything, and nothing warned that brain pages are org-visible (the disclosure boundary).

- `brain_write` description: pages are visible to every agent and user in the org; only durable org-level facts; personal/user-private context belongs in memory_save.
- `memory_save` description: mirror-image pointer to brain_write for org-level facts, with the safe default (unsure → memory_save; memory stays scoped, brain is org-visible).
- `brain_search`/`brain_query` descriptions: check before claiming org-level knowledge is unknown (parallel to the existing memory_search rule).
- One compact line in the operating guidance block reinforcing read-routing + the write seam with the memory-safe default.

## Why the prompt line is terse

The compiled system prompt runs against a hard 26,000-char total budget and was already at the boundary — a verbose two-line version displaced tail sections (caught by `prompt-profile.test.ts` when `scheduler_upsert_job` guidance fell off the end). The full seam semantics live in the tool descriptions, which cost no prompt budget; the guidance line is deliberate reinforcement at minimal cost. Also kept `prompt-profile-service.ts` within its 783-line file budget.

## Verification

- `npm run test:unit` 464 files / 5313 passed (incl. prompt-profile and locked-introspection suites)
- `python3 .codex/scripts/check_architecture.py` clean (file-size budgets included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU2M65wVzK8jA7a4terXjE