### PR TITLE
Fix Bedrock Mantle chat completions route

### DIFF
--- a/apps/core/src/shared/model-provider-registry-openai-compatible.ts
+++ b/apps/core/src/shared/model-provider-registry-openai-compatible.ts
@@ -28,7 +28,7 @@ import type { ModelWorkload } from './model-catalog.js';
 //     cerebras    -> https://api.cerebras.ai/v1/chat/completions
 //     perplexity  -> https://api.perplexity.ai/chat/completions (bare path)
 //     google gen  -> https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
-//     bedrock     -> Bedrock Runtime regional /v1 chat-completions endpoint
+//     bedrock     -> Bedrock Mantle regional /v1 chat-completions endpoint
 //   assertProviderPathAllowed strips the per-provider prefix, leaving
 //   `/chat/completions`, which is allowlisted for the DeepAgents engine.
 //
@@ -386,7 +386,7 @@ function resolveBedrockUpstream(input: {
     'AWS region',
   );
   return {
-    origin: `https://bedrock-runtime.${region}.amazonaws.com`,
+    origin: `https://bedrock-mantle.${region}.api.aws`,
     pathPrefix: BEDROCK_CHAT_PATH_PREFIX,
   };
 }
@@ -512,7 +512,7 @@ export const OPENAI_COMPATIBLE_PROVIDER_DEFINITIONS = [
     credentialModes: BEDROCK_CREDENTIAL_MODES,
     gateway: {
       pathSegment: 'bedrock',
-      upstreamOrigin: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      upstreamOrigin: 'https://bedrock-mantle.us-east-1.api.aws',
       upstreamPathPrefix: BEDROCK_CHAT_PATH_PREFIX,
       upstreamResolver: resolveBedrockUpstream,
       sdkProjection: openAiCompatibleSdkProjection('bedrock'),

--- a/apps/core/test/unit/core/gantry-model-gateway.test.ts
+++ b/apps/core/test/unit/core/gantry-model-gateway.test.ts
@@ -311,7 +311,7 @@ describe('GantryModelGatewayBroker', () => {
     signAwsSigV4Request({
       method: 'POST',
       url: new URL(
-        'https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions?b=two&a=one&a=zero&space=a%20b',
+        'https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions?b=two&a=one&a=zero&space=a%20b',
       ),
       headers,
       body: Buffer.from('{"model":"openai.gpt-oss-120b-1:0"}'),
@@ -330,7 +330,7 @@ describe('GantryModelGatewayBroker', () => {
       'e6f5b76929970d12f510677a95e505022a28268c8cfcc023e92171adbc006101',
     );
     expect(headers.authorization).toBe(
-      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260614/us-east-1/bedrock/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-meta-a;x-amz-meta-z;x-amz-security-token, Signature=9ca220b8a1973977afd325d4d2bbf0b66aecb7526d9e58f88551693e5a863a91',
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260614/us-east-1/bedrock/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-meta-a;x-amz-meta-z;x-amz-security-token, Signature=4cdbaf49e3dfc9fba8f49918ba3b3ba947962ef45872812d5fdce97ac16a38dc',
     );
   });
 
@@ -342,7 +342,7 @@ describe('GantryModelGatewayBroker', () => {
     signAwsSigV4Request({
       method: 'POST',
       url: new URL(
-        'https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions?x=a+b&plus=%2B',
+        'https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions?x=a+b&plus=%2B',
       ),
       headers,
       body: Buffer.from('{"model":"openai.gpt-oss-120b-1:0"}'),
@@ -356,7 +356,7 @@ describe('GantryModelGatewayBroker', () => {
     });
 
     expect(headers.authorization).toBe(
-      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260614/us-east-1/bedrock/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=acea999188994dd6fd93f65f2b63331d18c89119e972a96823c9b3ff96e638ae',
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260614/us-east-1/bedrock/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=17644a21688828ebaed34d77b4061cb80824ff7eb88412c6ee7a666d3dfe120d',
     );
   });
 
@@ -1518,9 +1518,7 @@ describe('GantryModelGatewayBroker', () => {
 
       expect(response.status).toBe(200);
       expect(upstreamFetch).toHaveBeenCalledWith(
-        new URL(
-          'https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions',
-        ),
+        new URL('https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions'),
         expect.objectContaining({
           headers: expect.objectContaining({
             authorization: 'Bearer bedrock-upstream-key',
@@ -1571,9 +1569,7 @@ describe('GantryModelGatewayBroker', () => {
       });
       expect(awsDefaultCredentialProviderMock).toHaveBeenCalledTimes(1);
       expect(upstreamFetch).toHaveBeenCalledWith(
-        new URL(
-          'https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions',
-        ),
+        new URL('https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions'),
         expect.objectContaining({
           headers: expect.objectContaining({
             authorization: expect.stringContaining(
@@ -1617,9 +1613,7 @@ describe('GantryModelGatewayBroker', () => {
         SecretId: 'prod/bedrock/api-key',
       });
       expect(upstreamFetch).toHaveBeenCalledWith(
-        new URL(
-          'https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions',
-        ),
+        new URL('https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions'),
         expect.objectContaining({
           headers: expect.objectContaining({
             authorization: 'Bearer bedrock-secret-ref-key',

--- a/apps/core/test/unit/core/model-provider-registry.test.ts
+++ b/apps/core/test/unit/core/model-provider-registry.test.ts
@@ -611,7 +611,7 @@ describe('model provider registry', () => {
         },
       }),
     ).toEqual({
-      origin: 'https://bedrock-runtime.ap-south-1.amazonaws.com',
+      origin: 'https://bedrock-mantle.ap-south-1.api.aws',
       pathPrefix: '/v1',
     });
     expect(bedrock!.cacheSupport.prompt.mode).toBe('none');


### PR DESCRIPTION
## Summary
Fixes Bedrock chat-completions routing for the OpenAI-compatible path by sending requests to the Mantle endpoint instead of the old Bedrock Runtime hostname.

## What changed
- updated the Bedrock upstream base URL to `https://bedrock-mantle.<region>.api.aws`
- kept the change scoped to the provider registry path used for OpenAI-compatible Bedrock requests
- updated Bedrock gateway tests and registry expectations to match the new endpoint and SigV4 signing behavior

## Why
Telegram/agent requests using Bedrock were failing because the host route used for chat completions was incorrect for this path. The result was runtime failures even though direct Bedrock calls worked.

## Verification
- `npm test`
- `.codex/scripts/verify.py` run with Python 3.11
- `python3 .codex/scripts/validate_artifacts.py --allow-missing-run`

## Scope
This change is limited to the Bedrock OpenAI-compatible routing path and related tests. It does not change Slack, Discord, Teams, or Telegram channel-specific delivery logic.