### PR TITLE
Scheduled jobs: quiet until terminal, honest single end message

### DIFF
--- a/apps/core/src/jobs/execution-notifications.ts
+++ b/apps/core/src/jobs/execution-notifications.ts
@@ -27,17 +27,6 @@ export type JobNotificationLifecycleUpdateResult =
   | 'updated'
   | 'unsupported'
   | 'failed';
-const START_NOTIFICATION_TIMEOUT_MS = 5_000;
-
-function startNotificationTimeout(): Promise<false> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(
-      () => resolve(false),
-      START_NOTIFICATION_TIMEOUT_MS,
-    );
-    timer.unref?.();
-  });
-}
 
 function recoveryActionAffordances(input: {
   job: Job;
@@ -84,26 +73,6 @@ export function logMemoryDreamJobFailure(input: {
     },
     'Memory dreaming system job failed',
   );
-}
-
-export async function notifySchedulerRunStart(input: {
-  job: Job;
-  runId: string;
-  runShortId?: number | null;
-  sendMessage: SchedulerSendMessage;
-}): Promise<boolean> {
-  if (input.job.silent) return false;
-  if (isMemoryDreamingSystemJob(input.job)) return false;
-  return Promise.race([
-    sendJobNotification({
-      job: input.job,
-      text: `**▶️ Running** · ${input.job.name}`,
-      phase: 'start',
-      runId: input.runId,
-      sendMessage: input.sendMessage,
-    }),
-    startNotificationTimeout(),
-  ]);
 }
 
 export async function notifySchedulerRunRecovered(input: {

--- a/apps/core/src/jobs/execution.ts
+++ b/apps/core/src/jobs/execution.ts
@@ -40,7 +40,6 @@ import {
 } from './execution-context.js';
 import {
   logMemoryDreamJobFailure,
-  notifySchedulerRunStart,
   notifySchedulerTerminalRunState,
 } from './execution-notifications.js';
 import {
@@ -242,7 +241,7 @@ export async function runJob(
       resultSummaryAccumulator.append(delta);
     };
     let accumulatedUsage: AgentOutput['usage'];
-    let startNotified = false;
+    const startNotified = false;
     try {
       const groupDir = resolveWorkspaceFolderPath(execution.group.folder);
       fs.mkdirSync(groupDir, { recursive: true });
@@ -253,15 +252,6 @@ export async function runJob(
       conversationKind: execution.group.conversationKind,
       executionJid: execution.executionJid,
     });
-    if (!(await deletionGuard.shouldSuppressDelivery())) {
-      startNotified = await notifySchedulerRunStart({
-        job: currentJob,
-        runId,
-        runShortId,
-        sendMessage: deps.sendMessage,
-      });
-      deletionGuard.resetDeliveryDeletionCheck();
-    }
     if (!error && isTrustedSystemJob(currentJob)) {
       const systemOutcome = await runSystemJobTurn({
         currentJob,

--- a/apps/core/src/jobs/ipc-agent-task-lifecycle-handlers.ts
+++ b/apps/core/src/jobs/ipc-agent-task-lifecycle-handlers.ts
@@ -307,7 +307,7 @@ const todoUpdateHandler: TaskHandler = async (context) => {
   const summary = toTrimmedString(payload.summary, { maxLen: 500 }) || null;
   const updatedAt = nowIso();
   const threadId = context.data.authThreadId || context.data.threadId || null;
-  if (context.deps.renderAgentTodo) {
+  if (context.deps.renderAgentTodo && !context.data.jobId) {
     await context.deps
       .renderAgentTodo(
         conversationId,

--- a/apps/core/src/jobs/status-formatting.ts
+++ b/apps/core/src/jobs/status-formatting.ts
@@ -34,11 +34,18 @@ export function formatRunStatusMessage(args: {
   const lines = [
     `**${statusEmoji(statusText)} ${statusText}** · ${args.job.name}${duration}`,
     `Completed: ${summary}`,
-    `Used: ${denial ? humanizeTechnicalIdentifier(denial.toolName) : 'none reported'}`,
-    'Changed: none',
-    'Delegated: no',
-    `Needs attention: ${action || 'none'}`,
   ];
+  if (denial)
+    lines.push(`Used: ${humanizeTechnicalIdentifier(denial.toolName)}`);
+  // A "Completed with issues" header must carry its blocker even when the
+  // compacted summary truncates it away.
+  const attention = hasMeaningfulReceiptValue(action)
+    ? action
+    : statusText === 'Completed with issues'
+      ? realNeedsAttention(displaySummary)
+      : null;
+  if (hasMeaningfulReceiptValue(attention))
+    lines.push(`Needs attention: ${attention}`);
   const next = nextRunLabel(args.nextRun, args.runStatus);
   if (next) lines.push(`Next: ${next}`);
   return lines.join('\n');
@@ -49,6 +56,8 @@ function statusEmoji(statusText: string): string {
     case 'Completed':
     case 'Completed, no report':
       return '✅';
+    case 'Completed with issues':
+      return '⚠️';
     case 'Needs permission':
       return '🔐';
     case 'Needs memory review':
@@ -82,7 +91,7 @@ export function selectJobNotificationSummary(summary: string): string {
   }
   const selected =
     markerIndex >= 0 ? normalized.slice(markerIndex) : normalized;
-  return selected.trim() || summary;
+  return stripTrailingEmptyReceiptLines(selected).trim() || summary;
 }
 
 function statusLabel(
@@ -92,6 +101,7 @@ function statusLabel(
 ): string {
   if (denial) return 'Needs permission';
   if (status === 'completed') {
+    if (realNeedsAttention(summary)) return 'Completed with issues';
     if (hasPendingMemoryReviewSummary(summary)) return 'Needs memory review';
     return hasReportableSummary(summary) ? 'Completed' : 'Completed, no report';
   }
@@ -259,14 +269,15 @@ function nextRunLabel(
   nextRun: string | null,
   status: 'completed' | 'failed' | 'timeout' | 'dead_lettered',
 ): string | null {
-  if (nextRun) return `Runs again ${formatNextRun(nextRun)}.`;
+  const formattedNextRun = nextRun ? formatNextRun(nextRun) : null;
+  if (formattedNextRun) return `Runs again ${formattedNextRun}.`;
   if (status === 'completed') return null;
   return 'Stopped until the job is fixed or rerun.';
 }
 
-function formatNextRun(nextRun: string): string {
+function formatNextRun(nextRun: string): string | null {
   const date = new Date(nextRun);
-  if (Number.isNaN(date.getTime())) return 'after the schedule is repaired';
+  if (Number.isNaN(date.getTime())) return null;
   return `at ${new Intl.DateTimeFormat(undefined, {
     year: 'numeric',
     month: 'short',
@@ -275,6 +286,33 @@ function formatNextRun(nextRun: string): string {
     minute: '2-digit',
     timeZoneName: 'short',
   }).format(date)}`;
+}
+
+function stripTrailingEmptyReceiptLines(summary: string): string {
+  const lines = summary.split('\n');
+  const emptyReceipt =
+    /^(?:Used:\s*none(?: reported)?|Changed:\s*none|Delegated:\s*no|Needs attention:\s*(?:none|no|n[/-]a))\.?$/i;
+  while (lines.length) {
+    const tail = lines.at(-1)?.trim() ?? '';
+    if (tail !== '' && !emptyReceipt.test(tail)) break;
+    lines.pop();
+  }
+  return lines.join('\n');
+}
+
+function realNeedsAttention(summary: string): string | null {
+  for (const match of summary.matchAll(/^Needs attention:\s*(.*?)\s*$/gim)) {
+    if (hasMeaningfulReceiptValue(match[1])) return match[1]!.trim();
+  }
+  return null;
+}
+
+function hasMeaningfulReceiptValue(
+  value: string | null | undefined,
+): value is string {
+  return (
+    Boolean(value?.trim()) && !/^(?:none|no|n[/-]a)\.?$/i.test(value!.trim())
+  );
 }
 
 function hasReportableSummary(summary: string): boolean {

--- a/apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts
+++ b/apps/core/test/integration/jobs-runs-memory-flow.integration.test.ts
@@ -316,13 +316,14 @@ maybeDescribe('jobs, runs, memory, and scheduler flow', () => {
     );
 
     expect(harness.channel.streams).toHaveLength(0);
+    // Quiet-until-terminal: no start message, exactly one terminal outcome.
+    expect(
+      harness.channel.sent.filter((message) =>
+        message.text.includes('Running** · Job'),
+      ),
+    ).toHaveLength(0);
     expect(harness.channel.sent).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          jid: 'tg:scheduler',
-          text: expect.stringContaining('Running** · Job'),
-          threadId: job.thread_id,
-        }),
         expect.objectContaining({
           jid: 'tg:scheduler',
           text: expect.stringContaining('Completed** · Job'),

--- a/apps/core/test/unit/jobs/execution-notifications.test.ts
+++ b/apps/core/test/unit/jobs/execution-notifications.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { Job, JobSetupState } from '@core/domain/types.js';
 import {
+  notifySchedulerRunRecovered,
   notifySchedulerSetupRequired,
-  notifySchedulerRunStart,
   notifySchedulerTerminalRunState,
 } from '@core/jobs/execution-notifications.js';
 
@@ -63,9 +63,9 @@ function makeMemoryDreamingJob(overrides: Partial<Job> = {}): Job {
 }
 
 describe('jobs/execution-notifications', () => {
-  it('sends start lifecycle notification for non-silent jobs', async () => {
+  it('sends recovery notifications for non-silent jobs', async () => {
     const sendMessage = vi.fn(async () => undefined);
-    const delivered = await notifySchedulerRunStart({
+    const delivered = await notifySchedulerRunRecovered({
       job: makeJob(),
       runId: 'run-123456789',
       sendMessage,
@@ -74,52 +74,9 @@ describe('jobs/execution-notifications', () => {
     expect(delivered).toBe(true);
     expect(sendMessage).toHaveBeenCalledWith(
       'tg:scheduler',
-      expect.stringContaining('**▶️ Running** · Daily summary'),
+      expect.stringContaining('Run recovered: previous worker lost its lease'),
       { threadId: 'thread-1' },
     );
-  });
-
-  it('skips start notifications for silent jobs', async () => {
-    const sendMessage = vi.fn(async () => undefined);
-    const delivered = await notifySchedulerRunStart({
-      job: makeJob({ silent: true }),
-      runId: 'run-1',
-      sendMessage,
-    });
-
-    expect(delivered).toBe(false);
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('skips start notifications for memory dreaming jobs', async () => {
-    const sendMessage = vi.fn(async () => undefined);
-    const delivered = await notifySchedulerRunStart({
-      job: makeMemoryDreamingJob(),
-      runId: 'run-1',
-      sendMessage,
-    });
-
-    expect(delivered).toBe(false);
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('does not block a run when start notification delivery hangs', async () => {
-    vi.useFakeTimers();
-    try {
-      const sendMessage = vi.fn(() => new Promise<void>(() => undefined));
-      const delivered = notifySchedulerRunStart({
-        job: makeJob(),
-        runId: 'run-1',
-        sendMessage,
-      });
-
-      await vi.advanceTimersByTimeAsync(5_000);
-
-      await expect(delivered).resolves.toBe(false);
-      expect(sendMessage).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it('prefers lifecycle update over summary fallback when update succeeds', async () => {
@@ -143,7 +100,7 @@ describe('jobs/execution-notifications', () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it('falls back once to summary notification when lifecycle update is unavailable', async () => {
+  it('sends one terminal outcome and no normal start notification', async () => {
     const sendMessage = vi.fn(async () => undefined);
 
     const notified = await notifySchedulerTerminalRunState({
@@ -164,6 +121,7 @@ describe('jobs/execution-notifications', () => {
       expect.stringContaining('**❌ Failed** · Daily summary'),
       expect.objectContaining({ threadId: 'thread-1' }),
     );
+    expect(String(sendMessage.mock.calls[0]?.[1])).not.toContain('Running');
   });
 
   it('cleans markdown job reports into readable terminal outcomes', async () => {
@@ -383,9 +341,7 @@ describe('jobs/execution-notifications', () => {
     });
 
     const message = String(sendMessage.mock.calls[0]?.[1]);
-    expect(message).toContain(
-      'Next: Runs again after the schedule is repaired.',
-    );
+    expect(message).toContain('Next: Stopped until the job is fixed or rerun.');
     expect(message).not.toContain('not-a-date');
   });
 

--- a/apps/core/test/unit/jobs/execution.test.ts
+++ b/apps/core/test/unit/jobs/execution.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AmbiguousDurableDeliveryError } from '@core/domain/messages/durable-delivery.js';
 import type { ConversationRoute, Job } from '@core/domain/types.js';
 
 const runtimeStoreMock = vi.hoisted(() => ({
@@ -536,7 +535,7 @@ describe('jobs/execution', () => {
       }),
     );
     const messages = sendMessage.mock.calls.map((call) => String(call[1]));
-    expect(messages).toContainEqual(
+    expect(messages).not.toContainEqual(
       expect.stringContaining('**▶️ Running** ·'),
     );
     expect(messages).toContainEqual(
@@ -900,19 +899,10 @@ describe('jobs/execution', () => {
     expect(runFailureEvent?.payload?.summary).not.toContain('json-error');
   });
 
-  it('sends one terminal summary when start notification settlement is ambiguous', async () => {
+  it('sends one terminal summary without a normal start notification', async () => {
     const job = makeJob();
     const opsRepository = makeOpsRepository(job);
-    const sendMessage = vi
-      .fn<(...args: [string, string, { threadId: string }]) => Promise<void>>()
-      .mockRejectedValueOnce(
-        new AmbiguousDurableDeliveryError({
-          provider: 'telegram',
-          conversationJid: 'tg:scheduler',
-          cause: new Error('sent settlement failed'),
-        }),
-      )
-      .mockResolvedValue(undefined);
+    const sendMessage = vi.fn(async () => undefined);
 
     await runJob(
       job,
@@ -930,15 +920,9 @@ describe('jobs/execution', () => {
       'tg:scheduler',
     );
 
-    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenNthCalledWith(
       1,
-      'tg:scheduler',
-      expect.stringContaining('**▶️ Running** · Daily summary'),
-      { threadId: 'thread-scheduled' },
-    );
-    expect(sendMessage).toHaveBeenNthCalledWith(
-      2,
       'tg:scheduler',
       expect.stringContaining('**✅ Completed** · Daily summary'),
       expect.objectContaining({ threadId: 'thread-scheduled' }),
@@ -1396,19 +1380,11 @@ describe('jobs/execution', () => {
       'tg:scheduler',
     );
 
-    expect(sendMessage.mock.calls).toEqual(
-      expect.arrayContaining([
-        [
-          'tg:scheduler',
-          expect.stringContaining('**▶️ Running** · Daily summary'),
-          { threadId: 'thread-scheduled' },
-        ],
-        [
-          'tg:scheduler',
-          expect.stringContaining('**✅ Completed** · Daily summary'),
-          expect.objectContaining({ threadId: 'thread-scheduled' }),
-        ],
-      ]),
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      'tg:scheduler',
+      expect.stringContaining('**✅ Completed** · Daily summary'),
+      expect.objectContaining({ threadId: 'thread-scheduled' }),
     );
   });
 

--- a/apps/core/test/unit/jobs/ipc-agent-task-lifecycle-handlers.test.ts
+++ b/apps/core/test/unit/jobs/ipc-agent-task-lifecycle-handlers.test.ts
@@ -318,6 +318,40 @@ describe('agent task lifecycle IPC handlers', () => {
     });
   });
 
+  it('accepts scheduled todo state without rendering it to the channel', async () => {
+    const runtimeHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gantry-task-ipc-'),
+    );
+    runtimeHomes.push(runtimeHome);
+    const { agentTaskLifecycleHandlers, taskData } =
+      await loadTaskLifecycleHandlers(runtimeHome);
+    const renderAgentTodo = vi.fn(async () => undefined);
+
+    await agentTaskLifecycleHandlers.todo_update(
+      contextFor({
+        data: {
+          ...taskData('todo-scheduled', 'todo_update', {
+            items: [
+              {
+                id: 'step-1',
+                title: 'Run scheduled work',
+                status: 'inProgress',
+              },
+            ],
+          }),
+          jobId: 'job-1',
+        },
+        renderAgentTodo,
+      }),
+    );
+
+    expect(renderAgentTodo).not.toHaveBeenCalled();
+    expect(readResponse(runtimeHome, 'todo-scheduled')).toMatchObject({
+      ok: true,
+      message: 'Plan updated.',
+    });
+  });
+
   it('rejects invalid todo_update before channel render', async () => {
     const runtimeHome = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gantry-task-ipc-'),

--- a/apps/core/test/unit/jobs/status-formatting.test.ts
+++ b/apps/core/test/unit/jobs/status-formatting.test.ts
@@ -41,9 +41,9 @@ describe('job status formatting', () => {
     expect(message).toContain(
       'Completed: Memory dreaming needs attention: 4 sent to review.',
     );
-    expect(message).toContain('Used: none reported');
-    expect(message).toContain('Changed: none');
-    expect(message).toContain('Delegated: no');
+    expect(message).not.toContain('Used:');
+    expect(message).not.toContain('Changed:');
+    expect(message).not.toContain('Delegated:');
     expect(message).toContain(
       'Needs attention: 4 memory changes need your review.',
     );
@@ -68,9 +68,9 @@ describe('job status formatting', () => {
     expect(message).toContain(
       'Completed: memory dreaming deadline exceeded. 2 pending memory reviews need review.',
     );
-    expect(message).toContain('Used: none reported');
-    expect(message).toContain('Changed: none');
-    expect(message).toContain('Delegated: no');
+    expect(message).not.toContain('Used:');
+    expect(message).not.toContain('Changed:');
+    expect(message).not.toContain('Delegated:');
     expect(message).toContain(
       'Needs attention: 2 memory changes need your review.',
     );
@@ -80,7 +80,7 @@ describe('job status formatting', () => {
     expect(message).not.toContain('memory_review_pending');
   });
 
-  it('includes the full terminal receipt fields when no action is needed', () => {
+  it('omits empty receipt fields and Next without a concrete next run', () => {
     const message = formatRunStatusMessage({
       job: job(),
       runId: 'cb7f3c0a-c8f8-40eb-82f0-3b21d2cfc342',
@@ -92,9 +92,88 @@ describe('job status formatting', () => {
     });
 
     expect(message).toContain('Completed: Completed, no reportable output.');
-    expect(message).toContain('Used: none reported');
-    expect(message).toContain('Changed: none');
-    expect(message).toContain('Delegated: no');
-    expect(message).toContain('Needs attention: none');
+    expect(message).not.toContain('Used:');
+    expect(message).not.toContain('Changed:');
+    expect(message).not.toContain('Delegated:');
+    expect(message).not.toContain('Needs attention:');
+    expect(message).not.toContain('Next:');
+  });
+
+  it('presents completed reports with real attention as completed with issues', () => {
+    const message = formatRunStatusMessage({
+      job: job(),
+      runId: 'cb7f3c0a-c8f8-40eb-82f0-3b21d2cfc342',
+      runStatus: 'completed',
+      summary:
+        '## Final Job Report\nCompleted: Imported 3 records.\nNeeds attention: Approve the remaining record.',
+      nextRun: '2026-05-20T21:45:00.000Z',
+      retryCount: 0,
+    });
+
+    expect(message).toContain('**⚠️ Completed with issues**');
+    expect(message).toContain('Needs attention: Approve the remaining record.');
+    expect(message).toContain('Next: Runs again at ');
+  });
+
+  it('keeps the blocker line when the compacted summary truncates it away', () => {
+    const message = formatRunStatusMessage({
+      job: job(),
+      runId: 'cb7f3c0a-c8f8-40eb-82f0-3b21d2cfc342',
+      runStatus: 'completed',
+      summary: [
+        '## Final Job Report',
+        `Completed: ${'Long narrative detail. '.repeat(30)}`,
+        'Needs attention: LinkedIn session expired, re-authenticate.',
+      ].join('\n'),
+      nextRun: null,
+      retryCount: 0,
+    });
+
+    expect(message).toContain('**⚠️ Completed with issues**');
+    expect(message).toContain(
+      'Needs attention: LinkedIn session expired, re-authenticate.',
+    );
+  });
+
+  it('strips trailing agent-authored all-none receipt lines', () => {
+    const message = formatRunStatusMessage({
+      job: job(),
+      runId: 'cb7f3c0a-c8f8-40eb-82f0-3b21d2cfc342',
+      runStatus: 'completed',
+      summary: `${[
+        '## Final Job Report',
+        'Completed: Imported 3 records.',
+        'Used: none reported',
+        'Changed: none',
+        'Delegated: no',
+        'Needs attention: n/a',
+      ].join('\n')}\n`,
+      nextRun: null,
+      retryCount: 0,
+    });
+
+    expect(message).toContain(
+      'Completed: Final Job Report Completed: Imported 3 records.',
+    );
+    expect(message).not.toContain('Used:');
+    expect(message).not.toContain('Changed: none');
+    expect(message).not.toContain('Delegated: no');
+    expect(message).not.toContain('Needs attention:');
+  });
+
+  it('keeps Used only for a parsed terminal tool denial', () => {
+    const message = formatRunStatusMessage({
+      job: job(),
+      runId: 'cb7f3c0a-c8f8-40eb-82f0-3b21d2cfc342',
+      runStatus: 'failed',
+      summary:
+        'Tool not on autonomous run allowlist: RunCommand. Recovery: request_access {"target":{"kind":"run_command","argvPattern":"npm test *"},"temporaryOnly":false}',
+      nextRun: null,
+      retryCount: 1,
+    });
+
+    expect(message).toContain('Used: RunCommand');
+    expect(message).toContain('Needs attention: Approve the missing access');
+    expect(message).toContain('Next: Stopped until the job is fixed or rerun.');
   });
 });

--- a/docs/architecture/autonomous-jobs.md
+++ b/docs/architecture/autonomous-jobs.md
@@ -156,8 +156,10 @@ Pre-spawn readiness blockers emit `job.setup_required` and pause before a
 `JobRun` is claimed. After a run is claimed, the scheduler emits
 `job.tool_activity` for tool-access-requirement preflight, SDK tool requests, allow/deny
 decisions, permission waits, browser IPC actions, and tool-access readiness
-results. Notification routes receive one terminal outcome message; they
-do not receive streamed assistant output or full-output fallback messages.
+results. Notification routes are quiet until terminal by default: they receive
+exactly one terminal outcome message, no normal start message, and no plan/todo
+mirror for scheduled runs. They do not receive streamed assistant output or
+full-output fallback messages.
 Successful scheduled runs must end with a concise user-facing
 `Final Job Report` that states the outcome, notable counts, and the next
 action, and the terminal outcome message may summarize that report.


### PR DESCRIPTION
## Summary

Scheduled jobs currently post a "▶️ Running" start message, mirror the agent's todo plan as a live-updating channel card, and end with a receipt whose `Used: none reported / Changed: none / Delegated: no / Needs attention: none` lines were unconditional literals. A run that hit auth failures still rendered as ✅ success. This makes job notifications quiet-until-terminal with one honest end message.

### Changes
- **No start message** for normal runs (`notifySchedulerRunStart` removed); recovery, setup-required, and terminal notifications unchanged; `start_notification_state` stays in events as `not_sent`
- **No plan mirror for jobs**: `todo_update` from a scheduled run is accepted but not rendered to the channel (guard at the host IPC seam, channel-neutral); interactive chats keep live plans
- **Adaptive terminal message** (`status-formatting.ts`): status header + the agent's concise final report; fabricated `Used/Changed/Delegated` lines dropped; `Needs attention` only with a real value; agent-authored all-none receipt lines stripped (incl. newline-terminated reports); `Next:` only with a concrete timestamp
- **Honest outcome**: a completed run whose report carries a real `Needs attention:` renders as **⚠️ Completed with issues** with the blocker line guaranteed present even when summary compaction truncates it. Presentation-only — durable run status/retries/leases unchanged (flipping durable state needs a structured failure marker at the adapter boundary; out of scope)
- Doc: `autonomous-jobs.md` states the quiet-until-terminal default

## Verification
- Focused unit suites green (76 tests: execution, execution-notifications, ipc-agent-task-lifecycle-handlers, status-formatting); build + architecture + task-completion gates pass
- Postgres integration test updated to the terminal-only contract (asserts zero "Running" messages)
- Three xhigh local autoreview rounds to clean (integration contract, blocker-survives-compaction, trailing-newline stripper)
- Deployed to the local runtime for live validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5M7Gsfzbeq7a1PTkHhu3u

### Also in this PR
- **Permission prompts: hide host-injected proxy env** (`032c12c45`) — prompts/receipts no longer render the spawn-time loopback proxy block (`GODEBUG=… HTTP_PROXY=127.0.0.1…`); agent-supplied env still displays as a security signal. Same noise family, same surface.

Note: `check_task_completion.py` currently fails on main (pre-existing from #211: telegram literal budget in `apps/core/src/messaging/text-styles.ts`); unrelated to this diff.


### Also in this PR (round 2)
- **Allow-5-min timed grants removed entirely** (`d537fbb72`, user decision) — mode, buttons, channel callbacks, runner timed-window machinery, contracts, docs; prompts are now Allow once / Allow for future / Cancel. Dead "Open in scheduler" button (no handler on any channel) removed from job notifications.
- **YOLO denylist = auto-approval backstop** — evaluated before rule-based auto-allows in the Anthropic gate (DeepAgents parity) AND host-side in the classifier floor (host-owned settings, no runner trust field); sees through host-injected env prefixes, covers RunCommand/cmd alias, fail-closed on sanitized commands, audited via permission.yolo_denylist_hit, and denylist-forced prompts never offer future grants. Hardened over nine xhigh review rounds.
- **Capability hygiene** (`295fc219b`) — "builtin" version label reserved for seeded tools, kind-checked implementation bindings, dead legacy parser deleted, product ids removed from core, neutral test fixtures.
