### PR TITLE
Fix Telegram long output delivery and fallback transcripts

### DIFF
--- a/apps/core/src/channels/telegram/channel-delivery-text-splitting.ts
+++ b/apps/core/src/channels/telegram/channel-delivery-text-splitting.ts
@@ -24,19 +24,18 @@ export function splitTelegramTextByCodeUnits(
   if (text.length <= maxCodeUnits) return [text];
 
   const chunks: string[] = [];
-  let chunkStart = 0;
-  let chunkLength = 0;
-  for (const codePoint of text) {
-    const codePointLength = codePoint.length;
-    if (chunkLength > 0 && chunkLength + codePointLength > maxCodeUnits) {
-      chunks.push(text.slice(chunkStart, chunkStart + chunkLength));
-      chunkStart += chunkLength;
-      chunkLength = 0;
+  for (let start = 0; start < text.length; ) {
+    const candidateEnd = nextCodePointEnd(text, start, maxCodeUnits);
+    if (candidateEnd <= start) {
+      chunks.push(text.slice(start));
+      break;
     }
-    chunkLength += codePointLength;
-  }
-  if (chunkStart < text.length) {
-    chunks.push(text.slice(chunkStart));
+    const end =
+      candidateEnd < text.length
+        ? choosePreferredSplitEnd(text, start, candidateEnd)
+        : candidateEnd;
+    chunks.push(text.slice(start, end));
+    start = end;
   }
   return chunks;
 }
@@ -70,6 +69,43 @@ function nextCodePointEnd(
   return endExclusive;
 }
 
+function choosePreferredSplitEnd(
+  text: string,
+  start: number,
+  candidateEnd: number,
+): number {
+  const minimumPreferredEnd =
+    start + Math.max(1, Math.floor((candidateEnd - start) * 0.6));
+  let whitespaceEnd = -1;
+  let punctuationEnd = -1;
+  for (let cursor = candidateEnd; cursor > start; ) {
+    const previousStart = previousCodePointStart(text, cursor);
+    const codePoint = text.slice(previousStart, cursor);
+    if (previousStart < minimumPreferredEnd) break;
+    if (isPreferredWhitespaceBoundary(codePoint)) {
+      whitespaceEnd = cursor;
+      break;
+    }
+    if (punctuationEnd === -1 && isPreferredPunctuationBoundary(codePoint)) {
+      punctuationEnd = cursor;
+    }
+    cursor = previousStart;
+  }
+  return whitespaceEnd > start
+    ? whitespaceEnd
+    : punctuationEnd > start
+      ? punctuationEnd
+      : candidateEnd;
+}
+
+function isPreferredWhitespaceBoundary(codePoint: string): boolean {
+  return /\s/u.test(codePoint);
+}
+
+function isPreferredPunctuationBoundary(codePoint: string): boolean {
+  return /[,.!?;:)]/u.test(codePoint);
+}
+
 function hasOddTrailingBackslashes(text: string): boolean {
   let trailingBackslashes = 0;
   for (let i = text.length - 1; i >= 0 && text[i] === '\\'; i -= 1) {
@@ -95,6 +131,7 @@ function splitTelegramTextByCodeUnitsEscapeAware(
     }
     let end = candidateEnd;
     if (candidateEnd < text.length) {
+      end = choosePreferredSplitEnd(text, start, candidateEnd);
       while (end > start && hasOddTrailingBackslashes(text.slice(start, end))) {
         end = previousCodePointStart(text, end);
       }
@@ -251,21 +288,55 @@ function splitTelegramPlainSegment(
 ): string[] {
   if (text.length <= maxCodeUnits) return [text];
   const out: string[] = [];
+  let current = '';
   const tokens = tokenizeTelegramStyledPlainText(text);
+
+  const flushCurrent = () => {
+    if (!current) return;
+    out.push(current);
+    current = '';
+  };
+
+  const appendFittedText = (
+    value: string,
+    splitter: (input: string, budget: number) => string[],
+  ) => {
+    let remaining = value;
+    while (remaining) {
+      let budget = maxCodeUnits - current.length;
+      if (budget <= 0) {
+        flushCurrent();
+        budget = maxCodeUnits;
+      }
+      if (remaining.length <= budget) {
+        current += remaining;
+        break;
+      }
+      const piece = splitter(remaining, budget)[0];
+      if (!piece) {
+        flushCurrent();
+        continue;
+      }
+      current += piece;
+      remaining = remaining.slice(piece.length);
+      flushCurrent();
+    }
+  };
+
   for (const token of tokens) {
     if (token.kind === 'plain') {
-      out.push(...splitTelegramTextByCodeUnits(token.text, maxCodeUnits));
+      appendFittedText(token.text, splitTelegramTextByCodeUnits);
       continue;
     }
 
     const wrapped = `${token.marker}${token.content}${token.marker}`;
     if (wrapped.length <= maxCodeUnits) {
-      out.push(wrapped);
+      appendFittedText(wrapped, splitTelegramTextByCodeUnits);
       continue;
     }
     const contentBudget = maxCodeUnits - 2;
     if (contentBudget <= 0) {
-      out.push(...splitTelegramTextByCodeUnits(wrapped, maxCodeUnits));
+      appendFittedText(wrapped, splitTelegramTextByCodeUnits);
       continue;
     }
     const contentParts = splitTelegramTextByCodeUnitsEscapeAware(
@@ -273,13 +344,17 @@ function splitTelegramPlainSegment(
       contentBudget,
     );
     if (contentParts.length === 0) {
-      out.push(wrapped);
+      appendFittedText(wrapped, splitTelegramTextByCodeUnits);
       continue;
     }
-    out.push(
-      ...contentParts.map((part) => `${token.marker}${part}${token.marker}`),
-    );
+    for (const part of contentParts) {
+      appendFittedText(
+        `${token.marker}${part}${token.marker}`,
+        splitTelegramTextByCodeUnits,
+      );
+    }
   }
+  flushCurrent();
   return out;
 }
 

--- a/apps/core/src/channels/telegram/telegram-markdown-v2-escape.ts
+++ b/apps/core/src/channels/telegram/telegram-markdown-v2-escape.ts
@@ -97,7 +97,9 @@ function isOpeningBoundary(value: string | undefined): boolean {
 }
 
 function isClosingBoundary(value: string | undefined): boolean {
-  return value === undefined || isWhitespace(value) || /[)\]}.,!?;:-]/u.test(value);
+  return (
+    value === undefined || isWhitespace(value) || /[)\]}.,!?;:-]/u.test(value)
+  );
 }
 
 function isValidOpeningMarker(

--- a/apps/core/src/channels/telegram/telegram-markdown-v2-escape.ts
+++ b/apps/core/src/channels/telegram/telegram-markdown-v2-escape.ts
@@ -35,7 +35,8 @@ type EscapeTelegramMarkdownV2Options = {
 
 /**
  * Escape text for Telegram MarkdownV2 while preserving markdown formatting
- * markers produced by parseTextStyles (bold/italic/strikethrough/links/code).
+ * markers produced by parseTextStyles (bold/italic/links/code) and model
+ * responses that use similarly well-delimited emphasis markers.
  */
 export function escapeTelegramMarkdownV2(
   text: string,
@@ -71,14 +72,9 @@ export function escapeTelegramMarkdownV2(
   return out;
 }
 
-type TelegramStyleMarker = '_' | '*' | '~' | '|';
+type TelegramStyleMarker = '_' | '*';
 
-const TELEGRAM_STYLE_MARKERS = new Set<TelegramStyleMarker>([
-  '_',
-  '*',
-  '~',
-  '|',
-]);
+const TELEGRAM_STYLE_MARKERS = new Set<TelegramStyleMarker>(['_', '*']);
 
 function isEscapedAt(text: string, index: number): boolean {
   let slashCount = 0;
@@ -86,6 +82,48 @@ function isEscapedAt(text: string, index: number): boolean {
     slashCount += 1;
   }
   return slashCount % 2 === 1;
+}
+
+function isWhitespace(value: string | undefined): boolean {
+  return value !== undefined && /\s/u.test(value);
+}
+
+function isWordChar(value: string | undefined): boolean {
+  return value !== undefined && /[\p{L}\p{N}]/u.test(value);
+}
+
+function isOpeningBoundary(value: string | undefined): boolean {
+  return value === undefined || isWhitespace(value) || /[([{\-]/u.test(value);
+}
+
+function isClosingBoundary(value: string | undefined): boolean {
+  return value === undefined || isWhitespace(value) || /[)\]}.,!?;:-]/u.test(value);
+}
+
+function isValidOpeningMarker(
+  text: string,
+  index: number,
+  marker: TelegramStyleMarker,
+): boolean {
+  const previous = text[index - 1];
+  const next = text[index + 1];
+  if (next === undefined || isWhitespace(next)) return false;
+  if (!isOpeningBoundary(previous)) return false;
+  if (marker === '_' && isWordChar(previous) && isWordChar(next)) return false;
+  return true;
+}
+
+function isValidClosingMarker(
+  text: string,
+  index: number,
+  marker: TelegramStyleMarker,
+): boolean {
+  const previous = text[index - 1];
+  const next = text[index + 1];
+  if (previous === undefined || isWhitespace(previous)) return false;
+  if (!isClosingBoundary(next)) return false;
+  if (marker === '_' && isWordChar(previous) && isWordChar(next)) return false;
+  return true;
 }
 
 function escapeTelegramMarkdownV2PlainSegment(
@@ -102,7 +140,11 @@ function escapeTelegramMarkdownV2PlainSegment(
   let index = 0;
   while (index < text.length) {
     const marker = text[index] as TelegramStyleMarker;
-    if (!TELEGRAM_STYLE_MARKERS.has(marker) || isEscapedAt(text, index)) {
+    if (
+      !TELEGRAM_STYLE_MARKERS.has(marker) ||
+      isEscapedAt(text, index) ||
+      !isValidOpeningMarker(text, index, marker)
+    ) {
       index += 1;
       continue;
     }
@@ -110,6 +152,7 @@ function escapeTelegramMarkdownV2PlainSegment(
     let closing = -1;
     for (let i = index + 1; i < text.length; i += 1) {
       if (text[i] !== marker || isEscapedAt(text, i)) continue;
+      if (!isValidClosingMarker(text, i, marker)) continue;
       closing = i;
       break;
     }

--- a/apps/core/src/runtime/group-output-buffer.ts
+++ b/apps/core/src/runtime/group-output-buffer.ts
@@ -64,7 +64,9 @@ export function createGroupOutputBuffer(input: {
     streamSanitizer = createRuntimeUserVisibleStreamSanitizer();
     pendingOutputRawChars = 0;
     pendingOutputHasParts = false;
-    const text = fullVisibleOutput ? formatOutboundForChannel(fullVisibleOutput) : '';
+    const text = fullVisibleOutput
+      ? formatOutboundForChannel(fullVisibleOutput)
+      : '';
     input.log.info(
       { group: input.groupName },
       `Agent output: ${rawChars} chars`,

--- a/apps/core/src/runtime/group-output-buffer.ts
+++ b/apps/core/src/runtime/group-output-buffer.ts
@@ -40,7 +40,9 @@ export function createGroupOutputBuffer(input: {
   log: RuntimeLogger;
 }) {
   const userVisibleTranscript = createRuntimeResultSummaryAccumulator();
-  let pendingOutputVisible = createRuntimeUserVisibleResultAccumulator();
+  const fullUserVisibleTranscriptParts: string[] = [];
+  let pendingOutputSummary = createRuntimeUserVisibleResultAccumulator();
+  let pendingFullVisibleParts: string[] = [];
   let streamSanitizer = createRuntimeUserVisibleStreamSanitizer();
   let pendingOutputRawChars = 0;
   let pendingOutputHasParts = false;
@@ -52,14 +54,17 @@ export function createGroupOutputBuffer(input: {
     if (!pendingOutputHasParts) return false;
     const done = options.done ?? true;
     const terminal = options.terminal ?? true;
-    const visibleOutput = pendingOutputVisible.snapshot();
+    const visibleSummary = pendingOutputSummary.snapshot();
     const finalStreamDelta = streamSanitizer.finish();
+    if (finalStreamDelta) pendingFullVisibleParts.push(finalStreamDelta);
+    const fullVisibleOutput = pendingFullVisibleParts.join('');
     const rawChars = pendingOutputRawChars;
-    pendingOutputVisible = createRuntimeUserVisibleResultAccumulator();
+    pendingOutputSummary = createRuntimeUserVisibleResultAccumulator();
+    pendingFullVisibleParts = [];
     streamSanitizer = createRuntimeUserVisibleStreamSanitizer();
     pendingOutputRawChars = 0;
     pendingOutputHasParts = false;
-    const text = visibleOutput ? formatOutboundForChannel(visibleOutput) : '';
+    const text = fullVisibleOutput ? formatOutboundForChannel(fullVisibleOutput) : '';
     input.log.info(
       { group: input.groupName },
       `Agent output: ${rawChars} chars`,
@@ -90,7 +95,8 @@ export function createGroupOutputBuffer(input: {
       );
       input.applyDeliverySettlement(settlement, { streamed: false, terminal });
     }
-    userVisibleTranscript.append(`${text}\n`);
+    if (visibleSummary) userVisibleTranscript.append(`${text}\n`);
+    if (text) fullUserVisibleTranscriptParts.push(text);
     return true;
   };
 
@@ -98,10 +104,10 @@ export function createGroupOutputBuffer(input: {
     appendRawOutput: async (raw: string) => {
       pendingOutputHasParts = true;
       pendingOutputRawChars += raw.length;
-      pendingOutputVisible.append(raw);
-      if (!input.supportsStreamingChunks) return;
+      pendingOutputSummary.append(raw);
       const safeDelta = streamSanitizer.append(raw);
-      if (!safeDelta) return;
+      if (safeDelta) pendingFullVisibleParts.push(safeDelta);
+      if (!input.supportsStreamingChunks || !safeDelta) return;
       const settlement = await settleDeliveryAttempt(
         () =>
           input.channelRuntime.sendStreamingChunk(
@@ -117,6 +123,10 @@ export function createGroupOutputBuffer(input: {
       });
     },
     flushBufferedOutput,
-    transcriptSnapshot: () => userVisibleTranscript.snapshot(),
+    boundedTranscriptSnapshot: () => userVisibleTranscript.snapshot(),
+    fullTranscriptSnapshot: () => {
+      if (fullUserVisibleTranscriptParts.length === 0) return null;
+      return fullUserVisibleTranscriptParts.join('\n').trim() || null;
+    },
   };
 }

--- a/apps/core/src/runtime/group-output-finalization.ts
+++ b/apps/core/src/runtime/group-output-finalization.ts
@@ -10,6 +10,7 @@ const NO_VISIBLE_OUTPUT_FALLBACK_MESSAGE =
 export async function finalizeGroupAgentUserVisibleOutput(input: {
   streamedTranscriptDeliveryStatus: 'none' | 'sent' | 'partially_sent';
   boundedTranscript: string | null;
+  fullTranscript: string | null;
   chatJid: string;
   activeThreadId?: string;
   outputSentToUser: boolean;
@@ -67,7 +68,7 @@ export async function finalizeGroupAgentUserVisibleOutput(input: {
     return { outputSentToUser, terminalSettlement };
   }
 
-  const fallbackText = transcriptText;
+  const fallbackText = input.fullTranscript?.trim() ?? transcriptText;
   if (fallbackText) {
     try {
       const messageOptions = await input.buildMessageOptions();

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -776,7 +776,8 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
     } else {
       const finalization = await finalizeGroupAgentUserVisibleOutput({
         streamedTranscriptDeliveryStatus,
-        boundedTranscript: outputBuffer.transcriptSnapshot(),
+        boundedTranscript: outputBuffer.boundedTranscriptSnapshot(),
+        fullTranscript: outputBuffer.fullTranscriptSnapshot(),
         chatJid,
         activeThreadId,
         outputSentToUser,

--- a/apps/core/test/unit/channels/telegram-splitting.test.ts
+++ b/apps/core/test/unit/channels/telegram-splitting.test.ts
@@ -209,4 +209,53 @@ describe('Telegram MarkdownV2 chunk planner', () => {
     }
     expect(chunks.join('')).toBe(escaped);
   });
+
+  it('prefers splitting prose at whitespace boundaries when available', () => {
+    const raw = `${'alpha '.repeat(800)}omega`;
+    const escaped = escapeTelegramMarkdownV2(raw);
+    const chunks = splitTelegramDeliveryText(
+      escaped,
+      TELEGRAM_STREAM_CHUNK_MAX_LENGTH,
+      TELEGRAM_MESSAGE_MAX_LENGTH,
+    );
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks.slice(0, -1)) {
+      expect(chunk.length).toBeLessThanOrEqual(
+        TELEGRAM_STREAM_CHUNK_MAX_LENGTH,
+      );
+      expect(chunk.endsWith(' ')).toBe(true);
+    }
+    expect(chunks.join('')).toBe(escaped);
+  });
+
+  it('keeps a short heading attached to following prose when room remains', () => {
+    const raw = `*India Story*
+
+${'word '.repeat(1200)}`;
+    const chunks = splitTelegramDeliveryText(
+      raw,
+      TELEGRAM_STREAM_CHUNK_MAX_LENGTH,
+      TELEGRAM_MESSAGE_MAX_LENGTH,
+    );
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0]).toContain('*India Story*');
+    expect(chunks[0]).toContain('word');
+    expect(chunks[0].length).toBeGreaterThan(100);
+    expect(chunks.join('')).toBe(raw);
+  });
+
+  it('still splits long text without whitespace when no better boundary exists', () => {
+    const raw = 'x'.repeat(8000);
+    const escaped = escapeTelegramMarkdownV2(raw);
+    const chunks = splitTelegramDeliveryText(
+      escaped,
+      TELEGRAM_STREAM_CHUNK_MAX_LENGTH,
+      TELEGRAM_MESSAGE_MAX_LENGTH,
+    );
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toBe(escaped);
+  });
 });

--- a/apps/core/test/unit/channels/telegram.test.ts
+++ b/apps/core/test/unit/channels/telegram.test.ts
@@ -2355,7 +2355,7 @@ describe('TelegramChannel', () => {
         chunkedWithLiteralMarkers,
       );
 
-      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(5);
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(4);
       expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
         1,
         '100200300',
@@ -2387,29 +2387,17 @@ describe('TelegramChannel', () => {
         {},
       );
       expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
-        3,
-        '100200300',
-        expect.stringContaining('~literal~'),
-        {},
-      );
-      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
         4,
-        '100200300',
-        expect.any(String),
-        {},
-      );
-      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
-        5,
         '100200300',
         expect.any(String),
         {},
       );
       expect(result).toEqual(
         expect.objectContaining({
-          deliveredParts: 4,
-          totalParts: 4,
-          externalMessageIds: ['201', '202', '203', '204'],
-          warnings: ['telegram.message.chunked:4:3500'],
+          deliveredParts: 3,
+          totalParts: 3,
+          externalMessageIds: ['201', '202', '203'],
+          warnings: ['telegram.message.chunked:3:3500'],
         }),
       );
     });

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -202,6 +202,10 @@ function createRunnerFixture(): {
     path.join(sharedDir, 'canonical-json.ts'),
   );
   fs.copyFileSync(
+    path.resolve('apps/core/src/shared/runtime-env-command.ts'),
+    path.join(sharedDir, 'runtime-env-command.ts'),
+  );
+  fs.copyFileSync(
     path.resolve('apps/core/src/shared/no-proxy.ts'),
     path.join(sharedDir, 'no-proxy.ts'),
   );

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -4471,11 +4471,10 @@ describe('createGroupProcessor', () => {
       const fallbackText = (
         streamingChannel.sendMessage as ReturnType<typeof vi.fn>
       ).mock.calls[0][1] as string;
-      expect(fallbackText.length).toBeLessThanOrEqual(
+      expect(fallbackText.length).toBeGreaterThan(
         RUNTIME_RESULT_SUMMARY_MAX_CHARS,
       );
-      expect(fallbackText).toMatch(/^\[output truncated; showing tail\]\n/);
-      expect(fallbackText).not.toContain('HEAD-START');
+      expect(fallbackText).toContain('HEAD-START');
       expect(fallbackText.endsWith(tailChunk)).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
Fixes Telegram long-response delivery so large replies keep safe Markdown formatting, split more naturally, and avoid tail-truncated fallback transcripts.

## What Changed
- improved Telegram chunk splitting to prefer whitespace and punctuation boundaries
- kept short styled headings attached to following prose when possible
- preserved only safe Markdown emphasis in long Telegram replies
- escaped accidental markers like `snake_case` and `2 * 3 * 4`
- changed runtime fallback delivery to send the full user-visible transcript instead of the bounded tail-only summary
- kept persisted runtime summaries bounded for storage

## Why
Long Telegram replies had two user-facing problems:
- formatting could break or degrade on large multi-message responses
- fallback delivery could send `[output truncated; showing tail]` content instead of the full visible response

This change keeps long Telegram output readable and safer while preserving bounded storage summaries internally.

## Tests
- `./node_modules/.bin/vitest run -c vitest.unit.config.ts apps/core/test/unit/channels/telegram-splitting.test.ts apps/core/test/unit/channels/telegram.test.ts apps/core/test/unit/runtime/group-processing.test.ts`

## Notes
- targeted only Telegram delivery/chunking behavior and runtime fallback transcript handling
- unrelated local root test scripts were not included in this branch