### PR TITLE
Arch quick wins: error counters, per-turn log correlation, durable send_message ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+/node_modules
 .npm-cache/
 # Build output
 dist/

--- a/apps/core/src/app/bootstrap/runtime-services.ts
+++ b/apps/core/src/app/bootstrap/runtime-services.ts
@@ -438,61 +438,64 @@ export async function startRuntimeServices(
     getBrowserStatus,
     publishRuntimeEvent: resolved.publishRuntimeEvent,
   });
-  resolved.startIpcWatcher({
-    sendMessage: (jid, text, options) =>
-      channelWiring.sendMessage(jid, text, {
-        durability: 'required',
-        throwOnMissing: true,
-        ...(options ? { messageOptions: options } : {}),
-      }),
-    conversationRoutes: () => app.getConversationRoutes(),
-    registerGroup: app.registerGroup,
-    syncGroups: (force: boolean) => channelWiring.syncGroups(force),
-    getAvailableGroups: app.getAvailableGroups,
-    writeGroupsSnapshot: (folder, availableGroups, registeredJids) =>
-      resolved.writeGroupsSnapshot(folder, availableGroups, registeredJids),
-    onSchedulerChanged,
-    opsRepository: resolved.opsRepository,
-    getToolRepository: resolved.getToolRepository,
-    getSkillRepository: resolved.getSkillRepository,
-    getAsyncTaskRepository: resolved.getAsyncTaskRepository,
-    getMcpServerRepository: resolved.getMcpServerRepository,
-    getCapabilitySecretRepository: resolved.getCapabilitySecretRepository,
-    getSkillArtifactStore: resolved.getSkillArtifactStore,
-    getMcpDnsValidationCache: resolved.getMcpDnsValidationCache,
-    executionAdapter: resolved.executionAdapter ?? app.executionAdapter,
-    executionAdapters: resolved.executionAdapters ?? app.executionAdapters,
-    runnerSandboxProvider: resolved.runnerSandboxProvider,
-    runApprovedCommand: resolved.runApprovedCommand,
-    getPermissionRepository: resolved.getPermissionRepository,
-    getPermissionPromotionRepository: resolved.getPermissionPromotionRepository,
-    publishRuntimeEvent: resolved.publishRuntimeEvent,
-    getPermissionRuntimeSettings: getRuntimeSettingsForConfig,
-    getPermissionMessageRepository: () => resolved.opsRepository,
-    subscribeRuntimeEvents: resolved.subscribeRuntimeEvents,
-    getEgressSettings: () => getRuntimeSettingsForConfig().permissions.egress,
-    mirrorAgentToolRulesToSettings,
-    reloadRuntimeState: () => app.loadState(),
-    getCredentialBroker: app.getCredentialBroker,
-    getCredentialBrokerProfile: () => getCredentialBrokerRuntimeConfig().mode,
-    callBrowserTool: resolved.callBrowserTool,
-    publishBrowserJobActivity: resolved.publishBrowserJobActivity,
-    getBrowserStatus,
-    closeBrowserToolBackends: resolved.closeBrowserToolBackends,
-    getBrowserUsageSettings: () => getRuntimeSettingsForConfig().browser.usage,
-    requestPermissionApproval: inlineInteractions.requestPermissionApproval,
-    isControlApproverAllowed: channelWiring.isControlApproverAllowed,
-    requestUserAnswer: inlineInteractions.requestUserAnswer,
-    renderAgentTodo: (jid, render, options) =>
-      liveTurnsEnabled && liveExecution
-        ? channelWiring.renderAgentTodo(jid, render, options)
-        : Promise.resolve(false),
-    renderRichInteraction: (jid, request, options) =>
-      liveTurnsEnabled && liveExecution
-        ? channelWiring.renderRichInteraction(jid, request, options)
-        : Promise.resolve(false),
-    mcpHostnameLookup: resolved.mcpHostnameLookup,
-  });
+  const startIpcWatcher = () =>
+    resolved.startIpcWatcher({
+      sendMessage: (jid, text, options) =>
+        channelWiring.sendMessage(jid, text, {
+          durability: 'required',
+          throwOnMissing: true,
+          ...(options ? { messageOptions: options } : {}),
+        }),
+      conversationRoutes: () => app.getConversationRoutes(),
+      registerGroup: app.registerGroup,
+      syncGroups: (force: boolean) => channelWiring.syncGroups(force),
+      getAvailableGroups: app.getAvailableGroups,
+      writeGroupsSnapshot: (folder, availableGroups, registeredJids) =>
+        resolved.writeGroupsSnapshot(folder, availableGroups, registeredJids),
+      onSchedulerChanged,
+      opsRepository: resolved.opsRepository,
+      getToolRepository: resolved.getToolRepository,
+      getSkillRepository: resolved.getSkillRepository,
+      getAsyncTaskRepository: resolved.getAsyncTaskRepository,
+      getMcpServerRepository: resolved.getMcpServerRepository,
+      getCapabilitySecretRepository: resolved.getCapabilitySecretRepository,
+      getSkillArtifactStore: resolved.getSkillArtifactStore,
+      getMcpDnsValidationCache: resolved.getMcpDnsValidationCache,
+      executionAdapter: resolved.executionAdapter ?? app.executionAdapter,
+      executionAdapters: resolved.executionAdapters ?? app.executionAdapters,
+      runnerSandboxProvider: resolved.runnerSandboxProvider,
+      runApprovedCommand: resolved.runApprovedCommand,
+      getPermissionRepository: resolved.getPermissionRepository,
+      getPermissionPromotionRepository:
+        resolved.getPermissionPromotionRepository,
+      publishRuntimeEvent: resolved.publishRuntimeEvent,
+      getPermissionRuntimeSettings: getRuntimeSettingsForConfig,
+      getPermissionMessageRepository: () => resolved.opsRepository,
+      subscribeRuntimeEvents: resolved.subscribeRuntimeEvents,
+      getEgressSettings: () => getRuntimeSettingsForConfig().permissions.egress,
+      mirrorAgentToolRulesToSettings,
+      reloadRuntimeState: () => app.loadState(),
+      getCredentialBroker: app.getCredentialBroker,
+      getCredentialBrokerProfile: () => getCredentialBrokerRuntimeConfig().mode,
+      callBrowserTool: resolved.callBrowserTool,
+      publishBrowserJobActivity: resolved.publishBrowserJobActivity,
+      getBrowserStatus,
+      closeBrowserToolBackends: resolved.closeBrowserToolBackends,
+      getBrowserUsageSettings: () =>
+        getRuntimeSettingsForConfig().browser.usage,
+      requestPermissionApproval: inlineInteractions.requestPermissionApproval,
+      isControlApproverAllowed: channelWiring.isControlApproverAllowed,
+      requestUserAnswer: inlineInteractions.requestUserAnswer,
+      renderAgentTodo: (jid, render, options) =>
+        liveTurnsEnabled && liveExecution
+          ? channelWiring.renderAgentTodo(jid, render, options)
+          : Promise.resolve(false),
+      renderRichInteraction: (jid, request, options) =>
+        liveTurnsEnabled && liveExecution
+          ? channelWiring.renderRichInteraction(jid, request, options)
+          : Promise.resolve(false),
+      mcpHostnameLookup: resolved.mcpHostnameLookup,
+    });
   syncGroupSnapshots();
   app.queue.setLiveTurnRunnerRegistrar(
     liveTurnAuthority
@@ -988,6 +991,7 @@ export async function startRuntimeServices(
       warn: (meta, message) => resolved.logger.warn(meta, message),
     });
   }
+  startIpcWatcher();
   if (jobExecution) await startScheduler();
   else {
     markRoleHasNoJobExecution();

--- a/apps/core/src/channels/slack/permission-approval-delivery.ts
+++ b/apps/core/src/channels/slack/permission-approval-delivery.ts
@@ -4,6 +4,7 @@ import type {
   PermissionApprovalRequest,
 } from '../../domain/types.js';
 import { logger } from '../../infrastructure/logging/logger.js';
+import { incrementOperationalError } from '../../shared/operational-error-counters.js';
 import {
   buildPermissionPromptParts,
   formatPermissionPromptPartsText,
@@ -170,6 +171,7 @@ export async function requestSlackPermissionApproval(input: {
       });
     });
   } catch (err) {
+    incrementOperationalError('channels', 'permission_prompt');
     logger.error(
       { jid: input.jid, requestId: input.request.requestId, err },
       'Failed to send Slack permission prompt',

--- a/apps/core/src/channels/teams.ts
+++ b/apps/core/src/channels/teams.ts
@@ -17,6 +17,7 @@ import type {
 } from '../domain/types.js';
 import type { AgentTodoRender } from '../domain/ports/task-lifecycle.js';
 import { logger } from '../infrastructure/logging/logger.js';
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
 import { PERMISSION_APPROVAL_TIMEOUT_MS } from '../shared/permission-timeout.js';
 import { nowIso } from '../shared/time/datetime.js';
 import {
@@ -443,6 +444,7 @@ export class TeamsChannel implements ChannelAdapter {
         });
       });
     } catch (err) {
+      incrementOperationalError('channels', 'permission_prompt');
       logger.error(
         { jid, requestId: request.requestId, err },
         'Failed to send Teams permission prompt',

--- a/apps/core/src/control/server/system-health.ts
+++ b/apps/core/src/control/server/system-health.ts
@@ -12,6 +12,7 @@ import {
   HOST_EXECUTION_SLOT_KEY_PREFIX,
   hostExecutionSlotKey,
 } from '../../shared/host-capacity.js';
+import { snapshotOperationalErrors } from '../../shared/operational-error-counters.js';
 
 /**
  * Process role string. Kept as a local union (not imported from the runtime
@@ -303,6 +304,15 @@ export async function renderMetrics(deps: MetricsDeps): Promise<string> {
       role: deps.role,
     },
   );
+  lines.push(
+    '# HELP gantry_errors_total Operational errors caught at load-bearing runtime boundaries.',
+  );
+  lines.push('# TYPE gantry_errors_total counter');
+  for (const counter of snapshotOperationalErrors()) {
+    lines.push(
+      `gantry_errors_total${renderLabels({ subsystem: counter.subsystem, kind: counter.kind })} ${counter.count}`,
+    );
+  }
 
   try {
     const rows = await deps.query<WorkerStatusRow>(

--- a/apps/core/src/infrastructure/logging/logger.ts
+++ b/apps/core/src/infrastructure/logging/logger.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import {
   Clock,
   nowIso,
@@ -44,6 +46,36 @@ export interface CreateLoggerOptions {
   clock?: Clock;
   context?: Record<string, unknown>;
   redact?: (value: unknown) => unknown;
+}
+
+export interface LogCorrelationContext {
+  runId?: string;
+  appId?: string;
+  agentId?: string;
+  traceId?: string;
+}
+
+const logContextStorage = new AsyncLocalStorage<LogCorrelationContext>();
+
+export function withLogContext<T>(
+  context: LogCorrelationContext,
+  callback: () => T,
+): T {
+  return logContextStorage.run(
+    { ...logContextStorage.getStore(), ...context },
+    callback,
+  );
+}
+
+export function updateLogContext(context: LogCorrelationContext): void {
+  const current = logContextStorage.getStore();
+  if (current) Object.assign(current, context);
+}
+
+export function currentLogContext():
+  | Readonly<LogCorrelationContext>
+  | undefined {
+  return logContextStorage.getStore();
 }
 
 const DEFAULT_REDACT_KEY_PATTERN =
@@ -267,6 +299,11 @@ export function createLogger(options: CreateLoggerOptions = {}): Logger {
       typeof dataOrMsg === 'string'
         ? redactString(dataOrMsg)
         : redactString(msg || '');
+    const activeContext = currentLogContext();
+    const inheritedContext = mergeContexts(
+      mergeContexts(baseContext, activeContext),
+      childContext,
+    );
     const record: LogRecord = {
       timestamp: nowIso(clock),
       level: currentLevel,
@@ -274,17 +311,14 @@ export function createLogger(options: CreateLoggerOptions = {}): Logger {
       pid: process.pid,
       ...(() => {
         if (typeof dataOrMsg === 'string') {
-          const context = redact(mergeContexts(baseContext, childContext)) as
+          const context = redact(inheritedContext) as
             | Record<string, unknown>
             | undefined;
           return context ? { context } : {};
         }
-        const context = redact(
-          mergeContexts(
-            mergeContexts(baseContext, childContext),
-            redact(dataOrMsg) as Record<string, unknown>,
-          ),
-        ) as Record<string, unknown> | undefined;
+        const context = redact(mergeContexts(inheritedContext, dataOrMsg)) as
+          | Record<string, unknown>
+          | undefined;
         return context ? { context } : {};
       })(),
     };

--- a/apps/core/src/infrastructure/observability/spawn-log-context.ts
+++ b/apps/core/src/infrastructure/observability/spawn-log-context.ts
@@ -1,0 +1,59 @@
+import { withLogContext } from '../logging/logger.js';
+import {
+  createSpawnTurnTracker,
+  type SpawnTurnTracker,
+} from './spawn-turn-tracker.js';
+
+interface SpawnLogTurnInput {
+  runId?: string;
+  appId?: string;
+  agentId?: string;
+  chatJid?: string;
+  threadId?: string;
+  jobId?: string;
+  memoryUserId?: string;
+  prompt: string;
+}
+
+interface SpawnLogFrame {
+  status: string;
+  result: string | null;
+  error?: string;
+  continuedByFollowup?: boolean;
+}
+
+export async function runSpawnWithLogContext<Frame extends SpawnLogFrame>(
+  input: {
+    agentName: string;
+    turn: SpawnLogTurnInput;
+    correlationRunId?: string;
+    appId: string;
+    agentId: string;
+    onOutput: ((output: Frame) => Promise<void>) | undefined;
+  },
+  run: (tracker: SpawnTurnTracker<Frame>) => Promise<Frame>,
+): Promise<Frame> {
+  const turnTracker = createSpawnTurnTracker(
+    input.agentName,
+    { ...input.turn, runId: input.correlationRunId },
+    input.onOutput,
+  );
+  const traceId = turnTracker.traceId();
+  let output: Frame | undefined;
+  return withLogContext(
+    {
+      runId: turnTracker.correlationId,
+      appId: input.appId,
+      agentId: input.agentId,
+      ...(traceId ? { traceId } : {}),
+    },
+    async () => {
+      try {
+        output = await run(turnTracker);
+        return output;
+      } finally {
+        turnTracker.finish(output);
+      }
+    },
+  );
+}

--- a/apps/core/src/infrastructure/observability/spawn-turn-tracker.ts
+++ b/apps/core/src/infrastructure/observability/spawn-turn-tracker.ts
@@ -6,6 +6,7 @@ import {
   tracingEnabled,
   TRACE_CONTENT_MAX_CHARS,
 } from './tracing.js';
+import { updateLogContext } from '../logging/logger.js';
 
 // Structural mirrors of the runtime's AgentInput/AgentOutput — this module
 // must not import runtime types (layer boundary), and only reads these
@@ -30,6 +31,7 @@ interface TurnFrameLike {
 
 export interface SpawnTurnTracker<F extends TurnFrameLike> {
   correlationId: string;
+  traceId: () => string | undefined;
   onOutput: ((frame: F) => Promise<void>) | undefined;
   finish: (output: F | undefined) => void;
 }
@@ -83,26 +85,37 @@ export function createSpawnTurnTracker<F extends TurnFrameLike>(
             // the content bound.
             streamedTurnOutput += String(frame.result).slice(0, remaining);
           }
-          // Rotate BEFORE awaiting delivery: the runner starts the buffered
-          // follow-up immediately after emitting this frame, so a late
-          // rotation would parent the next turn's first LLM calls under the
-          // previous span (and a rejected callback would skip rotation).
+          // Rotate the OTel span before awaiting delivery: the runner starts
+          // the buffered follow-up immediately after emitting this frame, so
+          // a late span rotation could parent its first LLM calls under the
+          // previous turn. Keep the log context on the completed turn until
+          // its terminal frame callback settles, then rotate it for later
+          // work.
           // ponytail: the host output chain still queues this callback, so a
           // narrow race remains, and the follow-up prompt is runner-side so
           // the rotated span has no input — both marked via
           // gantry.continuation; fixing them needs a synchronous frame hook
           // in agent-spawn-process plus follow-up prompt plumbing.
+          let continuationTraceId: string | undefined;
           if (frame.continuedByFollowup && !closed) {
             if (streamedTurnOutput) turnSpan.setOutput(streamedTurnOutput);
             turnSpan.end('success');
             streamedTurnOutput = '';
             turnSpan = openTurnSpan(true);
+            continuationTraceId = turnSpan.traceId;
           }
-          await onOutput(frame);
+          try {
+            await onOutput(frame);
+          } finally {
+            if (continuationTraceId) {
+              updateLogContext({ traceId: continuationTraceId });
+            }
+          }
         }
       : onOutput;
   return {
     correlationId,
+    traceId: () => turnSpan.traceId,
     onOutput: tracedOnOutput,
     finish: (output) => {
       closed = true;

--- a/apps/core/src/infrastructure/observability/tracing.ts
+++ b/apps/core/src/infrastructure/observability/tracing.ts
@@ -192,6 +192,7 @@ export function boundedJsonArray(
 }
 
 export interface TurnSpanHandle {
+  traceId?: string;
   setInput: (content: string) => void;
   setOutput: (content: string) => void;
   end: (outcome: 'success' | 'error' | 'stopped', error?: string) => void;
@@ -234,6 +235,7 @@ export function startTurnSpan(input: {
     turnSpans.set(input.runId, span);
     let ended = false;
     return {
+      traceId: span.spanContext().traceId,
       setInput: (content) => {
         if (!ended && current.captureContent) {
           span.setAttribute(

--- a/apps/core/src/jobs/delivery.ts
+++ b/apps/core/src/jobs/delivery.ts
@@ -1,4 +1,5 @@
 import { logger } from '../infrastructure/logging/logger.js';
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
 import type { Job, MessageSendOptions } from '../domain/types.js';
 import {
   getPartialMessageDeliveryMetadata,
@@ -183,6 +184,7 @@ export async function sendJobNotification(input: {
         });
         if (enqueueResult !== false) delivered = true;
       } catch (err) {
+        incrementOperationalError('delivery', 'notification_enqueue');
         logger.warn(
           {
             err,
@@ -223,8 +225,13 @@ export async function sendJobNotification(input: {
         ),
         { scope: 'job-notification', target: route.conversationJid },
       );
-      if (isDeliverySent(settlement)) delivered = true;
+      if (isDeliverySent(settlement)) {
+        delivered = true;
+      } else {
+        incrementOperationalError('delivery', 'notification_send');
+      }
     } catch (err) {
+      incrementOperationalError('delivery', 'notification_send');
       logger.warn(
         { jobId: input.job.id, jid: route.conversationJid, err },
         'Failed to send scheduler status message',

--- a/apps/core/src/jobs/execution-context.ts
+++ b/apps/core/src/jobs/execution-context.ts
@@ -37,17 +37,7 @@ export function resolveExecutionContext(
   const executionProviderAccountId = normalizeOptional(
     primaryExecutionRoute?.providerAccountId,
   );
-  const explicitAgentId = normalizeOptional(
-    (job.execution_context as Record<string, unknown> | undefined)?.agentId,
-  );
-  const workspaceKey =
-    normalizeOptional(job.execution_context?.workspaceKey) ??
-    normalizeOptional(job.workspace_key);
-  const executionAgentId = explicitAgentId
-    ? explicitAgentId
-    : workspaceKey
-      ? agentIdForJobWorkspaceKey(workspaceKey)
-      : undefined;
+  const executionAgentId = resolveJobExecutionAgentId(job);
   const group = executionAgentId
     ? findConversationRouteForQueue(
         groups,
@@ -77,6 +67,17 @@ export function resolveExecutionContext(
     threadId: executionThreadId ?? primaryExecutionRoute?.threadId ?? null,
     stopAliasJids,
   };
+}
+
+export function resolveJobExecutionAgentId(job: Job): string | undefined {
+  const explicitAgentId = normalizeOptional(
+    (job.execution_context as Record<string, unknown> | undefined)?.agentId,
+  );
+  if (explicitAgentId) return explicitAgentId;
+  const workspaceKey =
+    normalizeOptional(job.execution_context?.workspaceKey) ??
+    normalizeOptional(job.workspace_key);
+  return workspaceKey ? agentIdForJobWorkspaceKey(workspaceKey) : undefined;
 }
 
 export function resolveExecutionMemoryContext(input: {

--- a/apps/core/src/jobs/execution-log-context.ts
+++ b/apps/core/src/jobs/execution-log-context.ts
@@ -1,0 +1,32 @@
+import type { Job } from '../domain/types.js';
+import { randomUUID } from 'node:crypto';
+import { withLogContext } from '../infrastructure/logging/logger.js';
+import { DEFAULT_JOB_RUNTIME_APP_ID } from '../application/jobs/job-access.js';
+import { nowIso } from '../shared/time/datetime.js';
+import { resolveJobExecutionAgentId } from './execution-context.js';
+
+export interface ActiveJobRunContext {
+  job: Job;
+  runId: string;
+  scheduledFor: string;
+}
+
+export async function runActiveJobWithLogContext(input: {
+  requestedJob: Job;
+  dispatch?: { runId?: string | null; scheduledFor?: string | null };
+  getJobById: (jobId: string) => Promise<Job | null | undefined>;
+  run: (context: ActiveJobRunContext) => Promise<void>;
+}): Promise<void> {
+  const job = await input.getJobById(input.requestedJob.id);
+  if (!job || job.status !== 'active') return;
+  const scheduledFor = input.dispatch?.scheduledFor || job.next_run || nowIso();
+  const runId = input.dispatch?.runId ?? randomUUID();
+  return withLogContext(
+    {
+      runId,
+      appId: DEFAULT_JOB_RUNTIME_APP_ID,
+      agentId: resolveJobExecutionAgentId(job),
+    },
+    () => input.run({ job, runId, scheduledFor }),
+  );
+}

--- a/apps/core/src/jobs/execution-operational-errors.ts
+++ b/apps/core/src/jobs/execution-operational-errors.ts
@@ -1,0 +1,30 @@
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
+
+export function recordJobAgentRunFailure(): void {
+  incrementOperationalError('jobs', 'agent_run');
+}
+
+function recordJobTerminalSettlementFailure(): void {
+  incrementOperationalError('jobs', 'terminal_settlement');
+}
+
+function terminalSettlementError(message: string): Error {
+  recordJobTerminalSettlementFailure();
+  return new Error(message);
+}
+
+export async function requireTerminalSettlement(
+  operation: Promise<boolean> | undefined,
+  unavailableMessage: string,
+  staleMessage: string,
+): Promise<void> {
+  if (!operation) throw terminalSettlementError(unavailableMessage);
+  let settled: boolean;
+  try {
+    settled = await operation;
+  } catch (error) {
+    recordJobTerminalSettlementFailure();
+    throw error;
+  }
+  if (!settled) throw terminalSettlementError(staleMessage);
+}

--- a/apps/core/src/jobs/execution.ts
+++ b/apps/core/src/jobs/execution.ts
@@ -1,9 +1,8 @@
-import { randomUUID } from 'crypto';
 import fs from 'fs';
 // prettier-ignore
 import { ASSISTANT_NAME, getEffectiveModelConfig, getRuntimeSettingsForConfig, getSelectedAgentHarness } from '../config/index.js';
 import type { Job } from '../domain/types.js';
-import { logger } from '../infrastructure/logging/logger.js';
+import { logger, updateLogContext } from '../infrastructure/logging/logger.js';
 // prettier-ignore
 import { getRuntimeControlRepository, getRuntimeEventExchange, getConfiguredModelProvidersForApp, getWorkerCoordinationRepository } from '../adapters/storage/postgres/runtime-store.js';
 import { DEFAULT_JOB_RUNTIME_APP_ID } from '../application/jobs/job-access.js';
@@ -76,6 +75,11 @@ import { isTrustedSystemJob } from '../shared/system-job-identity.js';
 import { completeFailedRunFailsafe } from './run-failsafe.js';
 import { createRunProviderMetadataUpdater } from './run-provider-metadata.js';
 import { hasAsyncTaskRepository } from './async-command-task-helpers.js';
+import { runActiveJobWithLogContext } from './execution-log-context.js';
+import {
+  recordJobAgentRunFailure,
+  requireTerminalSettlement,
+} from './execution-operational-errors.js';
 import type {
   JobTurnContext,
   SchedulerDependencies,
@@ -89,11 +93,32 @@ export async function runJob(
   dispatch?: SchedulerDispatchPayload,
   control?: { abortSignal?: AbortSignal },
 ): Promise<void> {
-  const currentJob = await deps.opsRepository.getJobById(job.id);
-  if (!currentJob || currentJob.status !== 'active') return;
-  const scheduledFor =
-    dispatch?.scheduledFor || currentJob.next_run || nowIso();
-  const runId = dispatch?.runId ?? randomUUID();
+  return runActiveJobWithLogContext({
+    requestedJob: job,
+    dispatch,
+    getJobById: (jobId) => deps.opsRepository.getJobById(jobId),
+    run: ({ job: currentJob, scheduledFor, runId }) =>
+      runActiveJob(
+        currentJob,
+        deps,
+        queueJid,
+        dispatch,
+        control,
+        scheduledFor,
+        runId,
+      ),
+  });
+}
+
+async function runActiveJob(
+  currentJob: Job,
+  deps: SchedulerDependencies,
+  queueJid: string,
+  dispatch: SchedulerDispatchPayload | undefined,
+  control: { abortSignal?: AbortSignal } | undefined,
+  scheduledFor: string,
+  runId: string,
+): Promise<void> {
   const startedAtMs = nowMs();
   const startedAt = toIso(startedAtMs);
   const runtimeAppId = DEFAULT_JOB_RUNTIME_APP_ID;
@@ -315,6 +340,10 @@ export async function runJob(
           const executionAgentId =
             turnContext?.agentId ??
             jobToolPolicy.agentIdForJobWorkspaceKey(execution.group.folder);
+          updateLogContext({
+            appId: executionAppId,
+            agentId: executionAgentId,
+          });
           const [
             toolPolicy,
             selectedSkillContext,
@@ -543,6 +572,7 @@ export async function runJob(
               });
               await updateRunProviderMetadata({ force: true });
               if (output.status === 'error') {
+                recordJobAgentRunFailure();
                 if (!error) error = output.error || 'Unknown error';
                 await failRun();
               } else if (output.result && !hasStreamedResult) {
@@ -580,6 +610,7 @@ export async function runJob(
             }
           }
         } catch (err) {
+          recordJobAgentRunFailure();
           error = runLeaseAbort.errorFor(err);
           if (!runLeaseAbort.isAborted()) {
             await updateRunProviderMetadata({ force: true });
@@ -619,59 +650,49 @@ export async function runJob(
       updateJobState: async (jobUpdates, state) => {
         if (deletionGuard.deletedDuringRun) return;
         const finalizeWithLease = deps.opsRepository.finalizeJobRunWithLease;
-        if (!finalizeWithLease) {
-          throw new Error(
-            'Scheduler run lease finalization is unavailable for terminal job write.',
-          );
-        }
-        const finalized = await finalizeWithLease.call(deps.opsRepository, {
-          jobId: currentJob.id,
-          runId,
-          leaseToken: leaseContext.lease.leaseToken,
-          workerInstanceId: leaseContext.lease.workerInstanceId,
-          fencingVersion: leaseContext.lease.fencingVersion,
-          leaseOutcome: error ? 'failed' : 'completed',
-          runStatus: state.runStatus,
-          resultSummary: safeResultSummary
-            ? safeResultSummary.slice(0, 500)
-            : null,
-          errorSummary: state.safeErrorSummary
-            ? state.safeErrorSummary.slice(0, 500)
-            : null,
-          jobUpdates,
-        });
-        if (!finalized) {
-          throw new Error(
-            'Scheduler run lease is no longer active during terminal finalization.',
-          );
-        }
+        await requireTerminalSettlement(
+          finalizeWithLease?.call(deps.opsRepository, {
+            jobId: currentJob.id,
+            runId,
+            leaseToken: leaseContext.lease.leaseToken,
+            workerInstanceId: leaseContext.lease.workerInstanceId,
+            fencingVersion: leaseContext.lease.fencingVersion,
+            leaseOutcome: error ? 'failed' : 'completed',
+            runStatus: state.runStatus,
+            resultSummary: safeResultSummary
+              ? safeResultSummary.slice(0, 500)
+              : null,
+            errorSummary: state.safeErrorSummary
+              ? state.safeErrorSummary.slice(0, 500)
+              : null,
+            jobUpdates,
+          }),
+          'Scheduler run lease finalization is unavailable for terminal job write.',
+          'Scheduler run lease is no longer active during terminal finalization.',
+        );
         terminalRunRecorded = true;
       },
     });
     if (!terminalRunRecorded && !deletionGuard.deletedDuringRun) {
       const finalizeRunLease = deps.opsRepository.finalizeJobRunLease;
-      if (!finalizeRunLease) {
-        throw new Error(
-          'Scheduler run lease finalization is unavailable for terminal run write.',
-        );
-      }
-      const finalized = await finalizeRunLease.call(deps.opsRepository, {
-        runId,
-        leaseToken: leaseContext.lease.leaseToken,
-        workerInstanceId: leaseContext.lease.workerInstanceId,
-        fencingVersion: leaseContext.lease.fencingVersion,
-        leaseOutcome: error ? 'failed' : 'completed',
-        runStatus,
-        resultSummary: safeResultSummary
-          ? safeResultSummary.slice(0, 500)
-          : null,
-        errorSummary: safeErrorSummary ? safeErrorSummary.slice(0, 500) : null,
-      });
-      if (!finalized) {
-        throw new Error(
-          'Scheduler run lease is no longer active during terminal finalization.',
-        );
-      }
+      await requireTerminalSettlement(
+        finalizeRunLease?.call(deps.opsRepository, {
+          runId,
+          leaseToken: leaseContext.lease.leaseToken,
+          workerInstanceId: leaseContext.lease.workerInstanceId,
+          fencingVersion: leaseContext.lease.fencingVersion,
+          leaseOutcome: error ? 'failed' : 'completed',
+          runStatus,
+          resultSummary: safeResultSummary
+            ? safeResultSummary.slice(0, 500)
+            : null,
+          errorSummary: safeErrorSummary
+            ? safeErrorSummary.slice(0, 500)
+            : null,
+        }),
+        'Scheduler run lease finalization is unavailable for terminal run write.',
+        'Scheduler run lease is no longer active during terminal finalization.',
+      );
       terminalRunRecorded = true;
     }
     if (runLeaseAbort.isAborted())
@@ -725,19 +746,16 @@ export async function runJob(
         sendMessage: deps.sendMessage,
       }));
     if (notified) {
-      const markedNotified = await deps.opsRepository.markJobRunNotified(
-        runId,
-        {
+      const markJobRunNotified = deps.opsRepository.markJobRunNotified;
+      await requireTerminalSettlement(
+        markJobRunNotified?.call(deps.opsRepository, runId, {
           leaseToken: leaseContext.lease.leaseToken,
           workerInstanceId: leaseContext.lease.workerInstanceId,
           fencingVersion: leaseContext.lease.fencingVersion,
-        },
+        }),
+        'Scheduler run lease notification finalization is unavailable.',
+        'Scheduler run lease is no longer valid during notification finalization.',
       );
-      if (!markedNotified) {
-        throw new Error(
-          'Scheduler run lease is no longer valid during notification finalization.',
-        );
-      }
     }
     await emitJobEvent(
       runStatus === 'completed'

--- a/apps/core/src/jobs/ipc-handler.ts
+++ b/apps/core/src/jobs/ipc-handler.ts
@@ -22,6 +22,7 @@ import {
 } from '../config/profiles.js';
 import { memoryAgentIdForWorkspaceFolder } from '../memory/app-memory-boundaries.js';
 import { RUNTIME_EVENT_TYPES } from '../domain/events/runtime-event-types.js';
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
 
 const DENIED_BY_PROFILE_REASON = 'denied_by_profile';
 
@@ -197,6 +198,7 @@ export async function processTaskIpc(
       sourceAgentFolderJids,
     });
   } catch (err) {
+    incrementOperationalError('ipc', 'task_dispatch');
     logger.error(
       { err, type: data.type, sourceAgentFolder },
       'Unhandled IPC task handler error',

--- a/apps/core/src/jobs/outbound-delivery-recovery.ts
+++ b/apps/core/src/jobs/outbound-delivery-recovery.ts
@@ -9,6 +9,7 @@ import type {
   OutboundDelivery,
 } from '../domain/outbound-delivery/outbound-delivery.js';
 import { nowIso } from '../shared/time/datetime.js';
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
 
 export interface OutboundDeliveryPartialRetryTail {
   canonicalText: string;
@@ -93,6 +94,7 @@ export async function runBoundedOutboundDeliveryRecovery(
         partialAt: inputSettle.partialAt,
       });
       if (!ambiguous.applied) {
+        incrementOperationalError('delivery', 'ambiguous_settlement');
         input.warn?.(
           {
             deliveryId: inputSettle.claimed.delivery.id,
@@ -105,6 +107,7 @@ export async function runBoundedOutboundDeliveryRecovery(
       failed += 1;
       return true;
     } catch (err) {
+      incrementOperationalError('delivery', 'ambiguous_settlement');
       input.warn?.(
         {
           err,
@@ -158,9 +161,12 @@ export async function runBoundedOutboundDeliveryRecovery(
       }
 
       let dispatchResult: OutboundDeliveryDispatchResult;
+      let dispatchThrew = false;
       try {
         dispatchResult = await input.dispatch(claimedItem);
       } catch (err) {
+        dispatchThrew = true;
+        incrementOperationalError('delivery', 'outbound_dispatch');
         if (isPartialMessageDeliveryError(err)) {
           const partialMetadata = getPartialMessageDeliveryMetadata(err);
           dispatchResult = {
@@ -193,6 +199,10 @@ export async function runBoundedOutboundDeliveryRecovery(
         }
       }
 
+      if (dispatchResult.status === 'failed' && !dispatchThrew) {
+        incrementOperationalError('delivery', 'outbound_dispatch');
+      }
+
       if (dispatchResult.status === 'sent') {
         let settledError: string | null = null;
         try {
@@ -211,9 +221,11 @@ export async function runBoundedOutboundDeliveryRecovery(
             sent += 1;
             continue;
           }
+          incrementOperationalError('delivery', 'sent_settlement');
           settledError =
             'Outbound delivery dispatch succeeded but sent settlement was not applied.';
         } catch (err) {
+          incrementOperationalError('delivery', 'sent_settlement');
           settledError =
             err instanceof Error
               ? err.message
@@ -258,6 +270,7 @@ export async function runBoundedOutboundDeliveryRecovery(
             failed += 1;
             continue;
           }
+          incrementOperationalError('delivery', 'partial_settlement');
           await settleAmbiguousNonRetryable({
             claimed: claimedItem,
             claimToken,
@@ -267,6 +280,7 @@ export async function runBoundedOutboundDeliveryRecovery(
               'Outbound delivery partial retry-tail settlement was not applied',
           });
         } catch (err) {
+          incrementOperationalError('delivery', 'partial_settlement');
           input.warn?.(
             {
               err,

--- a/apps/core/src/memory/memory-ipc.ts
+++ b/apps/core/src/memory/memory-ipc.ts
@@ -57,6 +57,7 @@ import {
   processMemoryReviewDecisionRequest,
   processPendingMemoryReviewRequest,
 } from './memory-review-ipc.js';
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
 
 const MEMORY_IPC_REQUEST_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
 
@@ -591,6 +592,7 @@ export async function processMemoryRequest(
         throw new Error(`Unsupported memory action: ${request.action}`);
     }
   } catch (error) {
+    incrementOperationalError('memory', 'ipc_request');
     return {
       ok: false,
       requestId: request.requestId,

--- a/apps/core/src/runtime/agent-inline.ts
+++ b/apps/core/src/runtime/agent-inline.ts
@@ -235,6 +235,7 @@ export async function runInlineAgent(
       options.credentialBroker,
       {
         purpose: 'model_runtime',
+        runId: options.correlationRunId as never,
         runContext: input,
         modelRouteId: resolvedModel.value.modelEntry.modelRoute.id,
       },

--- a/apps/core/src/runtime/agent-spawn-execution-adapter.ts
+++ b/apps/core/src/runtime/agent-spawn-execution-adapter.ts
@@ -1,0 +1,38 @@
+import { resolveAgentExecutionAdapter } from '../application/agent-execution/agent-execution-adapter-registry.js';
+import type { AgentOutput, RunAgentOptions } from './agent-spawn-types.js';
+
+type ExecutionAdapter = NonNullable<RunAgentOptions['executionAdapter']>;
+
+export function resolveSpawnExecutionAdapter(
+  executionProviderId: string,
+  options: RunAgentOptions | undefined,
+):
+  | { ok: true; executionAdapter: ExecutionAdapter }
+  | { ok: false; output: AgentOutput } {
+  try {
+    const executionAdapter = resolveAgentExecutionAdapter({
+      executionProviderId,
+      registry: options?.executionAdapters,
+      fallback: options?.executionAdapter,
+    }) as ExecutionAdapter;
+    if (executionAdapter) return { ok: true, executionAdapter };
+    return {
+      ok: false,
+      output: {
+        status: 'error',
+        result: null,
+        error:
+          'No LLM execution adapter configured. Runtime bootstrap must provide an AgentExecutionAdapterRegistry.',
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      output: {
+        status: 'error',
+        result: null,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}

--- a/apps/core/src/runtime/agent-spawn-identity.ts
+++ b/apps/core/src/runtime/agent-spawn-identity.ts
@@ -1,0 +1,51 @@
+import type { ConversationRoute } from '../domain/types.js';
+import { memoryAgentIdForWorkspaceFolder } from '../memory/app-memory-boundaries.js';
+import type { AgentInput } from './agent-spawn-types.js';
+
+export function resolveSpawnAgentId(input: {
+  inputAgentId?: string;
+  routeAgentId?: string;
+  workspaceFolder: string;
+}): string {
+  return (
+    input.inputAgentId ??
+    input.routeAgentId ??
+    memoryAgentIdForWorkspaceFolder(input.workspaceFolder)
+  );
+}
+
+export function resolveAgentSpawnLogContext(
+  group: ConversationRoute,
+  input: AgentInput,
+  correlationRunId?: string,
+) {
+  const appId = input.appId ?? 'default';
+  const agentId = resolveSpawnAgentId({
+    inputAgentId: input.agentId,
+    routeAgentId: group.agentId,
+    workspaceFolder: group.folder,
+  });
+  return {
+    agentName: group.name,
+    turn: { ...input, appId, agentId },
+    correlationRunId: input.runId ?? correlationRunId,
+    appId,
+    agentId,
+  };
+}
+
+export function stripIncompleteRunLeaseIdentity(input: AgentInput): AgentInput {
+  const hasRunId = Boolean(input.runId);
+  const hasLeaseToken = Boolean(input.runLeaseToken);
+  const hasFencingVersion = typeof input.runLeaseFencingVersion === 'number';
+  if (hasRunId && hasLeaseToken && hasFencingVersion) return input;
+  if (!hasRunId && !hasLeaseToken && !hasFencingVersion) return input;
+
+  const {
+    runId: _runId,
+    runLeaseToken: _runLeaseToken,
+    runLeaseFencingVersion: _runLeaseFencingVersion,
+    ...correlationOnlyInput
+  } = input;
+  return correlationOnlyInput;
+}

--- a/apps/core/src/runtime/agent-spawn-preparation.ts
+++ b/apps/core/src/runtime/agent-spawn-preparation.ts
@@ -1,0 +1,67 @@
+import type { ChildProcess } from 'node:child_process';
+
+import type { ConversationRoute } from '../domain/types.js';
+import type { AgentRuntime } from '../shared/agent-runtime.js';
+import { nowMs } from '../shared/time/datetime.js';
+import { prepareRunnerWorkspace } from './agent-spawn-helpers.js';
+import { createRunnerHostStartupTiming } from './agent-spawn-startup-timing.js';
+import type {
+  AgentInput,
+  AgentOutput,
+  RunAgentOptions,
+} from './agent-spawn-types.js';
+
+type HostStartupTiming = ReturnType<typeof createRunnerHostStartupTiming>;
+
+export type AgentSpawnPreparation =
+  | { kind: 'inline'; output: AgentOutput }
+  | {
+      kind: 'worker';
+      agentRuntime: AgentRuntime;
+      startTime: number;
+      hostStartup: HostStartupTiming;
+      groupDir: string;
+      processName: string;
+    };
+
+export async function prepareAgentSpawn(input: {
+  group: ConversationRoute;
+  agentInput: AgentInput;
+  agentRuntime: AgentRuntime;
+  onProcess: (proc: ChildProcess, runHandle: string) => void;
+  onOutput: ((output: AgentOutput) => Promise<void>) | undefined;
+  options: RunAgentOptions;
+  warn: (context: Record<string, unknown>, message: string) => void;
+}): Promise<AgentSpawnPreparation> {
+  const { agentRuntime } = input;
+  if (agentRuntime === 'inline') {
+    const { runInlineAgent } = await import('./agent-inline.js');
+    return {
+      kind: 'inline',
+      output: await runInlineAgent(
+        input.group,
+        input.agentInput,
+        input.onProcess,
+        input.onOutput,
+        input.options,
+      ),
+    };
+  }
+  const startTime = nowMs();
+  const hostStartup = createRunnerHostStartupTiming({ nowMs });
+  const { groupDir, processName } = hostStartup.measure('workspacePrepMs', () =>
+    prepareRunnerWorkspace({
+      folder: input.group.folder,
+      nowMs,
+      warn: input.warn,
+    }),
+  );
+  return {
+    kind: 'worker',
+    agentRuntime,
+    startTime,
+    hostStartup,
+    groupDir,
+    processName,
+  };
+}

--- a/apps/core/src/runtime/agent-spawn-types.ts
+++ b/apps/core/src/runtime/agent-spawn-types.ts
@@ -141,6 +141,7 @@ export interface AgentOutputRuntimeEvent {
 export interface RunAgentOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
+  correlationRunId?: string;
   credentialBroker?: AgentCredentialBroker;
   skillRepository?: SkillCatalogRepository;
   skillArtifactStore?: SkillArtifactStore;

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -17,7 +17,8 @@ import {
 } from '../config/index.js';
 import { resolveAgentAccessPolicy } from '../config/profiles.js';
 import { logger } from '../infrastructure/logging/logger.js';
-import { createSpawnTurnTracker } from '../infrastructure/observability/spawn-turn-tracker.js';
+import { runSpawnWithLogContext } from '../infrastructure/observability/spawn-log-context.js';
+import type { SpawnTurnTracker } from '../infrastructure/observability/spawn-turn-tracker.js';
 import { ConversationRoute } from '../domain/types.js';
 import * as host from './agent-spawn-host.js';
 import {
@@ -63,17 +64,18 @@ import {
   sandboxAllowedNetworkHostsFromRuntimeAccess,
   writeProtectedFilesystemEnv,
 } from './agent-spawn-runtime-policy.js';
-import { nowMs as currentTimeMs } from '../shared/time/datetime.js';
+import {
+  resolveAgentSpawnLogContext,
+  stripIncompleteRunLeaseIdentity,
+} from './agent-spawn-identity.js';
 import {
   getConfiguredModelProvidersForApp,
   getRuntimeFileArtifactStore,
 } from '../adapters/storage/postgres/runtime-store.js';
 import { effectiveYoloModeSettings } from '../shared/yolo-mode-policy.js';
 import { formatGeneratedRuntimePathPermissionError } from './generated-runtime-path-error.js';
-import { resolveAgentExecutionAdapter } from '../application/agent-execution/agent-execution-adapter-registry.js';
 import { writeRunnerMcpConfigFile } from './agent-spawn-mcp-config.js';
 import { withStdioMcpEgressEnv } from './agent-spawn-mcp-egress-env.js';
-import { createRunnerHostStartupTiming } from './agent-spawn-startup-timing.js';
 import { publishRunnerHostStartupDiagnosticFromSpawn } from './agent-spawn-startup-diagnostic.js';
 import { resolveSelectedSkillEnvForSpawn } from './agent-spawn-selected-skill-env.js';
 import { configureSpawnAsyncCommandSandboxPolicy } from './async-command-sandbox-policy.js';
@@ -89,7 +91,6 @@ import {
   protectedWritePathsForOuterSandbox,
   sandboxRuntimeToolProcessEnv,
   sandboxRuntimeToolNetworkEnv,
-  prepareRunnerWorkspace,
   resolveRunnerSandboxStartup,
   uniqueStrings,
   buildRunnerSandboxSpawnInput,
@@ -97,6 +98,8 @@ import {
   buildAndLogRunnerRuntimeDetails,
   type RunnerAgentInput,
 } from './agent-spawn-helpers.js';
+import { prepareAgentSpawn } from './agent-spawn-preparation.js';
+import { resolveSpawnExecutionAdapter } from './agent-spawn-execution-adapter.js';
 export { writeGroupsSnapshot } from './agent-spawn-snapshots.js';
 export type { AvailableGroup } from './agent-spawn-types.js';
 export type { AgentInput, AgentOutput } from './agent-spawn-types.js';
@@ -107,20 +110,36 @@ export async function spawnAgent(
   onOutput: ((output: AgentOutput) => Promise<void>) | undefined,
   options: RunAgentOptions,
 ): Promise<AgentOutput> {
-  const agentRuntime = input.runtime ?? getSelectedAgentRuntime(group.folder);
-  if (agentRuntime === 'inline') {
-    const { runInlineAgent } = await import('./agent-inline.js');
-    return runInlineAgent(group, input, onProcess, onOutput, options);
-  }
-  const startTime = currentTimeMs();
-  const hostStartup = createRunnerHostStartupTiming({ nowMs: currentTimeMs });
-  const { groupDir, processName } = hostStartup.measure('workspacePrepMs', () =>
-    prepareRunnerWorkspace({
-      folder: group.folder,
-      nowMs: currentTimeMs,
-      warn: logger.warn.bind(logger),
-    }),
+  const spawnInput = stripIncompleteRunLeaseIdentity(input);
+  return runSpawnWithLogContext(
+    {
+      ...resolveAgentSpawnLogContext(group, input, options?.correlationRunId),
+      onOutput,
+    },
+    (turnTracker) =>
+      spawnAgentWithContext(group, spawnInput, onProcess, options, turnTracker),
   );
+}
+
+async function spawnAgentWithContext(
+  group: ConversationRoute,
+  input: AgentInput,
+  onProcess: (proc: ChildProcess, runHandle: string) => void,
+  options: RunAgentOptions,
+  turnTracker: SpawnTurnTracker<AgentOutput>,
+): Promise<AgentOutput> {
+  const preparation = await prepareAgentSpawn({
+    group,
+    agentInput: input,
+    agentRuntime: input.runtime ?? getSelectedAgentRuntime(group.folder),
+    onProcess,
+    onOutput: turnTracker.onOutput,
+    options: { ...options, correlationRunId: turnTracker.correlationId },
+    warn: logger.warn.bind(logger),
+  });
+  if (preparation.kind === 'inline') return preparation.output;
+  const { agentRuntime, startTime, hostStartup, groupDir, processName } =
+    preparation;
   const modelResolutionStarted = hostStartup.start();
   const runtimeSettings = getRuntimeSettingsForConfig();
   const modelConfig = getEffectiveModelConfig(
@@ -206,29 +225,12 @@ export async function spawnAgent(
     yoloMode: effectiveYoloModeSettings(runtimeSettings.permissions.yoloMode),
   };
   const hostRuntime = host.prepareHostRuntimeContext(group);
-  let executionAdapter: NonNullable<RunAgentOptions['executionAdapter']>;
-  try {
-    executionAdapter = resolveAgentExecutionAdapter({
-      executionProviderId: resolvedModel.value.executionProviderId,
-      registry: options?.executionAdapters,
-      fallback: options?.executionAdapter,
-    }) as NonNullable<RunAgentOptions['executionAdapter']>;
-  } catch (err) {
-    return {
-      status: 'error',
-      result: null,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
-  if (!executionAdapter) {
-    return {
-      status: 'error',
-      result: null,
-      error:
-        'No LLM execution adapter configured. Runtime bootstrap must provide an AgentExecutionAdapterRegistry.',
-    };
-  }
-  const turnTracker = createSpawnTurnTracker(group.name, input, onOutput);
+  const adapterResolution = resolveSpawnExecutionAdapter(
+    resolvedModel.value.executionProviderId,
+    options,
+  );
+  if (!adapterResolution.ok) return adapterResolution.output;
+  const { executionAdapter } = adapterResolution;
   let mcpConfigPath: string | undefined;
   let sandboxConfigPath: string | undefined;
   let runnerTempDir: string | undefined;
@@ -771,7 +773,6 @@ export async function spawnAgent(
     });
     return output;
   } finally {
-    turnTracker.finish(output);
     cleanupRunnerTempDir(runnerTempDir, logger.warn.bind(logger));
     if (browserIpcEnabled) {
       revokeBrowserIpcAuthorization({

--- a/apps/core/src/runtime/group-agent-runner.ts
+++ b/apps/core/src/runtime/group-agent-runner.ts
@@ -51,7 +51,12 @@ import {
 import { forwardRuntimeEvents } from './runtime-event-forwarding.js';
 import { isMissingProviderSessionError } from './failover-eligibility.js';
 import { createConfiguredRunTokenBudget } from './agent-spawn-host.js';
-import { logger, redactString } from '../infrastructure/logging/logger.js';
+import {
+  logger,
+  redactString,
+  updateLogContext,
+  withLogContext,
+} from '../infrastructure/logging/logger.js';
 import { memoryReviewerApproverAllowed } from './group-agent-runner-memory-review.js';
 import { prepareCompactionDeltaReplay } from './group-agent-runner-compaction-delta.js';
 import { maintenanceCompactionPromptForExecutionProvider } from './group-agent-runner-maintenance-compaction.js';
@@ -77,7 +82,7 @@ export function createGroupAgentRunner(input: {
   const { deps, ops } = input;
   const runAgentImpl = deps.runAgent ?? spawnAgent;
   const collectSessionMemory = deps.collectSessionMemory;
-  return async function runAgent(
+  async function runAgentWithContext(
     group: ConversationRoute,
     prompt: string,
     chatJid: string,
@@ -473,6 +478,12 @@ export function createGroupAgentRunner(input: {
                 : 'message',
           })
         : undefined;
+    updateLogContext({
+      runId: runState.runId,
+      appId: runtimeAppId,
+      agentId:
+        turnContext?.agentId ?? memoryAgentIdForWorkspaceFolder(group.folder),
+    });
     try {
       const credentialBroker = await deps.getCredentialBroker?.();
       const runOptions = buildRuntimeRunOptions({
@@ -550,14 +561,12 @@ export function createGroupAgentRunner(input: {
             ...(agentInput.resumeSessionId
               ? { sessionId: agentInput.resumeSessionId }
               : {}),
-            ...(options?.existingRunId && runState.runId
-              ? { runId: runState.runId }
-              : {}),
-            ...(options?.existingRunLeaseToken
-              ? { runLeaseToken: options.existingRunLeaseToken }
-              : {}),
-            ...(typeof options?.existingRunLeaseFencingVersion === 'number'
+            ...(options?.existingRunId &&
+            options.existingRunLeaseToken &&
+            typeof options.existingRunLeaseFencingVersion === 'number'
               ? {
+                  runId: options.existingRunId,
+                  runLeaseToken: options.existingRunLeaseToken,
                   runLeaseFencingVersion:
                     options.existingRunLeaseFencingVersion,
                 }
@@ -590,7 +599,7 @@ export function createGroupAgentRunner(input: {
             );
           },
           wrappedOnOutput,
-          runOptions,
+          { ...runOptions, correlationRunId: runState.runId },
         ).then((output) => runTokenBudget.enforce(output));
       let output = await invokeAgent({
         memoryContextBlock,
@@ -744,5 +753,16 @@ export function createGroupAgentRunner(input: {
       }
       return 'error';
     }
+  }
+
+  return (...args: Parameters<typeof runAgentWithContext>) => {
+    const [group, , chatJid] = args;
+    return withLogContext(
+      {
+        appId: appIdFromConversationJid(chatJid) ?? 'default',
+        agentId: memoryAgentIdForWorkspaceFolder(group.folder),
+      },
+      () => runAgentWithContext(...args),
+    );
   };
 }

--- a/apps/core/src/runtime/ipc-interaction-processing.ts
+++ b/apps/core/src/runtime/ipc-interaction-processing.ts
@@ -16,6 +16,7 @@ import {
   persistentPermissionUpdates,
 } from '../shared/permission-tool-rules.js';
 import { redactSensitiveText } from '../shared/sensitive-material.js';
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
 import { archiveIpcErrorFile } from './ipc-filesystem.js';
 import {
   getIpcResponseSigningPrivateKey,
@@ -376,6 +377,7 @@ export async function processPermissionInteractionIpc(input: {
       updatedPermissions: responsePermissionUpdates,
     });
     if (!resolved) {
+      incrementOperationalError('interaction', 'permission_request');
       input.logger.warn(
         permissionTelemetryContext(input.request, {
           sourceAgentFolder: input.sourceAgentFolder,
@@ -424,6 +426,7 @@ export async function processPermissionInteractionIpc(input: {
       );
       return;
     }
+    incrementOperationalError('interaction', 'permission_request');
     writePermissionInteractionFailure({
       ipcBaseDir: input.ipcBaseDir,
       sourceAgentFolder: input.sourceAgentFolder,
@@ -780,6 +783,7 @@ export async function processUserQuestionInteractionIpc(input: {
       response,
     });
     if (!resolved) {
+      incrementOperationalError('interaction', 'user_question_request');
       input.logger.warn(
         {
           sourceAgentFolder: input.sourceAgentFolder,
@@ -819,6 +823,7 @@ export async function processUserQuestionInteractionIpc(input: {
       );
       return;
     }
+    incrementOperationalError('interaction', 'user_question_request');
     writeUserQuestionInteractionFailure({
       ipcBaseDir: input.ipcBaseDir,
       sourceAgentFolder: input.sourceAgentFolder,

--- a/apps/core/src/runtime/ipc.ts
+++ b/apps/core/src/runtime/ipc.ts
@@ -33,6 +33,7 @@ import {
 import { IpcWakeupScopeTracker } from './ipc-wakeup-scope.js';
 import { processRichInteractionRequestDirectory } from './ipc-rich-interaction-directory.js';
 import { resolveRunnerIpcRoute } from './ipc-route-authorization.js';
+import { incrementOperationalError } from '../shared/operational-error-counters.js';
 export type { IpcDeps } from './ipc-domain-types.js';
 export { processTaskIpc } from '../jobs/ipc-handler.js';
 export { validateIpcAuthRequest } from './ipc-auth-validation.js';
@@ -327,6 +328,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
                 );
                 runnerControlPort.removeClaimedRequest(claimedPath);
               } catch (err) {
+                incrementOperationalError('ipc', 'message_dispatch');
                 logger.error(
                   { file, sourceAgentFolder, err },
                   'Error processing IPC message',

--- a/apps/core/src/shared/operational-error-counters.ts
+++ b/apps/core/src/shared/operational-error-counters.ts
@@ -1,0 +1,61 @@
+export interface OperationalErrorKindsBySubsystem {
+  channels: 'permission_prompt';
+  delivery:
+    | 'ambiguous_settlement'
+    | 'notification_enqueue'
+    | 'notification_send'
+    | 'outbound_dispatch'
+    | 'partial_settlement'
+    | 'sent_settlement';
+  interaction: 'permission_request' | 'user_question_request';
+  ipc: 'message_dispatch' | 'task_dispatch';
+  jobs: 'agent_run' | 'terminal_settlement';
+  memory: 'ipc_request';
+}
+
+export type OperationalErrorSubsystem = keyof OperationalErrorKindsBySubsystem;
+export type OperationalErrorKind =
+  OperationalErrorKindsBySubsystem[OperationalErrorSubsystem];
+
+export interface OperationalErrorCounter {
+  subsystem: OperationalErrorSubsystem;
+  kind: OperationalErrorKind;
+  count: number;
+}
+
+const counters = new Map<string, OperationalErrorCounter>();
+
+function counterKey(
+  subsystem: OperationalErrorSubsystem,
+  kind: OperationalErrorKind,
+): string {
+  return `${subsystem}:${kind}`;
+}
+
+export function incrementOperationalError<
+  Subsystem extends OperationalErrorSubsystem,
+>(
+  subsystem: Subsystem,
+  kind: OperationalErrorKindsBySubsystem[Subsystem],
+): void {
+  const key = counterKey(subsystem, kind);
+  const current = counters.get(key);
+  if (current) {
+    current.count += 1;
+    return;
+  }
+  counters.set(key, { subsystem, kind, count: 1 });
+}
+
+export function getOperationalErrorCount<
+  Subsystem extends OperationalErrorSubsystem,
+>(
+  subsystem: Subsystem,
+  kind: OperationalErrorKindsBySubsystem[Subsystem],
+): number {
+  return counters.get(counterKey(subsystem, kind))?.count ?? 0;
+}
+
+export function snapshotOperationalErrors(): readonly OperationalErrorCounter[] {
+  return [...counters.values()];
+}

--- a/apps/core/test/integration/inline-agent-runtime.integration.test.ts
+++ b/apps/core/test/integration/inline-agent-runtime.integration.test.ts
@@ -152,6 +152,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     error: vi.fn(),
   },
   redactString: (value: string) => value,
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 import { RUNTIME_EVENT_TYPES } from '@core/domain/events/runtime-event-types.js';

--- a/apps/core/test/integration/runtime-host-child-process.integration.test.ts
+++ b/apps/core/test/integration/runtime-host-child-process.integration.test.ts
@@ -129,6 +129,9 @@ describe('host child-process runtime smoke', () => {
         error: vi.fn(),
       },
       redactString: (value: string) => value,
+      withLogContext: (_context: unknown, callback: () => unknown) =>
+        callback(),
+      updateLogContext: vi.fn(),
     }));
     vi.doMock('@core/runtime/agent-spawn-host.js', () => ({
       getHostRuntimeCredentialEnv: async () => ({

--- a/apps/core/test/unit/app/start-runtime-preflight.test.ts
+++ b/apps/core/test/unit/app/start-runtime-preflight.test.ts
@@ -6,6 +6,8 @@ const validateRuntimePreflightWithStorage = vi.fn(async () => ({ ok: true }));
 vi.mock('@core/infrastructure/logging/logger.js', () => ({
   installGlobalErrorHandlers: vi.fn(),
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 vi.mock('@core/app/bootstrap/runtime-app.js', () => ({
   getDefaultRuntimeApp: vi.fn(() => ({

--- a/apps/core/test/unit/bootstrap/fleet-boot.test.ts
+++ b/apps/core/test/unit/bootstrap/fleet-boot.test.ts
@@ -88,7 +88,11 @@ vi.mock('@core/config/settings/settings-import-service.js', async () => {
   };
 });
 
-vi.mock('@core/infrastructure/logging/logger.js', () => ({ logger: log }));
+vi.mock('@core/infrastructure/logging/logger.js', () => ({
+  logger: log,
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
+}));
 
 import {
   buildBakeOutcomeNotice,

--- a/apps/core/test/unit/bootstrap/runtime-services.test.ts
+++ b/apps/core/test/unit/bootstrap/runtime-services.test.ts
@@ -7,6 +7,7 @@ import {
   stopLiveAdmissionLoop,
   stopLiveTurnRecoveryLoop,
 } from '@core/app/bootstrap/runtime-services.js';
+import { createChannelWiring } from '@core/app/bootstrap/channel-wiring.js';
 import { buildLiveTurnRecoveryCapabilityGate } from '@core/app/bootstrap/live-turn-recovery-capability-gate.js';
 import { RuntimeApp } from '@core/app/bootstrap/runtime-app.js';
 import type { ChannelWiring } from '@core/app/bootstrap/channel-wiring-types.js';
@@ -187,6 +188,61 @@ function makeChannelWiring(): ChannelWiring {
     disconnectChannels: vi.fn(async () => {}),
     isControlApproverAllowed: vi.fn(async () => true),
   };
+}
+
+async function makeConnectedTelegramWiring(
+  app: RuntimeApp,
+  providerSend: ReturnType<typeof vi.fn>,
+): Promise<ChannelWiring> {
+  const channelWiring = createChannelWiring(app, {
+    providerIds: [
+      {
+        id: 'telegram',
+        label: 'Telegram',
+        jidPrefix: 'tg:',
+        folderPrefix: 'telegram_',
+        isGroupJid: (jid: string) => jid.startsWith('tg:'),
+        canStreamToJid: () => false,
+        formatting: 'telegram-html',
+        isEnabled: () => true,
+        create: () => ({
+          name: 'telegram',
+          connect: vi.fn(async () => undefined),
+          sendMessage: providerSend,
+          isConnected: vi.fn(() => true),
+          ownsJid: vi.fn((jid: string) => jid.startsWith('tg:')),
+          disconnect: vi.fn(async () => undefined),
+        }),
+        setup: {
+          envKeys: [],
+          describe: () => 'Telegram',
+          run: async () => undefined,
+        },
+      },
+    ],
+    opsRepository: {
+      storeMessage: vi.fn(async () => undefined),
+      storeChatMetadata: vi.fn(async () => undefined),
+    },
+  });
+  await channelWiring.connectEnabledChannels(
+    {
+      providers: { telegram: { enabled: true } },
+      runtime: {
+        liveTurns: { enabled: false },
+      },
+      providerAccounts: {
+        telegram_default: {
+          agentId: 'agent:main',
+          provider: 'telegram',
+          label: 'Telegram',
+          runtimeSecretRefs: {},
+        },
+      },
+    } as never,
+    { providerInbound: false },
+  );
+  return channelWiring;
 }
 
 describe('buildLiveTurnRecoveryCapabilityGate', () => {
@@ -1818,10 +1874,11 @@ describe('startRuntimeServices', () => {
     }
   });
 
-  it('installs durable outbound delivery before scheduler startup', async () => {
+  it('installs durable outbound delivery before IPC and scheduler startup', async () => {
     const order: string[] = [];
     const app = makeApp();
     const channelWiring = makeChannelWiring();
+    let ipcDeps: any;
     vi.mocked(
       channelWiring.setDurableOutboundAttemptFactory as any,
     ).mockImplementation(() => {
@@ -1837,7 +1894,8 @@ describe('startRuntimeServices', () => {
         startSchedulerLoop: vi.fn(() => {
           order.push('startSchedulerLoop');
         }) as any,
-        startIpcWatcher: vi.fn(() => {
+        startIpcWatcher: vi.fn((deps) => {
+          ipcDeps = deps;
           order.push('startIpcWatcher');
         }) as any,
         writeGroupsSnapshot: vi.fn() as any,
@@ -1858,11 +1916,148 @@ describe('startRuntimeServices', () => {
     );
 
     expect(order).toEqual([
-      'startIpcWatcher',
       'setDurableOutboundAttemptFactory',
       'startOutboundDeliveryRecoveryLoop',
+      'startIpcWatcher',
       'startSchedulerLoop',
     ]);
+
+    await ipcDeps.sendMessage('tg:primary', 'durable', {
+      threadId: '42',
+    });
+    expect(channelWiring.sendMessage).toHaveBeenCalledWith(
+      'tg:primary',
+      'durable',
+      {
+        durability: 'required',
+        throwOnMissing: true,
+        messageOptions: { threadId: '42' },
+      },
+    );
+  });
+
+  it('persists IPC sends and leaves provider failures retryable', async () => {
+    const order: string[] = [];
+    const app = makeApp();
+    const providerSend = vi.fn(async () => {
+      order.push('providerSend');
+      throw new Error('provider unavailable');
+    });
+    const channelWiring = await makeConnectedTelegramWiring(app, providerSend);
+    let ipcDeps: any;
+    let queuedDelivery: any;
+    let queuedItem: any;
+    const enqueueDelivery = vi.fn(async (input: any) => {
+      order.push('enqueueDelivery');
+      queuedDelivery = input.delivery;
+      queuedItem = { ...input.items[0] };
+      return { created: true, delivery: input.delivery };
+    });
+    const markDeliveryItemFailed = vi.fn(async (input: any) => {
+      order.push('markDeliveryItemFailed');
+      queuedItem = {
+        ...queuedItem,
+        status:
+          queuedItem.attemptCount < input.maxAttempts ? 'pending' : 'failed',
+        claimToken: undefined,
+        claimExpiresAt: undefined,
+        nextAttemptAt: '2026-07-17T00:00:01.000Z',
+      };
+      return { applied: true, delivery: queuedDelivery };
+    });
+
+    try {
+      await startRuntimeServices(
+        { app, channelWiring },
+        {
+          startSchedulerLoop: vi.fn() as any,
+          startIpcWatcher: vi.fn((deps) => {
+            ipcDeps = deps;
+          }) as any,
+          writeGroupsSnapshot: vi.fn() as any,
+          opsRepository: {} as any,
+          getToolRepository: vi.fn(() => ({}) as any),
+          getOutboundDeliveryRepository: vi.fn(
+            () =>
+              ({
+                enqueueDelivery,
+                markDeliveryItemFailed,
+              }) as any,
+          ),
+          recoverPendingMessages: vi.fn() as any,
+          startOutboundDeliveryRecoveryLoop: vi.fn() as any,
+          logger: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            fatal: vi.fn(),
+          },
+          exit: vi.fn() as any,
+        },
+      );
+
+      await expect(
+        ipcDeps.sendMessage('tg:primary', 'retry me'),
+      ).rejects.toThrow('provider unavailable');
+
+      expect(order).toEqual([
+        'enqueueDelivery',
+        'providerSend',
+        'markDeliveryItemFailed',
+      ]);
+      expect(enqueueDelivery).toHaveBeenCalledOnce();
+      expect(markDeliveryItemFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxAttempts: 4,
+          retryBaseDelayMs: 1_000,
+          retryMaxDelayMs: 30_000,
+        }),
+      );
+      expect(queuedItem).toMatchObject({
+        status: 'pending',
+        attemptCount: 1,
+        claimToken: undefined,
+        claimExpiresAt: undefined,
+        nextAttemptAt: '2026-07-17T00:00:01.000Z',
+      });
+    } finally {
+      await channelWiring.disconnectChannels();
+    }
+  });
+
+  it('fails closed for required IPC sends without outbound storage', async () => {
+    const app = makeApp();
+    const providerSend = vi.fn(async () => undefined);
+    const channelWiring = await makeConnectedTelegramWiring(app, providerSend);
+    let ipcDeps: any;
+
+    try {
+      await startRuntimeServices(
+        { app, channelWiring },
+        {
+          startSchedulerLoop: vi.fn() as any,
+          startIpcWatcher: vi.fn((deps) => {
+            ipcDeps = deps;
+          }) as any,
+          writeGroupsSnapshot: vi.fn() as any,
+          opsRepository: {} as any,
+          getToolRepository: vi.fn(() => ({}) as any),
+          recoverPendingMessages: vi.fn() as any,
+          logger: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            fatal: vi.fn(),
+          },
+          exit: vi.fn() as any,
+        },
+      );
+
+      await expect(
+        ipcDeps.sendMessage('tg:primary', 'must persist'),
+      ).rejects.toThrow(/Durable outbound delivery is required/);
+      expect(providerSend).not.toHaveBeenCalled();
+    } finally {
+      await channelWiring.disconnectChannels();
+    }
   });
 
   it('wires durable scheduler sends', async () => {

--- a/apps/core/test/unit/channels/slack.test.ts
+++ b/apps/core/test/unit/channels/slack.test.ts
@@ -31,6 +31,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 vi.mock('@core/platform/workspace-folder.js', () => ({

--- a/apps/core/test/unit/channels/teams.test.ts
+++ b/apps/core/test/unit/channels/teams.test.ts
@@ -31,6 +31,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 afterEach(() => {

--- a/apps/core/test/unit/channels/telegram.test.ts
+++ b/apps/core/test/unit/channels/telegram.test.ts
@@ -17,6 +17,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 // Mock workspace-folder (used by downloadFile)

--- a/apps/core/test/unit/control/system-health.test.ts
+++ b/apps/core/test/unit/control/system-health.test.ts
@@ -6,6 +6,10 @@ import {
   type ReadinessDeps,
   type MetricsDeps,
 } from '@core/control/server/system-health.js';
+import {
+  getOperationalErrorCount,
+  incrementOperationalError,
+} from '@core/shared/operational-error-counters.js';
 
 const ALL_REQUIREMENTS = {
   requiresApiAuthConfigured: false,
@@ -272,6 +276,24 @@ function makeMetricsDeps(overrides: Partial<MetricsDeps> = {}): MetricsDeps {
 }
 
 describe('renderMetrics', () => {
+  it('renders process-local operational error counters', async () => {
+    const before = getOperationalErrorCount('delivery', 'notification_send');
+    incrementOperationalError('delivery', 'notification_send');
+
+    const body = await renderMetrics(
+      makeMetricsDeps({
+        query: vi.fn(async () => {
+          throw new Error('database unavailable');
+        }),
+      }),
+    );
+
+    expect(body).toContain('# TYPE gantry_errors_total counter');
+    expect(body).toContain(
+      `gantry_errors_total{subsystem="delivery",kind="notification_send"} ${before + 1}`,
+    );
+  });
+
   it('renders valid Prometheus text with process, worker, and queue gauges', async () => {
     const body = await renderMetrics(makeMetricsDeps());
     expect(body.endsWith('\n')).toBe(true);

--- a/apps/core/test/unit/core/logger.test.ts
+++ b/apps/core/test/unit/core/logger.test.ts
@@ -3,11 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fixedClock } from '@core/shared/time/datetime.js';
 import {
   createLogger,
+  currentLogContext,
   installGlobalErrorHandlers,
   logger,
   redactString,
   type LogRecord,
   type LogSink,
+  withLogContext,
 } from '@core/infrastructure/logging/logger.js';
 
 describe('logger', () => {
@@ -81,6 +83,56 @@ describe('logger', () => {
       message: 'child event',
       context: { scope: 'root', group: 'team-a', event: 'start' },
     });
+  });
+
+  it('isolates per-turn context across concurrent async work', async () => {
+    const records: LogRecord[] = [];
+    const l = createLogger({
+      level: 'debug',
+      sink: { write: (record) => records.push(record) },
+    });
+
+    await Promise.all([
+      withLogContext(
+        { runId: 'run-a', appId: 'app-a', agentId: 'agent-a' },
+        async () => {
+          await Promise.resolve();
+          l.info('turn a');
+        },
+      ),
+      withLogContext(
+        { runId: 'run-b', appId: 'app-b', agentId: 'agent-b' },
+        async () => {
+          await Promise.resolve();
+          l.info('turn b');
+        },
+      ),
+    ]);
+
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          context: { runId: 'run-a', appId: 'app-a', agentId: 'agent-a' },
+        }),
+        expect.objectContaining({
+          context: { runId: 'run-b', appId: 'app-b', agentId: 'agent-b' },
+        }),
+      ]),
+    );
+    expect(currentLogContext()).toBeUndefined();
+  });
+
+  it('redacts merged object context once', () => {
+    const redact = vi.fn((value: unknown) => value);
+    const l = createLogger({
+      level: 'debug',
+      sink: { write: () => undefined },
+      redact,
+    });
+
+    l.info({ event: 'start' }, 'event');
+
+    expect(redact).toHaveBeenCalledTimes(1);
   });
 
   it('keeps base and child context for string-only log calls', () => {

--- a/apps/core/test/unit/core/observability-tracing.test.ts
+++ b/apps/core/test/unit/core/observability-tracing.test.ts
@@ -14,6 +14,11 @@ import {
   startTurnSpan,
   tracingEnabled,
 } from '@core/infrastructure/observability/tracing.js';
+import { createSpawnTurnTracker } from '@core/infrastructure/observability/spawn-turn-tracker.js';
+import {
+  currentLogContext,
+  withLogContext,
+} from '@core/infrastructure/logging/logger.js';
 
 afterEach(async () => {
   await shutdownTracing();
@@ -66,6 +71,7 @@ describe('observability tracing', () => {
     const activeSpan = getTurnSpan('run-1');
 
     expect(activeSpan).toBeDefined();
+    expect(handle.traceId).toBe(activeSpan?.spanContext().traceId);
     handle.setInput('hello');
     handle.setOutput('world');
     handle.end('success');
@@ -123,6 +129,7 @@ describe('observability tracing', () => {
     const handle = startTurnSpan({ runId: 'disabled', agentName: 'Agent' });
 
     expect(tracingEnabled()).toBe(false);
+    expect(handle.traceId).toBeUndefined();
     expect(getTurnSpan('disabled')).toBeUndefined();
     expect(() => {
       handle.setInput('input');
@@ -130,5 +137,50 @@ describe('observability tracing', () => {
       handle.end('error', 'failure');
     }).not.toThrow();
     expect(exporter.getFinishedSpans()).toEqual([]);
+  });
+
+  it('carries the real trace id and rotates it for a continuation', async () => {
+    const exporter = new InMemorySpanExporter();
+    initTracing(
+      { enabled: true, captureContent: false, sampleRate: 1 },
+      exporter,
+    );
+    const observedTraceIds: Array<string | undefined> = [];
+    const tracker = createSpawnTurnTracker(
+      'Researcher',
+      {
+        runId: 'run-continuation',
+        appId: 'app-1',
+        agentId: 'agent-1',
+        prompt: 'hello',
+      },
+      async () => {
+        observedTraceIds.push(currentLogContext()?.traceId);
+      },
+    );
+    const firstTraceId = tracker.traceId();
+
+    expect(firstTraceId).toMatch(/^[0-9a-f]{32}$/);
+    await withLogContext(
+      {
+        runId: tracker.correlationId,
+        appId: 'app-1',
+        agentId: 'agent-1',
+        traceId: firstTraceId,
+      },
+      async () => {
+        await tracker.onOutput?.({
+          status: 'success',
+          result: 'first',
+          continuedByFollowup: true,
+        });
+        expect(currentLogContext()?.traceId).toBe(tracker.traceId());
+        expect(tracker.traceId()).not.toBe(firstTraceId);
+        tracker.finish({ status: 'success', result: 'second' });
+      },
+    );
+
+    expect(observedTraceIds).toEqual([firstTraceId]);
+    expect(exporter.getFinishedSpans()).toHaveLength(2);
   });
 });

--- a/apps/core/test/unit/jobs/delivery.test.ts
+++ b/apps/core/test/unit/jobs/delivery.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@core/jobs/delivery.js';
 import type { Job } from '@core/domain/types.js';
 import { logger } from '@core/infrastructure/logging/logger.js';
+import { getOperationalErrorCount } from '@core/shared/operational-error-counters.js';
 
 function makeJob(overrides: Partial<Job> = {}): Job {
   return {
@@ -33,6 +34,57 @@ function makeJob(overrides: Partial<Job> = {}): Job {
 }
 
 describe('jobs/delivery', () => {
+  it('increments the delivery error counter when a direct send fails', async () => {
+    const before = getOperationalErrorCount('delivery', 'notification_send');
+    const delivered = await sendJobNotification({
+      job: makeJob({
+        notification_routes: [
+          {
+            conversationJid: 'tg:1',
+            threadId: null,
+            label: 'dm',
+          },
+        ],
+      }),
+      text: 'done',
+      phase: 'summary',
+      runId: 'run-1',
+      sendMessage: vi.fn(async () => {
+        throw new Error('delivery failed');
+      }),
+    });
+
+    expect(delivered).toBe(false);
+    expect(getOperationalErrorCount('delivery', 'notification_send')).toBe(
+      before + 1,
+    );
+  });
+
+  it('increments the delivery error counter when direct delivery is incomplete', async () => {
+    const before = getOperationalErrorCount('delivery', 'notification_send');
+
+    const delivered = await sendJobNotification({
+      job: makeJob({
+        notification_routes: [
+          {
+            conversationJid: 'tg:1',
+            threadId: null,
+            label: 'dm',
+          },
+        ],
+      }),
+      text: 'done',
+      phase: 'summary',
+      runId: 'run-1',
+      sendMessage: vi.fn(async () => false) as never,
+    });
+
+    expect(delivered).toBe(false);
+    expect(getOperationalErrorCount('delivery', 'notification_send')).toBe(
+      before + 1,
+    );
+  });
+
   it('classifies partial delivery exceptions as delivery_incomplete', async () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     const partial = new PartialMessageDeliveryError({

--- a/apps/core/test/unit/jobs/execution-log-context.test.ts
+++ b/apps/core/test/unit/jobs/execution-log-context.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Job } from '@core/domain/types.js';
+import { currentLogContext } from '@core/infrastructure/logging/logger.js';
+import { runActiveJobWithLogContext } from '@core/jobs/execution-log-context.js';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: 'job-1',
+    name: 'Job',
+    prompt: 'Run',
+    schedule_type: 'once',
+    schedule_value: '',
+    status: 'active',
+    session_id: null,
+    thread_id: null,
+    workspace_key: 'alpha',
+    created_by: 'agent',
+    created_at: '2026-07-17T00:00:00.000Z',
+    updated_at: '2026-07-17T00:00:00.000Z',
+    next_run: null,
+    last_run: null,
+    silent: false,
+    cleanup_after_ms: 0,
+    timeout_ms: 30_000,
+    max_retries: 0,
+    retry_backoff_ms: 0,
+    max_consecutive_failures: 1,
+    consecutive_failures: 0,
+    lease_run_id: null,
+    lease_expires_at: null,
+    pause_reason: null,
+    ...overrides,
+  };
+}
+
+describe('runActiveJobWithLogContext', () => {
+  it('uses execution_context agentId for the initial log context', async () => {
+    const activeJob = makeJob({
+      execution_context: {
+        conversationJid: 'sl:C123',
+        threadId: null,
+        workspaceKey: 'alpha',
+        agentId: 'agent:beta',
+      } as Job['execution_context'],
+    });
+    let observedContext: ReturnType<typeof currentLogContext>;
+
+    await runActiveJobWithLogContext({
+      requestedJob: activeJob,
+      dispatch: {
+        runId: 'run-1',
+        scheduledFor: '2026-07-17T01:00:00.000Z',
+      },
+      getJobById: async () => activeJob,
+      run: async () => {
+        observedContext = currentLogContext();
+      },
+    });
+
+    expect(observedContext).toEqual({
+      runId: 'run-1',
+      appId: 'default',
+      agentId: 'agent:beta',
+    });
+  });
+});

--- a/apps/core/test/unit/jobs/execution.test.ts
+++ b/apps/core/test/unit/jobs/execution.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ConversationRoute, Job } from '@core/domain/types.js';
+import { currentLogContext } from '@core/infrastructure/logging/logger.js';
+import { getOperationalErrorCount } from '@core/shared/operational-error-counters.js';
 
 const runtimeStoreMock = vi.hoisted(() => ({
   publish: vi.fn(async () => undefined),
@@ -216,9 +218,11 @@ describe('jobs/execution', () => {
 
   it('records a failed terminal run when execution throws before normal settlement', async () => {
     const job = makeJob();
+    let observedLogContext: ReturnType<typeof currentLogContext> = undefined;
     const opsRepository = {
       ...makeOpsRepository(job),
       getJobRunById: vi.fn(async () => {
+        observedLogContext = currentLogContext();
         throw new Error('run lookup down');
       }),
     };
@@ -238,6 +242,7 @@ describe('jobs/execution', () => {
           })) as never,
         },
         'tg:scheduler',
+        { runId: 'run-context', scheduledFor: '2026-05-08T00:00:00.000Z' },
       ),
     ).rejects.toThrow('run lookup down');
 
@@ -246,6 +251,47 @@ describe('jobs/execution', () => {
       'failed',
       null,
       'Scheduler run failed before terminal settlement.',
+    );
+    expect(observedLogContext).toEqual({
+      runId: 'run-context',
+      appId: 'default',
+      agentId: 'agent:scheduler_agent',
+    });
+  });
+
+  it('counts a rejecting terminal finalizer exactly once and rethrows', async () => {
+    const job = makeJob();
+    const settlementError = new Error(
+      'terminal settlement database unavailable',
+    );
+    const opsRepository = {
+      ...makeOpsRepository(job),
+      finalizeJobRunWithLease: vi.fn(async () => {
+        throw settlementError;
+      }),
+    };
+    const before = getOperationalErrorCount('jobs', 'terminal_settlement');
+
+    await expect(
+      runJob(
+        job,
+        {
+          conversationRoutes: () => ({ 'tg:scheduler': makeRoute() }),
+          queue: {} as never,
+          onProcess: () => {},
+          sendMessage: vi.fn(async () => undefined) as never,
+          opsRepository: opsRepository as never,
+          runAgent: vi.fn(async () => ({
+            status: 'success',
+            result: 'runtime flow completed',
+          })) as never,
+        },
+        'tg:scheduler',
+      ),
+    ).rejects.toBe(settlementError);
+
+    expect(getOperationalErrorCount('jobs', 'terminal_settlement')).toBe(
+      before + 1,
     );
   });
 
@@ -490,6 +536,7 @@ describe('jobs/execution', () => {
     const sendMessage = vi.fn(async () => undefined);
     const error =
       'Tool not on autonomous run allowlist: mcp__gantry__browser_act. Recovery: request_access { "target": { "kind": "capability", "id": "browser.use" }, "temporaryOnly": false }';
+    const before = getOperationalErrorCount('jobs', 'agent_run');
 
     await runJob(
       job,
@@ -524,6 +571,7 @@ describe('jobs/execution', () => {
       null,
       expect.stringContaining('Tool not on autonomous run allowlist'),
     );
+    expect(getOperationalErrorCount('jobs', 'agent_run')).toBe(before + 1);
     const deniedEvent = runtimeStoreMock.publish.mock.calls.find(
       ([event]) => event?.eventType === 'job.tool_denied',
     )?.[0];

--- a/apps/core/test/unit/jobs/ipc-handler-operational-error-counter.test.ts
+++ b/apps/core/test/unit/jobs/ipc-handler-operational-error-counter.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  dataDir: `/tmp/gantry-task-ipc-operational-errors-${process.pid}`,
+  failingHandler: vi.fn(async () => {
+    throw new Error('simulated task handler failure');
+  }),
+}));
+
+vi.mock('@core/config/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@core/config/index.js')>()),
+  DATA_DIR: testState.dataDir,
+}));
+
+vi.mock('@core/jobs/ipc-admin-handlers.js', () => ({
+  adminTaskHandlers: {
+    simulated_failure: testState.failingHandler,
+  },
+}));
+
+import { processTaskIpc } from '@core/jobs/ipc-handler.js';
+import { createIpcAuthEnvelope } from '@core/runtime/ipc-auth.js';
+import { getOperationalErrorCount } from '@core/shared/operational-error-counters.js';
+
+afterAll(() => {
+  fs.rmSync(testState.dataDir, { recursive: true, force: true });
+});
+
+describe('task IPC operational error counter', () => {
+  it('increments task dispatch once when a handler failure becomes an error response', async () => {
+    fs.rmSync(testState.dataDir, { recursive: true, force: true });
+    const before = getOperationalErrorCount('ipc', 'task_dispatch');
+    const responseKeyId = createIpcAuthEnvelope('counter_agent').responseKeyId;
+
+    await processTaskIpc(
+      {
+        taskId: 'task-dispatch-failure',
+        type: 'simulated_failure',
+        chatJid: 'tg:counter',
+        responseKeyId,
+      } as never,
+      'counter_agent',
+      {
+        conversationRoutes: () => ({
+          'tg:counter': { folder: 'counter_agent' },
+        }),
+        opsRepository: {},
+      } as never,
+    );
+
+    expect(testState.failingHandler).toHaveBeenCalledOnce();
+    expect(getOperationalErrorCount('ipc', 'task_dispatch')).toBe(before + 1);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(
+            testState.dataDir,
+            'ipc',
+            'counter_agent',
+            'task-responses',
+            'task-task-dispatch-failure.json',
+          ),
+          'utf8',
+        ),
+      ),
+    ).toMatchObject({
+      ok: false,
+      code: 'internal_error',
+      error: 'simulated task handler failure',
+    });
+  });
+});

--- a/apps/core/test/unit/jobs/outbound-delivery-recovery.test.ts
+++ b/apps/core/test/unit/jobs/outbound-delivery-recovery.test.ts
@@ -9,6 +9,7 @@ import {
   startOutboundDeliveryRecoveryLoop,
   stopOutboundDeliveryRecoveryLoop,
 } from '@core/jobs/outbound-delivery-recovery.js';
+import { getOperationalErrorCount } from '@core/shared/operational-error-counters.js';
 
 function makeClaimedItem(overrides: Partial<ClaimedOutboundDeliveryItem> = {}) {
   const itemId =
@@ -458,6 +459,7 @@ describe('runBoundedOutboundDeliveryRecovery', () => {
         claims: [[claimed], []],
       });
 
+    const before = getOperationalErrorCount('delivery', 'outbound_dispatch');
     const result = await runBoundedOutboundDeliveryRecovery({
       service,
       appId: 'app:test' as never,
@@ -472,6 +474,9 @@ describe('runBoundedOutboundDeliveryRecovery', () => {
 
     expect(result.sent).toBe(0);
     expect(result.failed).toBe(1);
+    expect(getOperationalErrorCount('delivery', 'outbound_dispatch')).toBe(
+      before + 1,
+    );
     expect(markDeliveryItemSent).not.toHaveBeenCalled();
     expect(markDeliveryItemFailed).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/core/test/unit/runtime/agent-inline.test.ts
+++ b/apps/core/test/unit/runtime/agent-inline.test.ts
@@ -60,6 +60,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 import type { ConversationRoute } from '@core/domain/types.js';
@@ -75,6 +77,7 @@ import type {
   AgentInput,
   AgentOutput,
 } from '@core/runtime/agent-spawn-types.js';
+import { getHostRuntimeCredentialEnv } from '@core/runtime/agent-spawn-host.js';
 import { GroupQueue } from '@core/runtime/group-queue.js';
 
 const group: ConversationRoute = {
@@ -108,6 +111,7 @@ const settleWhenAborted: InlineAgentLoopLane = ({ signal }) =>
 describe('runInlineAgent', () => {
   beforeEach(() => {
     revokeGatewayToken.mockClear();
+    vi.mocked(getHostRuntimeCredentialEnv).mockClear();
     inlineAgentSettings.current = {};
     fs.rmSync(INLINE_DATA_DIR, { recursive: true, force: true });
   });
@@ -158,6 +162,31 @@ describe('runInlineAgent', () => {
 
     expect(output).toEqual(terminal);
     expect(revokeGatewayToken).toHaveBeenCalledOnce();
+  });
+
+  it('binds inline credentials to turn correlation without adding lease identity', async () => {
+    const lane = vi.fn<InlineAgentLoopLane>(async ({ input }) => {
+      expect(input).not.toHaveProperty('runId');
+      expect(input).not.toHaveProperty('runLeaseToken');
+      expect(input).not.toHaveProperty('runLeaseFencingVersion');
+      return { status: 'success', result: null };
+    });
+
+    await runInlineAgent(group, agentInput, vi.fn(), undefined, {
+      ...options(lane),
+      correlationRunId: 'turn-correlation-1',
+    });
+
+    expect(getHostRuntimeCredentialEnv).toHaveBeenCalledWith(
+      'inline-test',
+      undefined,
+      {
+        purpose: 'model_runtime',
+        runId: 'turn-correlation-1',
+        runContext: agentInput,
+        modelRouteId: 'test-route',
+      },
+    );
   });
 
   it('preserves a structured error returned by the lane seam', async () => {

--- a/apps/core/test/unit/runtime/agent-spawn-log-context.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-log-context.test.ts
@@ -1,0 +1,108 @@
+import { InMemorySpanExporter } from '@opentelemetry/sdk-trace-node';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { currentLogContext } from '@core/infrastructure/logging/logger.js';
+import {
+  initTracing,
+  shutdownTracing,
+} from '@core/infrastructure/observability/tracing.js';
+import { runSpawnWithLogContext } from '@core/infrastructure/observability/spawn-log-context.js';
+import { resolveAgentSpawnLogContext } from '@core/runtime/agent-spawn-identity.js';
+
+afterEach(async () => {
+  await shutdownTracing();
+});
+
+describe('agent spawn log context', () => {
+  it('carries canonical run, app, agent, and trace ids', async () => {
+    const exporter = new InMemorySpanExporter();
+    initTracing(
+      { enabled: true, captureContent: false, sampleRate: 1 },
+      exporter,
+    );
+    let observed: ReturnType<typeof currentLogContext>;
+
+    const context = resolveAgentSpawnLogContext(
+      {
+        name: 'Researcher',
+        folder: 'researcher',
+        agentId: 'agent:canonical-researcher',
+        trigger: '@researcher',
+        added_at: '2026-07-17T00:00:00.000Z',
+      },
+      {
+        runId: 'run-spawn-context',
+        appId: 'app-spawn-context',
+        workspaceFolder: 'researcher',
+        chatJid: 'tg:research',
+        prompt: 'research this',
+      },
+    );
+    await runSpawnWithLogContext(
+      {
+        ...context,
+        onOutput: undefined,
+      },
+      async () => {
+        observed = currentLogContext();
+        return { status: 'success', result: 'done' };
+      },
+    );
+
+    const span = exporter.getFinishedSpans()[0];
+    expect(observed).toEqual({
+      runId: 'run-spawn-context',
+      appId: 'app-spawn-context',
+      agentId: 'agent:canonical-researcher',
+      traceId: span?.spanContext().traceId,
+    });
+    expect(observed?.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(span?.attributes).toMatchObject({
+      'gantry.run_id': 'run-spawn-context',
+      'gantry.app_id': 'app-spawn-context',
+      'gen_ai.agent.id': 'agent:canonical-researcher',
+    });
+  });
+
+  it('uses the outer interactive run only for log and trace correlation', async () => {
+    const exporter = new InMemorySpanExporter();
+    initTracing(
+      { enabled: true, captureContent: false, sampleRate: 1 },
+      exporter,
+    );
+    let observed: ReturnType<typeof currentLogContext>;
+
+    const context = resolveAgentSpawnLogContext(
+      {
+        name: 'Researcher',
+        folder: 'researcher',
+        trigger: '@researcher',
+        added_at: '2026-07-17T00:00:00.000Z',
+      },
+      {
+        appId: 'app-spawn-context',
+        workspaceFolder: 'researcher',
+        chatJid: 'tg:research',
+        prompt: 'research this',
+      },
+      'run-interactive-context',
+    );
+    expect(context.turn).not.toHaveProperty('runId');
+
+    await runSpawnWithLogContext(
+      {
+        ...context,
+        onOutput: undefined,
+      },
+      async () => {
+        observed = currentLogContext();
+        return { status: 'success', result: 'done' };
+      },
+    );
+
+    expect(observed?.runId).toBe('run-interactive-context');
+    expect(exporter.getFinishedSpans()[0]?.attributes).toMatchObject({
+      'gantry.run_id': 'run-interactive-context',
+    });
+  });
+});

--- a/apps/core/test/unit/runtime/agent-spawn-process.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-process.test.ts
@@ -57,6 +57,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
       .replace(/\bprovider-session:[A-Za-z0-9._:-]+\b/g, '[REDACTED]')
       .replace(/\bxox[baprs]-[A-Za-z0-9-]+\b/g, '[REDACTED]')
       .replace(/\b\d{6,12}:[A-Za-z0-9_-]{20,}\b/g, '[REDACTED]'),
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 vi.mock('fs', async () => {

--- a/apps/core/test/unit/runtime/agent-spawn.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn.test.ts
@@ -16,6 +16,10 @@ const mockEnsureEgressGateway = vi.hoisted(() =>
   })),
 );
 const mockCloseEgressGateway = vi.hoisted(() => vi.fn(async () => undefined));
+const observedSpawnLogContexts = vi.hoisted(
+  () => [] as Array<Record<string, unknown>>,
+);
+const observedSpawnTrackerIds = vi.hoisted(() => [] as string[]);
 
 // Mock config
 vi.mock('@core/config/index.js', () => ({
@@ -77,7 +81,32 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     error: vi.fn(),
   },
   redactString: (value: string) => value,
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: () => undefined,
 }));
+
+vi.mock(
+  '@core/infrastructure/observability/spawn-log-context.js',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@core/infrastructure/observability/spawn-log-context.js')
+      >();
+    return {
+      ...actual,
+      runSpawnWithLogContext: (
+        input: Record<string, unknown>,
+        run: Parameters<typeof actual.runSpawnWithLogContext>[1],
+      ) => {
+        observedSpawnLogContexts.push(input);
+        return actual.runSpawnWithLogContext(input as never, (tracker) => {
+          observedSpawnTrackerIds.push(tracker.correlationId);
+          return run(tracker);
+        });
+      },
+    };
+  },
+);
 
 // Mock fs
 vi.mock('fs', async () => {
@@ -296,6 +325,11 @@ import type {
 } from '@core/shared/runner-sandbox-provider.js';
 import type { RunAgentOptions } from '@core/runtime/agent-spawn-types.js';
 import { SANDBOX_RUNTIME_MODEL_GATEWAY_HOST } from '@core/runtime/agent-spawn-runtime-policy.js';
+import {
+  processPermissionIpcRequest,
+  processUserQuestionIpcRequest,
+} from '@core/runtime/ipc-interaction-handler.js';
+import { isActiveRunLeaseForInteraction } from '@core/application/interactions/pending-interaction-durability.js';
 
 const anthropicEnvKey = (suffix: string) => ['ANTHROPIC', suffix].join('_');
 
@@ -700,6 +734,8 @@ describe('agent-spawn timeout behavior', () => {
         },
       },
     } as any);
+    observedSpawnLogContexts.length = 0;
+    observedSpawnTrackerIds.length = 0;
     process.env.GANTRY_IMAGE_CAPABILITIES_JSON = JSON.stringify([
       'acme.records.get',
       'acme.invoices.read',
@@ -1009,6 +1045,8 @@ describe('agent-spawn timeout behavior', () => {
         appId: 'app-one',
         agentId: 'agent-one',
         runId: 'run-one',
+        runLeaseToken: 'lease-one',
+        runLeaseFencingVersion: 1,
         threadId: 'reply-one',
         toolPolicyRules: ['Browser'],
         attachedSkillSourceIds: ['skill:one'],
@@ -3991,6 +4029,144 @@ describe('agent-spawn timeout behavior', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it('passes canonical correlation ids through the spawn entrypoint', async () => {
+    await runtimeSpawnAgent(
+      { ...testGroup, agentId: 'agent:route-canonical' },
+      {
+        ...testInput,
+        runId: 'run-entrypoint-context',
+        appId: 'app-entrypoint-context',
+      },
+      () => {},
+    );
+
+    expect(observedSpawnLogContexts.at(-1)).toMatchObject({
+      correlationRunId: 'run-entrypoint-context',
+      appId: 'app-entrypoint-context',
+      agentId: 'agent:route-canonical',
+      turn: expect.objectContaining({
+        runId: 'run-entrypoint-context',
+        appId: 'app-entrypoint-context',
+        agentId: 'agent:route-canonical',
+      }),
+    });
+  });
+
+  it('keeps an unfenced delegated child run id only for correlation while interactions remain live', async () => {
+    vi.mocked(getSelectedAgentRuntime).mockReturnValueOnce('inline');
+    const requestPermissionApproval = vi.fn(async (request) => {
+      if (!(await isActiveRunLeaseForInteraction(request))) {
+        throw new Error('stale delegated child run');
+      }
+      return {
+        approved: true,
+        mode: 'allow_once' as const,
+        decidedBy: 'owner',
+        decisionClassification: 'user_temporary' as const,
+      };
+    });
+    const requestUserAnswer = vi.fn(async (request) => {
+      if (!(await isActiveRunLeaseForInteraction(request))) {
+        throw new Error('stale delegated child run');
+      }
+      return {
+        requestId: 'question-delegated-child',
+        answers: { choice: 'continue' },
+        answeredBy: 'owner',
+      };
+    });
+    const inlineAgentLoopLane = vi.fn(async ({ input }) => {
+      expect(input).not.toHaveProperty('runId');
+      expect(input).not.toHaveProperty('runLeaseToken');
+      expect(input).not.toHaveProperty('runLeaseFencingVersion');
+      await expect(
+        isActiveRunLeaseForInteraction({
+          runId: input.runId,
+          runLeaseToken: input.runLeaseToken,
+          runLeaseFencingVersion: input.runLeaseFencingVersion,
+        }),
+      ).resolves.toBe(true);
+      await expect(
+        processPermissionIpcRequest(
+          {
+            requestId: 'permission-delegated-child',
+            sourceAgentFolder: testGroup.folder,
+            targetJid: testInput.chatJid,
+            runId: input.runId,
+            runLeaseToken: input.runLeaseToken,
+            runLeaseFencingVersion: input.runLeaseFencingVersion,
+            toolName: 'Bash',
+          },
+          { requestPermissionApproval },
+        ),
+      ).resolves.toMatchObject({ approved: true });
+      await expect(
+        processUserQuestionIpcRequest(
+          {
+            requestId: 'question-delegated-child',
+            sourceAgentFolder: testGroup.folder,
+            targetJid: testInput.chatJid,
+            runId: input.runId,
+            runLeaseToken: input.runLeaseToken,
+            runLeaseFencingVersion: input.runLeaseFencingVersion,
+            questions: [],
+          },
+          { requestUserAnswer },
+        ),
+      ).resolves.toMatchObject({ answers: { choice: 'continue' } });
+      return { status: 'success' as const, result: 'delegated child done' };
+    });
+
+    await expect(
+      spawnTestAgent(
+        testGroup,
+        {
+          ...testInput,
+          runtime: 'inline',
+          parentTaskId: 'delegated-task-1',
+          runId: 'persisted-child-run-1',
+        },
+        vi.fn(),
+        undefined,
+        { inlineAgentLoopLane } as never,
+      ),
+    ).resolves.toMatchObject({
+      status: 'success',
+      result: 'delegated child done',
+    });
+
+    expect(requestPermissionApproval).toHaveBeenCalledOnce();
+    expect(requestUserAnswer).toHaveBeenCalledOnce();
+    expect(observedSpawnLogContexts.at(-1)).toMatchObject({
+      correlationRunId: 'persisted-child-run-1',
+      turn: expect.objectContaining({ runId: 'persisted-child-run-1' }),
+    });
+    expect(getHostRuntimeCredentialEnv).toHaveBeenLastCalledWith(
+      'test-group',
+      undefined,
+      expect.objectContaining({
+        runId: 'persisted-child-run-1',
+        runContext: expect.not.objectContaining({
+          runId: expect.anything(),
+          runLeaseToken: expect.anything(),
+          runLeaseFencingVersion: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it('passes log-only correlation without adding runner identity', async () => {
+    await runtimeSpawnAgent(testGroup, testInput, () => {}, undefined, {
+      correlationRunId: 'run-entrypoint-log-only',
+      runnerSandboxProvider: new DirectRunnerSandboxProvider(),
+    });
+
+    expect(observedSpawnLogContexts.at(-1)).toMatchObject({
+      correlationRunId: 'run-entrypoint-log-only',
+      turn: expect.not.objectContaining({ runId: expect.anything() }),
+    });
+  });
+
   it('routes an OpenAI model to the DeepAgents adapter (engine derived from provider)', async () => {
     const result = await spawnTestAgent(
       testGroup,
@@ -4369,6 +4545,28 @@ describe('agent-spawn timeout behavior', () => {
       'inline',
     );
     expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('uses the minted turn tracker id for inline credential correlation', async () => {
+    vi.mocked(getSelectedAgentRuntime).mockReturnValueOnce('inline');
+
+    await spawnTestAgent(testGroup, testInput, vi.fn());
+
+    const trackerId = observedSpawnTrackerIds.at(-1);
+    expect(trackerId).toMatch(/^credential-run:/);
+    expect(getHostRuntimeCredentialEnv).toHaveBeenCalledWith(
+      'test-group',
+      undefined,
+      expect.objectContaining({
+        purpose: 'model_runtime',
+        runId: trackerId,
+        runContext: expect.not.objectContaining({
+          runId: expect.anything(),
+          runLeaseToken: expect.anything(),
+          runLeaseFencingVersion: expect.anything(),
+        }),
+      }),
+    );
   });
 
   it('rejects response schemas for worker runtime before spawning', async () => {

--- a/apps/core/test/unit/runtime/browser-capability.test.ts
+++ b/apps/core/test/unit/runtime/browser-capability.test.ts
@@ -115,6 +115,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     info: vi.fn(),
     warn: vi.fn(),
   },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 function cdpResponse(body: unknown): Response {

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -50,10 +50,13 @@ const mockLogger = vi.hoisted(() => ({
   warn: vi.fn(),
   error: vi.fn(),
   debug: vi.fn(),
+  updateLogContext: vi.fn(),
 }));
 vi.mock('@core/infrastructure/logging/logger.js', () => ({
   logger: mockLogger,
   redactString: (value: string) => value,
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: mockLogger.updateLogContext,
 }));
 
 const mockRunDreamingSweep = vi.fn();
@@ -4970,6 +4973,34 @@ describe('createGroupProcessor', () => {
         }), // options
       );
       expect(mockSpawnAgent.mock.calls[0][1]).not.toHaveProperty('sessionId');
+    });
+
+    it('keeps unfenced interactive permission and question IPC outside scheduled run identity', async () => {
+      const { deps } = setupHappyPath();
+      (deps.opsRepository as any).getAgentTurnContext = vi
+        .fn()
+        .mockResolvedValue({
+          appId: 'app:test',
+          agentId: 'agent:test',
+          agentSessionId: 'agent-session:1',
+        });
+      (deps.opsRepository as any).createSessionAgentRun = vi
+        .fn()
+        .mockResolvedValue('agent-run:interactive-1');
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await processGroupMessages('group1@g.us');
+
+      const agentInput = mockSpawnAgent.mock.calls[0][1];
+      expect(agentInput).not.toHaveProperty('runId');
+      expect(agentInput).not.toHaveProperty('runLeaseToken');
+      expect(agentInput).not.toHaveProperty('runLeaseFencingVersion');
+      expect(mockSpawnAgent.mock.calls[0][4]).toMatchObject({
+        correlationRunId: 'agent-run:interactive-1',
+      });
+      expect(mockLogger.updateLogContext).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: 'agent-run:interactive-1' }),
+      );
     });
 
     it('passes channel conversation kind to getAgentTurnContext', async () => {

--- a/apps/core/test/unit/runtime/group-registry.test.ts
+++ b/apps/core/test/unit/runtime/group-registry.test.ts
@@ -26,6 +26,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     error: vi.fn(),
     debug: vi.fn(),
   },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 vi.mock('@core/platform/workspace-folder.js', () => ({

--- a/apps/core/test/unit/runtime/ipc-auth-secret-source.test.ts
+++ b/apps/core/test/unit/runtime/ipc-auth-secret-source.test.ts
@@ -53,6 +53,9 @@ describe('ipc auth secret source', () => {
     }));
     vi.doMock('@core/infrastructure/logging/logger.js', () => ({
       logger: { warn: vi.fn() },
+      withLogContext: (_context: unknown, callback: () => unknown) =>
+        callback(),
+      updateLogContext: vi.fn(),
     }));
 
     const { computeIpcAuthToken } = await import('@core/runtime/ipc-auth.js');
@@ -95,6 +98,9 @@ describe('ipc auth secret source', () => {
     }));
     vi.doMock('@core/infrastructure/logging/logger.js', () => ({
       logger: { warn: vi.fn() },
+      withLogContext: (_context: unknown, callback: () => unknown) =>
+        callback(),
+      updateLogContext: vi.fn(),
     }));
 
     const { computeIpcAuthToken } = await import('@core/runtime/ipc-auth.js');
@@ -135,6 +141,9 @@ describe('ipc auth secret source', () => {
     }));
     vi.doMock('@core/infrastructure/logging/logger.js', () => ({
       logger: { warn: vi.fn() },
+      withLogContext: (_context: unknown, callback: () => unknown) =>
+        callback(),
+      updateLogContext: vi.fn(),
     }));
 
     await expect(import('@core/runtime/ipc-auth.js')).rejects.toThrow(

--- a/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
+++ b/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
@@ -11,6 +11,7 @@ import { createIpcAuthEnvelope } from '@core/runtime/ipc-auth.js';
 import { agentIdForFolder } from '@core/domain/agent/agent-folder-id.js';
 import { semanticCapabilityInputSchema } from '@core/shared/semantic-capabilities.js';
 import { makeAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
+import { getOperationalErrorCount } from '@core/shared/operational-error-counters.js';
 
 import {
   processPermissionIpcRequest,
@@ -1534,6 +1535,10 @@ describe('ipc-interaction-handler', () => {
   });
 
   it('does not write a scheduled permission response when durable resolution fails', async () => {
+    const before = getOperationalErrorCount(
+      'interaction',
+      'permission_request',
+    );
     const envelope = createIpcAuthEnvelope('main_agent', null);
     const claimedPath = path.join(
       tempDir,
@@ -1600,9 +1605,16 @@ describe('ipc-interaction-handler', () => {
         ),
       ),
     ).toBe(false);
+    expect(getOperationalErrorCount('interaction', 'permission_request')).toBe(
+      before + 1,
+    );
   });
 
   it('does not write scheduled question answers when durable resolution fails', async () => {
+    const before = getOperationalErrorCount(
+      'interaction',
+      'user_question_request',
+    );
     const envelope = createIpcAuthEnvelope('main_agent', null);
     const claimedPath = path.join(tempDir, 'claimed-unresolved-question.json');
     fs.writeFileSync(claimedPath, '{}');
@@ -1673,6 +1685,9 @@ describe('ipc-interaction-handler', () => {
         ),
       ),
     ).toBe(false);
+    expect(
+      getOperationalErrorCount('interaction', 'user_question_request'),
+    ).toBe(before + 1);
   });
 
   it('does not write scheduled question answers after lease recovery', async () => {

--- a/apps/core/test/unit/runtime/ipc-operational-error-counters.test.ts
+++ b/apps/core/test/unit/runtime/ipc-operational-error-counters.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  dataDir: `/tmp/gantry-ipc-operational-errors-${process.pid}`,
+}));
+
+vi.mock('@core/config/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@core/config/index.js')>()),
+  DATA_DIR: testState.dataDir,
+  IPC_POLL_INTERVAL: 5,
+}));
+
+import { createSignedIpcRequestEnvelope } from '@core/shared/ipc-signing.js';
+import { computeIpcAuthToken } from '@core/runtime/ipc-auth.js';
+import { FilesystemRunnerControlPort } from '@core/runtime/filesystem-runner-control-port.js';
+import { getOperationalErrorCount } from '@core/shared/operational-error-counters.js';
+import { startIpcWatcher, stopIpcWatcher } from '@core/runtime/ipc.js';
+import { processMemoryRequest } from '@core/memory/memory-ipc.js';
+
+describe('IPC operational error counters', () => {
+  beforeEach(() => {
+    fs.rmSync(testState.dataDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    stopIpcWatcher();
+    fs.rmSync(testState.dataDir, { recursive: true, force: true });
+  });
+
+  it('increments message dispatch once when delivery is archived as failed', async () => {
+    const sourceAgentFolder = 'counter_agent';
+    const targetJid = 'tg:counter';
+    const controlPort = new FilesystemRunnerControlPort(
+      path.join(testState.dataDir, 'ipc'),
+    );
+    controlPort.ensureRoot();
+    controlPort.ensureWorkspaceLayout(sourceAgentFolder);
+    const payload = createSignedIpcRequestEnvelope(
+      computeIpcAuthToken(sourceAgentFolder, undefined, {
+        appId: 'app:test',
+        agentId: 'agent:counter',
+      }),
+      {
+        type: 'message',
+        requestId: 'message-dispatch-failure',
+        chatJid: targetJid,
+        text: 'fail this delivery',
+        context: { appId: 'app:test', agentId: 'agent:counter' },
+      },
+    );
+    fs.writeFileSync(
+      path.join(
+        controlPort.requestDir(sourceAgentFolder, 'messages'),
+        'message-dispatch-failure.json',
+      ),
+      JSON.stringify(payload),
+    );
+    const before = getOperationalErrorCount('ipc', 'message_dispatch');
+
+    startIpcWatcher({
+      conversationRoutes: () => ({
+        [targetJid]: {
+          name: 'Counter agent',
+          folder: sourceAgentFolder,
+          trigger: '',
+          added_at: new Date(0).toISOString(),
+        },
+      }),
+      sendMessage: vi.fn(async () => {
+        throw new Error('simulated channel failure');
+      }),
+    } as never);
+
+    await vi.waitFor(() => {
+      expect(getOperationalErrorCount('ipc', 'message_dispatch')).toBe(
+        before + 1,
+      );
+    });
+  });
+
+  it('increments memory IPC once when a failure becomes an error response', async () => {
+    const before = getOperationalErrorCount('memory', 'ipc_request');
+
+    await expect(
+      processMemoryRequest(
+        {
+          requestId: 'memory-request-failure',
+          action: 'memory_search',
+          payload: { query: '' },
+          allowedActions: ['memory_search'],
+        },
+        'counter_agent',
+      ),
+    ).resolves.toMatchObject({ ok: false, error: 'query is required' });
+    expect(getOperationalErrorCount('memory', 'ipc_request')).toBe(before + 1);
+  });
+});

--- a/apps/core/test/unit/runtime/permission-classifier.test.ts
+++ b/apps/core/test/unit/runtime/permission-classifier.test.ts
@@ -17,6 +17,8 @@ vi.mock('@core/memory/memory-llm-port.js', () => ({
 
 vi.mock('@core/infrastructure/logging/logger.js', () => ({
   logger: { warn },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 import {

--- a/apps/core/test/unit/runtime/prompt-profile.test.ts
+++ b/apps/core/test/unit/runtime/prompt-profile.test.ts
@@ -23,6 +23,8 @@ vi.mock('@core/infrastructure/logging/logger.js', () => ({
     info: loggerSpies.info,
     warn: loggerSpies.warn,
   },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
 }));
 
 type ArtifactKey = `${string}:${string}:${string}:${string}`;

--- a/apps/core/test/unit/runtime/session-resume-runtime.test.ts
+++ b/apps/core/test/unit/runtime/session-resume-runtime.test.ts
@@ -3,6 +3,7 @@ import type { RuntimeAgentSessionRepository } from '@core/domain/repositories/op
 import type { SkillArtifactStore } from '@core/domain/ports/skill-artifact-store.js';
 import type { SkillCatalogRepository } from '@core/domain/ports/repositories.js';
 import { createGroupAgentRunner } from '@core/runtime/group-agent-runner.js';
+import { currentLogContext } from '@core/infrastructure/logging/logger.js';
 import { buildProviderSessionAccessFingerprint } from '@core/runtime/provider-session-access-fingerprint.js';
 import {
   buildApprovedSkillContextBlock,
@@ -29,7 +30,9 @@ describe('session-resume-runtime', () => {
       at: '2026-07-11T00:00:00.000Z',
     } as const;
     const publishRuntimeEvent = vi.fn(async () => undefined);
-    const runAgent = vi.fn(async (_group, _input, _register, onOutput) => {
+    let observedLogContext: ReturnType<typeof currentLogContext> = undefined;
+    const runAgent = vi.fn(async (_group, input, _register, onOutput) => {
+      observedLogContext = currentLogContext();
       await onOutput?.({
         status: 'success',
         result: null,
@@ -121,6 +124,15 @@ describe('session-resume-runtime', () => {
         }),
       }),
     ]);
+    expect(runAgent.mock.calls[0]?.[1]).not.toHaveProperty('runId');
+    expect(runAgent.mock.calls[0]?.[4]).toMatchObject({
+      correlationRunId: 'run:live-turn-1',
+    });
+    expect(observedLogContext).toEqual({
+      runId: 'run:live-turn-1',
+      appId: 'app-one',
+      agentId: 'agent:main_agent',
+    });
   });
 
   it('runs maintenance-locked provider sessions without resume or head writes', async () => {

--- a/docs/architecture/arch-quick-wins-assumptions.md
+++ b/docs/architecture/arch-quick-wins-assumptions.md
@@ -1,0 +1,79 @@
+# Architecture Quick Wins Assumptions
+
+This ledger records the bounded decisions for findings 8 and 1 from the
+2026-07-16 Fable architecture review. The review document is not present at
+this branch's `HEAD`; its accepted findings were read from repository history
+and checked against the current implementation before changes were made.
+
+## 1. Deferred durable-work primitive
+
+Retention was removed from this quick win and deferred to the durable-work-primitive cycle (Fable finding 1) because it entangles with scheduler run-recording (which must prune `agent_runs` job-backed history, not `job_runs`), agent materialization (which needs an agentless/hidden system principal that never creates `agent:system` through `insertRun`/`ensureJobRunGraph` or workspace preparation), and lease fencing (cluster re-registration must not erase live leases, and deadline must not be conflated with cancellation).
+
+## 2. Error counters
+
+- `gantry_errors_total{subsystem,kind}` is a process-local monotonic Prometheus
+  counter. Restart reset is expected for process metrics.
+- Labels are a closed, low-cardinality vocabulary selected at load-bearing
+  top-level failure boundaries. Exception text, identifiers, and provider
+  payloads never become labels.
+- The counter records failures that are caught, converted, retried, or
+  downgraded at the selected runtime, job, delivery, and channel seams. It does
+  not attempt to instrument every `catch`.
+
+## 3. Per-turn log context
+
+- Async-local context is used because Gantry's shared logger is imported by
+  deep helpers; threading child logger parameters through those stacks would
+  be a broader refactor.
+- Context is scoped with `run`, not ambient mutation, so concurrent turns do
+  not leak `runId`, `appId`, `agentId`, or `traceId` into one another.
+- An ordinary interactive turn's persisted run ID is log/trace correlation
+  only. Worker and inline model credential bindings use that tracked ID for
+  gateway trace/audit parenting without copying it into `AgentInput`.
+  `GANTRY_JOB_RUN_ID` is projected only with a complete scheduled lease token
+  and fencing version, so unfenced permission and question IPC remains outside
+  scheduled-lease validation.
+- `traceId` is copied only from a real OpenTelemetry turn span. It is absent
+  when tracing is disabled rather than being synthesized from a run ID.
+- Per-call fields retain the logger's existing override order. Structured log
+  data is merged first and redacted once.
+
+## 4. Durable `send_message`
+
+- Current repository reality differs from the review anchor: runner IPC
+  already delegates through channel wiring with `durability: 'required'`, and
+  that path creates an outbound delivery before provider dispatch.
+- The reliability gap is startup order. When outbound storage is available,
+  IPC processing starts only after the existing durable outbound attempt
+  factory and recovery loop are installed. A repository-absent runtime still
+  starts IPC, but required sends fail closed before provider dispatch.
+- No second queue or enqueue-only IPC path is introduced. The existing path
+  retains route authorization, message projection, partial-delivery handling,
+  attachment behavior, and immediate delivery while making provider failures
+  retry-eligible.
+
+## 5. Deferred IPC overload backpressure
+
+IPC overload backpressure was split out alongside retention and deferred to the
+durable-work-primitive cycle (Fable finding 1). It needs bounded scanning with a
+persistent cursor across polls: ignored `.processing-*`, temp, and non-JSON
+entries must not consume the scan budget or starve later valid requests. The
+design must never archive valid work, must reject genuine floods at ingress,
+and must define lane-aware task-deadline semantics. This requires a proper
+durable queue design, not a poll patch.
+
+## Surface Impact Matrix
+
+| Surface                      | Classification      | Decision                                                                                                                         |
+| ---------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime behavior             | Changed             | Adds failure counters, per-turn child log context without widening lease-gated IPC, and durable-send startup ordering.           |
+| `settings.yaml`              | Unchanged by design | The three retained quick wins add no configuration keys.                                                                         |
+| Postgres/runtime projection  | Unchanged by design | Durable send reuses the existing outbound-delivery rows and repository; no schema or settings projection changes.                |
+| Control API                  | Unchanged by design | No control endpoint, request, or response changes.                                                                               |
+| SDK/contracts                | Unchanged by design | No public request, response, or tool schema changes.                                                                             |
+| CLI                          | Unchanged by design | No commands or settings validation/rendering changes.                                                                            |
+| Gantry MCP tools/admin skill | Unchanged by design | No new agent or admin authority is introduced.                                                                                   |
+| Channel/provider adapters    | Changed             | Selected Slack and Teams failure seams increment the closed-label error counter.                                                 |
+| Docs/prompts                 | Changed             | This ledger records the narrowed quick-win scope and its durable-work follow-up.                                                 |
+| Audit/events                 | Unchanged by design | Existing audit and outbound-delivery event contracts are reused unchanged.                                                       |
+| Tests/verification           | Changed             | Focused tests pin counters, `{runId, appId, agentId, traceId}` log context, durable send, and unfenced interactive IPC identity. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -852,13 +852,40 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "peer": true
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
-      "optional": true
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,7 +252,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
       "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
         "standardwebhooks": "^1.0.0"
@@ -815,8 +814,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@clack/core": {
       "version": "1.3.0",
@@ -853,16 +851,14 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+    "node_modules/@emnapi/core": {
       "dev": true,
-      "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
+      "peer": true
+    },
+    "node_modules/@emnapi/runtime": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -2161,7 +2157,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.48.tgz",
       "integrity": "sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -2180,7 +2175,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.1.tgz",
       "integrity": "sha512-rrDIeSYUqKKNASZgB5BqAFZ5y1zjrh/qc/pP/W0J7zV5+2HxrqgdMdTV6zy3RtNgDnrWShaI4EZnqObw1blWqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.0",
         "@langchain/langgraph-sdk": "~1.9.21",
@@ -2207,7 +2201,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.0.tgz",
       "integrity": "sha512-okFt51NDyJ9J5Ey0dIfqbbdBDx+5/pXlvv9PIfdDJjAQD5bVSLuA5A9Ap7NV6Bip7qg7WCn7VdiGwv8QPq1qTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uuid": "^14.0.0"
       },
@@ -2385,7 +2378,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2635,7 +2627,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3493,6 +3484,7 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -3514,6 +3506,7 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3549,6 +3542,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3560,7 +3554,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3599,7 +3594,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3610,13 +3604,15 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -3624,7 +3620,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3650,6 +3645,7 @@
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3659,6 +3655,7 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
@@ -3718,7 +3715,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -3962,7 +3958,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -4105,7 +4100,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5004,7 +4998,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5257,7 +5250,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5853,7 +5845,6 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.42.0.tgz",
       "integrity": "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.26.0",
         "abort-controller": "^3.0.0",
@@ -5918,7 +5909,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6353,7 +6343,6 @@
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.7.tgz",
       "integrity": "sha512-ccXRX1kRDSIf+jtH+XerEhz8TmZN4SEu0QzMs9Zqd/hl5SGvMK4hPTv7+Pwpooprzenib+41RyZYDqgb9KWjcA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-queue": "6.6.2"
       },
@@ -7356,7 +7345,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -7471,7 +7459,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7710,7 +7697,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7721,7 +7707,6 @@
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8482,7 +8467,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8575,7 +8559,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -8708,7 +8691,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8949,7 +8931,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,7 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
       "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
         "standardwebhooks": "^1.0.0"
@@ -814,7 +815,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@clack/core": {
       "version": "1.3.0",
@@ -851,14 +853,16 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@emnapi/core": {
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "peer": true
-    },
-    "node_modules/@emnapi/runtime": {
-      "dev": true,
-      "optional": true
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -2157,6 +2161,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.48.tgz",
       "integrity": "sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -2175,6 +2180,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.1.tgz",
       "integrity": "sha512-rrDIeSYUqKKNASZgB5BqAFZ5y1zjrh/qc/pP/W0J7zV5+2HxrqgdMdTV6zy3RtNgDnrWShaI4EZnqObw1blWqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.0",
         "@langchain/langgraph-sdk": "~1.9.21",
@@ -2201,6 +2207,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.0.tgz",
       "integrity": "sha512-okFt51NDyJ9J5Ey0dIfqbbdBDx+5/pXlvv9PIfdDJjAQD5bVSLuA5A9Ap7NV6Bip7qg7WCn7VdiGwv8QPq1qTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uuid": "^14.0.0"
       },
@@ -2378,6 +2385,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2627,6 +2635,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3484,7 +3493,6 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -3506,7 +3514,6 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3542,7 +3549,6 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3554,8 +3560,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3594,6 +3599,7 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3604,15 +3610,13 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -3620,6 +3624,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3645,7 +3650,6 @@
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3655,7 +3659,6 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
@@ -3715,6 +3718,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -3958,6 +3962,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -4100,6 +4105,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4998,6 +5004,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5250,6 +5257,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5845,6 +5853,7 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.42.0.tgz",
       "integrity": "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.26.0",
         "abort-controller": "^3.0.0",
@@ -5909,6 +5918,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6343,6 +6353,7 @@
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.7.tgz",
       "integrity": "sha512-ccXRX1kRDSIf+jtH+XerEhz8TmZN4SEu0QzMs9Zqd/hl5SGvMK4hPTv7+Pwpooprzenib+41RyZYDqgb9KWjcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-queue": "6.6.2"
       },
@@ -7345,6 +7356,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -7459,6 +7471,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7697,6 +7710,7 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7707,6 +7721,7 @@
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8467,6 +8482,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8559,6 +8575,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -8691,6 +8708,7 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8931,6 +8949,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Bounded subset of the 2026-07-16 Fable architecture review (findings 8 and 1). Retention and IPC overload backpressure are **deferred** to the durable-work-primitive cycle — they entangle with scheduler run-recording, agent materialization, and lease fencing, and need bounded cursor-based scanning respectively.

## What landed
- **Operational error counters** — `gantry_errors_total{subsystem,kind}`, a process-local, closed-vocabulary Prometheus counter at load-bearing runtime/job/delivery/channel failure seams; surfaced via system-health. No identifiers or payloads become labels.
- **Per-turn / per-job log correlation** — async-local context carrying `run/app/agent/trace` ids, scoped with `run()` so concurrent turns can't leak ids into one another. `traceId` is copied only from a real OTel turn span (absent when tracing is off, never synthesized). `agent-spawn` decomposed into `agent-spawn-identity` / `-preparation` / `-execution-adapter` to carry the scoped context without threading child loggers through deep helpers.
- **Durable `send_message` ordering** — fail-closed startup: IPC processing begins only after the durable outbound attempt factory + recovery loop are installed, closing a startup-order reliability gap. No second queue introduced; existing route-auth/projection/partial-delivery behavior preserved.

## Verification
- `tsc --noEmit` clean.
- Unit suite: 1584 passing in-worktree; architecture gate clean (0 violations beyond the pre-accepted `text-styles.ts` cases).
- Local autoreview (`--mode local --thinking xhigh`): `patch is correct (0.86)`, no actionable findings.

Ledger: `docs/architecture/arch-quick-wins-assumptions.md`