### PR TITLE
Messaging latency: pipe first token before usage audit; inline prompt-cache parity; SDK context-usage off critical path

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway.ts
@@ -499,7 +499,7 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
       parsedResponse?.payload,
       usage,
     );
-    await this.publishGatewayUseAudit(tokenRecord, {
+    const auditInput = {
       outcome: response.ok ? 'forwarded' : 'upstream_error',
       method: req.method ?? 'GET',
       status,
@@ -507,7 +507,17 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
       upstreamPath: upstreamUrl.pathname,
       credentialFingerprint: credential.fingerprint,
       usage,
-    });
+    } as const;
+    const isStreamingResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .includes('text/event-stream');
+    const auditPromise = isStreamingResponse
+      ? this.publishGatewayUseAudit(tokenRecord, auditInput)
+      : undefined;
+    if (!auditPromise) {
+      await this.publishGatewayUseAudit(tokenRecord, auditInput);
+    }
     res.statusCode = status;
     response.headers.forEach((value, key) => {
       if (!shouldForwardGatewayResponseHeader(key)) return;
@@ -515,7 +525,16 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
     });
     const tap = resolveGatewayTap(observation, response);
     try {
-      await pipeUpstreamBody(response, res, tap);
+      const pipePromise = pipeUpstreamBody(response, res, tap);
+      if (auditPromise) {
+        const [, pipeResult] = await Promise.allSettled([
+          auditPromise,
+          pipePromise,
+        ]);
+        if (pipeResult.status === 'rejected') throw pipeResult.reason;
+      } else {
+        await pipePromise;
+      }
       if (observation?.isStreaming) observation.finish({ status });
     } catch (error) {
       if (observation?.isStreaming)

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/runner/query-loop.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/runner/query-loop.ts
@@ -642,7 +642,7 @@ export async function runQuery(
           message,
           fallbackModel: configuredModel,
         });
-        const contextUsage = await readContextUsage(sdkQuery);
+        const contextUsagePromise = readContextUsage(sdkQuery);
         const continuedByFollowup = steeringGate.pendingCount() > 0;
         writeOutput({
           status: 'success',
@@ -650,7 +650,6 @@ export async function runQuery(
           newSessionId,
           ...(primeToolAttempts.length > 0 ? { primeToolAttempts } : {}),
           ...(continuedByFollowup ? { continuedByFollowup: true } : {}),
-          ...(contextUsage ? { contextUsage } : {}),
           ...(usage
             ? {
                 usage,
@@ -670,6 +669,16 @@ export async function runQuery(
         visibleTextSinceLastResult = '';
         pendingStructuredToPartialBoundary = false;
         steeringGate.markTurnBoundary();
+        const contextUsage = await contextUsagePromise;
+        if (contextUsage) {
+          writeOutput({
+            status: 'success',
+            result: null,
+            newSessionId,
+            runtimeEventOnly: true,
+            contextUsage,
+          });
+        }
       }
     }
   } finally {

--- a/apps/core/src/adapters/llm/deepagents-langchain/execution-adapter.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/execution-adapter.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { createHash, randomUUID } from 'crypto';
+import { randomUUID } from 'crypto';
 
 import type {
   AgentExecutionAdapter,
@@ -12,9 +12,8 @@ import { projectDeepAgentModelCredentialEnv } from './model-credential-env.js';
 import { validateDeepAgentCredentialProjection } from './credential-validation.js';
 import { isMissingDeepAgentSessionError } from './runner/session-store.js';
 import { ensureDeepAgentsCheckpointSchema } from './checkpoint-setup.js';
-import { resolveModelCacheSupport } from '../../../shared/model-cache-support.js';
-import { getModelProviderDefinition } from '../../../shared/model-provider-registry.js';
 import { resolveDeepAgentSkillProjection } from './skill-projection.js';
+import { resolveDeepAgentsPromptCache } from './prompt-cache.js';
 import type { OpenRouterProviderRouting } from '../../../shared/model-catalog-provider-metadata.js';
 
 const GANTRY_DEEPAGENTS_MODEL_ID_ENV = 'GANTRY_DEEPAGENTS_MODEL_ID';
@@ -32,24 +31,6 @@ const GANTRY_DEEPAGENTS_MAX_INPUT_TOKENS_ENV =
   'GANTRY_DEEPAGENTS_MAX_INPUT_TOKENS';
 const GANTRY_DEEPAGENTS_OPENROUTER_PROVIDER_ROUTING_ENV =
   'GANTRY_DEEPAGENTS_OPENROUTER_PROVIDER_ROUTING';
-
-// Maps the resolved model's prompt-cache request control (catalog descriptor) to
-// the runner's gated cache_control mode. 'provider_automatic_prefix' (OpenAI
-// gpt, OpenRouter Kimi) -> 'automatic' (inject nothing, the upstream caches the
-// prefix); 'cache_control_blocks' (Anthropic/Gemini/Qwen sub-models) ->
-// 'explicit' (runner adds ephemeral breakpoints); otherwise 'none'.
-function cachePromptControlMode(
-  requestControl: 'none' | 'cache_control_blocks' | 'provider_automatic_prefix',
-): 'automatic' | 'explicit' | 'none' {
-  switch (requestControl) {
-    case 'provider_automatic_prefix':
-      return 'automatic';
-    case 'cache_control_blocks':
-      return 'explicit';
-    default:
-      return 'none';
-  }
-}
 
 function openRouterProviderRoutingEnv(
   routing: OpenRouterProviderRouting | undefined,
@@ -152,18 +133,15 @@ export class DeepAgentsLangChainExecutionAdapter implements AgentExecutionAdapte
     if (input.effectiveModelEntry) {
       env[GANTRY_DEEPAGENTS_MODEL_PROVIDER_ENV] =
         input.effectiveModelEntry.modelRoute.id;
-      env[GANTRY_DEEPAGENTS_CACHE_PROMPT_CONTROL_ENV] = cachePromptControlMode(
-        resolveModelCacheSupport(input.effectiveModelEntry).prompt
-          .requestControl,
-      );
-      const provider = getModelProviderDefinition(
-        input.effectiveModelEntry.modelRoute.id,
-      );
-      if (provider?.cacheSupport.prompt.promptCacheKey) {
-        env[GANTRY_DEEPAGENTS_PROMPT_CACHE_KEY_ENV] = promptCacheKey({
-          conversationId: input.input.chatJid,
-          threadId: input.input.threadId,
-        });
+      const promptCache = resolveDeepAgentsPromptCache({
+        modelEntry: input.effectiveModelEntry,
+        conversationId: input.input.chatJid,
+        threadId: input.input.threadId,
+      });
+      env[GANTRY_DEEPAGENTS_CACHE_PROMPT_CONTROL_ENV] = promptCache.cacheMode;
+      if (promptCache.promptCacheKey) {
+        env[GANTRY_DEEPAGENTS_PROMPT_CACHE_KEY_ENV] =
+          promptCache.promptCacheKey;
       }
       // Project the curated window only when the catalog declares one; absent ->
       // the runner uses the library's real profile (gpt-5.5/gpt-5.4).
@@ -247,18 +225,6 @@ export class DeepAgentsLangChainExecutionAdapter implements AgentExecutionAdapte
 
 function safePathSegment(value: string): string {
   return value.replace(/[^A-Za-z0-9_.-]/g, '_');
-}
-
-function promptCacheKey(input: {
-  conversationId: string;
-  threadId?: string;
-}): string {
-  return createHash('sha256')
-    .update('gantry-deepagents-prompt-cache-key\0')
-    .update(input.conversationId)
-    .update('\0')
-    .update(input.threadId ?? '')
-    .digest('hex');
 }
 
 export function createDeepAgentsLangChainExecutionAdapter(): AgentExecutionAdapter {

--- a/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts
@@ -40,7 +40,9 @@ import {
   reconcileDeepAgentSkillFiles,
   resolveDeepAgentSkillProjection,
 } from '../skill-projection.js';
+import { resolveDeepAgentsPromptCache } from '../prompt-cache.js';
 import { createBuiltinToolExclusionMiddleware } from '../runner/builtin-tool-exclusion.js';
+import { applyCachePromptControl } from '../runner/cache-control.js';
 import { isAbortError } from '../runner/live-control.js';
 import {
   buildRunnerModel,
@@ -101,6 +103,11 @@ export function createDeepAgentsInlineAgentLoopLane(input: {
       new StateBackend(config);
 
     const sessionId = laneInput.input.sessionId ?? randomUUID();
+    const promptCache = resolveDeepAgentsPromptCache({
+      modelEntry: laneInput.resolvedModel.value.modelEntry,
+      conversationId: laneInput.input.chatJid,
+      threadId: laneInput.input.threadId,
+    });
     const stop = new AbortController();
     const pendingFollowups: string[] = [];
     let closeRequested = false;
@@ -141,7 +148,11 @@ export function createDeepAgentsInlineAgentLoopLane(input: {
         });
       }
 
-      const model = await buildInlineModel(laneInput, sessionId);
+      const model = await buildInlineModel(
+        laneInput,
+        sessionId,
+        promptCache.promptCacheKey,
+      );
       remoteMcp = toolsDisabled
         ? { tools: [], close: () => Promise.resolve() }
         : await connectRemoteMcpTools(laneInput.mcpServers, {
@@ -212,9 +223,12 @@ export function createDeepAgentsInlineAgentLoopLane(input: {
           : queued.join('\n');
         if (!prompt) break;
         currentMemoryQuery = prompt;
-        const messages = memory.buildInlineTurnMessages(
-          prompt,
-          firstTurn ? laneInput.input.memoryContextBlock : undefined,
+        const messages = applyCachePromptControl(
+          memory.buildInlineTurnMessages(
+            prompt,
+            firstTurn ? laneInput.input.memoryContextBlock : undefined,
+          ),
+          promptCache.cacheMode,
         );
         firstTurn = false;
 
@@ -371,6 +385,7 @@ async function openCheckpointer(input: {
 async function buildInlineModel(
   input: Parameters<ProviderInlineAgentLoopLane>[0],
   sessionId: string,
+  promptCacheKey?: string,
 ): Promise<ResolvedRunnerModel> {
   if (!input.resolvedModel.ok) throw new Error(input.resolvedModel.message);
   const baseUrl = input.modelCredentialEnv.OPENAI_BASE_URL?.trim();
@@ -389,6 +404,7 @@ async function buildInlineModel(
     gatewayBaseUrl: baseUrl,
     gatewayToken: token,
     sessionId,
+    ...(promptCacheKey ? { promptCacheKey } : {}),
     effort: input.effort,
     configuredThinking: input.configuredThinking,
     maxOutputTokens: input.maxOutputTokens,

--- a/apps/core/src/adapters/llm/deepagents-langchain/prompt-cache.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/prompt-cache.ts
@@ -1,0 +1,43 @@
+import { createHash } from 'crypto';
+
+import type { ModelCatalogEntry } from '../../../shared/model-catalog.js';
+import { resolveModelCacheSupport } from '../../../shared/model-cache-support.js';
+import type { CachePromptControlMode } from './runner/cache-control.js';
+
+export function resolveDeepAgentsPromptCache(input: {
+  modelEntry: ModelCatalogEntry;
+  conversationId: string;
+  threadId?: string;
+}): {
+  cacheMode: CachePromptControlMode;
+  promptCacheKey?: string;
+} {
+  const promptSupport = resolveModelCacheSupport(input.modelEntry).prompt;
+  const cacheMode = cachePromptControlMode(promptSupport.requestControl);
+  return {
+    cacheMode,
+    ...(promptSupport.promptCacheKey
+      ? {
+          promptCacheKey: createHash('sha256')
+            .update('gantry-deepagents-prompt-cache-key\0')
+            .update(input.conversationId)
+            .update('\0')
+            .update(input.threadId ?? '')
+            .digest('hex'),
+        }
+      : {}),
+  };
+}
+
+function cachePromptControlMode(
+  requestControl: 'none' | 'cache_control_blocks' | 'provider_automatic_prefix',
+): CachePromptControlMode {
+  switch (requestControl) {
+    case 'provider_automatic_prefix':
+      return 'automatic';
+    case 'cache_control_blocks':
+      return 'explicit';
+    default:
+      return 'none';
+  }
+}

--- a/apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
+++ b/apps/core/test/integration/claude-agent-sdk-boundary.integration.test.ts
@@ -38,6 +38,14 @@ const sdkState = vi.hoisted(() => ({
     streamMessages: unknown[];
     permissionDecision?: unknown;
   }>,
+  getContextUsage: undefined as
+    | undefined
+    | (() => Promise<{
+        totalTokens: number;
+        maxTokens: number;
+        percentage: number;
+        model?: string;
+      }>),
 }));
 const clockState = vi.hoisted(() => ({
   nowMs: () => Date.now(),
@@ -52,9 +60,8 @@ vi.mock('@core/shared/time/datetime.js', async (importOriginal) => {
   };
 });
 
-vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
-  SYSTEM_PROMPT_DYNAMIC_BOUNDARY: '__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__',
-  query: async function* ({
+vi.mock('@anthropic-ai/claude-agent-sdk', () => {
+  const query = async function* ({
     prompt,
     options,
   }: {
@@ -293,8 +300,15 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
     }
 
     yield { type: 'result', subtype: 'success', result: 'ok' };
-  },
-}));
+  };
+  Object.defineProperty(query.prototype, 'getContextUsage', {
+    get: () => sdkState.getContextUsage,
+  });
+  return {
+    SYSTEM_PROMPT_DYNAMIC_BOUNDARY: '__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__',
+    query,
+  };
+});
 
 async function nextWithTimeout<T>(
   iterator: AsyncIterator<T>,
@@ -386,6 +400,7 @@ afterEach(() => {
   }
   sdkState.mode = 'success';
   sdkState.calls.length = 0;
+  sdkState.getContextUsage = undefined;
   clockState.nowMs = () => Date.now();
   vi.unstubAllEnvs();
 });
@@ -508,6 +523,79 @@ describe('Claude Agent SDK boundary integration', () => {
         }),
       ]),
     );
+  });
+
+  it('emits result-only output before context usage retrieval settles', async () => {
+    const env = prepareRuntimeEnv();
+    let releaseContextUsage!: (usage: {
+      totalTokens: number;
+      maxTokens: number;
+      percentage: number;
+      model: string;
+    }) => void;
+    sdkState.getContextUsage = () =>
+      new Promise((resolve) => {
+        releaseContextUsage = resolve;
+      });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { runQuery } = await importRunQuery();
+
+    const queryDone = runQuery(
+      'hello from Gantry',
+      env.mcpServerPath,
+      runnerInput(),
+      sdkProcessEnv(),
+      'sonnet',
+      undefined,
+      undefined,
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        logSpy.mock.calls
+          .map((call) => String(call[0] ?? ''))
+          .filter((line) => line.startsWith('{'))
+          .map((line) => JSON.parse(line) as { result: string | null })
+          .some((output) => output.result === 'ok'),
+      ).toBe(true);
+    });
+    releaseContextUsage({
+      totalTokens: 120,
+      maxTokens: 1_000,
+      percentage: 12,
+      model: 'sonnet',
+    });
+    await queryDone;
+
+    const outputs = logSpy.mock.calls
+      .map((call) => String(call[0] ?? ''))
+      .filter((line) => line.startsWith('{'))
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            result: string | null;
+            runtimeEventOnly?: boolean;
+            contextUsage?: { totalTokens: number };
+          },
+      );
+    logSpy.mockRestore();
+    const resultIndex = outputs.findIndex((output) => output.result === 'ok');
+    const contextUsageIndex = outputs.findIndex(
+      (output) => output.contextUsage?.totalTokens === 120,
+    );
+
+    expect(resultIndex).toBeGreaterThanOrEqual(0);
+    expect(contextUsageIndex).toBeGreaterThan(resultIndex);
+    expect(outputs[contextUsageIndex]).toMatchObject({
+      result: null,
+      runtimeEventOnly: true,
+      contextUsage: {
+        totalTokens: 120,
+        maxTokens: 1_000,
+        percentage: 12,
+        model: 'sonnet',
+      },
+    });
   });
 
   it('ignores SDK thinking deltas and streams only text deltas', async () => {

--- a/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
@@ -273,6 +273,49 @@ describe('DeepAgents inline lane', () => {
     );
   });
 
+  it('uses a stable conversation/thread prompt cache key in automatic cache mode', async () => {
+    deep.streamEvents.mockImplementation(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield streamEvent('done');
+      },
+    }));
+    const lane = createDeepAgentsInlineAgentLoopLane({
+      databaseUrl: 'postgres://gantry:test@localhost:5432/gantry',
+      schema: 'gantry_deepagents',
+    });
+    const cachedInput = (threadId: string) => {
+      const base = laneInput();
+      return laneInput({
+        input: { ...base.input, threadId },
+        mcpServers: [],
+        resolvedModel: {
+          ok: true,
+          value: {
+            ...base.resolvedModel.value,
+            modelEntry: {
+              ...base.resolvedModel.value.modelEntry,
+              modelRoute: { id: 'xai' },
+            },
+          },
+        },
+      });
+    };
+
+    await lane(cachedInput('thread:one'));
+    await lane(cachedInput('thread:one'));
+    await lane(cachedInput('thread:two'));
+
+    const keys = model.build.mock.calls.map(
+      ([input]) => input.promptCacheKey as string,
+    );
+    expect(keys[0]).toMatch(/^[a-f0-9]{64}$/);
+    expect(keys[1]).toBe(keys[0]);
+    expect(keys[2]).not.toBe(keys[0]);
+    expect(
+      deep.streamEvents.mock.calls.map(([input]) => input.messages[0].content),
+    ).toEqual(['first prompt', 'first prompt', 'first prompt']);
+  });
+
   it('emits and returns a named max_turns error on graph recursion', async () => {
     deep.streamEvents.mockImplementation(() => ({
       async *[Symbol.asyncIterator]() {

--- a/apps/core/test/unit/core/gantry-model-gateway.test.ts
+++ b/apps/core/test/unit/core/gantry-model-gateway.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'node:http';
 import { createHash } from 'node:crypto';
+import { Readable, Writable } from 'node:stream';
 
 import {
   extractGatewayResponseUsage,
@@ -207,17 +208,29 @@ function gatewayRequest(input: {
 }
 
 function gatewayStreamingRequest(input: { url: string; token: string }): {
-  firstChunk: Promise<string>;
-  done: Promise<{ status: number; body: string }>;
+  firstChunk: Promise<{
+    status: number;
+    headers: http.IncomingHttpHeaders;
+    body: Buffer;
+  }>;
+  done: Promise<{ status: number; body: Buffer }>;
 } {
-  let resolveFirstChunk!: (value: string) => void;
+  let resolveFirstChunk!: (value: {
+    status: number;
+    headers: http.IncomingHttpHeaders;
+    body: Buffer;
+  }) => void;
   let rejectFirstChunk!: (error: unknown) => void;
   let sawFirstChunk = false;
-  const firstChunk = new Promise<string>((resolve, reject) => {
+  const firstChunk = new Promise<{
+    status: number;
+    headers: http.IncomingHttpHeaders;
+    body: Buffer;
+  }>((resolve, reject) => {
     resolveFirstChunk = resolve;
     rejectFirstChunk = reject;
   });
-  const done = new Promise<{ status: number; body: string }>(
+  const done = new Promise<{ status: number; body: Buffer }>(
     (resolve, reject) => {
       const req = http.request(
         input.url,
@@ -235,13 +248,17 @@ function gatewayStreamingRequest(input: { url: string; token: string }): {
             chunks.push(buffer);
             if (!sawFirstChunk) {
               sawFirstChunk = true;
-              resolveFirstChunk(buffer.toString('utf-8'));
+              resolveFirstChunk({
+                status: res.statusCode ?? 0,
+                headers: res.headers,
+                body: buffer,
+              });
             }
           });
           res.on('end', () =>
             resolve({
               status: res.statusCode ?? 0,
-              body: Buffer.concat(chunks).toString('utf-8'),
+              body: Buffer.concat(chunks),
             }),
           );
         },
@@ -934,10 +951,29 @@ describe('GantryModelGatewayBroker', () => {
     }
   });
 
-  it('streams upstream provider responses without buffering the full body', async () => {
+  it('streams byte-identically before a blocked usage audit settles', async () => {
     const repo = new MutableModelCredentialRepository();
-    repo.set('anthropic', 'sk-ant-stream');
+    repo.set('anthropic', 'mock-anthropic-cred');
+    const firstBytes = Buffer.from('data: first\n\n');
+    const secondBytes = Buffer.from('data: second\n\n');
     let releaseSecondChunk!: () => void;
+    let releaseUsageAudit!: () => void;
+    let resolveUsageAuditSettled!: () => void;
+    let auditCalls = 0;
+    let usageAuditSettled = false;
+    const usageAuditGate = new Promise<void>((resolve) => {
+      releaseUsageAudit = resolve;
+    });
+    const usageAuditSettledPromise = new Promise<void>((resolve) => {
+      resolveUsageAuditSettled = resolve;
+    });
+    const audit = vi.fn(async () => {
+      auditCalls += 1;
+      if (auditCalls !== 2) return;
+      await usageAuditGate;
+      usageAuditSettled = true;
+      resolveUsageAuditSettled();
+    });
     vi.stubGlobal(
       'fetch',
       vi.fn(
@@ -945,9 +981,9 @@ describe('GantryModelGatewayBroker', () => {
           new Response(
             new ReadableStream<Uint8Array>({
               start(controller) {
-                controller.enqueue(Buffer.from('data: first\n\n'));
+                controller.enqueue(firstBytes);
                 releaseSecondChunk = () => {
-                  controller.enqueue(Buffer.from('data: second\n\n'));
+                  controller.enqueue(secondBytes);
                   controller.close();
                 };
               },
@@ -958,7 +994,7 @@ describe('GantryModelGatewayBroker', () => {
           ),
       ),
     );
-    const broker = new GantryModelGatewayBroker(repo);
+    const broker = new GantryModelGatewayBroker(repo, { audit });
     try {
       const injection = await broker.getInjection({
         binding: {
@@ -974,11 +1010,160 @@ describe('GantryModelGatewayBroker', () => {
         token: injection.env[anthropicApiKeyKey]!,
       });
 
-      await expect(response.firstChunk).resolves.toBe('data: first\n\n');
+      const firstChunk = await response.firstChunk;
+      expect(firstChunk).toMatchObject({
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+      expect(firstChunk.body).toEqual(firstBytes);
+      expect(usageAuditSettled).toBe(false);
       releaseSecondChunk();
+      releaseUsageAudit();
+      await usageAuditSettledPromise;
       await expect(response.done).resolves.toMatchObject({
         status: 200,
-        body: 'data: first\n\ndata: second\n\n',
+        body: Buffer.concat([firstBytes, secondBytes]),
+      });
+    } finally {
+      await broker.close();
+    }
+  });
+
+  it('awaits the usage audit before surfacing a streaming pipe error', async () => {
+    const repo = new MutableModelCredentialRepository();
+    repo.set('anthropic', 'mock-anthropic-cred');
+    const pipeError = new Error('client disconnected');
+    let releaseUsageAudit!: () => void;
+    let auditCalls = 0;
+    let pipeWrites = 0;
+    let pipeRejected = false;
+    let usageAuditSettled = false;
+    const usageAuditGate = new Promise<void>((resolve) => {
+      releaseUsageAudit = resolve;
+    });
+    const audit = vi.fn(async () => {
+      auditCalls += 1;
+      if (auditCalls !== 2) return;
+      await usageAuditGate;
+      usageAuditSettled = true;
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(Buffer.from('data: first\n\n'));
+                controller.enqueue(Buffer.from('data: second\n\n'));
+                controller.close();
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    );
+    const broker = new GantryModelGatewayBroker(repo, { audit });
+    try {
+      const injection = await broker.getInjection({
+        binding: {
+          profile: 'gantry',
+          purpose: 'model_runtime',
+          appId,
+          modelRouteId: 'anthropic',
+        },
+      });
+      const req = Object.assign(Readable.from(['{}']), {
+        url: '/anthropic/v1/messages',
+        method: 'POST',
+        headers: {
+          'x-api-key': injection.env[anthropicApiKeyKey]!,
+          'content-type': 'application/json',
+        },
+      }) as unknown as http.IncomingMessage;
+      const res = Object.assign(
+        new Writable({
+          write(_chunk, _encoding, callback) {
+            pipeWrites += 1;
+            if (pipeWrites === 1) {
+              callback();
+              return;
+            }
+            pipeRejected = true;
+            callback(pipeError);
+          },
+        }),
+        { statusCode: 200, setHeader: vi.fn() },
+      ) as unknown as http.ServerResponse;
+
+      const handlerPromise = (
+        broker as unknown as {
+          handleRequest(
+            request: http.IncomingMessage,
+            response: http.ServerResponse,
+          ): Promise<void>;
+        }
+      ).handleRequest(req, res);
+      let handlerSettled = false;
+      void handlerPromise.then(
+        () => {
+          handlerSettled = true;
+        },
+        () => {
+          handlerSettled = true;
+        },
+      );
+
+      await vi.waitFor(() => expect(audit).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(pipeRejected).toBe(true));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(handlerSettled).toBe(false);
+      expect(usageAuditSettled).toBe(false);
+      releaseUsageAudit();
+      await expect(handlerPromise).rejects.toBe(pipeError);
+      expect(usageAuditSettled).toBe(true);
+    } finally {
+      await broker.close();
+    }
+  });
+
+  it('delivers the full stream when the usage audit throws', async () => {
+    const repo = new MutableModelCredentialRepository();
+    repo.set('anthropic', 'mock-anthropic-cred');
+    const expected = Buffer.from('data: first\n\ndata: second\n\n');
+    let auditCalls = 0;
+    const audit = vi.fn(async () => {
+      auditCalls += 1;
+      if (auditCalls === 2) throw new Error('audit unavailable');
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(expected, {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      ),
+    );
+    const broker = new GantryModelGatewayBroker(repo, { audit });
+    try {
+      const injection = await broker.getInjection({
+        binding: {
+          profile: 'gantry',
+          purpose: 'model_runtime',
+          appId,
+          modelRouteId: 'anthropic',
+        },
+      });
+
+      const response = gatewayStreamingRequest({
+        url: `${injection.env[anthropicBaseUrlKey]}/v1/messages`,
+        token: injection.env[anthropicApiKeyKey]!,
+      });
+
+      await expect(response.done).resolves.toMatchObject({
+        status: 200,
+        body: expected,
       });
     } finally {
       await broker.close();


### PR DESCRIPTION
Stage 2 of docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md — the validated latency wins. Directly targets time-to-first-token on every agent reply.

## Changes
- **Gateway: first token pipes immediately** (the #1 win, confirmed by *two* independent audits). The streaming path used to await the durable usage-audit write — a Postgres txn + event-bus + webhook enqueue — *before* setting headers and piping bytes. Now: start the audit, pipe immediately, then await audit + pipe together via `Promise.allSettled`. The credential audit still always completes (even on mid-stream client disconnect) before the pipe error surfaces — no lost audit. Non-streaming path, OTel tap, byte handling unchanged.
- **Inline DeepAgents prompt-cache parity**: the inline lane now passes the same stable conversation/thread `prompt_cache_key` and cache-control mode as the spawned lane (shared helper) — latency *and* cost.
- **SDK `getContextUsage()` off the result path**: runs concurrently, result/follow-up emitted first, usage as a later telemetry frame.

## Verification
Full unit 6454/6454, typecheck clean. An independent adversarial review caught and fixed a real defect (the disconnect path could lose the audit); the fix and all three changes were then re-reviewed clean across all points. The normal autoreview skill was blocked by a phantom secret-scanner false-positive (a self-generated 4-char 'test' fragment), so review was done via direct adversarial passes — see commit body. Deferred Stage 3 (hydration watermark / upsert collapse / double-fetch / ambient-liveness heartbeat) needs supervised contract design per plan-validation.