### PR TITLE
Silence allow-for-future permission receipts (ambient-only acknowledgements)

### DIFF
--- a/apps/core/src/channels/permission-interaction.ts
+++ b/apps/core/src/channels/permission-interaction.ts
@@ -199,7 +199,7 @@ export function formatPermissionReceiptText(
   request: PermissionApprovalRequest | undefined,
   decision: PermissionApprovalDecision,
 ): string {
-  const summary = formatPermissionReceiptActionSummary(request);
+  const summary = formatPermissionReceiptActionSummary(request); // Existing-prompt settlement, not a new chat receipt.
   if (!decision.approved || decision.mode === 'cancel') {
     return limitPermissionMessage(`Canceled: ${summary}. Nothing changed.`);
   }

--- a/apps/core/src/runtime/ipc-interaction-processing.ts
+++ b/apps/core/src/runtime/ipc-interaction-processing.ts
@@ -8,10 +8,7 @@ import type {
 import { RUNTIME_EVENT_TYPES } from '../domain/events/runtime-event-types.js';
 import { PermissionManagementService } from '../application/permissions/permission-management-service.js';
 import type { PausedJobCapabilityRecheckResult } from '../application/jobs/job-permission-recovery.js';
-import {
-  formatDurableAccessRuleForEvent,
-  formatDurableAccessRulesForUser,
-} from '../shared/durable-access-policy.js';
+import { formatDurableAccessRuleForEvent } from '../shared/durable-access-policy.js';
 import {
   permissionUpdateAllowedToolRules,
   persistentPermissionUpdates,
@@ -251,16 +248,12 @@ export async function processPermissionInteractionIpc(input: {
             payload: persistedContext,
           },
         );
-        await sendPermissionOutcomeMessage(input.deps, input.request, {
-          text: formatPersistentPermissionOutcome({
-            rules: permissionUpdateAllowedToolRules(
-              claimedDecision.updatedPermissions,
-            ),
-            semanticCapabilityDefinitions:
-              input.request.semanticCapabilityDefinitions,
-            recovery,
-          }),
-        });
+        const outcomeMessage = formatPersistentPermissionOutcome(recovery);
+        if (outcomeMessage) {
+          await sendPermissionOutcomeMessage(input.deps, input.request, {
+            text: outcomeMessage,
+          });
+        }
       },
     });
     if (!applied) {
@@ -541,37 +534,14 @@ function persistentPermissionScopeRequest(
   return parentConversationRequest;
 }
 
-function formatPersistentPermissionOutcome(input: {
-  rules: string[];
-  semanticCapabilityDefinitions?: PermissionApprovalRequest['semanticCapabilityDefinitions'];
-  recovery: PausedJobCapabilityRecheckResult;
-}): string {
-  const lines = [
-    `Allowed for future: ${formatDurableAccessRulesForUser(input.rules, {
-      semanticCapabilityDefinitions: input.semanticCapabilityDefinitions,
-    })}.`,
-  ];
-  if (input.recovery.queued.length > 0) {
-    lines.push(
-      `Job ready: ${input.recovery.queued
-        .map((job) => job.name || job.jobId)
-        .join(', ')}. It will run now.`,
-    );
-  }
-  if (input.recovery.stillBlocked.length > 0) {
-    const blocker = input.recovery.stillBlocked[0];
-    lines.push(
-      `Still needs setup: ${blocker.nextAction ?? 'review job setup'}.`,
-    );
-  }
-  if (
-    input.recovery.checked === 0 &&
-    input.recovery.queued.length === 0 &&
-    input.recovery.stillBlocked.length === 0
-  ) {
-    lines.push('No paused setup jobs needed retry.');
-  }
-  return lines.join('\n');
+function formatPersistentPermissionOutcome(
+  recovery: PausedJobCapabilityRecheckResult,
+): string | undefined {
+  const blocker = recovery.stillBlocked[0];
+  if (!blocker) return undefined;
+  const nextAction = blocker.nextAction ?? 'review job setup';
+  const punctuation = /[.!?]$/.test(nextAction) ? '' : '.';
+  return `Still needs setup: ${nextAction}${punctuation}`;
 }
 
 async function sendPermissionOutcomeMessage(

--- a/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
+++ b/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
@@ -336,14 +336,10 @@ describe('ipc-interaction-handler', () => {
       { appId: 'app:test' },
     );
     expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledOnce();
-    expect(sendMessage).toHaveBeenCalledWith(
-      'tg:team',
-      expect.stringContaining('Allowed for future:'),
-      expect.any(Object),
-    );
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it('records persistent approvals at parent conversation scope while routing the receipt to the thread', async () => {
+  it('records persistent approvals at parent conversation scope and reports only a remaining setup blocker', async () => {
     const claimedPath = path.join(tempDir, 'claimed-thread-permission.json');
     fs.writeFileSync(claimedPath, '{}');
     const saveDecision = vi.fn(async () => undefined);
@@ -391,7 +387,21 @@ describe('ipc-interaction-handler', () => {
         })),
         sendMessage,
         publishRuntimeEvent,
-        opsRepository: createEmptyJobRepository() as never,
+        opsRepository: {
+          listJobs: vi.fn(async () => [
+            {
+              id: 'job-still-blocked',
+              name: 'Lead sync',
+              workspace_key: 'main_agent',
+              status: 'paused',
+              pause_reason: 'Setup required',
+              setup_state: { state: 'blocked' },
+              recovery_intent: { state: 'running' },
+            },
+          ]),
+          getJobById: vi.fn(async () => null),
+          updateJob: vi.fn(async () => null),
+        } as never,
         getToolRepository: () => toolRepository as never,
         getPermissionRepository: () =>
           ({
@@ -427,7 +437,7 @@ describe('ipc-interaction-handler', () => {
     );
     expect(sendMessage).toHaveBeenCalledWith(
       'tg:team',
-      expect.stringContaining('Allowed for future:'),
+      'Still needs setup: Recovery is already running for this job.',
       { threadId: 'topic-7' },
     );
   });


### PR DESCRIPTION
Live UX bug: tapping "Allow for future" posted a chat receipt ("Allowed for future: matching command access (...)" + "No paused setup jobs needed retry.") while "Allow once" was silent. Per the no-status-clutter rule, permission grants must not post chat receipts.

- onPersistentGrantApplied no longer sends a user-visible outcome message in the normal case — silent, matching allow-once. Internal audit (logger + PERMISSION_PERSISTED runtime event) unchanged.
- The only user-visible line kept: "Still needs setup: ..." when a paused job remains blocked after the grant (actionable, silence would mislead).
- Channel button edit-in-place feedback (ambient) untouched.

Verified: typecheck clean, full unit 6457/6457, autoreview 0 findings (patch-is-correct 0.96).

First slice of permission-floor-and-promotion Stage 3 (unify acknowledgement surface).