### PR TITLE
Strengthen permission durable-authority test (review findings 1-5)

### DIFF
--- a/apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts
+++ b/apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts
@@ -1,8 +1,17 @@
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+
 import { eq } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createPostgresDomainRepositories } from '@core/adapters/storage/postgres/repositories/domain-repositories.postgres.js';
 import * as pgSchema from '@core/adapters/storage/postgres/schema/index.js';
+import { PostgresRuntimeRepositoryBundle } from '@core/adapters/storage/postgres/schema/canonical-ops-repo.postgres.js';
+import { PostgresRuntimeEventNotifier } from '@core/adapters/storage/postgres/runtime-event-notifier.postgres.js';
+import {
+  DEFAULT_AGENT_CONFIG_VERSION_ID,
+  DEFAULT_LLM_PROFILE_ID,
+} from '@core/adapters/storage/postgres/seeds.js';
 import { PostgresStorageService } from '@core/adapters/storage/postgres/storage-service.js';
 import { beginDurablePermissionInteraction } from '@core/application/interactions/durable-interaction-handler.js';
 import {
@@ -14,6 +23,16 @@ import {
 } from '@core/application/interactions/pending-interaction-durability.js';
 import { durablePermissionRequestSnapshot } from '@core/application/interactions/pending-interaction-permission-envelope.js';
 import { synthesizeHostPermissionSuggestions } from '@core/application/permissions/permission-suggestion-synthesis.js';
+import { RuntimeEventExchange } from '@core/application/runtime-events/runtime-event-exchange.js';
+import { GANTRY_HOME, RUNTIME_SETTINGS_PATH } from '@core/config/index.js';
+import { createAgentToolRuleSettingsMirror } from '@core/config/settings/agent-tool-rule-settings-mirror.js';
+import { SettingsDesiredStateService } from '@core/config/settings/desired-state-service.js';
+import {
+  capabilityToToolRule,
+  ensureConfiguredAgent,
+  loadRuntimeSettings,
+  saveRuntimeSettings,
+} from '@core/config/settings/runtime-settings.js';
 import type { PermissionApprovalDecisionMode } from '@core/domain/types.js';
 import type { PermissionApprovalRequest } from '@core/domain/types.js';
 import { evaluateAutonomousToolUse } from '@core/shared/tool-rule-matcher.js';
@@ -28,11 +47,14 @@ import {
 
 const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
 
-// Uses the seeded default app/agent (seeds.ts) — no agent tool bindings exist
-// at start, so the durable-rule assertions start from a clean policy.
+// Uses the seeded default app/agent (seeds.ts). A second configured agent
+// guards the (appId, agentId) scoping of durable rules: a regression to
+// app-wide binding lookups would leak AGENT_ID's rule to it.
 const APP_ID = 'default';
 const AGENT_ID = 'agent:main_agent';
 const AGENT_FOLDER = 'main_agent';
+const SECOND_AGENT_ID = 'agent:second_agent';
+const SECOND_AGENT_FOLDER = 'second_agent';
 const APPROVER = 'user:approver';
 
 // Matrix §6 durable-authority chain, driven through the REAL channel
@@ -40,48 +62,94 @@ const APPROVER = 'user:approver';
 // claim → resolveDurablePermissionInteractionByRequestId (the same functions
 // the Slack/Telegram callback handlers invoke; see
 // pending-interaction-permission-callback.ts). No decide-API is invented.
+//
+// Persistence uses the REAL production wiring (runtime-services.ts):
+// createAgentToolRuleSettingsMirror over the full repository bundle, so an
+// allow_persistent_rule decision writes desired-state settings + a settings
+// revision and reconciles it (agent-tool-rule-settings-mirror.ts →
+// restart-sync.ts → desired-state-capability-reconcile.ts) — no recorder
+// stubs. `desired_state.authoritative: true` means restart reconciliation
+// REPLACES agent capability bindings from settings.yaml, so the restart
+// assertions can only pass through the settings mirror: a binding that exists
+// only as a raw DB row is wiped by the reconcile in restartAndEvaluateGate.
+//
 // Note: PERMISSION_* runtime events are published by the IPC processor
 // (ipc-interaction-processing.ts), not by this decision-application path, so
 // the durable evidence asserted here is rows: pending_interactions status +
-// resolution, agent tool bindings, and permission_decisions.
+// resolution, agent tool bindings, settings.yaml capabilities, transient
+// grants, and permission_decisions.
 maybeDescribe('permission durable authority chain (Postgres)', () => {
   let runtime: PostgresIntegrationRuntime;
-  const mirroredRuleCalls: Array<{
-    sourceAgentFolder: string;
-    rules: string[];
-    mode?: 'add' | 'remove';
-  }> = [];
+  let originalSettingsYaml: string;
+  let originalEnv: Record<string, string | undefined>;
 
   beforeAll(async () => {
     runtime = await createPostgresIntegrationRuntime({
       schemaPrefix: 'perm_durable',
     });
+    // The REAL settings-import preflight (validateLoadedRuntimeSettings)
+    // requires runtime storage + credential-encryption env. Satisfy it with
+    // this run's own throwaway integration database — the runtime under test.
+    originalEnv = {
+      GANTRY_DATABASE_URL: process.env.GANTRY_DATABASE_URL,
+      SECRET_ENCRYPTION_KEY: process.env.SECRET_ENCRYPTION_KEY,
+    };
+    process.env.GANTRY_DATABASE_URL = process.env.GANTRY_TEST_DATABASE_URL;
+    process.env.SECRET_ENCRYPTION_KEY ??= randomBytes(32).toString('base64');
+    // Declare both agents in the runtime settings the way production setup
+    // flows do (ensureConfiguredAgent), with authoritative desired state.
+    originalSettingsYaml = fs.readFileSync(RUNTIME_SETTINGS_PATH, 'utf-8');
+    const settings = loadRuntimeSettings(GANTRY_HOME);
+    settings.desiredState.authoritative = true;
+    ensureConfiguredAgent(settings, {
+      agentId: AGENT_FOLDER,
+      agentName: 'Main Agent',
+      agentFolder: AGENT_FOLDER,
+    });
+    ensureConfiguredAgent(settings, {
+      agentId: SECOND_AGENT_FOLDER,
+      agentName: 'Second Agent',
+      agentFolder: SECOND_AGENT_FOLDER,
+    });
+    saveRuntimeSettings(GANTRY_HOME, settings);
+
     configurePendingInteractionDurability({
       repository: runtime.repositories.workerCoordination,
+      warn: (context, message) => {
+        console.error(message, context.err ?? context);
+      },
     });
     configurePendingInteractionPermissionPersistence({
       opsRepository: runtime.ops,
       getToolRepository: () => runtime.repositories.tools,
       getPermissionRepository: () => runtime.repositories.permissions,
-      mirrorAgentToolRulesToSettings: (sourceAgentFolder, rules, options) => {
-        mirroredRuleCalls.push({
-          sourceAgentFolder,
-          rules: [...rules],
-          ...(options?.mode ? { mode: options.mode } : {}),
-        });
-      },
+      // REAL settings mirror (same factory + arguments as runtime-services.ts),
+      // including the settings-revision append via the full repository bundle.
+      mirrorAgentToolRulesToSettings: createAgentToolRuleSettingsMirror({
+        opsRepository: runtime.ops,
+        repositories: runtime.repositories,
+        reloadRuntimeState: async () => {},
+      }),
     });
   }, 60_000);
 
   afterAll(async () => {
     configurePendingInteractionDurability(null);
     configurePendingInteractionPermissionPersistence(null);
+    if (originalSettingsYaml !== undefined) {
+      fs.writeFileSync(RUNTIME_SETTINGS_PATH, originalSettingsYaml, 'utf-8');
+    }
+    for (const [key, value] of Object.entries(originalEnv ?? {})) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     if (runtime) await runtime.cleanup();
   });
 
   function makeRequest(
     requestId: string,
     command: string,
+    run?: { runId: string; leaseToken: string; fencingVersion: number },
   ): PermissionApprovalRequest {
     return {
       requestId,
@@ -94,6 +162,13 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       // Same argv-leaf suggestion synthesis the host applies on the IPC path
       // (ipc-interaction-processing.ts sets request.suggestions from it).
       suggestions: synthesizeHostPermissionSuggestions('Bash', { command }),
+      ...(run
+        ? {
+            runId: run.runId,
+            runLeaseToken: run.leaseToken,
+            runLeaseFencingVersion: run.fencingVersion,
+          }
+        : {}),
     };
   }
 
@@ -146,13 +221,22 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
   }
 
   /**
-   * Restart simulation: brand-new service + repository instances over the SAME
-   * schema (no in-memory state carried over), then the same deterministic
+   * Restart simulation over the SAME schema with brand-new service +
+   * repository instances (no in-memory state carried over), running the REAL
+   * startup path: settings desired-state reconciliation exactly as
+   * runStartup does for a 'file' settings authority (startup.ts →
+   * SettingsDesiredStateService.reconcile →
+   * desired-state-capability-reconcile.ts replaceDesiredStateCapabilities),
+   * then the callback receives fresh repositories for the same deterministic
    * policy evaluation the autonomous gate runs
    * (tool-execution-policy-service.ts → evaluateAutonomousToolUse over
    * resolveConfiguredAllowedTools).
    */
-  async function evaluateGateWithFreshServices(command: string) {
+  async function withRestartedServices<T>(
+    fn: (
+      repositories: PostgresIntegrationRuntime['repositories'],
+    ) => Promise<T>,
+  ): Promise<T> {
     const fresh = new PostgresStorageService(
       process.env.GANTRY_TEST_DATABASE_URL!,
       runtime.schemaName,
@@ -162,53 +246,98 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
         fresh.db,
         fresh.pool,
       );
+      const ops = new PostgresRuntimeRepositoryBundle(fresh.pool, fresh.db, {
+        runtimeEvents: new RuntimeEventExchange(
+          repositories.runtimeEvents,
+          new PostgresRuntimeEventNotifier(fresh.pool),
+        ),
+      });
+      const settings = loadRuntimeSettings(GANTRY_HOME);
+      const reconcile = await new SettingsDesiredStateService({
+        ops,
+        repositories,
+      }).reconcile(settings);
+      expect(reconcile.invalidReferences).toEqual([]);
+      return await fn(repositories);
+    } finally {
+      await fresh.close();
+    }
+  }
+
+  async function restartAndEvaluateGate(command: string, agentId = AGENT_ID) {
+    return withRestartedServices(async (repositories) => {
       const rules = await resolveConfiguredAllowedTools({
         repository: repositories.tools,
         appId: APP_ID,
-        agentId: AGENT_ID,
+        agentId,
       });
       return evaluateAutonomousToolUse({
         rules: rules ?? [],
         toolName: 'Bash',
         toolInput: { command },
       });
-    } finally {
-      await fresh.close();
-    }
+    });
   }
 
-  it('allow_persistent_rule persists an argv-leaf RunCommand rule that auto-allows the same leaf and survives restart', async () => {
+  async function activeBindingsWithTools(agentId = AGENT_ID) {
+    const bindings = await runtime.repositories.tools.listAgentToolBindings({
+      appId: APP_ID as never,
+      agentId: agentId as never,
+    });
+    return Promise.all(
+      bindings
+        .filter((binding) => binding.status === 'active')
+        .map(async (binding) => ({
+          binding,
+          tool: await runtime.repositories.tools.getTool(binding.toolId),
+        })),
+    );
+  }
+
+  function settingsAgentRules(agentFolder: string): string[] {
+    const agent = loadRuntimeSettings(GANTRY_HOME).agents[agentFolder];
+    expect(agent).toBeDefined();
+    return agent!.capabilities.map((capability) =>
+      capabilityToToolRule(capability.id),
+    );
+  }
+
+  it('allow_persistent_rule persists the exact argv-leaf rule via the settings mirror, auto-allows only that leaf for only that agent, and survives restart reconciliation', async () => {
     const command = '/usr/local/bin/report-status --daily';
     const request = makeRequest('req-perm-durable-future', command);
     const [expectedRule] = permissionUpdateAllowedToolRules(
       request.suggestions,
     );
-    expect(expectedRule).toMatch(/^RunCommand\(/);
+    // The EXACT rule derived from the input command: a regression that widens
+    // it (e.g. `RunCommand(/usr/local/bin/report-status *)`) fails here.
+    expect(expectedRule).toBe(`RunCommand(${command})`);
 
-    // Precondition: nothing allows this command before the decision.
-    const before = await evaluateGateWithFreshServices(command);
-    expect(before.allowed).toBe(false);
+    // Precondition: nothing allows this command before the decision, even
+    // after a full restart reconciliation.
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+    const activeToolIdsBefore = new Set(
+      (await activeBindingsWithTools()).map(({ binding }) => binding.toolId),
+    );
 
     await decideViaChannelCallback(request, 'allow_persistent_rule');
 
     // Durable rule persisted as an agent-scoped tool binding (CURRENT
-    // semantics: binding identity is app+agent, not conversation).
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
-    });
-    const activeBindings = bindings.filter(
-      (binding) => binding.status === 'active',
+    // semantics: binding identity is app+agent, not conversation). Exactly
+    // one ACTIVE binding references the expected rule and it is new relative
+    // to the pre-decision set — independent of whatever else is seeded.
+    const boundTools = await activeBindingsWithTools();
+    const ruleBindings = boundTools.filter(
+      ({ tool }) => tool?.name === expectedRule,
     );
-    expect(activeBindings).toHaveLength(1);
-    const tool = await runtime.repositories.tools.getTool(
-      activeBindings[0]!.toolId,
+    expect(ruleBindings).toHaveLength(1);
+    expect(activeToolIdsBefore.has(ruleBindings[0]!.binding.toolId)).toBe(
+      false,
     );
-    expect(tool?.name).toBe(expectedRule);
-    expect(mirroredRuleCalls).toContainEqual({
-      sourceAgentFolder: AGENT_FOLDER,
-      rules: [expectedRule],
-    });
+
+    // The REAL settings mirror wrote desired state: the rule is now a
+    // capability of the deciding agent in settings.yaml — and only of it.
+    expect(settingsAgentRules(AGENT_FOLDER)).toContain(expectedRule);
+    expect(settingsAgentRules(SECOND_AGENT_FOLDER)).not.toContain(expectedRule);
 
     // Fresh policy evaluation of the SAME command leaf auto-allows — the
     // deterministic gate matches the persisted rule, so no new prompt is
@@ -226,13 +355,37 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
     });
     expect(evaluation.allowed).toBe(true);
 
-    // A DIFFERENT command leaf is still not allowed (argv-leaf scope, not a
-    // command-name class).
+    // Argv-leaf scope: the SAME executable with different arguments is still
+    // not allowed (the rule is not an executable-wide grant)...
+    expect(
+      evaluateAutonomousToolUse({
+        rules: rules ?? [],
+        toolName: 'Bash',
+        toolInput: { command: '/usr/local/bin/report-status --monthly' },
+      }).allowed,
+    ).toBe(false);
+    // ...and neither is a different executable.
     expect(
       evaluateAutonomousToolUse({
         rules: rules ?? [],
         toolName: 'Bash',
         toolInput: { command: '/usr/local/bin/other-tool --daily' },
+      }).allowed,
+    ).toBe(false);
+
+    // Agent scope: the second configured agent does NOT see the rule
+    // (guards the (appId, agentId) filter in tool-repository.postgres.ts).
+    const secondAgentRules = await resolveConfiguredAllowedTools({
+      repository: runtime.repositories.tools,
+      appId: APP_ID,
+      agentId: SECOND_AGENT_ID,
+    });
+    expect(secondAgentRules ?? []).not.toContain(expectedRule);
+    expect(
+      evaluateAutonomousToolUse({
+        rules: secondAgentRules ?? [],
+        toolName: 'Bash',
+        toolInput: { command },
       }).allowed,
     ).toBe(false);
 
@@ -267,16 +420,59 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       classification: 'user_permanent',
     });
 
-    // Restart simulation: new service + repository instances, same database —
-    // the rule is still effective.
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(true);
-  });
+    // Restart: the REAL startup reconciliation replaces every agent's
+    // bindings from authoritative settings.yaml, so this stays allowed ONLY
+    // because the settings mirror durably wrote the rule (a DB-only binding
+    // would have been wiped by the reconcile). The second agent still gets
+    // nothing.
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(true);
+    expect(
+      (await restartAndEvaluateGate(command, SECOND_AGENT_ID)).allowed,
+    ).toBe(false);
+  }, 60_000);
 
-  it('allow_once resolves the interaction without persisting any durable rule', async () => {
+  it('allow_once grants run-scoped transient authority under the active lease only, with no durable rule and nothing after restart', async () => {
     const command = '/usr/local/bin/send-digest --weekly';
-    const request = makeRequest('req-perm-durable-once', command);
+    const runId = 'run-perm-durable-once';
+    const workerId = 'worker-perm-durable-once';
 
+    // Real run + claimed lease: the once-grant path
+    // (pending-interaction-grants.ts applyPendingInteractionGrantDecision →
+    // recordRunScopedTransientGrant) only issues authority against the
+    // ACTIVE run lease.
+    const now = new Date().toISOString();
+    await runtime.service.db
+      .insert(pgSchema.agentRunsPostgres)
+      .values({
+        id: runId,
+        appId: APP_ID,
+        agentId: AGENT_ID,
+        configVersionId: DEFAULT_AGENT_CONFIG_VERSION_ID,
+        llmProfileId: DEFAULT_LLM_PROFILE_ID,
+        executionProviderId: 'test:integration',
+        cause: 'integration',
+        status: 'running',
+        permissionDecisionIdsJson: '[]',
+        createdAt: now,
+        startedAt: now,
+      })
+      .onConflictDoNothing();
+    await runtime.repositories.workerCoordination.registerWorker({
+      id: workerId,
+      bootNonce: 'perm-durable-once',
+    });
+    const lease = await runtime.repositories.workerCoordination.claimRunLease({
+      runId,
+      workerInstanceId: workerId,
+      ttlMs: 60_000,
+    });
+    expect(lease).not.toBeNull();
+
+    const request = makeRequest('req-perm-durable-once', command, {
+      runId,
+      leaseToken: lease!.leaseToken,
+      fencingVersion: lease!.fencingVersion,
+    });
     await decideViaChannelCallback(request, 'allow_once');
 
     const row = await interactionRow(request.requestId);
@@ -286,32 +482,65 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       mode: 'allow_once',
     });
 
-    // No durable rule for this command leaf: only the allow_persistent_rule
-    // binding from the previous case may exist.
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
+    // The once-authority is real and usable: a transient grant recorded
+    // against the active lease, readable through the same lease-fenced read
+    // model the runtime uses.
+    const grants =
+      await runtime.repositories.workerCoordination.listActiveTransientGrants({
+        runId,
+      });
+    expect(grants).toHaveLength(1);
+    expect(grants[0]!.leaseToken).toBe(lease!.leaseToken);
+    expect(grants[0]!.grant).toMatchObject({
+      toolName: 'Bash',
+      mode: 'allow_once',
+      requestId: request.requestId,
     });
-    const tools = await Promise.all(
-      bindings
-        .filter((binding) => binding.status === 'active')
-        .map((binding) => runtime.repositories.tools.getTool(binding.toolId)),
-    );
-    expect(tools.some((tool) => tool?.name?.includes('send-digest'))).toBe(
-      false,
-    );
 
-    // No run-scoped transient grant either (no runId on this request).
-    const grants = await runtime.service.db
-      .select()
-      .from(pgSchema.transientGrantsPostgres);
-    expect(grants).toHaveLength(0);
+    // Once-only: no durable rule for this command leaf — not as an agent
+    // tool binding, not in mirrored settings, and the deterministic gate
+    // does not auto-allow it even while the transient grant is live.
+    const boundTools = await activeBindingsWithTools();
+    expect(
+      boundTools.some(({ tool }) => tool?.name?.includes('send-digest')),
+    ).toBe(false);
+    expect(
+      settingsAgentRules(AGENT_FOLDER).some((rule) =>
+        rule.includes('send-digest'),
+      ),
+    ).toBe(false);
+    const liveRules = await resolveConfiguredAllowedTools({
+      repository: runtime.repositories.tools,
+      appId: APP_ID,
+      agentId: AGENT_ID,
+    });
+    expect(
+      evaluateAutonomousToolUse({
+        rules: liveRules ?? [],
+        toolName: 'Bash',
+        toolInput: { command },
+      }).allowed,
+    ).toBe(false);
 
-    // Restart simulation: transient authority is gone — a fresh policy
-    // evaluation of the same command does NOT auto-allow.
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(false);
-  });
+    // The run ends (lease settles, as on worker shutdown/restart): the
+    // transient grant is no longer readable from fresh service instances and
+    // the durable gate still denies — once-authority did not outlive the run.
+    await expect(
+      runtime.repositories.workerCoordination.settleRunLease({
+        runId,
+        leaseToken: lease!.leaseToken,
+        workerInstanceId: workerId,
+        fencingVersion: lease!.fencingVersion,
+        outcome: 'completed',
+      }),
+    ).resolves.toBe(true);
+    await withRestartedServices(async (repositories) => {
+      await expect(
+        repositories.workerCoordination.listActiveTransientGrants({ runId }),
+      ).resolves.toEqual([]);
+    });
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+  }, 60_000);
 
   it('cancel records the interaction as cancelled and persists no rule', async () => {
     const command = '/usr/local/bin/rotate-keys --now';
@@ -326,19 +555,15 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       mode: 'cancel',
     });
 
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
-    });
-    const tools = await Promise.all(
-      bindings
-        .filter((binding) => binding.status === 'active')
-        .map((binding) => runtime.repositories.tools.getTool(binding.toolId)),
-    );
-    expect(tools.some((tool) => tool?.name?.includes('rotate-keys'))).toBe(
-      false,
-    );
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(false);
-  });
+    const boundTools = await activeBindingsWithTools();
+    expect(
+      boundTools.some(({ tool }) => tool?.name?.includes('rotate-keys')),
+    ).toBe(false);
+    expect(
+      settingsAgentRules(AGENT_FOLDER).some((rule) =>
+        rule.includes('rotate-keys'),
+      ),
+    ).toBe(false);
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+  }, 60_000);
 });

--- a/docs/architecture/agent-e2e-test-matrix.md
+++ b/docs/architecture/agent-e2e-test-matrix.md
@@ -36,189 +36,189 @@ Legend: ✅ covered (cite) · 🔨 to build · 🏷 label-gated (live lane) · �
 
 ## 1. Runtime & boot
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Image starts, migrations current, healthy | e2e | 🔨 |
-| Restart preserves desired state (settings revision projection) | e2e | 🔨 |
-| Security posture: prod image requires enforcing sandbox + non-prod secrets | integration | ✅ security-posture.test.ts |
-| Harness refuses to run against ~/gantry or live DB (isolation guard) | e2e (harness self-test) | 🔨 |
-| **Upgrade survivor** (adopted from OpenClaw): boot version N-1 state (settings revisions + DB) under version N image → migrations apply → agents/bindings/grants survive | e2e | 🔨 (post-ponytail-cutover — baseline resets first) |
-| Startup benchmark lane (boot time / first-turn latency budgets) | perf | 💤 deferred until the gate is stable |
+| Scenario                                                                                                                                                                 | Layer                   | Status                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | -------------------------------------------------- |
+| Image starts, migrations current, healthy                                                                                                                                | e2e                     | 🔨                                                 |
+| Restart preserves desired state (settings revision projection)                                                                                                           | e2e                     | 🔨                                                 |
+| Security posture: prod image requires enforcing sandbox + non-prod secrets                                                                                               | integration             | ✅ security-posture.test.ts                        |
+| Harness refuses to run against ~/gantry or live DB (isolation guard)                                                                                                     | e2e (harness self-test) | 🔨                                                 |
+| **Upgrade survivor** (adopted from OpenClaw): boot version N-1 state (settings revisions + DB) under version N image → migrations apply → agents/bindings/grants survive | e2e                     | 🔨 (post-ponytail-cutover — baseline resets first) |
+| Startup benchmark lane (boot time / first-turn latency budgets)                                                                                                          | perf                    | 💤 deferred until the gate is stable               |
 
 ## 2. Onboarding & model selection (API-driven)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Create agent + conversation binding via desired-state API; revision appended; survives restart | e2e | 🔨 |
-| Select `haiku` alias; turn evidence routes to selected model/provider/harness | e2e | 🔨 |
-| API contract: status codes + response shapes on onboarding endpoints | e2e (same pass) | 🔨 |
-| Scope enforcement: sessions-only key → 403 on admin endpoint | integration | 🔨 |
-| `sessions/ensure` honors `agentId` (bug fix first) | integration + e2e | 🔨 blocked on ponytail landing |
+| Scenario                                                                                       | Layer             | Status                         |
+| ---------------------------------------------------------------------------------------------- | ----------------- | ------------------------------ |
+| Create agent + conversation binding via desired-state API; revision appended; survives restart | e2e               | 🔨                             |
+| Select `haiku` alias; turn evidence routes to selected model/provider/harness                  | e2e               | 🔨                             |
+| API contract: status codes + response shapes on onboarding endpoints                           | e2e (same pass)   | 🔨                             |
+| Scope enforcement: sessions-only key → 403 on admin endpoint                                   | integration       | 🔨                             |
+| `sessions/ensure` honors `agentId` (bug fix first)                                             | integration + e2e | 🔨 blocked on ponytail landing |
 
 ## 3. Agent turn (haiku, behavioral)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| ensure → message (202 ≠ done) → events → visible completion | e2e | 🔨 |
-| Evidence bundle complete (ids, alias/route, timings, audit ids, redacted failure) | e2e | 🔨 |
-| Inline-lane turn (LLM API path) completes once | e2e | 🔨 |
-| Turn-failure surfaces cleanly (bad model alias → clean terminal state, no zombie) | e2e | 🔨 |
+| Scenario                                                                          | Layer | Status |
+| --------------------------------------------------------------------------------- | ----- | ------ |
+| ensure → message (202 ≠ done) → events → visible completion                       | e2e   | 🔨     |
+| Evidence bundle complete (ids, alias/route, timings, audit ids, redacted failure) | e2e   | 🔨     |
+| Inline-lane turn (LLM API path) completes once                                    | e2e   | 🔨     |
+| Turn-failure surfaces cleanly (bad model alias → clean terminal state, no zombie) | e2e   | 🔨     |
 
 ## 4. Skills
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Install vendored `internal-comms` zip via `/v1/skills/install`; catalog + binding identity | e2e | 🔨 |
-| Selection survives restart; assets materialize incl. `examples/3p-updates.md` (progressive disclosure) | e2e | 🔨 |
-| Turn produces 3P STRUCTURE (Progress/Plans/Problems sections exist — structure, not wording) | e2e | 🔨 |
-| `gantry-admin` reserved name rejected by install API | integration | 🔨 |
-| `admin_permission_list` callable, returns expected shape | e2e | 🔨 |
-| **Agent-driven skill acquisition**: turn asks the agent to get itself a skill → `request_skill_install` → REAL approval path → installed+selected → follow-up turn USES it (materialized assets asserted) | e2e (haiku, Stage C) | 🔨 |
-| Skill install/registry logic | integration | ✅ skills-registry-flow.integration.test.ts |
+| Scenario                                                                                                                                                                                                  | Layer                | Status                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------- |
+| Install vendored `internal-comms` zip via `/v1/skills/install`; catalog + binding identity                                                                                                                | e2e                  | 🔨                                          |
+| Selection survives restart; assets materialize incl. `examples/3p-updates.md` (progressive disclosure)                                                                                                    | e2e                  | 🔨                                          |
+| Turn produces 3P STRUCTURE (Progress/Plans/Problems sections exist — structure, not wording)                                                                                                              | e2e                  | 🔨                                          |
+| `gantry-admin` reserved name rejected by install API                                                                                                                                                      | integration          | 🔨                                          |
+| `admin_permission_list` callable, returns expected shape                                                                                                                                                  | e2e                  | 🔨                                          |
+| **Agent-driven skill acquisition**: turn asks the agent to get itself a skill → `request_skill_install` → REAL approval path → installed+selected → follow-up turn USES it (materialized assets asserted) | e2e (haiku, Stage C) | 🔨                                          |
+| Skill install/registry logic                                                                                                                                                                              | integration          | ✅ skills-registry-flow.integration.test.ts |
 
 ## 5. MCP
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Register HTTP server via SDK; approve ONLY echo+get-sum | e2e | 🔨 |
-| Discovery + schema; denied tools invisible to the agent | e2e | ✅ mcp-client-loop.postgres.e2e.test.ts |
-| Turn calls `get-sum(20,22)`; fixture records call; tool result 42; MCP audit event | e2e | ✅ client path (non-model: fixture records exact args, result 42, MCP audit + runtime event) mcp-client-loop.postgres.e2e.test.ts · 🔨 real-turn |
-| stdio transport | integration | ✅ ipc-mcp-stdio.test.ts |
-| MCP server management lifecycle | integration | ✅ mcp-server-management.integration.test.ts + mcp-server.postgres.integration.test.ts |
-| Deep-MCP: every capability class of vendored everything-server (tools, resources, prompts, sampling, progress, logging, completions) — unsupported class = product bug or documented non-support | e2e-live | 🏷 |
-| **Agent-driven MCP acquisition**: turn asks the agent to get itself the fixture MCP server → agent calls `request_mcp_server` → REAL approval path decides → server registered+bound → follow-up turn agent CALLS its tool (fixture records it) | e2e (haiku, Stage C) | 🔨 |
-| Agent-driven acquisition via CHAT (Slack): same loop driven by a channel message + button approval | e2e-live | 🏷 |
+| Scenario                                                                                                                                                                                                                                        | Layer                | Status                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Register HTTP server via SDK; approve ONLY echo+get-sum                                                                                                                                                                                         | e2e                  | 🔨                                                                                                                                               |
+| Discovery + schema; denied tools invisible to the agent                                                                                                                                                                                         | e2e                  | ✅ mcp-client-loop.postgres.e2e.test.ts                                                                                                          |
+| Turn calls `get-sum(20,22)`; fixture records call; tool result 42; MCP audit event                                                                                                                                                              | e2e                  | ✅ client path (non-model: fixture records exact args, result 42, MCP audit + runtime event) mcp-client-loop.postgres.e2e.test.ts · 🔨 real-turn |
+| stdio transport                                                                                                                                                                                                                                 | integration          | ✅ ipc-mcp-stdio.test.ts                                                                                                                         |
+| MCP server management lifecycle                                                                                                                                                                                                                 | integration          | ✅ mcp-server-management.integration.test.ts + mcp-server.postgres.integration.test.ts                                                           |
+| Deep-MCP: every capability class of vendored everything-server (tools, resources, prompts, sampling, progress, logging, completions) — unsupported class = product bug or documented non-support                                                | e2e-live             | 🏷                                                                                                                                               |
+| **Agent-driven MCP acquisition**: turn asks the agent to get itself the fixture MCP server → agent calls `request_mcp_server` → REAL approval path decides → server registered+bound → follow-up turn agent CALLS its tool (fixture records it) | e2e (haiku, Stage C) | 🔨                                                                                                                                               |
+| Agent-driven acquisition via CHAT (Slack): same loop driven by a channel message + button approval                                                                                                                                              | e2e-live             | 🏷                                                                                                                                               |
 
 ## 6. Permissions (granular)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| `ask`: eligible tool → human prompt, nothing auto-decided | integration | ✅ permission-classifier tests |
-| `auto`: read-only gate as evidence → classifier allow → auto_classifier allow_once | integration | ✅ permission-classifier.test.ts:539-612 |
-| `auto_strict`: unproven-safety asks WITHOUT classifier; proven still consults strict classifier | integration | ✅ permission-classifier.test.ts:614-667 |
-| Classifier unavailable/failure → fail-safe ask | integration | ✅ unit |
-| YOLO denylist hit → ask + event; unattended converts to denial | integration | ✅ classifier.test.ts:868-941 (attended); 🔨 unattended-context chain |
-| Locked agent: forged authority IPC denied at parent | integration | ✅ ipc-locked-permission-denial.test.ts |
-| Eligibility: only Bash/RunCommand + non-gantry MCP reach classifier | integration | ✅ unit |
-| Full chain: real IPC boundary → durable interaction → decision → event repo | integration | 🔨 (the one genuinely new chain) |
-| Allow ONCE: runs, then authority expires after restart | integration + e2e recovery scenario | ✅ integration permission-durable-authority.postgres.integration.test.ts · 🔨 e2e recovery |
-| Allow FUTURE: argv-leaf rule persists, auto-allows next same-leaf command, survives restart, agent-scoped (current semantics) | integration | ✅ permission-durable-authority.postgres.integration.test.ts |
-| Record-before-prompt ordering | integration | 🔨 |
-| Cancel: run interrupts cleanly, no partial effect, audit `cancelled` | integration | ✅ decision chain (cancelled record, no rule persisted) permission-durable-authority.postgres.integration.test.ts · 🔨 run-interrupt |
-| Deny: recorded, no execution | integration | 🔨 |
-| NO chat receipt on allow-future (regression, #239) | integration | 🔨 |
-| Real decision paths only — via classifier / in-process button-resolution callback / real Slack button (never a decide-API) | (constraint on all above) | — |
-| Whole-chain credential-absence in events/logs | integration | 🔨 |
+| Scenario                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Layer                               | Status                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ask`: eligible tool → human prompt, nothing auto-decided                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | integration                         | ✅ permission-classifier tests                                                                                                                                                                 |
+| `auto`: read-only gate as evidence → classifier allow → auto_classifier allow_once                                                                                                                                                                                                                                                                                                                                                                                                                                                     | integration                         | ✅ permission-classifier.test.ts:539-612                                                                                                                                                       |
+| `auto_strict`: unproven-safety asks WITHOUT classifier; proven still consults strict classifier                                                                                                                                                                                                                                                                                                                                                                                                                                        | integration                         | ✅ permission-classifier.test.ts:614-667                                                                                                                                                       |
+| Classifier unavailable/failure → fail-safe ask                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | integration                         | ✅ unit                                                                                                                                                                                        |
+| YOLO denylist hit → ask + event; unattended converts to denial                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | integration                         | ✅ classifier.test.ts:868-941 (attended); 🔨 unattended-context chain                                                                                                                          |
+| Locked agent: forged authority IPC denied at parent                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | integration                         | ✅ ipc-locked-permission-denial.test.ts                                                                                                                                                        |
+| Eligibility: only Bash/RunCommand + non-gantry MCP reach classifier                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | integration                         | ✅ unit                                                                                                                                                                                        |
+| Full chain: real IPC boundary → durable interaction → decision → event repo                                                                                                                                                                                                                                                                                                                                                                                                                                                            | integration                         | 🔨 (the one genuinely new chain)                                                                                                                                                               |
+| Allow ONCE: run-scoped transient grant issued under the REAL claimed run lease (channel-callback decision → `applyPendingInteractionGrantDecision` → `recordRunScopedTransientGrant`), readable via the lease-fenced read model; no durable binding, no settings mirror write, durable gate denies even while the grant is live; unreadable after the lease settles + fresh services                                                                                                                                                   | integration + e2e recovery scenario | ✅ integration permission-durable-authority.postgres.integration.test.ts (grant issuance/expiry; does NOT prove the live tool-call resume — that is the IPC processor's job) · 🔨 e2e recovery |
+| Allow FUTURE: EXACT argv-leaf rule (asserted string equality against the input command) persisted through the REAL settings mirror (`createAgentToolRuleSettingsMirror` → settings.yaml + settings revision + desired-state reconcile); auto-allows the same leaf, denies same-executable-different-args and other executables; survives restart via REAL startup reconciliation over authoritative settings (DB-only bindings are wiped, so survival proves the mirror); agent-scoped — a second configured agent never sees the rule | integration                         | ✅ permission-durable-authority.postgres.integration.test.ts                                                                                                                                   |
+| Record-before-prompt ordering                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | integration                         | 🔨                                                                                                                                                                                             |
+| Cancel: run interrupts cleanly, no partial effect, audit `cancelled`                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | integration                         | ✅ decision chain (cancelled record, no rule persisted) permission-durable-authority.postgres.integration.test.ts · 🔨 run-interrupt                                                           |
+| Deny: recorded, no execution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | integration                         | 🔨                                                                                                                                                                                             |
+| NO chat receipt on allow-future (regression, #239)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | integration                         | 🔨                                                                                                                                                                                             |
+| Real decision paths only — via classifier / in-process button-resolution callback / real Slack button (never a decide-API)                                                                                                                                                                                                                                                                                                                                                                                                             | (constraint on all above)           | —                                                                                                                                                                                              |
+| Whole-chain credential-absence in events/logs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | integration                         | 🔨                                                                                                                                                                                             |
 
 ## 7. Capabilities
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection | integration | ✅ configured-agent-tools.test.ts |
-| local_cli pinning (path/version/hash/templates); unrelated command denied | integration | ✅ semantic-capabilities.test.ts |
-| Persisted selected binding → projection → real admission | integration | 🔨 |
-| Real-image preflight pass AND fail-closed | e2e | 🔨 |
-| Secret lifecycle store→retrieve→rotate→audit (all four in one test) | integration | 🔨 |
-| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak | integration | ✅ capability-secret units; 🔨 through-sandbox chain |
-| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair |
-| Real gog/Sheets tier (throwaway sheet) | e2e-live | 🏷 |
+| Scenario                                                                                          | Layer       | Status                                               |
+| ------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection              | integration | ✅ configured-agent-tools.test.ts                    |
+| local_cli pinning (path/version/hash/templates); unrelated command denied                         | integration | ✅ semantic-capabilities.test.ts                     |
+| Persisted selected binding → projection → real admission                                          | integration | 🔨                                                   |
+| Real-image preflight pass AND fail-closed                                                         | e2e         | 🔨                                                   |
+| Secret lifecycle store→retrieve→rotate→audit (all four in one test)                               | integration | 🔨                                                   |
+| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak                 | integration | ✅ capability-secret units; 🔨 through-sandbox chain |
+| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair  |
+| Real gog/Sheets tier (throwaway sheet)                                                            | e2e-live    | 🏷                                                   |
 
 ## 8. Memories
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Write → recall → subject-boundary isolation (person/group/channel) | integration | ✅ memory-write-recall-boundary.postgres.integration.test.ts (subject-scoped fetch recall; embedding recall stays hermetically disabled) |
-| Turn 1 states fact → durable memory row collected; turn 2 → memory READ occurred | e2e | 🔨 |
-| Memory survives restart, still recallable | e2e | 🔨 |
-| Job-run memory collection persists | e2e (job scenario) | 🔨 |
+| Scenario                                                                         | Layer              | Status                                                                                                                                   |
+| -------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Write → recall → subject-boundary isolation (person/group/channel)               | integration        | ✅ memory-write-recall-boundary.postgres.integration.test.ts (subject-scoped fetch recall; embedding recall stays hermetically disabled) |
+| Turn 1 states fact → durable memory row collected; turn 2 → memory READ occurred | e2e                | 🔨                                                                                                                                       |
+| Memory survives restart, still recallable                                        | e2e                | 🔨                                                                                                                                       |
+| Job-run memory collection persists                                               | e2e (job scenario) | 🔨                                                                                                                                       |
 
 ## 9. Jobs
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Create via API → trigger → run completes → delivery → health `completed` (API twin of agent-job-smoke.sh) | e2e | 🔨 |
-| Pause → resume → trigger transitions + events | e2e | 🔨 |
-| Forced failure exhausts retries → dead-letter + clean terminal event | e2e | 🔨 |
-| Autonomous tool dead-end: ungranted tool surfaces cleanly (regression) | integration | 🔨 |
-| MCP-readiness race: slow init must NOT hard-fail (regression, fix on main) | integration (unit exists) + e2e real-turn | ✅ mcp-server-validation.test.ts · 🔨 e2e |
-| Local live smoke against the real runtime | manual/script | ✅ scripts/agent-job-smoke.sh |
+| Scenario                                                                                                  | Layer                                     | Status                                    |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------------------------- |
+| Create via API → trigger → run completes → delivery → health `completed` (API twin of agent-job-smoke.sh) | e2e                                       | 🔨                                        |
+| Pause → resume → trigger transitions + events                                                             | e2e                                       | 🔨                                        |
+| Forced failure exhausts retries → dead-letter + clean terminal event                                      | e2e                                       | 🔨                                        |
+| Autonomous tool dead-end: ungranted tool surfaces cleanly (regression)                                    | integration                               | 🔨                                        |
+| MCP-readiness race: slow init must NOT hard-fail (regression, fix on main)                                | integration (unit exists) + e2e real-turn | ✅ mcp-server-validation.test.ts · 🔨 e2e |
+| Local live smoke against the real runtime                                                                 | manual/script                             | ✅ scripts/agent-job-smoke.sh             |
 
 ## 10. Attachments & delivery
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Turn sends the deterministic attachment → workspace-direct delivery record, hash matches | e2e | 🔨 |
-| Oversize handling (>25MB refused cleanly) | integration | 🔨 |
-| Webhook fires with expected payload shape (loopback receiver) | e2e | 🔨 |
+| Scenario                                                                                 | Layer       | Status |
+| ---------------------------------------------------------------------------------------- | ----------- | ------ |
+| Turn sends the deterministic attachment → workspace-direct delivery record, hash matches | e2e         | 🔨     |
+| Oversize handling (>25MB refused cleanly)                                                | integration | 🔨     |
+| Webhook fires with expected payload shape (loopback receiver)                            | e2e         | 🔨     |
 
 ## 11. Route integrity (incident regressions)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Loader collapses mixed legacy key forms to ONE route (total preference order) | unit/integration | 🔨 in route-fix lane |
+| Scenario                                                                           | Layer            | Status               |
+| ---------------------------------------------------------------------------------- | ---------------- | -------------------- |
+| Loader collapses mixed legacy key forms to ONE route (total preference order)      | unit/integration | 🔨 in route-fix lane |
 | Divergent conversationId rows load via derive+warn, never throw, never drop a chat | unit/integration | 🔨 in route-fix lane |
-| Corrupt-state seed via direct test-DB rows (documented API exception) | integration | 🔨 |
+| Corrupt-state seed via direct test-DB rows (documented API exception)              | integration      | 🔨                   |
 
 ## 12. Channel loop (Slack, dedicated test app)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Real user-pattern message → agent turn → outbound reply in channel | e2e-live | 🏷 |
+| Scenario                                                                                      | Layer    | Status                                                                   |
+| --------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------ |
+| Real user-pattern message → agent turn → outbound reply in channel                            | e2e-live | 🏷                                                                       |
 | Permission block renders (header/context structure); approve callback → tool proceeds + audit | e2e-live | 🏷 (needs real-user or signed-callback fixture — constraint per round-3) |
-| Attachment delivered in channel | e2e-live | 🏷 |
+| Attachment delivered in channel                                                               | e2e-live | 🏷                                                                       |
 
 ## 13. Model matrix & policy gate
 
-| Scenario | Layer | Status |
-|---|---|---|
-| `haiku` + anthropic_sdk turn (required gate) | e2e | 🔨 |
-| `gpt-mini` + deepagents turn | e2e-live | 🏷 |
-| Catalog base/head diff adds changed aliases to live matrix | CI policy job | 🔨 |
-| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨 |
-| `agent-e2e-gate` aggregates + branch protection verified | CI | 🔨 |
+| Scenario                                                                                 | Layer         | Status |
+| ---------------------------------------------------------------------------------------- | ------------- | ------ |
+| `haiku` + anthropic_sdk turn (required gate)                                             | e2e           | 🔨     |
+| `gpt-mini` + deepagents turn                                                             | e2e-live      | 🏷     |
+| Catalog base/head diff adds changed aliases to live matrix                               | CI policy job | 🔨     |
+| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨     |
+| `agent-e2e-gate` aggregates + branch protection verified                                 | CI            | 🔨     |
 
 ## 14. All-tools sweep
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Enumerate effective tool set (internal inspector); every read-only + fixture-backed tool invoked once; call + effect + audit asserted; unreachable granted tool = FAIL | e2e | 🔨 |
-| Authority/lifecycle tools covered by their own scenarios (not blind invocation) | — | design rule |
-| Browser tool against loopback page | e2e | 🔨 (image lacks Chrome — runs in local smoke until media-render ships provisioning) |
+| Scenario                                                                                                                                                               | Layer | Status                                                                              |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------- |
+| Enumerate effective tool set (internal inspector); every read-only + fixture-backed tool invoked once; call + effect + audit asserted; unreachable granted tool = FAIL | e2e   | 🔨                                                                                  |
+| Authority/lifecycle tools covered by their own scenarios (not blind invocation)                                                                                        | —     | design rule                                                                         |
+| Browser tool against loopback page                                                                                                                                     | e2e   | 🔨 (image lacks Chrome — runs in local smoke until media-render ships provisioning) |
 
 ## 15. Multi-agent, delegation & elevated access (user, 2026-07-20)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| **Elevated access loop**: agent hits a denied operation → calls `request_access` (scoped target) → REAL approval path grants → durable grant persisted (revision) → retry succeeds → grant survives restart; denied variant stays denied | e2e (haiku) + integration chain | 🔨 |
-| **Subagent delegation**: turn delegates via `AgentDelegation` to the fixture target agent → delegated turn runs → result returns to the parent turn → both runs + linkage in evidence/audit | e2e (haiku) | 🔨 |
-| Delegated/async task lifecycle plumbing (create → run → complete → result surfaced; failure → clean terminal state) | integration | ✅ partial: ipc-agent-task-lifecycle units; 🔨 durable chain through repos |
-| **Async task**: agent starts async work → turn ends → task completes later → completion notification/result recorded (quiet-until-terminal rule respected) | e2e | 🔨 |
-| **Bash/RunCommand real execution**: agent runs a scoped command in the worker sandbox → output captured in turn → permission decision + audit recorded (beyond the sweep: asserts output round-trip) | e2e (haiku) | 🔨 |
-| **Agents-as-tools**: agent invokes another agent as a TOOL (not delegation) and consumes its structured result | e2e | 🔨 (verify feature state first — agents-as-tools lane; row activates when shipped) |
-| **Two agents, one conversation**: two installed agents with distinct triggers → message for A runs ONLY A; message for B runs ONLY B; no cross-talk; routes stay disambiguated (incident-regression adjacent) | integration (routing) + e2e-live (chat) | 🔨 / 🏷 |
-| Two agents: permission prompt from A answered → grants apply to A only (scope isolation across co-resident agents) | integration | 🔨 |
+| Scenario                                                                                                                                                                                                                                 | Layer                                   | Status                                                                             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Elevated access loop**: agent hits a denied operation → calls `request_access` (scoped target) → REAL approval path grants → durable grant persisted (revision) → retry succeeds → grant survives restart; denied variant stays denied | e2e (haiku) + integration chain         | 🔨                                                                                 |
+| **Subagent delegation**: turn delegates via `AgentDelegation` to the fixture target agent → delegated turn runs → result returns to the parent turn → both runs + linkage in evidence/audit                                              | e2e (haiku)                             | 🔨                                                                                 |
+| Delegated/async task lifecycle plumbing (create → run → complete → result surfaced; failure → clean terminal state)                                                                                                                      | integration                             | ✅ partial: ipc-agent-task-lifecycle units; 🔨 durable chain through repos         |
+| **Async task**: agent starts async work → turn ends → task completes later → completion notification/result recorded (quiet-until-terminal rule respected)                                                                               | e2e                                     | 🔨                                                                                 |
+| **Bash/RunCommand real execution**: agent runs a scoped command in the worker sandbox → output captured in turn → permission decision + audit recorded (beyond the sweep: asserts output round-trip)                                     | e2e (haiku)                             | 🔨                                                                                 |
+| **Agents-as-tools**: agent invokes another agent as a TOOL (not delegation) and consumes its structured result                                                                                                                           | e2e                                     | 🔨 (verify feature state first — agents-as-tools lane; row activates when shipped) |
+| **Two agents, one conversation**: two installed agents with distinct triggers → message for A runs ONLY A; message for B runs ONLY B; no cross-talk; routes stay disambiguated (incident-regression adjacent)                            | integration (routing) + e2e-live (chat) | 🔨 / 🏷                                                                            |
+| Two agents: permission prompt from A answered → grants apply to A only (scope isolation across co-resident agents)                                                                                                                       | integration                             | 🔨                                                                                 |
 
 ## 16. Security & recovery
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Skill+MCP selections survive restart; allow_once does NOT | e2e | 🔨 |
-| Logs + evidence credential-scrubbed (whole run grep) | e2e | 🔨 |
-| Fork PRs never see secrets (workflow config review) | CI review | 🔨 |
-| i-have-adhd zero references (scoped guard, fragment-built token) | unit | 🔨 |
+| Scenario                                                         | Layer     | Status |
+| ---------------------------------------------------------------- | --------- | ------ |
+| Skill+MCP selections survive restart; allow_once does NOT        | e2e       | 🔨     |
+| Logs + evidence credential-scrubbed (whole run grep)             | e2e       | 🔨     |
+| Fork PRs never see secrets (workflow config review)              | CI review | 🔨     |
+| i-have-adhd zero references (scoped guard, fragment-built token) | unit      | 🔨     |
 
 ## 17. Orphan suites (never ran in CI — adopt deliberately)
 
-| Suite | Status |
-|---|---|
-| live-waiting-admission.postgres.integration | 💤 excluded-by-name; adopt = delete one exclude line |
-| pattern-candidate-atomic-claim.postgres.integration | 💤 same |
-| proactive-surfacing-opt-in.postgres.integration | 💤 same |
-| toolchain-bake-reconciler.postgres.integration | 💤 same |
-| worker-coordination.postgres.integration | 💤 same (known flaky-under-load heartbeat test) |
+| Suite                                               | Status                                               |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| live-waiting-admission.postgres.integration         | 💤 excluded-by-name; adopt = delete one exclude line |
+| pattern-candidate-atomic-claim.postgres.integration | 💤 same                                              |
+| proactive-surfacing-opt-in.postgres.integration     | 💤 same                                              |
+| toolchain-bake-reconciler.postgres.integration      | 💤 same                                              |
+| worker-coordination.postgres.integration            | 💤 same (known flaky-under-load heartbeat test)      |
 
 ## Add new scenarios below
 
 | Feature | Scenario | Layer | Notes |
-|---|---|---|---|
-| | | | |
+| ------- | -------- | ----- | ----- |
+|         |          |       |       |


### PR DESCRIPTION
Strengthens `apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts` per the 5 findings in `docs/architecture/e2e-tests-review-238.md` against PR #238. Every fix strengthens an assertion; nothing was weakened to pass.

## Finding → fix

**1. [P1] allow-once never proved once-only authority** (no runId/lease meant `applyPendingInteractionGrantDecision` granted nothing)
→ The test now seeds a real run row, registers a worker, and claims a REAL run lease; the request carries `runId`/`runLeaseToken`/`runLeaseFencingVersion`, so the channel-callback decision flows through `recordRunScopedTransientGrant` against the active lease. Asserted: exactly one transient grant, lease-bound, with the request's tool/mode/requestId; the durable gate denies the command even while the grant is live; after the lease settles, fresh service instances read zero grants and the gate still denies. (The live tool-call resume is the IPC processor's job and is honestly excluded — see matrix note.)

**2. [P1] restart-survival bypassed the settings mirror and startup reconcile** (recorder stub + re-reading the already-written row)
→ The recorder stub is gone. Persistence is wired with the production `createAgentToolRuleSettingsMirror` over the full repository bundle, so an `allow_persistent_rule` decision writes settings.yaml, appends a settings revision, and reconciles desired state. The restart helper now runs the REAL startup reconciliation (`SettingsDesiredStateService.reconcile` over `desired_state.authoritative: true` settings), which REPLACES agent bindings from settings — a DB-only binding cannot survive it. Mutation-verified: stubbing the mirror back to a no-op makes the test fail at the settings and restart assertions.

**3. [P1] agent scope untested** (only one agent ever evaluated)
→ A second configured agent (`agent:second_agent`) is declared in settings and reconciled. After the grant, its resolved rules must not contain the persisted rule and its gate evaluation of the same command must deny — live and after restart. Guards the `(appId, agentId)` filter in `tool-repository.postgres.ts`.

**4. [P2] negative case could not distinguish argv-leaf from executable-wide rules**
→ The persisted rule is asserted by exact string equality: `RunCommand(/usr/local/bin/report-status --daily)` derived from the input command. The negative cases now keep the SAME executable with different args (`report-status --monthly` denied) in addition to the different-executable case.

**5. [P2] `toHaveLength(1)` froze the seeded binding count**
→ Replaced with the invariant: exactly one ACTIVE binding references the expected rule, and that binding is new relative to the pre-decision binding set — independent of how many bindings the seed creates.

## Also
- `docs/architecture/agent-e2e-test-matrix.md` Allow ONCE / Allow FUTURE rows updated to cite exactly what is now proven (and what deliberately is not).
- Durability backend `warn` is wired to `console.error` so grant-application failures surface loudly instead of a silent `false`.

## Verification
- `npx vitest run -c vitest.integration.postgres.config.ts apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts` — 3/3 green against a throwaway database (`gantry_permtest_fix`, dropped after).
- Mutation check: no-op mirror → test fails (finding 2 assertion is load-bearing).
- `tsc --noEmit` clean, `eslint` clean, `prettier --write` applied to both touched files.