### PR TITLE
sessions/ensure honors agentId (API turns run the onboarded agent, not a synthetic folder)

### DIFF
--- a/apps/core/src/adapters/storage/postgres/repositories/control-plane-graph.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/control-plane-graph.postgres.ts
@@ -78,8 +78,10 @@ export async function ensureControlGraph(
     })
     .onConflictDoUpdate({
       target: pgSchema.agentsPostgres.id,
+      // Do not overwrite name on conflict: synthetic agents already have
+      // name === folder, and sessions ensured against a real onboarded agent
+      // must not clobber its human-assigned name.
       set: {
-        name: input.agentFolder || 'default',
         updatedAt: now,
       },
     });

--- a/apps/core/src/application/sessions/session-interaction-module.ts
+++ b/apps/core/src/application/sessions/session-interaction-module.ts
@@ -13,11 +13,14 @@ import type {
 } from '../../domain/repositories/ops-repo.js';
 import type { LiveAdmissionWorkItemEnqueueResult } from '../../domain/ports/live-turns.js';
 import type {
+  AgentRepository,
   AgentRunRepository,
   AgentSessionRepository,
   MessageRepository,
   ProviderSessionRepository,
 } from '../../domain/ports/repositories.js';
+import type { AgentId } from '../../domain/agent/agent.js';
+import { folderForAgentId } from '../../domain/agent/agent-folder-id.js';
 import type { IsoTimestamp } from '../../shared/time/primitives.js';
 import type { AgentRuntime } from '../../shared/agent-runtime.js';
 import { ApplicationError } from '../common/application-error.js';
@@ -78,6 +81,7 @@ export type SessionInteractionDeps = {
   control: SessionControlPort;
   ops: RuntimeChatMetadataRepository & RuntimeMessageRepository;
   repositories: {
+    agents: AgentRepository;
     agentSessions: AgentSessionRepository;
     providerSessions: ProviderSessionRepository;
     messages: MessageRepository;
@@ -104,6 +108,7 @@ export class SessionInteractionModule {
   async ensureSession(input: {
     appId: string;
     assertedAppId?: string | null;
+    agentId?: string | null;
     conversationId: string;
     title?: string | null;
     responseMode?: unknown;
@@ -127,7 +132,7 @@ export class SessionInteractionModule {
       );
     }
     const conversationJid = `app:${input.appId}:${conversationId}`;
-    const group = makeAppGroup({
+    let group = makeAppGroup({
       appId: input.appId,
       conversationId,
       conversationJid,
@@ -136,6 +141,31 @@ export class SessionInteractionModule {
         .slice(0, 12),
       addedAt: this.deps.now(),
     });
+    const requestedAgentId = input.agentId?.trim();
+    if (requestedAgentId) {
+      const agent = await this.deps.repositories.agents.getAgent(
+        requestedAgentId as AgentId,
+      );
+      if (!agent || agent.appId !== input.appId) {
+        throw new ApplicationError('NOT_FOUND', 'Agent not found');
+      }
+      if (agent.status !== 'active') {
+        throw new ApplicationError(
+          'INVALID_REQUEST',
+          `Agent is not active: ${requestedAgentId}`,
+        );
+      }
+      const agentFolder = folderForAgentId(agent.id);
+      if (!agentFolder) {
+        throw new ApplicationError(
+          'INVALID_REQUEST',
+          'Agent does not have a settings folder.',
+        );
+      }
+      // Bind the session to the requested agent's workspace folder so turns
+      // run with that agent's config and grants instead of a synthetic one.
+      group = { ...group, name: agent.name, folder: agentFolder };
+    }
     const defaultWebhookId = await this.resolveOwnedWebhookId(
       input.appId,
       input.webhookId ?? null,

--- a/apps/core/src/control/server/openapi-schemas.ts
+++ b/apps/core/src/control/server/openapi-schemas.ts
@@ -629,6 +629,11 @@ export const openApiSchemas: Record<string, JsonSchema> = {
     required: ['conversationId'],
     properties: {
       appId: { type: 'string', description: 'Optional API key app assertion.' },
+      agentId: {
+        type: 'string',
+        description:
+          'Optional agent id to bind the session to that agent workspace.',
+      },
       conversationId: { type: 'string' },
       title: { type: 'string' },
       responseMode: {

--- a/apps/core/src/control/server/routes/sessions.ts
+++ b/apps/core/src/control/server/routes/sessions.ts
@@ -34,7 +34,9 @@ function sendApplicationError(res: ServerResponse, error: unknown): boolean {
   const notFoundCode =
     error instanceof Error && error.message === 'Webhook not found'
       ? 'WEBHOOK_NOT_FOUND'
-      : 'SESSION_NOT_FOUND';
+      : error instanceof Error && error.message === 'Agent not found'
+        ? 'AGENT_NOT_FOUND'
+        : 'SESSION_NOT_FOUND';
   return sendApplicationErrorResponse(res, error, { NOT_FOUND: notFoundCode });
 }
 
@@ -176,6 +178,7 @@ export async function handleSessionRoutes(
       const result = await ensureSessionForControl(ctx, {
         appId,
         assertedAppId,
+        agentId: body.agentId ?? null,
         conversationId,
         title: body.title ?? null,
         responseMode: body.responseMode,

--- a/apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts
+++ b/apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts
@@ -1,8 +1,17 @@
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+
 import { eq } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createPostgresDomainRepositories } from '@core/adapters/storage/postgres/repositories/domain-repositories.postgres.js';
 import * as pgSchema from '@core/adapters/storage/postgres/schema/index.js';
+import { PostgresRuntimeRepositoryBundle } from '@core/adapters/storage/postgres/schema/canonical-ops-repo.postgres.js';
+import { PostgresRuntimeEventNotifier } from '@core/adapters/storage/postgres/runtime-event-notifier.postgres.js';
+import {
+  DEFAULT_AGENT_CONFIG_VERSION_ID,
+  DEFAULT_LLM_PROFILE_ID,
+} from '@core/adapters/storage/postgres/seeds.js';
 import { PostgresStorageService } from '@core/adapters/storage/postgres/storage-service.js';
 import { beginDurablePermissionInteraction } from '@core/application/interactions/durable-interaction-handler.js';
 import {
@@ -14,6 +23,16 @@ import {
 } from '@core/application/interactions/pending-interaction-durability.js';
 import { durablePermissionRequestSnapshot } from '@core/application/interactions/pending-interaction-permission-envelope.js';
 import { synthesizeHostPermissionSuggestions } from '@core/application/permissions/permission-suggestion-synthesis.js';
+import { RuntimeEventExchange } from '@core/application/runtime-events/runtime-event-exchange.js';
+import { GANTRY_HOME, RUNTIME_SETTINGS_PATH } from '@core/config/index.js';
+import { createAgentToolRuleSettingsMirror } from '@core/config/settings/agent-tool-rule-settings-mirror.js';
+import { SettingsDesiredStateService } from '@core/config/settings/desired-state-service.js';
+import {
+  capabilityToToolRule,
+  ensureConfiguredAgent,
+  loadRuntimeSettings,
+  saveRuntimeSettings,
+} from '@core/config/settings/runtime-settings.js';
 import type { PermissionApprovalDecisionMode } from '@core/domain/types.js';
 import type { PermissionApprovalRequest } from '@core/domain/types.js';
 import { evaluateAutonomousToolUse } from '@core/shared/tool-rule-matcher.js';
@@ -28,11 +47,14 @@ import {
 
 const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
 
-// Uses the seeded default app/agent (seeds.ts) — no agent tool bindings exist
-// at start, so the durable-rule assertions start from a clean policy.
+// Uses the seeded default app/agent (seeds.ts). A second configured agent
+// guards the (appId, agentId) scoping of durable rules: a regression to
+// app-wide binding lookups would leak AGENT_ID's rule to it.
 const APP_ID = 'default';
 const AGENT_ID = 'agent:main_agent';
 const AGENT_FOLDER = 'main_agent';
+const SECOND_AGENT_ID = 'agent:second_agent';
+const SECOND_AGENT_FOLDER = 'second_agent';
 const APPROVER = 'user:approver';
 
 // Matrix §6 durable-authority chain, driven through the REAL channel
@@ -40,48 +62,94 @@ const APPROVER = 'user:approver';
 // claim → resolveDurablePermissionInteractionByRequestId (the same functions
 // the Slack/Telegram callback handlers invoke; see
 // pending-interaction-permission-callback.ts). No decide-API is invented.
+//
+// Persistence uses the REAL production wiring (runtime-services.ts):
+// createAgentToolRuleSettingsMirror over the full repository bundle, so an
+// allow_persistent_rule decision writes desired-state settings + a settings
+// revision and reconciles it (agent-tool-rule-settings-mirror.ts →
+// restart-sync.ts → desired-state-capability-reconcile.ts) — no recorder
+// stubs. `desired_state.authoritative: true` means restart reconciliation
+// REPLACES agent capability bindings from settings.yaml, so the restart
+// assertions can only pass through the settings mirror: a binding that exists
+// only as a raw DB row is wiped by the reconcile in restartAndEvaluateGate.
+//
 // Note: PERMISSION_* runtime events are published by the IPC processor
 // (ipc-interaction-processing.ts), not by this decision-application path, so
 // the durable evidence asserted here is rows: pending_interactions status +
-// resolution, agent tool bindings, and permission_decisions.
+// resolution, agent tool bindings, settings.yaml capabilities, transient
+// grants, and permission_decisions.
 maybeDescribe('permission durable authority chain (Postgres)', () => {
   let runtime: PostgresIntegrationRuntime;
-  const mirroredRuleCalls: Array<{
-    sourceAgentFolder: string;
-    rules: string[];
-    mode?: 'add' | 'remove';
-  }> = [];
+  let originalSettingsYaml: string;
+  let originalEnv: Record<string, string | undefined>;
 
   beforeAll(async () => {
     runtime = await createPostgresIntegrationRuntime({
       schemaPrefix: 'perm_durable',
     });
+    // The REAL settings-import preflight (validateLoadedRuntimeSettings)
+    // requires runtime storage + credential-encryption env. Satisfy it with
+    // this run's own throwaway integration database — the runtime under test.
+    originalEnv = {
+      GANTRY_DATABASE_URL: process.env.GANTRY_DATABASE_URL,
+      SECRET_ENCRYPTION_KEY: process.env.SECRET_ENCRYPTION_KEY,
+    };
+    process.env.GANTRY_DATABASE_URL = process.env.GANTRY_TEST_DATABASE_URL;
+    process.env.SECRET_ENCRYPTION_KEY ??= randomBytes(32).toString('base64');
+    // Declare both agents in the runtime settings the way production setup
+    // flows do (ensureConfiguredAgent), with authoritative desired state.
+    originalSettingsYaml = fs.readFileSync(RUNTIME_SETTINGS_PATH, 'utf-8');
+    const settings = loadRuntimeSettings(GANTRY_HOME);
+    settings.desiredState.authoritative = true;
+    ensureConfiguredAgent(settings, {
+      agentId: AGENT_FOLDER,
+      agentName: 'Main Agent',
+      agentFolder: AGENT_FOLDER,
+    });
+    ensureConfiguredAgent(settings, {
+      agentId: SECOND_AGENT_FOLDER,
+      agentName: 'Second Agent',
+      agentFolder: SECOND_AGENT_FOLDER,
+    });
+    saveRuntimeSettings(GANTRY_HOME, settings);
+
     configurePendingInteractionDurability({
       repository: runtime.repositories.workerCoordination,
+      warn: (context, message) => {
+        console.error(message, context.err ?? context);
+      },
     });
     configurePendingInteractionPermissionPersistence({
       opsRepository: runtime.ops,
       getToolRepository: () => runtime.repositories.tools,
       getPermissionRepository: () => runtime.repositories.permissions,
-      mirrorAgentToolRulesToSettings: (sourceAgentFolder, rules, options) => {
-        mirroredRuleCalls.push({
-          sourceAgentFolder,
-          rules: [...rules],
-          ...(options?.mode ? { mode: options.mode } : {}),
-        });
-      },
+      // REAL settings mirror (same factory + arguments as runtime-services.ts),
+      // including the settings-revision append via the full repository bundle.
+      mirrorAgentToolRulesToSettings: createAgentToolRuleSettingsMirror({
+        opsRepository: runtime.ops,
+        repositories: runtime.repositories,
+        reloadRuntimeState: async () => {},
+      }),
     });
   }, 60_000);
 
   afterAll(async () => {
     configurePendingInteractionDurability(null);
     configurePendingInteractionPermissionPersistence(null);
+    if (originalSettingsYaml !== undefined) {
+      fs.writeFileSync(RUNTIME_SETTINGS_PATH, originalSettingsYaml, 'utf-8');
+    }
+    for (const [key, value] of Object.entries(originalEnv ?? {})) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     if (runtime) await runtime.cleanup();
   });
 
   function makeRequest(
     requestId: string,
     command: string,
+    run?: { runId: string; leaseToken: string; fencingVersion: number },
   ): PermissionApprovalRequest {
     return {
       requestId,
@@ -94,6 +162,13 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       // Same argv-leaf suggestion synthesis the host applies on the IPC path
       // (ipc-interaction-processing.ts sets request.suggestions from it).
       suggestions: synthesizeHostPermissionSuggestions('Bash', { command }),
+      ...(run
+        ? {
+            runId: run.runId,
+            runLeaseToken: run.leaseToken,
+            runLeaseFencingVersion: run.fencingVersion,
+          }
+        : {}),
     };
   }
 
@@ -146,13 +221,22 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
   }
 
   /**
-   * Restart simulation: brand-new service + repository instances over the SAME
-   * schema (no in-memory state carried over), then the same deterministic
+   * Restart simulation over the SAME schema with brand-new service +
+   * repository instances (no in-memory state carried over), running the REAL
+   * startup path: settings desired-state reconciliation exactly as
+   * runStartup does for a 'file' settings authority (startup.ts →
+   * SettingsDesiredStateService.reconcile →
+   * desired-state-capability-reconcile.ts replaceDesiredStateCapabilities),
+   * then the callback receives fresh repositories for the same deterministic
    * policy evaluation the autonomous gate runs
    * (tool-execution-policy-service.ts → evaluateAutonomousToolUse over
    * resolveConfiguredAllowedTools).
    */
-  async function evaluateGateWithFreshServices(command: string) {
+  async function withRestartedServices<T>(
+    fn: (
+      repositories: PostgresIntegrationRuntime['repositories'],
+    ) => Promise<T>,
+  ): Promise<T> {
     const fresh = new PostgresStorageService(
       process.env.GANTRY_TEST_DATABASE_URL!,
       runtime.schemaName,
@@ -162,53 +246,98 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
         fresh.db,
         fresh.pool,
       );
+      const ops = new PostgresRuntimeRepositoryBundle(fresh.pool, fresh.db, {
+        runtimeEvents: new RuntimeEventExchange(
+          repositories.runtimeEvents,
+          new PostgresRuntimeEventNotifier(fresh.pool),
+        ),
+      });
+      const settings = loadRuntimeSettings(GANTRY_HOME);
+      const reconcile = await new SettingsDesiredStateService({
+        ops,
+        repositories,
+      }).reconcile(settings);
+      expect(reconcile.invalidReferences).toEqual([]);
+      return await fn(repositories);
+    } finally {
+      await fresh.close();
+    }
+  }
+
+  async function restartAndEvaluateGate(command: string, agentId = AGENT_ID) {
+    return withRestartedServices(async (repositories) => {
       const rules = await resolveConfiguredAllowedTools({
         repository: repositories.tools,
         appId: APP_ID,
-        agentId: AGENT_ID,
+        agentId,
       });
       return evaluateAutonomousToolUse({
         rules: rules ?? [],
         toolName: 'Bash',
         toolInput: { command },
       });
-    } finally {
-      await fresh.close();
-    }
+    });
   }
 
-  it('allow_persistent_rule persists an argv-leaf RunCommand rule that auto-allows the same leaf and survives restart', async () => {
+  async function activeBindingsWithTools(agentId = AGENT_ID) {
+    const bindings = await runtime.repositories.tools.listAgentToolBindings({
+      appId: APP_ID as never,
+      agentId: agentId as never,
+    });
+    return Promise.all(
+      bindings
+        .filter((binding) => binding.status === 'active')
+        .map(async (binding) => ({
+          binding,
+          tool: await runtime.repositories.tools.getTool(binding.toolId),
+        })),
+    );
+  }
+
+  function settingsAgentRules(agentFolder: string): string[] {
+    const agent = loadRuntimeSettings(GANTRY_HOME).agents[agentFolder];
+    expect(agent).toBeDefined();
+    return agent!.capabilities.map((capability) =>
+      capabilityToToolRule(capability.id),
+    );
+  }
+
+  it('allow_persistent_rule persists the exact argv-leaf rule via the settings mirror, auto-allows only that leaf for only that agent, and survives restart reconciliation', async () => {
     const command = '/usr/local/bin/report-status --daily';
     const request = makeRequest('req-perm-durable-future', command);
     const [expectedRule] = permissionUpdateAllowedToolRules(
       request.suggestions,
     );
-    expect(expectedRule).toMatch(/^RunCommand\(/);
+    // The EXACT rule derived from the input command: a regression that widens
+    // it (e.g. `RunCommand(/usr/local/bin/report-status *)`) fails here.
+    expect(expectedRule).toBe(`RunCommand(${command})`);
 
-    // Precondition: nothing allows this command before the decision.
-    const before = await evaluateGateWithFreshServices(command);
-    expect(before.allowed).toBe(false);
+    // Precondition: nothing allows this command before the decision, even
+    // after a full restart reconciliation.
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+    const activeToolIdsBefore = new Set(
+      (await activeBindingsWithTools()).map(({ binding }) => binding.toolId),
+    );
 
     await decideViaChannelCallback(request, 'allow_persistent_rule');
 
     // Durable rule persisted as an agent-scoped tool binding (CURRENT
-    // semantics: binding identity is app+agent, not conversation).
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
-    });
-    const activeBindings = bindings.filter(
-      (binding) => binding.status === 'active',
+    // semantics: binding identity is app+agent, not conversation). Exactly
+    // one ACTIVE binding references the expected rule and it is new relative
+    // to the pre-decision set — independent of whatever else is seeded.
+    const boundTools = await activeBindingsWithTools();
+    const ruleBindings = boundTools.filter(
+      ({ tool }) => tool?.name === expectedRule,
     );
-    expect(activeBindings).toHaveLength(1);
-    const tool = await runtime.repositories.tools.getTool(
-      activeBindings[0]!.toolId,
+    expect(ruleBindings).toHaveLength(1);
+    expect(activeToolIdsBefore.has(ruleBindings[0]!.binding.toolId)).toBe(
+      false,
     );
-    expect(tool?.name).toBe(expectedRule);
-    expect(mirroredRuleCalls).toContainEqual({
-      sourceAgentFolder: AGENT_FOLDER,
-      rules: [expectedRule],
-    });
+
+    // The REAL settings mirror wrote desired state: the rule is now a
+    // capability of the deciding agent in settings.yaml — and only of it.
+    expect(settingsAgentRules(AGENT_FOLDER)).toContain(expectedRule);
+    expect(settingsAgentRules(SECOND_AGENT_FOLDER)).not.toContain(expectedRule);
 
     // Fresh policy evaluation of the SAME command leaf auto-allows — the
     // deterministic gate matches the persisted rule, so no new prompt is
@@ -226,13 +355,37 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
     });
     expect(evaluation.allowed).toBe(true);
 
-    // A DIFFERENT command leaf is still not allowed (argv-leaf scope, not a
-    // command-name class).
+    // Argv-leaf scope: the SAME executable with different arguments is still
+    // not allowed (the rule is not an executable-wide grant)...
+    expect(
+      evaluateAutonomousToolUse({
+        rules: rules ?? [],
+        toolName: 'Bash',
+        toolInput: { command: '/usr/local/bin/report-status --monthly' },
+      }).allowed,
+    ).toBe(false);
+    // ...and neither is a different executable.
     expect(
       evaluateAutonomousToolUse({
         rules: rules ?? [],
         toolName: 'Bash',
         toolInput: { command: '/usr/local/bin/other-tool --daily' },
+      }).allowed,
+    ).toBe(false);
+
+    // Agent scope: the second configured agent does NOT see the rule
+    // (guards the (appId, agentId) filter in tool-repository.postgres.ts).
+    const secondAgentRules = await resolveConfiguredAllowedTools({
+      repository: runtime.repositories.tools,
+      appId: APP_ID,
+      agentId: SECOND_AGENT_ID,
+    });
+    expect(secondAgentRules ?? []).not.toContain(expectedRule);
+    expect(
+      evaluateAutonomousToolUse({
+        rules: secondAgentRules ?? [],
+        toolName: 'Bash',
+        toolInput: { command },
       }).allowed,
     ).toBe(false);
 
@@ -267,16 +420,59 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       classification: 'user_permanent',
     });
 
-    // Restart simulation: new service + repository instances, same database —
-    // the rule is still effective.
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(true);
-  });
+    // Restart: the REAL startup reconciliation replaces every agent's
+    // bindings from authoritative settings.yaml, so this stays allowed ONLY
+    // because the settings mirror durably wrote the rule (a DB-only binding
+    // would have been wiped by the reconcile). The second agent still gets
+    // nothing.
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(true);
+    expect(
+      (await restartAndEvaluateGate(command, SECOND_AGENT_ID)).allowed,
+    ).toBe(false);
+  }, 60_000);
 
-  it('allow_once resolves the interaction without persisting any durable rule', async () => {
+  it('allow_once grants run-scoped transient authority under the active lease only, with no durable rule and nothing after restart', async () => {
     const command = '/usr/local/bin/send-digest --weekly';
-    const request = makeRequest('req-perm-durable-once', command);
+    const runId = 'run-perm-durable-once';
+    const workerId = 'worker-perm-durable-once';
 
+    // Real run + claimed lease: the once-grant path
+    // (pending-interaction-grants.ts applyPendingInteractionGrantDecision →
+    // recordRunScopedTransientGrant) only issues authority against the
+    // ACTIVE run lease.
+    const now = new Date().toISOString();
+    await runtime.service.db
+      .insert(pgSchema.agentRunsPostgres)
+      .values({
+        id: runId,
+        appId: APP_ID,
+        agentId: AGENT_ID,
+        configVersionId: DEFAULT_AGENT_CONFIG_VERSION_ID,
+        llmProfileId: DEFAULT_LLM_PROFILE_ID,
+        executionProviderId: 'test:integration',
+        cause: 'integration',
+        status: 'running',
+        permissionDecisionIdsJson: '[]',
+        createdAt: now,
+        startedAt: now,
+      })
+      .onConflictDoNothing();
+    await runtime.repositories.workerCoordination.registerWorker({
+      id: workerId,
+      bootNonce: 'perm-durable-once',
+    });
+    const lease = await runtime.repositories.workerCoordination.claimRunLease({
+      runId,
+      workerInstanceId: workerId,
+      ttlMs: 60_000,
+    });
+    expect(lease).not.toBeNull();
+
+    const request = makeRequest('req-perm-durable-once', command, {
+      runId,
+      leaseToken: lease!.leaseToken,
+      fencingVersion: lease!.fencingVersion,
+    });
     await decideViaChannelCallback(request, 'allow_once');
 
     const row = await interactionRow(request.requestId);
@@ -286,32 +482,65 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       mode: 'allow_once',
     });
 
-    // No durable rule for this command leaf: only the allow_persistent_rule
-    // binding from the previous case may exist.
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
+    // The once-authority is real and usable: a transient grant recorded
+    // against the active lease, readable through the same lease-fenced read
+    // model the runtime uses.
+    const grants =
+      await runtime.repositories.workerCoordination.listActiveTransientGrants({
+        runId,
+      });
+    expect(grants).toHaveLength(1);
+    expect(grants[0]!.leaseToken).toBe(lease!.leaseToken);
+    expect(grants[0]!.grant).toMatchObject({
+      toolName: 'Bash',
+      mode: 'allow_once',
+      requestId: request.requestId,
     });
-    const tools = await Promise.all(
-      bindings
-        .filter((binding) => binding.status === 'active')
-        .map((binding) => runtime.repositories.tools.getTool(binding.toolId)),
-    );
-    expect(tools.some((tool) => tool?.name?.includes('send-digest'))).toBe(
-      false,
-    );
 
-    // No run-scoped transient grant either (no runId on this request).
-    const grants = await runtime.service.db
-      .select()
-      .from(pgSchema.transientGrantsPostgres);
-    expect(grants).toHaveLength(0);
+    // Once-only: no durable rule for this command leaf — not as an agent
+    // tool binding, not in mirrored settings, and the deterministic gate
+    // does not auto-allow it even while the transient grant is live.
+    const boundTools = await activeBindingsWithTools();
+    expect(
+      boundTools.some(({ tool }) => tool?.name?.includes('send-digest')),
+    ).toBe(false);
+    expect(
+      settingsAgentRules(AGENT_FOLDER).some((rule) =>
+        rule.includes('send-digest'),
+      ),
+    ).toBe(false);
+    const liveRules = await resolveConfiguredAllowedTools({
+      repository: runtime.repositories.tools,
+      appId: APP_ID,
+      agentId: AGENT_ID,
+    });
+    expect(
+      evaluateAutonomousToolUse({
+        rules: liveRules ?? [],
+        toolName: 'Bash',
+        toolInput: { command },
+      }).allowed,
+    ).toBe(false);
 
-    // Restart simulation: transient authority is gone — a fresh policy
-    // evaluation of the same command does NOT auto-allow.
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(false);
-  });
+    // The run ends (lease settles, as on worker shutdown/restart): the
+    // transient grant is no longer readable from fresh service instances and
+    // the durable gate still denies — once-authority did not outlive the run.
+    await expect(
+      runtime.repositories.workerCoordination.settleRunLease({
+        runId,
+        leaseToken: lease!.leaseToken,
+        workerInstanceId: workerId,
+        fencingVersion: lease!.fencingVersion,
+        outcome: 'completed',
+      }),
+    ).resolves.toBe(true);
+    await withRestartedServices(async (repositories) => {
+      await expect(
+        repositories.workerCoordination.listActiveTransientGrants({ runId }),
+      ).resolves.toEqual([]);
+    });
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+  }, 60_000);
 
   it('cancel records the interaction as cancelled and persists no rule', async () => {
     const command = '/usr/local/bin/rotate-keys --now';
@@ -326,19 +555,15 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       mode: 'cancel',
     });
 
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
-    });
-    const tools = await Promise.all(
-      bindings
-        .filter((binding) => binding.status === 'active')
-        .map((binding) => runtime.repositories.tools.getTool(binding.toolId)),
-    );
-    expect(tools.some((tool) => tool?.name?.includes('rotate-keys'))).toBe(
-      false,
-    );
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(false);
-  });
+    const boundTools = await activeBindingsWithTools();
+    expect(
+      boundTools.some(({ tool }) => tool?.name?.includes('rotate-keys')),
+    ).toBe(false);
+    expect(
+      settingsAgentRules(AGENT_FOLDER).some((rule) =>
+        rule.includes('rotate-keys'),
+      ),
+    ).toBe(false);
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+  }, 60_000);
 });

--- a/apps/core/test/integration/session-ensure-agent-binding.integration.test.ts
+++ b/apps/core/test/integration/session-ensure-agent-binding.integration.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { startTestControlServer } from '../harness/control-http-server.js';
+
+const state = vi.hoisted(() => ({
+  sessions: new Map<string, any>(),
+  ensureInputs: [] as any[],
+  storedMessages: [] as any[],
+  agents: new Map<string, any>(),
+}));
+
+vi.mock('@core/config/index.js', () => ({
+  GANTRY_HOME: '/tmp/gantry-session-ensure-agent-home',
+  getControlEnvValue: vi.fn((key: string) => process.env[key]?.trim() || ''),
+  syncRuntimeSettingsFromProjection: vi.fn(async () => undefined),
+  getDefaultModelConfig: vi.fn(() => ({
+    model: 'opus',
+    source: 'system default',
+  })),
+  getRuntimeModelDefaults: vi.fn(() => ({ defaults: {} })),
+  patchRuntimeModelDefaults: vi.fn(() => ({ ok: true })),
+  configureDesiredSettingsStorageProvider: vi.fn(() => undefined),
+}));
+
+vi.mock('@core/jobs/scheduler.js', () => ({
+  enqueueJobTrigger: vi.fn(async () => undefined),
+  isJobTriggerQueueReady: vi.fn(() => true),
+  isSchedulerReady: vi.fn(() => true),
+  runtimeJobSchedulePlanner: {
+    createManualJobId: () => 'job-test',
+    createJobId: () => 'job-test',
+    planAppSchedule: () => ({
+      scheduleType: 'manual',
+      scheduleValue: 'manual',
+      nextRun: null,
+    }),
+    planInitial: () => ({ nextRun: '2026-04-24T01:00:00.000Z' }),
+    planResume: ({ job, clock }) =>
+      job.next_run ??
+      (job.schedule_type === 'manual'
+        ? null
+        : job.schedule_type === 'once'
+          ? job.schedule_value
+          : clock.now()),
+  },
+  requestSchedulerSync: vi.fn(),
+}));
+
+vi.mock('@core/adapters/storage/postgres/runtime-store.js', () => ({
+  getRuntimeControlRepository: () => ({
+    listDueWebhookDeliveries: vi.fn(async () => []),
+    claimDueWebhookDeliveries: vi.fn(async () => []),
+    ensureAppSession: vi.fn(async (input: any) => {
+      state.ensureInputs.push(input);
+      const sessionId = `session-${input.conversationId}`;
+      const record = {
+        sessionId,
+        appId: input.appId,
+        conversationId: input.conversationId,
+        chatJid: input.chatJid,
+        workspaceKey: input.workspaceFolder,
+        title: input.title ?? null,
+        defaultResponseMode: input.defaultResponseMode ?? 'sse',
+        defaultWebhookId: input.defaultWebhookId ?? null,
+      };
+      state.sessions.set(sessionId, record);
+      return record;
+    }),
+    getAppSessionById: vi.fn(
+      async (sessionId: string) => state.sessions.get(sessionId) ?? null,
+    ),
+    getWebhookById: vi.fn(async () => undefined),
+    upsertAppResponseRoute: vi.fn(async () => ({
+      responseMode: 'sse',
+      webhookId: null,
+      correlationId: null,
+    })),
+  }),
+  getRuntimeEventExchange: () => ({
+    publish: vi.fn(async () => ({ eventId: 1 })),
+    list: vi.fn(async () => []),
+    subscribe: vi.fn(async () => ({
+      next: vi.fn(async () => []),
+      close: vi.fn(),
+    })),
+  }),
+  getRuntimeRepositories: () => ({
+    storeChatMetadata: vi.fn(async () => undefined),
+    storeMessage: vi.fn(async (message: any) => {
+      state.storedMessages.push(message);
+    }),
+  }),
+  getRuntimeStorage: () => ({
+    repositories: {
+      agents: {
+        getAgent: vi.fn(
+          async (agentId: string) => state.agents.get(agentId) ?? null,
+        ),
+      },
+    },
+  }),
+}));
+
+async function readJson(response: Response): Promise<any> {
+  return await response.json();
+}
+
+function makeRuntimeApp() {
+  return {
+    registerGroup: vi.fn(async () => undefined),
+    queue: { enqueueMessageCheck: vi.fn() },
+  };
+}
+
+async function startServer(runtimeApp: ReturnType<typeof makeRuntimeApp>) {
+  return await startTestControlServer({
+    token: 'token-session-ensure',
+    appId: 'app-one',
+    scopes: ['sessions:write', 'sessions:read'],
+    runtimeApp,
+    liveTurnsEnabled: false,
+  });
+}
+
+describe('session ensure agent binding integration', () => {
+  beforeEach(() => {
+    state.sessions.clear();
+    state.ensureInputs.length = 0;
+    state.storedMessages.length = 0;
+    state.agents.clear();
+    state.agents.set('agent:folder-one', {
+      id: 'agent:folder-one',
+      appId: 'app-one',
+      name: 'Agent One',
+      status: 'active',
+    });
+    state.agents.set('agent:disabled-agent', {
+      id: 'agent:disabled-agent',
+      appId: 'app-one',
+      name: 'Sleeper',
+      status: 'disabled',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('binds the ensured session to the requested agent and admits messages on its queue', async () => {
+    const runtimeApp = makeRuntimeApp();
+    const server = await startServer(runtimeApp);
+
+    try {
+      const ensureResponse = await fetch(
+        `${server.baseUrl}/v1/sessions/ensure`,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${server.token}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            conversationId: 'conv-agent',
+            agentId: 'agent:folder-one',
+          }),
+        },
+      );
+      const ensureBody = await readJson(ensureResponse);
+
+      expect(ensureResponse.status).toBe(200);
+      expect(ensureBody.chatJid).toBe('app:app-one:conv-agent');
+      // Persisted session identity uses the agent's workspace folder, not a
+      // synthetic app_<hash> folder.
+      expect(state.ensureInputs).toEqual([
+        expect.objectContaining({
+          appId: 'app-one',
+          conversationId: 'conv-agent',
+          chatJid: 'app:app-one:conv-agent',
+          workspaceFolder: 'folder-one',
+        }),
+      ]);
+      expect(runtimeApp.registerGroup).toHaveBeenCalledWith(
+        'app:app-one:conv-agent',
+        expect.objectContaining({ folder: 'folder-one', name: 'Agent One' }),
+      );
+
+      const messageResponse = await fetch(
+        `${server.baseUrl}/v1/sessions/${encodeURIComponent(ensureBody.sessionId)}/messages`,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${server.token}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ message: 'hello agent' }),
+        },
+      );
+      const messageBody = await readJson(messageResponse);
+
+      expect(messageResponse.status).toBe(202);
+      expect(messageBody.accepted).toBe(true);
+      expect(state.storedMessages).toEqual([
+        expect.objectContaining({ chat_jid: 'app:app-one:conv-agent' }),
+      ]);
+      // The admitted queue key is the jid whose registered route carries the
+      // agent's folder — the agent's queue, not a synthetic one.
+      expect(runtimeApp.queue.enqueueMessageCheck).toHaveBeenCalledWith(
+        'app:app-one:conv-agent',
+      );
+      const [registeredJid, registeredGroup] =
+        runtimeApp.registerGroup.mock.calls[0];
+      expect(registeredJid).toBe('app:app-one:conv-agent');
+      expect(registeredGroup.folder).toBe('folder-one');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('keeps the synthetic folder when agentId is omitted', async () => {
+    const runtimeApp = makeRuntimeApp();
+    const server = await startServer(runtimeApp);
+
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/sessions/ensure`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${server.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ conversationId: 'conv-plain' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(state.ensureInputs).toHaveLength(1);
+      expect(state.ensureInputs[0].workspaceFolder).toMatch(
+        /^app_[0-9a-f]{12}_app_one_conv_plain$/,
+      );
+      expect(runtimeApp.registerGroup).toHaveBeenCalledWith(
+        'app:app-one:conv-plain',
+        expect.objectContaining({
+          folder: state.ensureInputs[0].workspaceFolder,
+        }),
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects an unknown agentId with AGENT_NOT_FOUND and creates nothing', async () => {
+    const runtimeApp = makeRuntimeApp();
+    const server = await startServer(runtimeApp);
+
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/sessions/ensure`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${server.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          conversationId: 'conv-x',
+          agentId: 'agent:missing',
+        }),
+      });
+      const body = await readJson(response);
+
+      expect(response.status).toBe(404);
+      expect(body.error.code).toBe('AGENT_NOT_FOUND');
+      expect(body.error.message).toBe('Agent not found');
+      expect(state.ensureInputs).toEqual([]);
+      expect(runtimeApp.registerGroup).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects a disabled agent with a clear error', async () => {
+    const runtimeApp = makeRuntimeApp();
+    const server = await startServer(runtimeApp);
+
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/sessions/ensure`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${server.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          conversationId: 'conv-y',
+          agentId: 'agent:disabled-agent',
+        }),
+      });
+      const body = await readJson(response);
+
+      expect(response.status).toBe(400);
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      expect(body.error.message).toBe(
+        'Agent is not active: agent:disabled-agent',
+      );
+      expect(state.ensureInputs).toEqual([]);
+      expect(runtimeApp.registerGroup).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
+++ b/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
@@ -460,4 +460,123 @@ describe('SessionInteractionModule', () => {
     expect(next).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  describe('ensureSession agent targeting', () => {
+    const agent = {
+      id: 'agent:folder-one',
+      appId: 'app-one',
+      name: 'My Agent',
+      status: 'active',
+    };
+
+    it('binds the ensured session to the requested agent folder', async () => {
+      const getAgent = vi.fn(async () => agent);
+      const { module, control } = makeModule({
+        repositories: { agents: { getAgent } },
+      });
+
+      const result = await module.ensureSession({
+        appId: 'app-one',
+        agentId: 'agent:folder-one',
+        conversationId: 'conv-1',
+      });
+
+      expect(getAgent).toHaveBeenCalledWith('agent:folder-one');
+      expect(control.ensureAppSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'app-one',
+          conversationId: 'conv-1',
+          conversationJid: 'app:app-one:conv-1',
+          folder: 'folder-one',
+        }),
+      );
+      expect(result.registerGroup.group).toMatchObject({
+        name: 'My Agent',
+        folder: 'folder-one',
+      });
+      expect(result.session.workspaceKey).toBe('folder-one');
+    });
+
+    it('keeps the synthetic folder when agentId is omitted', async () => {
+      const getAgent = vi.fn();
+      const { module, control } = makeModule({
+        repositories: { agents: { getAgent } },
+      });
+
+      const result = await module.ensureSession({
+        appId: 'app-one',
+        conversationId: 'conv-1',
+      });
+
+      expect(getAgent).not.toHaveBeenCalled();
+      expect(result.registerGroup.group.folder).toBe(
+        'app_123456789abc_app_one_conv_1',
+      );
+      expect(control.ensureAppSession).toHaveBeenCalledWith(
+        expect.objectContaining({ folder: 'app_123456789abc_app_one_conv_1' }),
+      );
+    });
+
+    it('rejects an unknown agentId without creating a session', async () => {
+      const { module, control } = makeModule({
+        repositories: { agents: { getAgent: vi.fn(async () => null) } },
+      });
+
+      await expect(
+        module.ensureSession({
+          appId: 'app-one',
+          agentId: 'agent:missing',
+          conversationId: 'conv-1',
+        }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Agent not found',
+      });
+      expect(control.ensureAppSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects an agent that belongs to another app', async () => {
+      const { module, control } = makeModule({
+        repositories: {
+          agents: {
+            getAgent: vi.fn(async () => ({ ...agent, appId: 'app-two' })),
+          },
+        },
+      });
+
+      await expect(
+        module.ensureSession({
+          appId: 'app-one',
+          agentId: 'agent:folder-one',
+          conversationId: 'conv-1',
+        }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Agent not found',
+      });
+      expect(control.ensureAppSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects an agent that is not active', async () => {
+      const { module, control } = makeModule({
+        repositories: {
+          agents: {
+            getAgent: vi.fn(async () => ({ ...agent, status: 'disabled' })),
+          },
+        },
+      });
+
+      await expect(
+        module.ensureSession({
+          appId: 'app-one',
+          agentId: 'agent:folder-one',
+          conversationId: 'conv-1',
+        }),
+      ).rejects.toMatchObject({
+        code: 'INVALID_REQUEST',
+        message: 'Agent is not active: agent:folder-one',
+      });
+      expect(control.ensureAppSession).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/docs/architecture/agent-e2e-test-matrix.md
+++ b/docs/architecture/agent-e2e-test-matrix.md
@@ -36,189 +36,189 @@ Legend: ✅ covered (cite) · 🔨 to build · 🏷 label-gated (live lane) · �
 
 ## 1. Runtime & boot
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Image starts, migrations current, healthy | e2e | 🔨 |
-| Restart preserves desired state (settings revision projection) | e2e | 🔨 |
-| Security posture: prod image requires enforcing sandbox + non-prod secrets | integration | ✅ security-posture.test.ts |
-| Harness refuses to run against ~/gantry or live DB (isolation guard) | e2e (harness self-test) | 🔨 |
-| **Upgrade survivor** (adopted from OpenClaw): boot version N-1 state (settings revisions + DB) under version N image → migrations apply → agents/bindings/grants survive | e2e | 🔨 (post-ponytail-cutover — baseline resets first) |
-| Startup benchmark lane (boot time / first-turn latency budgets) | perf | 💤 deferred until the gate is stable |
+| Scenario                                                                                                                                                                 | Layer                   | Status                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | -------------------------------------------------- |
+| Image starts, migrations current, healthy                                                                                                                                | e2e                     | 🔨                                                 |
+| Restart preserves desired state (settings revision projection)                                                                                                           | e2e                     | 🔨                                                 |
+| Security posture: prod image requires enforcing sandbox + non-prod secrets                                                                                               | integration             | ✅ security-posture.test.ts                        |
+| Harness refuses to run against ~/gantry or live DB (isolation guard)                                                                                                     | e2e (harness self-test) | 🔨                                                 |
+| **Upgrade survivor** (adopted from OpenClaw): boot version N-1 state (settings revisions + DB) under version N image → migrations apply → agents/bindings/grants survive | e2e                     | 🔨 (post-ponytail-cutover — baseline resets first) |
+| Startup benchmark lane (boot time / first-turn latency budgets)                                                                                                          | perf                    | 💤 deferred until the gate is stable               |
 
 ## 2. Onboarding & model selection (API-driven)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Create agent + conversation binding via desired-state API; revision appended; survives restart | e2e | 🔨 |
-| Select `haiku` alias; turn evidence routes to selected model/provider/harness | e2e | 🔨 |
-| API contract: status codes + response shapes on onboarding endpoints | e2e (same pass) | 🔨 |
-| Scope enforcement: sessions-only key → 403 on admin endpoint | integration | 🔨 |
-| `sessions/ensure` honors `agentId` (bug fix first) | integration + e2e | 🔨 blocked on ponytail landing |
+| Scenario                                                                                       | Layer             | Status                         |
+| ---------------------------------------------------------------------------------------------- | ----------------- | ------------------------------ |
+| Create agent + conversation binding via desired-state API; revision appended; survives restart | e2e               | 🔨                             |
+| Select `haiku` alias; turn evidence routes to selected model/provider/harness                  | e2e               | 🔨                             |
+| API contract: status codes + response shapes on onboarding endpoints                           | e2e (same pass)   | 🔨                             |
+| Scope enforcement: sessions-only key → 403 on admin endpoint                                   | integration       | 🔨                             |
+| `sessions/ensure` honors `agentId` (bug fix first)                                             | integration + e2e | 🔨 blocked on ponytail landing |
 
 ## 3. Agent turn (haiku, behavioral)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| ensure → message (202 ≠ done) → events → visible completion | e2e | 🔨 |
-| Evidence bundle complete (ids, alias/route, timings, audit ids, redacted failure) | e2e | 🔨 |
-| Inline-lane turn (LLM API path) completes once | e2e | 🔨 |
-| Turn-failure surfaces cleanly (bad model alias → clean terminal state, no zombie) | e2e | 🔨 |
+| Scenario                                                                          | Layer | Status |
+| --------------------------------------------------------------------------------- | ----- | ------ |
+| ensure → message (202 ≠ done) → events → visible completion                       | e2e   | 🔨     |
+| Evidence bundle complete (ids, alias/route, timings, audit ids, redacted failure) | e2e   | 🔨     |
+| Inline-lane turn (LLM API path) completes once                                    | e2e   | 🔨     |
+| Turn-failure surfaces cleanly (bad model alias → clean terminal state, no zombie) | e2e   | 🔨     |
 
 ## 4. Skills
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Install vendored `internal-comms` zip via `/v1/skills/install`; catalog + binding identity | e2e | 🔨 |
-| Selection survives restart; assets materialize incl. `examples/3p-updates.md` (progressive disclosure) | e2e | 🔨 |
-| Turn produces 3P STRUCTURE (Progress/Plans/Problems sections exist — structure, not wording) | e2e | 🔨 |
-| `gantry-admin` reserved name rejected by install API | integration | 🔨 |
-| `admin_permission_list` callable, returns expected shape | e2e | 🔨 |
-| **Agent-driven skill acquisition**: turn asks the agent to get itself a skill → `request_skill_install` → REAL approval path → installed+selected → follow-up turn USES it (materialized assets asserted) | e2e (haiku, Stage C) | 🔨 |
-| Skill install/registry logic | integration | ✅ skills-registry-flow.integration.test.ts |
+| Scenario                                                                                                                                                                                                  | Layer                | Status                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------- |
+| Install vendored `internal-comms` zip via `/v1/skills/install`; catalog + binding identity                                                                                                                | e2e                  | 🔨                                          |
+| Selection survives restart; assets materialize incl. `examples/3p-updates.md` (progressive disclosure)                                                                                                    | e2e                  | 🔨                                          |
+| Turn produces 3P STRUCTURE (Progress/Plans/Problems sections exist — structure, not wording)                                                                                                              | e2e                  | 🔨                                          |
+| `gantry-admin` reserved name rejected by install API                                                                                                                                                      | integration          | 🔨                                          |
+| `admin_permission_list` callable, returns expected shape                                                                                                                                                  | e2e                  | 🔨                                          |
+| **Agent-driven skill acquisition**: turn asks the agent to get itself a skill → `request_skill_install` → REAL approval path → installed+selected → follow-up turn USES it (materialized assets asserted) | e2e (haiku, Stage C) | 🔨                                          |
+| Skill install/registry logic                                                                                                                                                                              | integration          | ✅ skills-registry-flow.integration.test.ts |
 
 ## 5. MCP
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Register HTTP server via SDK; approve ONLY echo+get-sum | e2e | 🔨 |
-| Discovery + schema; denied tools invisible to the agent | e2e | ✅ mcp-client-loop.postgres.e2e.test.ts |
-| Turn calls `get-sum(20,22)`; fixture records call; tool result 42; MCP audit event | e2e | ✅ client path (non-model: fixture records exact args, result 42, MCP audit + runtime event) mcp-client-loop.postgres.e2e.test.ts · 🔨 real-turn |
-| stdio transport | integration | ✅ ipc-mcp-stdio.test.ts |
-| MCP server management lifecycle | integration | ✅ mcp-server-management.integration.test.ts + mcp-server.postgres.integration.test.ts |
-| Deep-MCP: every capability class of vendored everything-server (tools, resources, prompts, sampling, progress, logging, completions) — unsupported class = product bug or documented non-support | e2e-live | 🏷 |
-| **Agent-driven MCP acquisition**: turn asks the agent to get itself the fixture MCP server → agent calls `request_mcp_server` → REAL approval path decides → server registered+bound → follow-up turn agent CALLS its tool (fixture records it) | e2e (haiku, Stage C) | 🔨 |
-| Agent-driven acquisition via CHAT (Slack): same loop driven by a channel message + button approval | e2e-live | 🏷 |
+| Scenario                                                                                                                                                                                                                                        | Layer                | Status                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Register HTTP server via SDK; approve ONLY echo+get-sum                                                                                                                                                                                         | e2e                  | 🔨                                                                                                                                               |
+| Discovery + schema; denied tools invisible to the agent                                                                                                                                                                                         | e2e                  | ✅ mcp-client-loop.postgres.e2e.test.ts                                                                                                          |
+| Turn calls `get-sum(20,22)`; fixture records call; tool result 42; MCP audit event                                                                                                                                                              | e2e                  | ✅ client path (non-model: fixture records exact args, result 42, MCP audit + runtime event) mcp-client-loop.postgres.e2e.test.ts · 🔨 real-turn |
+| stdio transport                                                                                                                                                                                                                                 | integration          | ✅ ipc-mcp-stdio.test.ts                                                                                                                         |
+| MCP server management lifecycle                                                                                                                                                                                                                 | integration          | ✅ mcp-server-management.integration.test.ts + mcp-server.postgres.integration.test.ts                                                           |
+| Deep-MCP: every capability class of vendored everything-server (tools, resources, prompts, sampling, progress, logging, completions) — unsupported class = product bug or documented non-support                                                | e2e-live             | 🏷                                                                                                                                               |
+| **Agent-driven MCP acquisition**: turn asks the agent to get itself the fixture MCP server → agent calls `request_mcp_server` → REAL approval path decides → server registered+bound → follow-up turn agent CALLS its tool (fixture records it) | e2e (haiku, Stage C) | 🔨                                                                                                                                               |
+| Agent-driven acquisition via CHAT (Slack): same loop driven by a channel message + button approval                                                                                                                                              | e2e-live             | 🏷                                                                                                                                               |
 
 ## 6. Permissions (granular)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| `ask`: eligible tool → human prompt, nothing auto-decided | integration | ✅ permission-classifier tests |
-| `auto`: read-only gate as evidence → classifier allow → auto_classifier allow_once | integration | ✅ permission-classifier.test.ts:539-612 |
-| `auto_strict`: unproven-safety asks WITHOUT classifier; proven still consults strict classifier | integration | ✅ permission-classifier.test.ts:614-667 |
-| Classifier unavailable/failure → fail-safe ask | integration | ✅ unit |
-| YOLO denylist hit → ask + event; unattended converts to denial | integration | ✅ classifier.test.ts:868-941 (attended); 🔨 unattended-context chain |
-| Locked agent: forged authority IPC denied at parent | integration | ✅ ipc-locked-permission-denial.test.ts |
-| Eligibility: only Bash/RunCommand + non-gantry MCP reach classifier | integration | ✅ unit |
-| Full chain: real IPC boundary → durable interaction → decision → event repo | integration | 🔨 (the one genuinely new chain) |
-| Allow ONCE: runs, then authority expires after restart | integration + e2e recovery scenario | ✅ integration permission-durable-authority.postgres.integration.test.ts · 🔨 e2e recovery |
-| Allow FUTURE: argv-leaf rule persists, auto-allows next same-leaf command, survives restart, agent-scoped (current semantics) | integration | ✅ permission-durable-authority.postgres.integration.test.ts |
-| Record-before-prompt ordering | integration | 🔨 |
-| Cancel: run interrupts cleanly, no partial effect, audit `cancelled` | integration | ✅ decision chain (cancelled record, no rule persisted) permission-durable-authority.postgres.integration.test.ts · 🔨 run-interrupt |
-| Deny: recorded, no execution | integration | 🔨 |
-| NO chat receipt on allow-future (regression, #239) | integration | 🔨 |
-| Real decision paths only — via classifier / in-process button-resolution callback / real Slack button (never a decide-API) | (constraint on all above) | — |
-| Whole-chain credential-absence in events/logs | integration | 🔨 |
+| Scenario                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Layer                               | Status                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ask`: eligible tool → human prompt, nothing auto-decided                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | integration                         | ✅ permission-classifier tests                                                                                                                                                                 |
+| `auto`: read-only gate as evidence → classifier allow → auto_classifier allow_once                                                                                                                                                                                                                                                                                                                                                                                                                                                     | integration                         | ✅ permission-classifier.test.ts:539-612                                                                                                                                                       |
+| `auto_strict`: unproven-safety asks WITHOUT classifier; proven still consults strict classifier                                                                                                                                                                                                                                                                                                                                                                                                                                        | integration                         | ✅ permission-classifier.test.ts:614-667                                                                                                                                                       |
+| Classifier unavailable/failure → fail-safe ask                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | integration                         | ✅ unit                                                                                                                                                                                        |
+| YOLO denylist hit → ask + event; unattended converts to denial                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | integration                         | ✅ classifier.test.ts:868-941 (attended); 🔨 unattended-context chain                                                                                                                          |
+| Locked agent: forged authority IPC denied at parent                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | integration                         | ✅ ipc-locked-permission-denial.test.ts                                                                                                                                                        |
+| Eligibility: only Bash/RunCommand + non-gantry MCP reach classifier                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | integration                         | ✅ unit                                                                                                                                                                                        |
+| Full chain: real IPC boundary → durable interaction → decision → event repo                                                                                                                                                                                                                                                                                                                                                                                                                                                            | integration                         | 🔨 (the one genuinely new chain)                                                                                                                                                               |
+| Allow ONCE: run-scoped transient grant issued under the REAL claimed run lease (channel-callback decision → `applyPendingInteractionGrantDecision` → `recordRunScopedTransientGrant`), readable via the lease-fenced read model; no durable binding, no settings mirror write, durable gate denies even while the grant is live; unreadable after the lease settles + fresh services                                                                                                                                                   | integration + e2e recovery scenario | ✅ integration permission-durable-authority.postgres.integration.test.ts (grant issuance/expiry; does NOT prove the live tool-call resume — that is the IPC processor's job) · 🔨 e2e recovery |
+| Allow FUTURE: EXACT argv-leaf rule (asserted string equality against the input command) persisted through the REAL settings mirror (`createAgentToolRuleSettingsMirror` → settings.yaml + settings revision + desired-state reconcile); auto-allows the same leaf, denies same-executable-different-args and other executables; survives restart via REAL startup reconciliation over authoritative settings (DB-only bindings are wiped, so survival proves the mirror); agent-scoped — a second configured agent never sees the rule | integration                         | ✅ permission-durable-authority.postgres.integration.test.ts                                                                                                                                   |
+| Record-before-prompt ordering                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | integration                         | 🔨                                                                                                                                                                                             |
+| Cancel: run interrupts cleanly, no partial effect, audit `cancelled`                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | integration                         | ✅ decision chain (cancelled record, no rule persisted) permission-durable-authority.postgres.integration.test.ts · 🔨 run-interrupt                                                           |
+| Deny: recorded, no execution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | integration                         | 🔨                                                                                                                                                                                             |
+| NO chat receipt on allow-future (regression, #239)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | integration                         | 🔨                                                                                                                                                                                             |
+| Real decision paths only — via classifier / in-process button-resolution callback / real Slack button (never a decide-API)                                                                                                                                                                                                                                                                                                                                                                                                             | (constraint on all above)           | —                                                                                                                                                                                              |
+| Whole-chain credential-absence in events/logs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | integration                         | 🔨                                                                                                                                                                                             |
 
 ## 7. Capabilities
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection | integration | ✅ configured-agent-tools.test.ts |
-| local_cli pinning (path/version/hash/templates); unrelated command denied | integration | ✅ semantic-capabilities.test.ts |
-| Persisted selected binding → projection → real admission | integration | 🔨 |
-| Real-image preflight pass AND fail-closed | e2e | 🔨 |
-| Secret lifecycle store→retrieve→rotate→audit (all four in one test) | integration | 🔨 |
-| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak | integration | ✅ capability-secret units; 🔨 through-sandbox chain |
-| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair |
-| Real gog/Sheets tier (throwaway sheet) | e2e-live | 🏷 |
+| Scenario                                                                                          | Layer       | Status                                               |
+| ------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection              | integration | ✅ configured-agent-tools.test.ts                    |
+| local_cli pinning (path/version/hash/templates); unrelated command denied                         | integration | ✅ semantic-capabilities.test.ts                     |
+| Persisted selected binding → projection → real admission                                          | integration | 🔨                                                   |
+| Real-image preflight pass AND fail-closed                                                         | e2e         | 🔨                                                   |
+| Secret lifecycle store→retrieve→rotate→audit (all four in one test)                               | integration | 🔨                                                   |
+| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak                 | integration | ✅ capability-secret units; 🔨 through-sandbox chain |
+| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair  |
+| Real gog/Sheets tier (throwaway sheet)                                                            | e2e-live    | 🏷                                                   |
 
 ## 8. Memories
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Write → recall → subject-boundary isolation (person/group/channel) | integration | ✅ memory-write-recall-boundary.postgres.integration.test.ts (subject-scoped fetch recall; embedding recall stays hermetically disabled) |
-| Turn 1 states fact → durable memory row collected; turn 2 → memory READ occurred | e2e | 🔨 |
-| Memory survives restart, still recallable | e2e | 🔨 |
-| Job-run memory collection persists | e2e (job scenario) | 🔨 |
+| Scenario                                                                         | Layer              | Status                                                                                                                                   |
+| -------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Write → recall → subject-boundary isolation (person/group/channel)               | integration        | ✅ memory-write-recall-boundary.postgres.integration.test.ts (subject-scoped fetch recall; embedding recall stays hermetically disabled) |
+| Turn 1 states fact → durable memory row collected; turn 2 → memory READ occurred | e2e                | 🔨                                                                                                                                       |
+| Memory survives restart, still recallable                                        | e2e                | 🔨                                                                                                                                       |
+| Job-run memory collection persists                                               | e2e (job scenario) | 🔨                                                                                                                                       |
 
 ## 9. Jobs
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Create via API → trigger → run completes → delivery → health `completed` (API twin of agent-job-smoke.sh) | e2e | 🔨 |
-| Pause → resume → trigger transitions + events | e2e | 🔨 |
-| Forced failure exhausts retries → dead-letter + clean terminal event | e2e | 🔨 |
-| Autonomous tool dead-end: ungranted tool surfaces cleanly (regression) | integration | 🔨 |
-| MCP-readiness race: slow init must NOT hard-fail (regression, fix on main) | integration (unit exists) + e2e real-turn | ✅ mcp-server-validation.test.ts · 🔨 e2e |
-| Local live smoke against the real runtime | manual/script | ✅ scripts/agent-job-smoke.sh |
+| Scenario                                                                                                  | Layer                                     | Status                                    |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------------------------- |
+| Create via API → trigger → run completes → delivery → health `completed` (API twin of agent-job-smoke.sh) | e2e                                       | 🔨                                        |
+| Pause → resume → trigger transitions + events                                                             | e2e                                       | 🔨                                        |
+| Forced failure exhausts retries → dead-letter + clean terminal event                                      | e2e                                       | 🔨                                        |
+| Autonomous tool dead-end: ungranted tool surfaces cleanly (regression)                                    | integration                               | 🔨                                        |
+| MCP-readiness race: slow init must NOT hard-fail (regression, fix on main)                                | integration (unit exists) + e2e real-turn | ✅ mcp-server-validation.test.ts · 🔨 e2e |
+| Local live smoke against the real runtime                                                                 | manual/script                             | ✅ scripts/agent-job-smoke.sh             |
 
 ## 10. Attachments & delivery
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Turn sends the deterministic attachment → workspace-direct delivery record, hash matches | e2e | 🔨 |
-| Oversize handling (>25MB refused cleanly) | integration | 🔨 |
-| Webhook fires with expected payload shape (loopback receiver) | e2e | 🔨 |
+| Scenario                                                                                 | Layer       | Status |
+| ---------------------------------------------------------------------------------------- | ----------- | ------ |
+| Turn sends the deterministic attachment → workspace-direct delivery record, hash matches | e2e         | 🔨     |
+| Oversize handling (>25MB refused cleanly)                                                | integration | 🔨     |
+| Webhook fires with expected payload shape (loopback receiver)                            | e2e         | 🔨     |
 
 ## 11. Route integrity (incident regressions)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Loader collapses mixed legacy key forms to ONE route (total preference order) | unit/integration | 🔨 in route-fix lane |
+| Scenario                                                                           | Layer            | Status               |
+| ---------------------------------------------------------------------------------- | ---------------- | -------------------- |
+| Loader collapses mixed legacy key forms to ONE route (total preference order)      | unit/integration | 🔨 in route-fix lane |
 | Divergent conversationId rows load via derive+warn, never throw, never drop a chat | unit/integration | 🔨 in route-fix lane |
-| Corrupt-state seed via direct test-DB rows (documented API exception) | integration | 🔨 |
+| Corrupt-state seed via direct test-DB rows (documented API exception)              | integration      | 🔨                   |
 
 ## 12. Channel loop (Slack, dedicated test app)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Real user-pattern message → agent turn → outbound reply in channel | e2e-live | 🏷 |
+| Scenario                                                                                      | Layer    | Status                                                                   |
+| --------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------ |
+| Real user-pattern message → agent turn → outbound reply in channel                            | e2e-live | 🏷                                                                       |
 | Permission block renders (header/context structure); approve callback → tool proceeds + audit | e2e-live | 🏷 (needs real-user or signed-callback fixture — constraint per round-3) |
-| Attachment delivered in channel | e2e-live | 🏷 |
+| Attachment delivered in channel                                                               | e2e-live | 🏷                                                                       |
 
 ## 13. Model matrix & policy gate
 
-| Scenario | Layer | Status |
-|---|---|---|
-| `haiku` + anthropic_sdk turn (required gate) | e2e | 🔨 |
-| `gpt-mini` + deepagents turn | e2e-live | 🏷 |
-| Catalog base/head diff adds changed aliases to live matrix | CI policy job | 🔨 |
-| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨 |
-| `agent-e2e-gate` aggregates + branch protection verified | CI | 🔨 |
+| Scenario                                                                                 | Layer         | Status |
+| ---------------------------------------------------------------------------------------- | ------------- | ------ |
+| `haiku` + anthropic_sdk turn (required gate)                                             | e2e           | 🔨     |
+| `gpt-mini` + deepagents turn                                                             | e2e-live      | 🏷     |
+| Catalog base/head diff adds changed aliases to live matrix                               | CI policy job | 🔨     |
+| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨     |
+| `agent-e2e-gate` aggregates + branch protection verified                                 | CI            | 🔨     |
 
 ## 14. All-tools sweep
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Enumerate effective tool set (internal inspector); every read-only + fixture-backed tool invoked once; call + effect + audit asserted; unreachable granted tool = FAIL | e2e | 🔨 |
-| Authority/lifecycle tools covered by their own scenarios (not blind invocation) | — | design rule |
-| Browser tool against loopback page | e2e | 🔨 (image lacks Chrome — runs in local smoke until media-render ships provisioning) |
+| Scenario                                                                                                                                                               | Layer | Status                                                                              |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------- |
+| Enumerate effective tool set (internal inspector); every read-only + fixture-backed tool invoked once; call + effect + audit asserted; unreachable granted tool = FAIL | e2e   | 🔨                                                                                  |
+| Authority/lifecycle tools covered by their own scenarios (not blind invocation)                                                                                        | —     | design rule                                                                         |
+| Browser tool against loopback page                                                                                                                                     | e2e   | 🔨 (image lacks Chrome — runs in local smoke until media-render ships provisioning) |
 
 ## 15. Multi-agent, delegation & elevated access (user, 2026-07-20)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| **Elevated access loop**: agent hits a denied operation → calls `request_access` (scoped target) → REAL approval path grants → durable grant persisted (revision) → retry succeeds → grant survives restart; denied variant stays denied | e2e (haiku) + integration chain | 🔨 |
-| **Subagent delegation**: turn delegates via `AgentDelegation` to the fixture target agent → delegated turn runs → result returns to the parent turn → both runs + linkage in evidence/audit | e2e (haiku) | 🔨 |
-| Delegated/async task lifecycle plumbing (create → run → complete → result surfaced; failure → clean terminal state) | integration | ✅ partial: ipc-agent-task-lifecycle units; 🔨 durable chain through repos |
-| **Async task**: agent starts async work → turn ends → task completes later → completion notification/result recorded (quiet-until-terminal rule respected) | e2e | 🔨 |
-| **Bash/RunCommand real execution**: agent runs a scoped command in the worker sandbox → output captured in turn → permission decision + audit recorded (beyond the sweep: asserts output round-trip) | e2e (haiku) | 🔨 |
-| **Agents-as-tools**: agent invokes another agent as a TOOL (not delegation) and consumes its structured result | e2e | 🔨 (verify feature state first — agents-as-tools lane; row activates when shipped) |
-| **Two agents, one conversation**: two installed agents with distinct triggers → message for A runs ONLY A; message for B runs ONLY B; no cross-talk; routes stay disambiguated (incident-regression adjacent) | integration (routing) + e2e-live (chat) | 🔨 / 🏷 |
-| Two agents: permission prompt from A answered → grants apply to A only (scope isolation across co-resident agents) | integration | 🔨 |
+| Scenario                                                                                                                                                                                                                                 | Layer                                   | Status                                                                             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Elevated access loop**: agent hits a denied operation → calls `request_access` (scoped target) → REAL approval path grants → durable grant persisted (revision) → retry succeeds → grant survives restart; denied variant stays denied | e2e (haiku) + integration chain         | 🔨                                                                                 |
+| **Subagent delegation**: turn delegates via `AgentDelegation` to the fixture target agent → delegated turn runs → result returns to the parent turn → both runs + linkage in evidence/audit                                              | e2e (haiku)                             | 🔨                                                                                 |
+| Delegated/async task lifecycle plumbing (create → run → complete → result surfaced; failure → clean terminal state)                                                                                                                      | integration                             | ✅ partial: ipc-agent-task-lifecycle units; 🔨 durable chain through repos         |
+| **Async task**: agent starts async work → turn ends → task completes later → completion notification/result recorded (quiet-until-terminal rule respected)                                                                               | e2e                                     | 🔨                                                                                 |
+| **Bash/RunCommand real execution**: agent runs a scoped command in the worker sandbox → output captured in turn → permission decision + audit recorded (beyond the sweep: asserts output round-trip)                                     | e2e (haiku)                             | 🔨                                                                                 |
+| **Agents-as-tools**: agent invokes another agent as a TOOL (not delegation) and consumes its structured result                                                                                                                           | e2e                                     | 🔨 (verify feature state first — agents-as-tools lane; row activates when shipped) |
+| **Two agents, one conversation**: two installed agents with distinct triggers → message for A runs ONLY A; message for B runs ONLY B; no cross-talk; routes stay disambiguated (incident-regression adjacent)                            | integration (routing) + e2e-live (chat) | 🔨 / 🏷                                                                            |
+| Two agents: permission prompt from A answered → grants apply to A only (scope isolation across co-resident agents)                                                                                                                       | integration                             | 🔨                                                                                 |
 
 ## 16. Security & recovery
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Skill+MCP selections survive restart; allow_once does NOT | e2e | 🔨 |
-| Logs + evidence credential-scrubbed (whole run grep) | e2e | 🔨 |
-| Fork PRs never see secrets (workflow config review) | CI review | 🔨 |
-| i-have-adhd zero references (scoped guard, fragment-built token) | unit | 🔨 |
+| Scenario                                                         | Layer     | Status |
+| ---------------------------------------------------------------- | --------- | ------ |
+| Skill+MCP selections survive restart; allow_once does NOT        | e2e       | 🔨     |
+| Logs + evidence credential-scrubbed (whole run grep)             | e2e       | 🔨     |
+| Fork PRs never see secrets (workflow config review)              | CI review | 🔨     |
+| i-have-adhd zero references (scoped guard, fragment-built token) | unit      | 🔨     |
 
 ## 17. Orphan suites (never ran in CI — adopt deliberately)
 
-| Suite | Status |
-|---|---|
-| live-waiting-admission.postgres.integration | 💤 excluded-by-name; adopt = delete one exclude line |
-| pattern-candidate-atomic-claim.postgres.integration | 💤 same |
-| proactive-surfacing-opt-in.postgres.integration | 💤 same |
-| toolchain-bake-reconciler.postgres.integration | 💤 same |
-| worker-coordination.postgres.integration | 💤 same (known flaky-under-load heartbeat test) |
+| Suite                                               | Status                                               |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| live-waiting-admission.postgres.integration         | 💤 excluded-by-name; adopt = delete one exclude line |
+| pattern-candidate-atomic-claim.postgres.integration | 💤 same                                              |
+| proactive-surfacing-opt-in.postgres.integration     | 💤 same                                              |
+| toolchain-bake-reconciler.postgres.integration      | 💤 same                                              |
+| worker-coordination.postgres.integration            | 💤 same (known flaky-under-load heartbeat test)      |
 
 ## Add new scenarios below
 
 | Feature | Scenario | Layer | Notes |
-|---|---|---|---|
-| | | | |
+| ------- | -------- | ----- | ----- |
+|         |          |       |       |

--- a/packages/sdk/src/generated/openapi.ts
+++ b/packages/sdk/src/generated/openapi.ts
@@ -2231,6 +2231,8 @@ export interface components {
         SessionEnsureRequest: {
             /** @description Optional API key app assertion. */
             appId?: string;
+            /** @description Optional agent id to bind the session to that agent workspace. */
+            agentId?: string;
             conversationId: string;
             title?: string;
             /** @enum {string} */


### PR DESCRIPTION
Product bug (found by E2E plan validation round 3): POST /v1/sessions/ensure accepted agentId in the contract but dropped it at the route, so every API-driven session ran a synthetic app-session folder without the onboarded agent's model/config/grants.

- ensureSession resolves + validates the agent (404 unknown/cross-app, 400 disabled) and binds the session to the agent's workspace folder; omitted agentId keeps the synthetic path unchanged.
- Graph upsert no longer clobbers human-assigned agent names.
- OpenAPI mirror gains the already-contracted property; SDK regenerated (+2 lines, minimal ponytail-collision surface).
- New integration test proves agent-bound ensure + message admission to the agent's queue (4/4), unit 15/15, full suite 6475/6475, autoreview clean.

Unblocks the E2E gate's agent-targeted haiku turns (Stage C).