### PR TITLE
Agent E2E Stage C: packaged-runtime harness + hermetic boot-restart scenario, CI-gated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           run_check npm run test:e2e:postgres
           run_check npm run test:integration:postgres
           run_check npm run test:integration:postgres:chaos
+          run_check npm run test:e2e:agent:hermetic
 
       - name: Debug CI Hang Context
         if: ${{ always() && steps.tests.outcome != 'success' }}

--- a/apps/core/test/agent-e2e/harness/api-client.ts
+++ b/apps/core/test/agent-e2e/harness/api-client.ts
@@ -1,0 +1,181 @@
+// Minimal typed Control API client for agent E2E runs. Plain fetch on purpose:
+// the hand SDK (packages/sdk) needs a build step and lacks agent/skill admin
+// wrappers (agent-e2e-plan-validation-round3.md §2), so the harness talks to
+// the same public HTTP surface any client would.
+
+export interface ApiResponse<T = unknown> {
+  status: number;
+  body: T;
+}
+
+export interface SessionEnsureResult {
+  sessionId: string;
+  appId: string;
+  conversationId: string;
+  chatJid: string;
+}
+
+export interface AcceptedMessage {
+  accepted: boolean;
+  messageId: string;
+  acceptedEventId: number;
+}
+
+export interface SessionEvent {
+  eventId: number;
+  eventType: string;
+  sessionId: string | null;
+  threadId: string | null;
+  correlationId: string | null;
+  createdAt: string;
+  payload: unknown;
+}
+
+/** Raw runtime event types that end a run (run-event-projection.ts). */
+export const TERMINAL_RUN_EVENT_TYPES = new Set([
+  'run.completed',
+  'run.failed',
+  'run.timeout',
+  'run.dead_lettered',
+  'run.canceled',
+]);
+
+export class AgentE2EApiClient {
+  constructor(
+    readonly baseUrl: string,
+    readonly apiKey: string,
+  ) {}
+
+  /** Generic escape hatch: any Control API request with bearer auth. */
+  async request<T = unknown>(
+    method: string,
+    requestPath: string,
+    options: {
+      body?: unknown;
+      /** Raw body (e.g. skill zip). Wins over `body`. */
+      rawBody?: Uint8Array;
+      contentType?: string;
+    } = {},
+  ): Promise<ApiResponse<T>> {
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${this.apiKey}`,
+    };
+    let body: string | Uint8Array | undefined;
+    if (options.rawBody !== undefined) {
+      headers['content-type'] = options.contentType ?? 'application/zip';
+      body = options.rawBody;
+    } else if (options.body !== undefined) {
+      headers['content-type'] = options.contentType ?? 'application/json';
+      body = JSON.stringify(options.body);
+    }
+    const res = await fetch(`${this.baseUrl}${requestPath}`, {
+      method,
+      headers,
+      body,
+    });
+    const text = await res.text();
+    let parsed: unknown = text;
+    try {
+      parsed = text ? JSON.parse(text) : undefined;
+    } catch {
+      // Non-JSON body (kept raw for the caller's assertion/message).
+    }
+    return { status: res.status, body: parsed as T };
+  }
+
+  private async expect<T>(
+    expectedStatus: number,
+    method: string,
+    requestPath: string,
+    options?: Parameters<AgentE2EApiClient['request']>[2],
+  ): Promise<T> {
+    const res = await this.request<T>(method, requestPath, options);
+    if (res.status !== expectedStatus) {
+      throw new Error(
+        `${method} ${requestPath} returned ${res.status} (expected ${expectedStatus}): ${JSON.stringify(res.body).slice(0, 500)}`,
+      );
+    }
+    return res.body;
+  }
+
+  async ensureSession(input: {
+    conversationId: string;
+    appId?: string;
+    title?: string;
+  }): Promise<SessionEnsureResult> {
+    return await this.expect<SessionEnsureResult>(
+      200,
+      'POST',
+      '/v1/sessions/ensure',
+      { body: input },
+    );
+  }
+
+  /** 202 = accepted, NOT completed — pair with waitForTerminalRunEvent. */
+  async postMessage(
+    sessionId: string,
+    message: string,
+    extra: Record<string, unknown> = {},
+  ): Promise<AcceptedMessage> {
+    return await this.expect<AcceptedMessage>(
+      202,
+      'POST',
+      `/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+      { body: { message, ...extra } },
+    );
+  }
+
+  async listEvents(
+    sessionId: string,
+    afterEventId = 0,
+  ): Promise<SessionEvent[]> {
+    const body = await this.expect<{ events: SessionEvent[] }>(
+      200,
+      'GET',
+      `/v1/sessions/${encodeURIComponent(sessionId)}/events?afterEventId=${afterEventId}`,
+    );
+    return body.events;
+  }
+
+  /**
+   * Poll events until a terminal run event appears (a 202 on the message POST
+   * is accepted-not-done). Returns every event observed plus the terminal one.
+   */
+  async waitForTerminalRunEvent(
+    sessionId: string,
+    options: { afterEventId?: number; timeoutMs?: number } = {},
+  ): Promise<{ terminal: SessionEvent; events: SessionEvent[] }> {
+    const timeoutMs = options.timeoutMs ?? 120_000;
+    const deadline = Date.now() + timeoutMs;
+    const events: SessionEvent[] = [];
+    let cursor = options.afterEventId ?? 0;
+    while (Date.now() < deadline) {
+      const page = await this.listEvents(sessionId, cursor);
+      for (const event of page) {
+        events.push(event);
+        cursor = Math.max(cursor, event.eventId);
+        if (TERMINAL_RUN_EVENT_TYPES.has(event.eventType)) {
+          return { terminal: event, events };
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    throw new Error(
+      `No terminal run event for session ${sessionId} within ${timeoutMs}ms ` +
+        `(saw: ${events.map((event) => event.eventType).join(', ') || 'none'})`,
+    );
+  }
+
+  /** POST /v1/skills/install (application/zip). Returns the created skill. */
+  async installSkillZip(
+    zip: Uint8Array,
+    options: { agentId?: string } = {},
+  ): Promise<unknown> {
+    const query = options.agentId
+      ? `?agentId=${encodeURIComponent(options.agentId)}`
+      : '';
+    return await this.expect(201, 'POST', `/v1/skills/install${query}`, {
+      rawBody: zip,
+    });
+  }
+}

--- a/apps/core/test/agent-e2e/harness/evidence.ts
+++ b/apps/core/test/agent-e2e/harness/evidence.ts
@@ -1,0 +1,98 @@
+// Evidence bundle assembly for agent E2E runs (AgentE2EEvidence in
+// ../types.ts). Uploaded as a CI artifact on success AND failure; everything
+// written is scrubbed against the run's generated secrets and any provided
+// credential before it reaches disk.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { AgentE2EEvidence } from '../types.js';
+import type { SessionEvent } from './api-client.js';
+
+export interface EvidenceRun {
+  evidence: AgentE2EEvidence;
+  /** Raw session/runtime event extracts written beside the evidence JSON. */
+  events: SessionEvent[];
+  /** Mark the start of a named phase; ended by the next mark or finish(). */
+  phase(name: string): void;
+  /** Close the current phase (if any). */
+  finishPhases(): void;
+  /**
+   * Write `<scenario>.evidence.json` (+ `<scenario>.events.json` when events
+   * were recorded) under dir, redacted. Returns the evidence file path.
+   */
+  write(dir: string): string;
+}
+
+export function startEvidenceRun(input: {
+  scenario: string;
+  secrets: string[];
+  imageDigest?: string;
+  modelAlias?: string;
+  modelRoute?: string;
+  provider?: string;
+  harness?: string;
+}): EvidenceRun {
+  const evidence: AgentE2EEvidence = {
+    scenario: input.scenario,
+    imageDigest: input.imageDigest ?? 'local-process',
+    modelAlias: input.modelAlias ?? 'none',
+    modelRoute: input.modelRoute ?? 'none',
+    provider: input.provider ?? 'none',
+    harness: input.harness ?? 'none',
+    selectedSkills: [],
+    mcpCalls: [],
+    capabilityDecisions: [],
+    auditIds: [],
+    timings: {},
+  };
+  const events: SessionEvent[] = [];
+  let openPhase: { name: string; startedAt: number } | undefined;
+
+  const closePhase = () => {
+    if (!openPhase) return;
+    evidence.timings[openPhase.name] = Date.now() - openPhase.startedAt;
+    openPhase = undefined;
+  };
+
+  return {
+    evidence,
+    events,
+    phase(name: string) {
+      closePhase();
+      openPhase = { name, startedAt: Date.now() };
+    },
+    finishPhases: closePhase,
+    write(dir: string): string {
+      closePhase();
+      fs.mkdirSync(dir, { recursive: true });
+      const evidencePath = path.join(dir, `${input.scenario}.evidence.json`);
+      fs.writeFileSync(
+        evidencePath,
+        redactText(JSON.stringify(evidence, null, 2), input.secrets),
+      );
+      if (events.length > 0) {
+        fs.writeFileSync(
+          path.join(dir, `${input.scenario}.events.json`),
+          redactText(JSON.stringify(events, null, 2), input.secrets),
+        );
+      }
+      return evidencePath;
+    },
+  };
+}
+
+/** Replace every occurrence of each secret with [REDACTED]. */
+export function redactText(text: string, secrets: string[]): string {
+  let redacted = text;
+  for (const secret of secrets) {
+    if (!secret) continue;
+    redacted = redacted.split(secret).join('[REDACTED]');
+    // Secrets can appear JSON-escaped inside stringified payloads.
+    const escaped = JSON.stringify(secret).slice(1, -1);
+    if (escaped !== secret) {
+      redacted = redacted.split(escaped).join('[REDACTED]');
+    }
+  }
+  return redacted;
+}

--- a/apps/core/test/agent-e2e/harness/runtime-harness.ts
+++ b/apps/core/test/agent-e2e/harness/runtime-harness.ts
@@ -1,0 +1,491 @@
+// Packaged-runtime harness for the agent E2E gate
+// (docs/architecture/agent-e2e-ci-merge-gate-goal-prompt.md, "Packaged-runtime
+// E2E proofs" + "Isolation guarantee"). Test-only; never imported by src.
+//
+// Boots the BUILT runtime (dist/ or the CI image) against a fresh per-run
+// GANTRY_HOME (mkdtemp) and a disposable per-run Postgres DATABASE created via
+// the admin connection in GANTRY_TEST_DATABASE_URL. All runtime secrets are
+// generated per run. The child env is constructed from scratch (never
+// inherited), so model-credential env vars are UNSET unless a scenario passes
+// them explicitly via `env` (env-hygiene discipline).
+//
+// Prerequisites:
+// - local-process mode: `npm run build:runtime` must have produced dist/
+//   (dist/index.js + dist/postgres-migrate.js — the same entries the launchd
+//   service / `npm start` uses).
+// - GANTRY_TEST_DATABASE_URL: admin/maintenance Postgres URL on a THROWAWAY
+//   server or database (CI service container / local scratch DB). The server
+//   must have the `vector` and `pg_trgm` extensions installed; the harness
+//   enables them in each per-run database.
+// - docker mode (AGENT_E2E_RUNTIME_MODE=docker): AGENT_E2E_RUNTIME_IMAGE names
+//   the CI-built image. Runs with --network host (Linux CI) so the container
+//   reaches the loopback DB and the control port needs no publish mapping; the
+//   image sets NODE_ENV=production, so the enforcing posture applies and the
+//   generated secrets satisfy the strong-secret gate.
+
+import { randomBytes } from 'node:crypto';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { Client } from 'pg';
+
+const execFileAsync = promisify(execFile);
+
+export type RuntimeHarnessMode = 'local-process' | 'docker';
+
+export interface RuntimeHarnessOptions {
+  /** Scopes carried by the run's generated control API key. */
+  scopes?: string[];
+  /** Selected via AGENT_E2E_RUNTIME_MODE by default; local-process otherwise. */
+  mode?: RuntimeHarnessMode;
+  /** docker mode: image ref/digest (default env AGENT_E2E_RUNTIME_IMAGE). */
+  image?: string;
+  /**
+   * Extra env for the runtime process/container. This is the ONLY way a model
+   * credential (or any other external secret) reaches the runtime.
+   */
+  env?: Record<string, string>;
+  readyTimeoutMs?: number;
+}
+
+export interface RuntimeHarness {
+  readonly mode: RuntimeHarnessMode;
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly home: string;
+  /** Per-run database URL the runtime uses (never the admin URL). */
+  readonly databaseUrl: string;
+  readonly databaseName: string;
+  /** Generated secrets (+ scenario-provided credential values) for redaction. */
+  readonly secrets: string[];
+  /** Runtime stdout/stderr captured so far (evidence on failure). */
+  logs(): string;
+  /** Stop + start preserving home/DB (restart-survival scenarios). */
+  restart(): Promise<void>;
+  /** Graceful stop with SIGKILL fallback. Idempotent. */
+  stop(): Promise<void>;
+  /**
+   * Stop, drop the per-run database, remove the home. With KEEP_EVIDENCE=1 and
+   * `failed: true`, the home and database are kept for inspection.
+   */
+  teardown(options?: { failed?: boolean }): Promise<void>;
+}
+
+/** The user's real workstation runtime home (launchd service target). */
+export function realRuntimeHome(): string {
+  return path.resolve(os.homedir(), 'gantry');
+}
+
+function databaseNameOf(databaseUrl: string): string {
+  const parsed = new URL(databaseUrl);
+  return decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+}
+
+/**
+ * HARD isolation guard (matrix §1 "isolation guard" scenario): the harness
+ * must never touch the live local runtime. Throws if the resolved home is the
+ * user's real runtime home, or if any involved database is the live `gantry`
+ * database.
+ */
+export function assertIsolatedRuntimeTarget(input: {
+  runtimeHome: string;
+  databaseUrl: string;
+}): void {
+  const resolvedHome = path.resolve(input.runtimeHome);
+  if (resolvedHome === realRuntimeHome()) {
+    throw new Error(
+      `Isolation guard: refusing to run against the live runtime home ${resolvedHome}. ` +
+        'The harness requires a fresh disposable GANTRY_HOME.',
+    );
+  }
+  let databaseName: string;
+  try {
+    databaseName = databaseNameOf(input.databaseUrl);
+  } catch (err) {
+    throw new Error(
+      `Isolation guard: database URL is not a valid URL: ${String(err)}`,
+    );
+  }
+  if (databaseName === 'gantry') {
+    throw new Error(
+      'Isolation guard: refusing to use the live `gantry` database. ' +
+        'Point GANTRY_TEST_DATABASE_URL at a throwaway server/database.',
+    );
+  }
+}
+
+function requireAdminDatabaseUrl(): string {
+  const url = process.env.GANTRY_TEST_DATABASE_URL?.trim();
+  if (!url) {
+    throw new Error(
+      'GANTRY_TEST_DATABASE_URL is required (admin URL of a throwaway Postgres).',
+    );
+  }
+  return url;
+}
+
+function perRunDatabaseUrl(adminUrl: string, databaseName: string): string {
+  const parsed = new URL(adminUrl);
+  parsed.pathname = `/${databaseName}`;
+  return parsed.toString();
+}
+
+async function pickFreePort(): Promise<number> {
+  // ponytail: listen(0)-then-close has a close-to-spawn race; per-run DBs and
+  // fresh homes make collisions rerunnable, so no retry loop until CI shows one.
+  return await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address === 'object' && address) {
+        const port = address.port;
+        server.close(() => resolve(port));
+      } else {
+        server.close(() => reject(new Error('No port assigned')));
+      }
+    });
+  });
+}
+
+async function withAdminClient<T>(
+  adminUrl: string,
+  fn: (client: Client) => Promise<T>,
+): Promise<T> {
+  const client = new Client({ connectionString: adminUrl });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+async function createRunDatabase(adminUrl: string): Promise<{
+  databaseName: string;
+  databaseUrl: string;
+}> {
+  const databaseName = `gantry_e2e_${Date.now().toString(36)}_${randomBytes(4).toString('hex')}`;
+  await withAdminClient(adminUrl, async (client) => {
+    await client.query(`CREATE DATABASE ${quoteIdent(databaseName)}`);
+  });
+  const databaseUrl = perRunDatabaseUrl(adminUrl, databaseName);
+  await withAdminClient(databaseUrl, async (client) => {
+    await client.query('CREATE EXTENSION IF NOT EXISTS vector');
+    await client.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+  });
+  return { databaseName, databaseUrl };
+}
+
+async function dropRunDatabase(
+  adminUrl: string,
+  databaseName: string,
+): Promise<void> {
+  await withAdminClient(adminUrl, async (client) => {
+    await client.query(
+      `DROP DATABASE IF EXISTS ${quoteIdent(databaseName)} WITH (FORCE)`,
+    );
+  });
+}
+
+async function waitForReady(input: {
+  baseUrl: string;
+  timeoutMs: number;
+  aborted?: () => string | undefined;
+}): Promise<void> {
+  const deadline = Date.now() + input.timeoutMs;
+  let lastDetail = '';
+  while (Date.now() < deadline) {
+    const abortReason = input.aborted?.();
+    if (abortReason) {
+      throw new Error(`Runtime exited before ready: ${abortReason}`);
+    }
+    try {
+      const res = await fetch(`${input.baseUrl}/readyz`);
+      const body = (await res.json()) as { status?: string };
+      if (res.status === 200 && body.status === 'ready') return;
+      lastDetail = `status=${res.status} body=${JSON.stringify(body)}`;
+    } catch (err) {
+      lastDetail = String(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(
+    `Runtime not ready within ${input.timeoutMs}ms (last: ${lastDetail})`,
+  );
+}
+
+const DEFAULT_SCOPES = ['sessions:read', 'sessions:write', 'agents:admin'];
+
+export async function startRuntimeHarness(
+  options: RuntimeHarnessOptions = {},
+): Promise<RuntimeHarness> {
+  const mode: RuntimeHarnessMode =
+    options.mode ??
+    (process.env.AGENT_E2E_RUNTIME_MODE === 'docker'
+      ? 'docker'
+      : 'local-process');
+  const adminUrl = requireAdminDatabaseUrl();
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'gantry-agent-e2e-'));
+
+  // Guard the admin URL before any connection, and the per-run URL after.
+  assertIsolatedRuntimeTarget({ runtimeHome: home, databaseUrl: adminUrl });
+  const { databaseName, databaseUrl } = await createRunDatabase(adminUrl);
+  assertIsolatedRuntimeTarget({ runtimeHome: home, databaseUrl });
+
+  const apiKey = randomBytes(32).toString('hex');
+  const secretEncryptionKey = randomBytes(32).toString('base64');
+  const ipcAuthSecret = randomBytes(32).toString('hex');
+  const port = await pickFreePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const controlKeysJson = JSON.stringify([
+    {
+      kid: 'agent-e2e',
+      token: apiKey,
+      appId: 'default',
+      scopes: options.scopes ?? DEFAULT_SCOPES,
+    },
+  ]);
+  const secrets = [
+    apiKey,
+    secretEncryptionKey,
+    ipcAuthSecret,
+    ...Object.values(options.env ?? {}),
+  ];
+
+  // Built from scratch — the harness process env NEVER leaks into the runtime.
+  const runtimeEnv: Record<string, string> = {
+    PATH: process.env.PATH ?? '/usr/bin:/bin',
+    HOME: home,
+    TZ: 'UTC',
+    LANG: 'C.UTF-8',
+    GANTRY_HOME: home,
+    GANTRY_DATABASE_URL: databaseUrl,
+    GANTRY_BOOTSTRAP_SETTINGS_IF_MISSING: '1',
+    GANTRY_CONTROL_HOST: '127.0.0.1',
+    GANTRY_CONTROL_PORT: String(port),
+    GANTRY_CONTROL_API_KEYS_JSON: controlKeysJson,
+    GANTRY_IPC_AUTH_SECRET: ipcAuthSecret,
+    SECRET_ENCRYPTION_KEY: secretEncryptionKey,
+    // NODE_ENV deliberately NOT set in local-process mode: the security
+    // posture stays local (the docker image pins NODE_ENV=production itself).
+    ...options.env,
+  };
+
+  const readyTimeoutMs =
+    options.readyTimeoutMs ?? (mode === 'docker' ? 180_000 : 90_000);
+  const logPath = path.join(home, 'runtime-harness.log');
+  const logs = () => {
+    try {
+      return fs.readFileSync(logPath, 'utf8');
+    } catch {
+      return '';
+    }
+  };
+
+  let stopped = false;
+  let child: ChildProcess | undefined;
+  let childExit: string | undefined;
+  const containerName = `gantry-agent-e2e-${randomBytes(4).toString('hex')}`;
+
+  const repoRoot = path.resolve(import.meta.dirname, '../../../../..');
+  const distEntry = path.join(repoRoot, 'dist', 'index.js');
+  const distMigrate = path.join(repoRoot, 'dist', 'postgres-migrate.js');
+
+  async function runLocalMigrations(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const migrate = spawn(process.execPath, [distMigrate], {
+        cwd: repoRoot,
+        env: runtimeEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const chunks: Buffer[] = [];
+      migrate.stdout.on('data', (chunk) => chunks.push(chunk));
+      migrate.stderr.on('data', (chunk) => chunks.push(chunk));
+      migrate.once('error', reject);
+      migrate.once('exit', (code) => {
+        if (code === 0) resolve();
+        else {
+          reject(
+            new Error(
+              `postgres-migrate exited with ${code}: ${Buffer.concat(chunks).toString('utf8').slice(-2000)}`,
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  function spawnLocalRuntime(): void {
+    childExit = undefined;
+    const logStream = fs.createWriteStream(logPath, { flags: 'a' });
+    const proc = spawn(process.execPath, [distEntry], {
+      cwd: repoRoot,
+      env: runtimeEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    proc.stdout.pipe(logStream);
+    proc.stderr.pipe(logStream);
+    proc.once('exit', (code, signal) => {
+      childExit = `code=${code} signal=${signal}`;
+    });
+    child = proc;
+  }
+
+  async function stopLocalRuntime(): Promise<void> {
+    const proc = child;
+    child = undefined;
+    if (!proc || proc.exitCode !== null || proc.signalCode !== null) return;
+    await new Promise<void>((resolve) => {
+      const killTimer = setTimeout(() => proc.kill('SIGKILL'), 10_000);
+      proc.once('exit', () => {
+        clearTimeout(killTimer);
+        resolve();
+      });
+      proc.kill('SIGTERM');
+    });
+  }
+
+  async function startDockerRuntime(): Promise<void> {
+    const image = options.image ?? process.env.AGENT_E2E_RUNTIME_IMAGE?.trim();
+    if (!image) {
+      throw new Error(
+        'docker mode requires an image ref (options.image or AGENT_E2E_RUNTIME_IMAGE)',
+      );
+    }
+    const args = [
+      'run',
+      '--detach',
+      '--name',
+      containerName,
+      // Linux CI: loopback DB + control port shared with the host directly.
+      '--network',
+      'host',
+      // bubblewrap needs user-namespace creation (enforcing sandbox posture).
+      '--security-opt',
+      'seccomp=unconfined',
+      '--volume',
+      `${home}:/var/lib/gantry`,
+    ];
+    for (const [key, value] of Object.entries({
+      ...runtimeEnv,
+      GANTRY_HOME: '/var/lib/gantry',
+      HOME: '/var/lib/gantry',
+    })) {
+      if (key === 'PATH') continue;
+      args.push('--env', `${key}=${value}`);
+    }
+    args.push(image);
+    await execFileAsync('docker', args);
+  }
+
+  async function dockerLogsToFile(): Promise<void> {
+    try {
+      const { stdout, stderr } = await execFileAsync('docker', [
+        'logs',
+        containerName,
+      ]);
+      fs.appendFileSync(logPath, stdout + stderr);
+    } catch {
+      // Container already gone; nothing to capture.
+    }
+  }
+
+  async function start(initial: boolean): Promise<void> {
+    if (mode === 'local-process') {
+      if (!fs.existsSync(distEntry)) {
+        throw new Error(
+          `Built runtime not found at ${distEntry}. Run \`npm run build:runtime\` first.`,
+        );
+      }
+      if (initial) await runLocalMigrations();
+      spawnLocalRuntime();
+    } else if (initial) {
+      // The image entrypoint runs migrations itself before dist/index.js.
+      await startDockerRuntime();
+    } else {
+      await execFileAsync('docker', ['restart', containerName]);
+    }
+    await waitForReady({
+      baseUrl,
+      timeoutMs: readyTimeoutMs,
+      aborted: mode === 'local-process' ? () => childExit : undefined,
+    });
+  }
+
+  async function stop(): Promise<void> {
+    if (stopped) return;
+    if (mode === 'local-process') {
+      await stopLocalRuntime();
+    } else {
+      await dockerLogsToFile();
+      await execFileAsync('docker', ['stop', '-t', '10', containerName]).catch(
+        () => undefined,
+      );
+    }
+  }
+
+  try {
+    await start(true);
+  } catch (err) {
+    await stop();
+    stopped = true;
+    if (mode === 'docker') {
+      await execFileAsync('docker', ['rm', '-f', containerName]).catch(
+        () => undefined,
+      );
+    }
+    const tail = logs().slice(-4000);
+    await dropRunDatabase(adminUrl, databaseName).catch(() => undefined);
+    fs.rmSync(home, { recursive: true, force: true });
+    throw new Error(`${String(err)}\n--- runtime log tail ---\n${tail}`);
+  }
+
+  return {
+    mode,
+    baseUrl,
+    apiKey,
+    home,
+    databaseUrl,
+    databaseName,
+    secrets,
+    logs,
+    async restart() {
+      if (mode === 'local-process') await stopLocalRuntime();
+      await start(false);
+    },
+    stop: async () => {
+      await stop();
+      stopped = true;
+    },
+    async teardown(teardownOptions?: { failed?: boolean }) {
+      await stop();
+      stopped = true;
+      const keep =
+        teardownOptions?.failed === true && process.env.KEEP_EVIDENCE === '1';
+      if (mode === 'docker') {
+        await execFileAsync('docker', ['rm', '-f', containerName]).catch(
+          () => undefined,
+        );
+      }
+      if (keep) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `KEEP_EVIDENCE=1: keeping home ${home} and database ${databaseName}`,
+        );
+        return;
+      }
+      await dropRunDatabase(adminUrl, databaseName);
+      fs.rmSync(home, { recursive: true, force: true });
+    },
+  };
+}

--- a/apps/core/test/agent-e2e/scenarios/boot-restart.agent-e2e.test.ts
+++ b/apps/core/test/agent-e2e/scenarios/boot-restart.agent-e2e.test.ts
@@ -1,0 +1,174 @@
+// Matrix §1 rows 1-2 (hermetic — NO model credential):
+// 1. The packaged runtime boots against a fresh home + disposable database,
+//    health goes green, migrations are applied (asserted via /readyz AND the
+//    drizzle migrations table in the per-run database).
+// 2. restart() preserves desired state: an agent created via the Control API
+//    (desired-state surface) before the restart is still projected after it.
+// Teardown is clean: the per-run database is dropped and the home removed.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { Client } from 'pg';
+
+import { AgentE2EApiClient } from '../harness/api-client.js';
+import { startEvidenceRun, type EvidenceRun } from '../harness/evidence.js';
+import {
+  startRuntimeHarness,
+  type RuntimeHarness,
+} from '../harness/runtime-harness.js';
+
+const hasDb = Boolean(process.env.GANTRY_TEST_DATABASE_URL?.trim());
+const maybeDescribe = hasDb ? describe : describe.skip;
+
+const BOOT_TIMEOUT_MS = 300_000;
+const AGENT_MARKER_NAME = 'agent-e2e-restart-marker';
+
+interface AgentResponse {
+  id: string;
+  name: string;
+  status: string;
+}
+
+maybeDescribe('agent-e2e boot + restart (packaged runtime, hermetic)', () => {
+  let harness: RuntimeHarness | undefined;
+  let api: AgentE2EApiClient;
+  let evidence: EvidenceRun | undefined;
+  let markerAgentId = '';
+  let sawFailure = false;
+
+  async function step<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      sawFailure = true;
+      throw err;
+    }
+  }
+
+  afterAll(async () => {
+    if (evidence && harness) {
+      if (sawFailure) {
+        evidence.evidence.redactedFailure = harness.logs().slice(-4000);
+      }
+      evidence.write(
+        process.env.AGENT_E2E_EVIDENCE_DIR ??
+          path.join(os.tmpdir(), 'gantry-agent-e2e-evidence'),
+      );
+    }
+    // Idempotent: the teardown-clean test already tore down on success.
+    await harness?.teardown({ failed: sawFailure });
+  });
+
+  it(
+    'boots healthy with migrations applied',
+    { timeout: BOOT_TIMEOUT_MS },
+    async () =>
+      step(async () => {
+        harness = await startRuntimeHarness({
+          scopes: ['sessions:read', 'sessions:write', 'agents:admin'],
+        });
+        api = new AgentE2EApiClient(harness.baseUrl, harness.apiKey);
+        evidence = startEvidenceRun({
+          scenario: 'boot-restart',
+          secrets: harness.secrets,
+        });
+        evidence.phase('verify-boot');
+
+        // Health green (readiness already gated startRuntimeHarness; assert
+        // the public contract explicitly).
+        const health = await fetch(`${harness.baseUrl}/healthz`);
+        expect(health.status).toBe(200);
+        const ready = await fetch(`${harness.baseUrl}/readyz`);
+        expect(ready.status).toBe(200);
+        const readyBody = (await ready.json()) as {
+          status: string;
+          checks: Record<string, string>;
+        };
+        expect(readyBody.status).toBe('ready');
+        expect(readyBody.checks.migrations).toBe('pass');
+        expect(readyBody.checks.database).toBe('pass');
+
+        // Migrations applied — asserted directly in the PER-RUN database.
+        const client = new Client({ connectionString: harness.databaseUrl });
+        await client.connect();
+        try {
+          const applied = await client.query(
+            'SELECT count(*)::int AS applied FROM "gantry"."__drizzle_migrations"',
+          );
+          expect(applied.rows[0].applied).toBeGreaterThan(0);
+        } finally {
+          await client.end();
+        }
+
+        // Bearer auth is live: the run's generated key works, garbage fails.
+        const authed = await api.request('GET', '/v1/agents');
+        expect(authed.status).toBe(200);
+        const unauthed = await fetch(`${harness.baseUrl}/v1/agents`);
+        expect(unauthed.status).toBe(401);
+      }),
+  );
+
+  it(
+    'restart preserves a desired-state marker created via the API',
+    { timeout: BOOT_TIMEOUT_MS },
+    async () =>
+      step(async () => {
+        if (!harness || !evidence) throw new Error('boot test did not run');
+        evidence.phase('create-marker');
+        const created = await api.request<AgentResponse>('POST', '/v1/agents', {
+          body: { appId: 'default', name: AGENT_MARKER_NAME },
+        });
+        expect(created.status).toBe(201);
+        expect(created.body.name).toBe(AGENT_MARKER_NAME);
+        markerAgentId = created.body.id;
+        expect(markerAgentId).toMatch(/^agent:/);
+
+        evidence.phase('restart');
+        await harness.restart();
+
+        evidence.phase('verify-post-restart');
+        const listed = await api.request<{ agents: AgentResponse[] }>(
+          'GET',
+          '/v1/agents',
+        );
+        expect(listed.status).toBe(200);
+        const marker = listed.body.agents.find(
+          (agent) => agent.id === markerAgentId,
+        );
+        expect(marker, 'marker agent projected post-restart').toBeDefined();
+        expect(marker?.name).toBe(AGENT_MARKER_NAME);
+        expect(marker?.status).toBe('active');
+      }),
+  );
+
+  it(
+    'teardown drops the database and removes the home',
+    { timeout: BOOT_TIMEOUT_MS },
+    async () =>
+      step(async () => {
+        if (!harness) throw new Error('boot test did not run');
+        const { home, databaseName } = harness;
+        evidence?.phase('teardown');
+        await harness.teardown();
+        evidence?.finishPhases();
+
+        expect(fs.existsSync(home)).toBe(false);
+        const admin = new Client({
+          connectionString: process.env.GANTRY_TEST_DATABASE_URL,
+        });
+        await admin.connect();
+        try {
+          const remaining = await admin.query(
+            'SELECT 1 FROM pg_database WHERE datname = $1',
+            [databaseName],
+          );
+          expect(remaining.rowCount).toBe(0);
+        } finally {
+          await admin.end();
+        }
+      }),
+  );
+});

--- a/apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts
+++ b/apps/core/test/integration/permission-durable-authority.postgres.integration.test.ts
@@ -1,8 +1,17 @@
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+
 import { eq } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createPostgresDomainRepositories } from '@core/adapters/storage/postgres/repositories/domain-repositories.postgres.js';
 import * as pgSchema from '@core/adapters/storage/postgres/schema/index.js';
+import { PostgresRuntimeRepositoryBundle } from '@core/adapters/storage/postgres/schema/canonical-ops-repo.postgres.js';
+import { PostgresRuntimeEventNotifier } from '@core/adapters/storage/postgres/runtime-event-notifier.postgres.js';
+import {
+  DEFAULT_AGENT_CONFIG_VERSION_ID,
+  DEFAULT_LLM_PROFILE_ID,
+} from '@core/adapters/storage/postgres/seeds.js';
 import { PostgresStorageService } from '@core/adapters/storage/postgres/storage-service.js';
 import { beginDurablePermissionInteraction } from '@core/application/interactions/durable-interaction-handler.js';
 import {
@@ -14,6 +23,16 @@ import {
 } from '@core/application/interactions/pending-interaction-durability.js';
 import { durablePermissionRequestSnapshot } from '@core/application/interactions/pending-interaction-permission-envelope.js';
 import { synthesizeHostPermissionSuggestions } from '@core/application/permissions/permission-suggestion-synthesis.js';
+import { RuntimeEventExchange } from '@core/application/runtime-events/runtime-event-exchange.js';
+import { GANTRY_HOME, RUNTIME_SETTINGS_PATH } from '@core/config/index.js';
+import { createAgentToolRuleSettingsMirror } from '@core/config/settings/agent-tool-rule-settings-mirror.js';
+import { SettingsDesiredStateService } from '@core/config/settings/desired-state-service.js';
+import {
+  capabilityToToolRule,
+  ensureConfiguredAgent,
+  loadRuntimeSettings,
+  saveRuntimeSettings,
+} from '@core/config/settings/runtime-settings.js';
 import type { PermissionApprovalDecisionMode } from '@core/domain/types.js';
 import type { PermissionApprovalRequest } from '@core/domain/types.js';
 import { evaluateAutonomousToolUse } from '@core/shared/tool-rule-matcher.js';
@@ -28,11 +47,14 @@ import {
 
 const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
 
-// Uses the seeded default app/agent (seeds.ts) — no agent tool bindings exist
-// at start, so the durable-rule assertions start from a clean policy.
+// Uses the seeded default app/agent (seeds.ts). A second configured agent
+// guards the (appId, agentId) scoping of durable rules: a regression to
+// app-wide binding lookups would leak AGENT_ID's rule to it.
 const APP_ID = 'default';
 const AGENT_ID = 'agent:main_agent';
 const AGENT_FOLDER = 'main_agent';
+const SECOND_AGENT_ID = 'agent:second_agent';
+const SECOND_AGENT_FOLDER = 'second_agent';
 const APPROVER = 'user:approver';
 
 // Matrix §6 durable-authority chain, driven through the REAL channel
@@ -40,48 +62,94 @@ const APPROVER = 'user:approver';
 // claim → resolveDurablePermissionInteractionByRequestId (the same functions
 // the Slack/Telegram callback handlers invoke; see
 // pending-interaction-permission-callback.ts). No decide-API is invented.
+//
+// Persistence uses the REAL production wiring (runtime-services.ts):
+// createAgentToolRuleSettingsMirror over the full repository bundle, so an
+// allow_persistent_rule decision writes desired-state settings + a settings
+// revision and reconciles it (agent-tool-rule-settings-mirror.ts →
+// restart-sync.ts → desired-state-capability-reconcile.ts) — no recorder
+// stubs. `desired_state.authoritative: true` means restart reconciliation
+// REPLACES agent capability bindings from settings.yaml, so the restart
+// assertions can only pass through the settings mirror: a binding that exists
+// only as a raw DB row is wiped by the reconcile in restartAndEvaluateGate.
+//
 // Note: PERMISSION_* runtime events are published by the IPC processor
 // (ipc-interaction-processing.ts), not by this decision-application path, so
 // the durable evidence asserted here is rows: pending_interactions status +
-// resolution, agent tool bindings, and permission_decisions.
+// resolution, agent tool bindings, settings.yaml capabilities, transient
+// grants, and permission_decisions.
 maybeDescribe('permission durable authority chain (Postgres)', () => {
   let runtime: PostgresIntegrationRuntime;
-  const mirroredRuleCalls: Array<{
-    sourceAgentFolder: string;
-    rules: string[];
-    mode?: 'add' | 'remove';
-  }> = [];
+  let originalSettingsYaml: string;
+  let originalEnv: Record<string, string | undefined>;
 
   beforeAll(async () => {
     runtime = await createPostgresIntegrationRuntime({
       schemaPrefix: 'perm_durable',
     });
+    // The REAL settings-import preflight (validateLoadedRuntimeSettings)
+    // requires runtime storage + credential-encryption env. Satisfy it with
+    // this run's own throwaway integration database — the runtime under test.
+    originalEnv = {
+      GANTRY_DATABASE_URL: process.env.GANTRY_DATABASE_URL,
+      SECRET_ENCRYPTION_KEY: process.env.SECRET_ENCRYPTION_KEY,
+    };
+    process.env.GANTRY_DATABASE_URL = process.env.GANTRY_TEST_DATABASE_URL;
+    process.env.SECRET_ENCRYPTION_KEY ??= randomBytes(32).toString('base64');
+    // Declare both agents in the runtime settings the way production setup
+    // flows do (ensureConfiguredAgent), with authoritative desired state.
+    originalSettingsYaml = fs.readFileSync(RUNTIME_SETTINGS_PATH, 'utf-8');
+    const settings = loadRuntimeSettings(GANTRY_HOME);
+    settings.desiredState.authoritative = true;
+    ensureConfiguredAgent(settings, {
+      agentId: AGENT_FOLDER,
+      agentName: 'Main Agent',
+      agentFolder: AGENT_FOLDER,
+    });
+    ensureConfiguredAgent(settings, {
+      agentId: SECOND_AGENT_FOLDER,
+      agentName: 'Second Agent',
+      agentFolder: SECOND_AGENT_FOLDER,
+    });
+    saveRuntimeSettings(GANTRY_HOME, settings);
+
     configurePendingInteractionDurability({
       repository: runtime.repositories.workerCoordination,
+      warn: (context, message) => {
+        console.error(message, context.err ?? context);
+      },
     });
     configurePendingInteractionPermissionPersistence({
       opsRepository: runtime.ops,
       getToolRepository: () => runtime.repositories.tools,
       getPermissionRepository: () => runtime.repositories.permissions,
-      mirrorAgentToolRulesToSettings: (sourceAgentFolder, rules, options) => {
-        mirroredRuleCalls.push({
-          sourceAgentFolder,
-          rules: [...rules],
-          ...(options?.mode ? { mode: options.mode } : {}),
-        });
-      },
+      // REAL settings mirror (same factory + arguments as runtime-services.ts),
+      // including the settings-revision append via the full repository bundle.
+      mirrorAgentToolRulesToSettings: createAgentToolRuleSettingsMirror({
+        opsRepository: runtime.ops,
+        repositories: runtime.repositories,
+        reloadRuntimeState: async () => {},
+      }),
     });
   }, 60_000);
 
   afterAll(async () => {
     configurePendingInteractionDurability(null);
     configurePendingInteractionPermissionPersistence(null);
+    if (originalSettingsYaml !== undefined) {
+      fs.writeFileSync(RUNTIME_SETTINGS_PATH, originalSettingsYaml, 'utf-8');
+    }
+    for (const [key, value] of Object.entries(originalEnv ?? {})) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     if (runtime) await runtime.cleanup();
   });
 
   function makeRequest(
     requestId: string,
     command: string,
+    run?: { runId: string; leaseToken: string; fencingVersion: number },
   ): PermissionApprovalRequest {
     return {
       requestId,
@@ -94,6 +162,13 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       // Same argv-leaf suggestion synthesis the host applies on the IPC path
       // (ipc-interaction-processing.ts sets request.suggestions from it).
       suggestions: synthesizeHostPermissionSuggestions('Bash', { command }),
+      ...(run
+        ? {
+            runId: run.runId,
+            runLeaseToken: run.leaseToken,
+            runLeaseFencingVersion: run.fencingVersion,
+          }
+        : {}),
     };
   }
 
@@ -146,13 +221,22 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
   }
 
   /**
-   * Restart simulation: brand-new service + repository instances over the SAME
-   * schema (no in-memory state carried over), then the same deterministic
+   * Restart simulation over the SAME schema with brand-new service +
+   * repository instances (no in-memory state carried over), running the REAL
+   * startup path: settings desired-state reconciliation exactly as
+   * runStartup does for a 'file' settings authority (startup.ts →
+   * SettingsDesiredStateService.reconcile →
+   * desired-state-capability-reconcile.ts replaceDesiredStateCapabilities),
+   * then the callback receives fresh repositories for the same deterministic
    * policy evaluation the autonomous gate runs
    * (tool-execution-policy-service.ts → evaluateAutonomousToolUse over
    * resolveConfiguredAllowedTools).
    */
-  async function evaluateGateWithFreshServices(command: string) {
+  async function withRestartedServices<T>(
+    fn: (
+      repositories: PostgresIntegrationRuntime['repositories'],
+    ) => Promise<T>,
+  ): Promise<T> {
     const fresh = new PostgresStorageService(
       process.env.GANTRY_TEST_DATABASE_URL!,
       runtime.schemaName,
@@ -162,53 +246,98 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
         fresh.db,
         fresh.pool,
       );
+      const ops = new PostgresRuntimeRepositoryBundle(fresh.pool, fresh.db, {
+        runtimeEvents: new RuntimeEventExchange(
+          repositories.runtimeEvents,
+          new PostgresRuntimeEventNotifier(fresh.pool),
+        ),
+      });
+      const settings = loadRuntimeSettings(GANTRY_HOME);
+      const reconcile = await new SettingsDesiredStateService({
+        ops,
+        repositories,
+      }).reconcile(settings);
+      expect(reconcile.invalidReferences).toEqual([]);
+      return await fn(repositories);
+    } finally {
+      await fresh.close();
+    }
+  }
+
+  async function restartAndEvaluateGate(command: string, agentId = AGENT_ID) {
+    return withRestartedServices(async (repositories) => {
       const rules = await resolveConfiguredAllowedTools({
         repository: repositories.tools,
         appId: APP_ID,
-        agentId: AGENT_ID,
+        agentId,
       });
       return evaluateAutonomousToolUse({
         rules: rules ?? [],
         toolName: 'Bash',
         toolInput: { command },
       });
-    } finally {
-      await fresh.close();
-    }
+    });
   }
 
-  it('allow_persistent_rule persists an argv-leaf RunCommand rule that auto-allows the same leaf and survives restart', async () => {
+  async function activeBindingsWithTools(agentId = AGENT_ID) {
+    const bindings = await runtime.repositories.tools.listAgentToolBindings({
+      appId: APP_ID as never,
+      agentId: agentId as never,
+    });
+    return Promise.all(
+      bindings
+        .filter((binding) => binding.status === 'active')
+        .map(async (binding) => ({
+          binding,
+          tool: await runtime.repositories.tools.getTool(binding.toolId),
+        })),
+    );
+  }
+
+  function settingsAgentRules(agentFolder: string): string[] {
+    const agent = loadRuntimeSettings(GANTRY_HOME).agents[agentFolder];
+    expect(agent).toBeDefined();
+    return agent!.capabilities.map((capability) =>
+      capabilityToToolRule(capability.id),
+    );
+  }
+
+  it('allow_persistent_rule persists the exact argv-leaf rule via the settings mirror, auto-allows only that leaf for only that agent, and survives restart reconciliation', async () => {
     const command = '/usr/local/bin/report-status --daily';
     const request = makeRequest('req-perm-durable-future', command);
     const [expectedRule] = permissionUpdateAllowedToolRules(
       request.suggestions,
     );
-    expect(expectedRule).toMatch(/^RunCommand\(/);
+    // The EXACT rule derived from the input command: a regression that widens
+    // it (e.g. `RunCommand(/usr/local/bin/report-status *)`) fails here.
+    expect(expectedRule).toBe(`RunCommand(${command})`);
 
-    // Precondition: nothing allows this command before the decision.
-    const before = await evaluateGateWithFreshServices(command);
-    expect(before.allowed).toBe(false);
+    // Precondition: nothing allows this command before the decision, even
+    // after a full restart reconciliation.
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+    const activeToolIdsBefore = new Set(
+      (await activeBindingsWithTools()).map(({ binding }) => binding.toolId),
+    );
 
     await decideViaChannelCallback(request, 'allow_persistent_rule');
 
     // Durable rule persisted as an agent-scoped tool binding (CURRENT
-    // semantics: binding identity is app+agent, not conversation).
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
-    });
-    const activeBindings = bindings.filter(
-      (binding) => binding.status === 'active',
+    // semantics: binding identity is app+agent, not conversation). Exactly
+    // one ACTIVE binding references the expected rule and it is new relative
+    // to the pre-decision set — independent of whatever else is seeded.
+    const boundTools = await activeBindingsWithTools();
+    const ruleBindings = boundTools.filter(
+      ({ tool }) => tool?.name === expectedRule,
     );
-    expect(activeBindings).toHaveLength(1);
-    const tool = await runtime.repositories.tools.getTool(
-      activeBindings[0]!.toolId,
+    expect(ruleBindings).toHaveLength(1);
+    expect(activeToolIdsBefore.has(ruleBindings[0]!.binding.toolId)).toBe(
+      false,
     );
-    expect(tool?.name).toBe(expectedRule);
-    expect(mirroredRuleCalls).toContainEqual({
-      sourceAgentFolder: AGENT_FOLDER,
-      rules: [expectedRule],
-    });
+
+    // The REAL settings mirror wrote desired state: the rule is now a
+    // capability of the deciding agent in settings.yaml — and only of it.
+    expect(settingsAgentRules(AGENT_FOLDER)).toContain(expectedRule);
+    expect(settingsAgentRules(SECOND_AGENT_FOLDER)).not.toContain(expectedRule);
 
     // Fresh policy evaluation of the SAME command leaf auto-allows — the
     // deterministic gate matches the persisted rule, so no new prompt is
@@ -226,13 +355,37 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
     });
     expect(evaluation.allowed).toBe(true);
 
-    // A DIFFERENT command leaf is still not allowed (argv-leaf scope, not a
-    // command-name class).
+    // Argv-leaf scope: the SAME executable with different arguments is still
+    // not allowed (the rule is not an executable-wide grant)...
+    expect(
+      evaluateAutonomousToolUse({
+        rules: rules ?? [],
+        toolName: 'Bash',
+        toolInput: { command: '/usr/local/bin/report-status --monthly' },
+      }).allowed,
+    ).toBe(false);
+    // ...and neither is a different executable.
     expect(
       evaluateAutonomousToolUse({
         rules: rules ?? [],
         toolName: 'Bash',
         toolInput: { command: '/usr/local/bin/other-tool --daily' },
+      }).allowed,
+    ).toBe(false);
+
+    // Agent scope: the second configured agent does NOT see the rule
+    // (guards the (appId, agentId) filter in tool-repository.postgres.ts).
+    const secondAgentRules = await resolveConfiguredAllowedTools({
+      repository: runtime.repositories.tools,
+      appId: APP_ID,
+      agentId: SECOND_AGENT_ID,
+    });
+    expect(secondAgentRules ?? []).not.toContain(expectedRule);
+    expect(
+      evaluateAutonomousToolUse({
+        rules: secondAgentRules ?? [],
+        toolName: 'Bash',
+        toolInput: { command },
       }).allowed,
     ).toBe(false);
 
@@ -267,16 +420,59 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       classification: 'user_permanent',
     });
 
-    // Restart simulation: new service + repository instances, same database —
-    // the rule is still effective.
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(true);
-  });
+    // Restart: the REAL startup reconciliation replaces every agent's
+    // bindings from authoritative settings.yaml, so this stays allowed ONLY
+    // because the settings mirror durably wrote the rule (a DB-only binding
+    // would have been wiped by the reconcile). The second agent still gets
+    // nothing.
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(true);
+    expect(
+      (await restartAndEvaluateGate(command, SECOND_AGENT_ID)).allowed,
+    ).toBe(false);
+  }, 60_000);
 
-  it('allow_once resolves the interaction without persisting any durable rule', async () => {
+  it('allow_once grants run-scoped transient authority under the active lease only, with no durable rule and nothing after restart', async () => {
     const command = '/usr/local/bin/send-digest --weekly';
-    const request = makeRequest('req-perm-durable-once', command);
+    const runId = 'run-perm-durable-once';
+    const workerId = 'worker-perm-durable-once';
 
+    // Real run + claimed lease: the once-grant path
+    // (pending-interaction-grants.ts applyPendingInteractionGrantDecision →
+    // recordRunScopedTransientGrant) only issues authority against the
+    // ACTIVE run lease.
+    const now = new Date().toISOString();
+    await runtime.service.db
+      .insert(pgSchema.agentRunsPostgres)
+      .values({
+        id: runId,
+        appId: APP_ID,
+        agentId: AGENT_ID,
+        configVersionId: DEFAULT_AGENT_CONFIG_VERSION_ID,
+        llmProfileId: DEFAULT_LLM_PROFILE_ID,
+        executionProviderId: 'test:integration',
+        cause: 'integration',
+        status: 'running',
+        permissionDecisionIdsJson: '[]',
+        createdAt: now,
+        startedAt: now,
+      })
+      .onConflictDoNothing();
+    await runtime.repositories.workerCoordination.registerWorker({
+      id: workerId,
+      bootNonce: 'perm-durable-once',
+    });
+    const lease = await runtime.repositories.workerCoordination.claimRunLease({
+      runId,
+      workerInstanceId: workerId,
+      ttlMs: 60_000,
+    });
+    expect(lease).not.toBeNull();
+
+    const request = makeRequest('req-perm-durable-once', command, {
+      runId,
+      leaseToken: lease!.leaseToken,
+      fencingVersion: lease!.fencingVersion,
+    });
     await decideViaChannelCallback(request, 'allow_once');
 
     const row = await interactionRow(request.requestId);
@@ -286,32 +482,65 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       mode: 'allow_once',
     });
 
-    // No durable rule for this command leaf: only the allow_persistent_rule
-    // binding from the previous case may exist.
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
+    // The once-authority is real and usable: a transient grant recorded
+    // against the active lease, readable through the same lease-fenced read
+    // model the runtime uses.
+    const grants =
+      await runtime.repositories.workerCoordination.listActiveTransientGrants({
+        runId,
+      });
+    expect(grants).toHaveLength(1);
+    expect(grants[0]!.leaseToken).toBe(lease!.leaseToken);
+    expect(grants[0]!.grant).toMatchObject({
+      toolName: 'Bash',
+      mode: 'allow_once',
+      requestId: request.requestId,
     });
-    const tools = await Promise.all(
-      bindings
-        .filter((binding) => binding.status === 'active')
-        .map((binding) => runtime.repositories.tools.getTool(binding.toolId)),
-    );
-    expect(tools.some((tool) => tool?.name?.includes('send-digest'))).toBe(
-      false,
-    );
 
-    // No run-scoped transient grant either (no runId on this request).
-    const grants = await runtime.service.db
-      .select()
-      .from(pgSchema.transientGrantsPostgres);
-    expect(grants).toHaveLength(0);
+    // Once-only: no durable rule for this command leaf — not as an agent
+    // tool binding, not in mirrored settings, and the deterministic gate
+    // does not auto-allow it even while the transient grant is live.
+    const boundTools = await activeBindingsWithTools();
+    expect(
+      boundTools.some(({ tool }) => tool?.name?.includes('send-digest')),
+    ).toBe(false);
+    expect(
+      settingsAgentRules(AGENT_FOLDER).some((rule) =>
+        rule.includes('send-digest'),
+      ),
+    ).toBe(false);
+    const liveRules = await resolveConfiguredAllowedTools({
+      repository: runtime.repositories.tools,
+      appId: APP_ID,
+      agentId: AGENT_ID,
+    });
+    expect(
+      evaluateAutonomousToolUse({
+        rules: liveRules ?? [],
+        toolName: 'Bash',
+        toolInput: { command },
+      }).allowed,
+    ).toBe(false);
 
-    // Restart simulation: transient authority is gone — a fresh policy
-    // evaluation of the same command does NOT auto-allow.
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(false);
-  });
+    // The run ends (lease settles, as on worker shutdown/restart): the
+    // transient grant is no longer readable from fresh service instances and
+    // the durable gate still denies — once-authority did not outlive the run.
+    await expect(
+      runtime.repositories.workerCoordination.settleRunLease({
+        runId,
+        leaseToken: lease!.leaseToken,
+        workerInstanceId: workerId,
+        fencingVersion: lease!.fencingVersion,
+        outcome: 'completed',
+      }),
+    ).resolves.toBe(true);
+    await withRestartedServices(async (repositories) => {
+      await expect(
+        repositories.workerCoordination.listActiveTransientGrants({ runId }),
+      ).resolves.toEqual([]);
+    });
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+  }, 60_000);
 
   it('cancel records the interaction as cancelled and persists no rule', async () => {
     const command = '/usr/local/bin/rotate-keys --now';
@@ -326,19 +555,15 @@ maybeDescribe('permission durable authority chain (Postgres)', () => {
       mode: 'cancel',
     });
 
-    const bindings = await runtime.repositories.tools.listAgentToolBindings({
-      appId: APP_ID as never,
-      agentId: AGENT_ID as never,
-    });
-    const tools = await Promise.all(
-      bindings
-        .filter((binding) => binding.status === 'active')
-        .map((binding) => runtime.repositories.tools.getTool(binding.toolId)),
-    );
-    expect(tools.some((tool) => tool?.name?.includes('rotate-keys'))).toBe(
-      false,
-    );
-    const afterRestart = await evaluateGateWithFreshServices(command);
-    expect(afterRestart.allowed).toBe(false);
-  });
+    const boundTools = await activeBindingsWithTools();
+    expect(
+      boundTools.some(({ tool }) => tool?.name?.includes('rotate-keys')),
+    ).toBe(false);
+    expect(
+      settingsAgentRules(AGENT_FOLDER).some((rule) =>
+        rule.includes('rotate-keys'),
+      ),
+    ).toBe(false);
+    expect((await restartAndEvaluateGate(command)).allowed).toBe(false);
+  }, 60_000);
 });

--- a/apps/core/test/unit/agent-e2e/runtime-harness-guard.test.ts
+++ b/apps/core/test/unit/agent-e2e/runtime-harness-guard.test.ts
@@ -1,0 +1,68 @@
+// Matrix §1 "Harness refuses to run against ~/gantry or live DB (isolation
+// guard)". The guard is a pure function so the refusal contract is provable
+// without booting anything.
+
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertIsolatedRuntimeTarget,
+  realRuntimeHome,
+} from '../../agent-e2e/harness/runtime-harness.js';
+
+const SAFE_DB_URL = 'postgres://user:pass@127.0.0.1:5432/gantry_e2e_abc123';
+const SAFE_HOME = path.join(os.tmpdir(), 'gantry-agent-e2e-guard-test');
+
+describe('agent-e2e runtime harness isolation guard', () => {
+  it('accepts a disposable home + per-run database', () => {
+    expect(() =>
+      assertIsolatedRuntimeTarget({
+        runtimeHome: SAFE_HOME,
+        databaseUrl: SAFE_DB_URL,
+      }),
+    ).not.toThrow();
+  });
+
+  it('refuses the real runtime home', () => {
+    expect(() =>
+      assertIsolatedRuntimeTarget({
+        runtimeHome: realRuntimeHome(),
+        databaseUrl: SAFE_DB_URL,
+      }),
+    ).toThrow(/live runtime home/);
+  });
+
+  it('refuses the real runtime home via an unnormalized path', () => {
+    expect(() =>
+      assertIsolatedRuntimeTarget({
+        runtimeHome: path.join(os.homedir(), 'gantry', '..', 'gantry'),
+        databaseUrl: SAFE_DB_URL,
+      }),
+    ).toThrow(/live runtime home/);
+  });
+
+  it('refuses the live `gantry` database on any host', () => {
+    for (const url of [
+      'postgres://user:pass@127.0.0.1:5432/gantry',
+      'postgresql://user:pass@db.internal:5432/gantry?sslmode=require',
+    ]) {
+      expect(() =>
+        assertIsolatedRuntimeTarget({
+          runtimeHome: SAFE_HOME,
+          databaseUrl: url,
+        }),
+      ).toThrow(/live `gantry` database/);
+    }
+  });
+
+  it('refuses an unparseable database URL', () => {
+    expect(() =>
+      assertIsolatedRuntimeTarget({
+        runtimeHome: SAFE_HOME,
+        databaseUrl: 'not a url',
+      }),
+    ).toThrow(/not a valid URL/);
+  });
+});

--- a/docs/architecture/agent-e2e-test-matrix.md
+++ b/docs/architecture/agent-e2e-test-matrix.md
@@ -36,189 +36,189 @@ Legend: ✅ covered (cite) · 🔨 to build · 🏷 label-gated (live lane) · �
 
 ## 1. Runtime & boot
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Image starts, migrations current, healthy | e2e | 🔨 |
-| Restart preserves desired state (settings revision projection) | e2e | 🔨 |
-| Security posture: prod image requires enforcing sandbox + non-prod secrets | integration | ✅ security-posture.test.ts |
-| Harness refuses to run against ~/gantry or live DB (isolation guard) | e2e (harness self-test) | 🔨 |
-| **Upgrade survivor** (adopted from OpenClaw): boot version N-1 state (settings revisions + DB) under version N image → migrations apply → agents/bindings/grants survive | e2e | 🔨 (post-ponytail-cutover — baseline resets first) |
-| Startup benchmark lane (boot time / first-turn latency budgets) | perf | 💤 deferred until the gate is stable |
+| Scenario                                                                                                                                                                 | Layer                   | Status                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | -------------------------------------------------- |
+| Image starts, migrations current, healthy                                                                                                                                | e2e                     | 🔨                                                 |
+| Restart preserves desired state (settings revision projection)                                                                                                           | e2e                     | 🔨                                                 |
+| Security posture: prod image requires enforcing sandbox + non-prod secrets                                                                                               | integration             | ✅ security-posture.test.ts                        |
+| Harness refuses to run against ~/gantry or live DB (isolation guard)                                                                                                     | e2e (harness self-test) | 🔨                                                 |
+| **Upgrade survivor** (adopted from OpenClaw): boot version N-1 state (settings revisions + DB) under version N image → migrations apply → agents/bindings/grants survive | e2e                     | 🔨 (post-ponytail-cutover — baseline resets first) |
+| Startup benchmark lane (boot time / first-turn latency budgets)                                                                                                          | perf                    | 💤 deferred until the gate is stable               |
 
 ## 2. Onboarding & model selection (API-driven)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Create agent + conversation binding via desired-state API; revision appended; survives restart | e2e | 🔨 |
-| Select `haiku` alias; turn evidence routes to selected model/provider/harness | e2e | 🔨 |
-| API contract: status codes + response shapes on onboarding endpoints | e2e (same pass) | 🔨 |
-| Scope enforcement: sessions-only key → 403 on admin endpoint | integration | 🔨 |
-| `sessions/ensure` honors `agentId` (bug fix first) | integration + e2e | 🔨 blocked on ponytail landing |
+| Scenario                                                                                       | Layer             | Status                         |
+| ---------------------------------------------------------------------------------------------- | ----------------- | ------------------------------ |
+| Create agent + conversation binding via desired-state API; revision appended; survives restart | e2e               | 🔨                             |
+| Select `haiku` alias; turn evidence routes to selected model/provider/harness                  | e2e               | 🔨                             |
+| API contract: status codes + response shapes on onboarding endpoints                           | e2e (same pass)   | 🔨                             |
+| Scope enforcement: sessions-only key → 403 on admin endpoint                                   | integration       | 🔨                             |
+| `sessions/ensure` honors `agentId` (bug fix first)                                             | integration + e2e | 🔨 blocked on ponytail landing |
 
 ## 3. Agent turn (haiku, behavioral)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| ensure → message (202 ≠ done) → events → visible completion | e2e | 🔨 |
-| Evidence bundle complete (ids, alias/route, timings, audit ids, redacted failure) | e2e | 🔨 |
-| Inline-lane turn (LLM API path) completes once | e2e | 🔨 |
-| Turn-failure surfaces cleanly (bad model alias → clean terminal state, no zombie) | e2e | 🔨 |
+| Scenario                                                                          | Layer | Status |
+| --------------------------------------------------------------------------------- | ----- | ------ |
+| ensure → message (202 ≠ done) → events → visible completion                       | e2e   | 🔨     |
+| Evidence bundle complete (ids, alias/route, timings, audit ids, redacted failure) | e2e   | 🔨     |
+| Inline-lane turn (LLM API path) completes once                                    | e2e   | 🔨     |
+| Turn-failure surfaces cleanly (bad model alias → clean terminal state, no zombie) | e2e   | 🔨     |
 
 ## 4. Skills
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Install vendored `internal-comms` zip via `/v1/skills/install`; catalog + binding identity | e2e | 🔨 |
-| Selection survives restart; assets materialize incl. `examples/3p-updates.md` (progressive disclosure) | e2e | 🔨 |
-| Turn produces 3P STRUCTURE (Progress/Plans/Problems sections exist — structure, not wording) | e2e | 🔨 |
-| `gantry-admin` reserved name rejected by install API | integration | 🔨 |
-| `admin_permission_list` callable, returns expected shape | e2e | 🔨 |
-| **Agent-driven skill acquisition**: turn asks the agent to get itself a skill → `request_skill_install` → REAL approval path → installed+selected → follow-up turn USES it (materialized assets asserted) | e2e (haiku, Stage C) | 🔨 |
-| Skill install/registry logic | integration | ✅ skills-registry-flow.integration.test.ts |
+| Scenario                                                                                                                                                                                                  | Layer                | Status                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------- |
+| Install vendored `internal-comms` zip via `/v1/skills/install`; catalog + binding identity                                                                                                                | e2e                  | 🔨                                          |
+| Selection survives restart; assets materialize incl. `examples/3p-updates.md` (progressive disclosure)                                                                                                    | e2e                  | 🔨                                          |
+| Turn produces 3P STRUCTURE (Progress/Plans/Problems sections exist — structure, not wording)                                                                                                              | e2e                  | 🔨                                          |
+| `gantry-admin` reserved name rejected by install API                                                                                                                                                      | integration          | 🔨                                          |
+| `admin_permission_list` callable, returns expected shape                                                                                                                                                  | e2e                  | 🔨                                          |
+| **Agent-driven skill acquisition**: turn asks the agent to get itself a skill → `request_skill_install` → REAL approval path → installed+selected → follow-up turn USES it (materialized assets asserted) | e2e (haiku, Stage C) | 🔨                                          |
+| Skill install/registry logic                                                                                                                                                                              | integration          | ✅ skills-registry-flow.integration.test.ts |
 
 ## 5. MCP
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Register HTTP server via SDK; approve ONLY echo+get-sum | e2e | 🔨 |
-| Discovery + schema; denied tools invisible to the agent | e2e | ✅ mcp-client-loop.postgres.e2e.test.ts |
-| Turn calls `get-sum(20,22)`; fixture records call; tool result 42; MCP audit event | e2e | ✅ client path (non-model: fixture records exact args, result 42, MCP audit + runtime event) mcp-client-loop.postgres.e2e.test.ts · 🔨 real-turn |
-| stdio transport | integration | ✅ ipc-mcp-stdio.test.ts |
-| MCP server management lifecycle | integration | ✅ mcp-server-management.integration.test.ts + mcp-server.postgres.integration.test.ts |
-| Deep-MCP: every capability class of vendored everything-server (tools, resources, prompts, sampling, progress, logging, completions) — unsupported class = product bug or documented non-support | e2e-live | 🏷 |
-| **Agent-driven MCP acquisition**: turn asks the agent to get itself the fixture MCP server → agent calls `request_mcp_server` → REAL approval path decides → server registered+bound → follow-up turn agent CALLS its tool (fixture records it) | e2e (haiku, Stage C) | 🔨 |
-| Agent-driven acquisition via CHAT (Slack): same loop driven by a channel message + button approval | e2e-live | 🏷 |
+| Scenario                                                                                                                                                                                                                                        | Layer                | Status                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Register HTTP server via SDK; approve ONLY echo+get-sum                                                                                                                                                                                         | e2e                  | 🔨                                                                                                                                               |
+| Discovery + schema; denied tools invisible to the agent                                                                                                                                                                                         | e2e                  | ✅ mcp-client-loop.postgres.e2e.test.ts                                                                                                          |
+| Turn calls `get-sum(20,22)`; fixture records call; tool result 42; MCP audit event                                                                                                                                                              | e2e                  | ✅ client path (non-model: fixture records exact args, result 42, MCP audit + runtime event) mcp-client-loop.postgres.e2e.test.ts · 🔨 real-turn |
+| stdio transport                                                                                                                                                                                                                                 | integration          | ✅ ipc-mcp-stdio.test.ts                                                                                                                         |
+| MCP server management lifecycle                                                                                                                                                                                                                 | integration          | ✅ mcp-server-management.integration.test.ts + mcp-server.postgres.integration.test.ts                                                           |
+| Deep-MCP: every capability class of vendored everything-server (tools, resources, prompts, sampling, progress, logging, completions) — unsupported class = product bug or documented non-support                                                | e2e-live             | 🏷                                                                                                                                               |
+| **Agent-driven MCP acquisition**: turn asks the agent to get itself the fixture MCP server → agent calls `request_mcp_server` → REAL approval path decides → server registered+bound → follow-up turn agent CALLS its tool (fixture records it) | e2e (haiku, Stage C) | 🔨                                                                                                                                               |
+| Agent-driven acquisition via CHAT (Slack): same loop driven by a channel message + button approval                                                                                                                                              | e2e-live             | 🏷                                                                                                                                               |
 
 ## 6. Permissions (granular)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| `ask`: eligible tool → human prompt, nothing auto-decided | integration | ✅ permission-classifier tests |
-| `auto`: read-only gate as evidence → classifier allow → auto_classifier allow_once | integration | ✅ permission-classifier.test.ts:539-612 |
-| `auto_strict`: unproven-safety asks WITHOUT classifier; proven still consults strict classifier | integration | ✅ permission-classifier.test.ts:614-667 |
-| Classifier unavailable/failure → fail-safe ask | integration | ✅ unit |
-| YOLO denylist hit → ask + event; unattended converts to denial | integration | ✅ classifier.test.ts:868-941 (attended); 🔨 unattended-context chain |
-| Locked agent: forged authority IPC denied at parent | integration | ✅ ipc-locked-permission-denial.test.ts |
-| Eligibility: only Bash/RunCommand + non-gantry MCP reach classifier | integration | ✅ unit |
-| Full chain: real IPC boundary → durable interaction → decision → event repo | integration | 🔨 (the one genuinely new chain) |
-| Allow ONCE: runs, then authority expires after restart | integration + e2e recovery scenario | ✅ integration permission-durable-authority.postgres.integration.test.ts · 🔨 e2e recovery |
-| Allow FUTURE: argv-leaf rule persists, auto-allows next same-leaf command, survives restart, agent-scoped (current semantics) | integration | ✅ permission-durable-authority.postgres.integration.test.ts |
-| Record-before-prompt ordering | integration | 🔨 |
-| Cancel: run interrupts cleanly, no partial effect, audit `cancelled` | integration | ✅ decision chain (cancelled record, no rule persisted) permission-durable-authority.postgres.integration.test.ts · 🔨 run-interrupt |
-| Deny: recorded, no execution | integration | 🔨 |
-| NO chat receipt on allow-future (regression, #239) | integration | 🔨 |
-| Real decision paths only — via classifier / in-process button-resolution callback / real Slack button (never a decide-API) | (constraint on all above) | — |
-| Whole-chain credential-absence in events/logs | integration | 🔨 |
+| Scenario                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Layer                               | Status                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ask`: eligible tool → human prompt, nothing auto-decided                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | integration                         | ✅ permission-classifier tests                                                                                                                                                                 |
+| `auto`: read-only gate as evidence → classifier allow → auto_classifier allow_once                                                                                                                                                                                                                                                                                                                                                                                                                                                     | integration                         | ✅ permission-classifier.test.ts:539-612                                                                                                                                                       |
+| `auto_strict`: unproven-safety asks WITHOUT classifier; proven still consults strict classifier                                                                                                                                                                                                                                                                                                                                                                                                                                        | integration                         | ✅ permission-classifier.test.ts:614-667                                                                                                                                                       |
+| Classifier unavailable/failure → fail-safe ask                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | integration                         | ✅ unit                                                                                                                                                                                        |
+| YOLO denylist hit → ask + event; unattended converts to denial                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | integration                         | ✅ classifier.test.ts:868-941 (attended); 🔨 unattended-context chain                                                                                                                          |
+| Locked agent: forged authority IPC denied at parent                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | integration                         | ✅ ipc-locked-permission-denial.test.ts                                                                                                                                                        |
+| Eligibility: only Bash/RunCommand + non-gantry MCP reach classifier                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | integration                         | ✅ unit                                                                                                                                                                                        |
+| Full chain: real IPC boundary → durable interaction → decision → event repo                                                                                                                                                                                                                                                                                                                                                                                                                                                            | integration                         | 🔨 (the one genuinely new chain)                                                                                                                                                               |
+| Allow ONCE: run-scoped transient grant issued under the REAL claimed run lease (channel-callback decision → `applyPendingInteractionGrantDecision` → `recordRunScopedTransientGrant`), readable via the lease-fenced read model; no durable binding, no settings mirror write, durable gate denies even while the grant is live; unreadable after the lease settles + fresh services                                                                                                                                                   | integration + e2e recovery scenario | ✅ integration permission-durable-authority.postgres.integration.test.ts (grant issuance/expiry; does NOT prove the live tool-call resume — that is the IPC processor's job) · 🔨 e2e recovery |
+| Allow FUTURE: EXACT argv-leaf rule (asserted string equality against the input command) persisted through the REAL settings mirror (`createAgentToolRuleSettingsMirror` → settings.yaml + settings revision + desired-state reconcile); auto-allows the same leaf, denies same-executable-different-args and other executables; survives restart via REAL startup reconciliation over authoritative settings (DB-only bindings are wiped, so survival proves the mirror); agent-scoped — a second configured agent never sees the rule | integration                         | ✅ permission-durable-authority.postgres.integration.test.ts                                                                                                                                   |
+| Record-before-prompt ordering                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | integration                         | 🔨                                                                                                                                                                                             |
+| Cancel: run interrupts cleanly, no partial effect, audit `cancelled`                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | integration                         | ✅ decision chain (cancelled record, no rule persisted) permission-durable-authority.postgres.integration.test.ts · 🔨 run-interrupt                                                           |
+| Deny: recorded, no execution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | integration                         | 🔨                                                                                                                                                                                             |
+| NO chat receipt on allow-future (regression, #239)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | integration                         | 🔨                                                                                                                                                                                             |
+| Real decision paths only — via classifier / in-process button-resolution callback / real Slack button (never a decide-API)                                                                                                                                                                                                                                                                                                                                                                                                             | (constraint on all above)           | —                                                                                                                                                                                              |
+| Whole-chain credential-absence in events/logs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | integration                         | 🔨                                                                                                                                                                                             |
 
 ## 7. Capabilities
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection | integration | ✅ configured-agent-tools.test.ts |
-| local_cli pinning (path/version/hash/templates); unrelated command denied | integration | ✅ semantic-capabilities.test.ts |
-| Persisted selected binding → projection → real admission | integration | 🔨 |
-| Real-image preflight pass AND fail-closed | e2e | 🔨 |
-| Secret lifecycle store→retrieve→rotate→audit (all four in one test) | integration | 🔨 |
-| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak | integration | ✅ capability-secret units; 🔨 through-sandbox chain |
-| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair |
-| Real gog/Sheets tier (throwaway sheet) | e2e-live | 🏷 |
+| Scenario                                                                                          | Layer       | Status                                               |
+| ------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection              | integration | ✅ configured-agent-tools.test.ts                    |
+| local_cli pinning (path/version/hash/templates); unrelated command denied                         | integration | ✅ semantic-capabilities.test.ts                     |
+| Persisted selected binding → projection → real admission                                          | integration | 🔨                                                   |
+| Real-image preflight pass AND fail-closed                                                         | e2e         | 🔨                                                   |
+| Secret lifecycle store→retrieve→rotate→audit (all four in one test)                               | integration | 🔨                                                   |
+| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak                 | integration | ✅ capability-secret units; 🔨 through-sandbox chain |
+| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair  |
+| Real gog/Sheets tier (throwaway sheet)                                                            | e2e-live    | 🏷                                                   |
 
 ## 8. Memories
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Write → recall → subject-boundary isolation (person/group/channel) | integration | ✅ memory-write-recall-boundary.postgres.integration.test.ts (subject-scoped fetch recall; embedding recall stays hermetically disabled) |
-| Turn 1 states fact → durable memory row collected; turn 2 → memory READ occurred | e2e | 🔨 |
-| Memory survives restart, still recallable | e2e | 🔨 |
-| Job-run memory collection persists | e2e (job scenario) | 🔨 |
+| Scenario                                                                         | Layer              | Status                                                                                                                                   |
+| -------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Write → recall → subject-boundary isolation (person/group/channel)               | integration        | ✅ memory-write-recall-boundary.postgres.integration.test.ts (subject-scoped fetch recall; embedding recall stays hermetically disabled) |
+| Turn 1 states fact → durable memory row collected; turn 2 → memory READ occurred | e2e                | 🔨                                                                                                                                       |
+| Memory survives restart, still recallable                                        | e2e                | 🔨                                                                                                                                       |
+| Job-run memory collection persists                                               | e2e (job scenario) | 🔨                                                                                                                                       |
 
 ## 9. Jobs
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Create via API → trigger → run completes → delivery → health `completed` (API twin of agent-job-smoke.sh) | e2e | 🔨 |
-| Pause → resume → trigger transitions + events | e2e | 🔨 |
-| Forced failure exhausts retries → dead-letter + clean terminal event | e2e | 🔨 |
-| Autonomous tool dead-end: ungranted tool surfaces cleanly (regression) | integration | 🔨 |
-| MCP-readiness race: slow init must NOT hard-fail (regression, fix on main) | integration (unit exists) + e2e real-turn | ✅ mcp-server-validation.test.ts · 🔨 e2e |
-| Local live smoke against the real runtime | manual/script | ✅ scripts/agent-job-smoke.sh |
+| Scenario                                                                                                  | Layer                                     | Status                                    |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------------------------- |
+| Create via API → trigger → run completes → delivery → health `completed` (API twin of agent-job-smoke.sh) | e2e                                       | 🔨                                        |
+| Pause → resume → trigger transitions + events                                                             | e2e                                       | 🔨                                        |
+| Forced failure exhausts retries → dead-letter + clean terminal event                                      | e2e                                       | 🔨                                        |
+| Autonomous tool dead-end: ungranted tool surfaces cleanly (regression)                                    | integration                               | 🔨                                        |
+| MCP-readiness race: slow init must NOT hard-fail (regression, fix on main)                                | integration (unit exists) + e2e real-turn | ✅ mcp-server-validation.test.ts · 🔨 e2e |
+| Local live smoke against the real runtime                                                                 | manual/script                             | ✅ scripts/agent-job-smoke.sh             |
 
 ## 10. Attachments & delivery
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Turn sends the deterministic attachment → workspace-direct delivery record, hash matches | e2e | 🔨 |
-| Oversize handling (>25MB refused cleanly) | integration | 🔨 |
-| Webhook fires with expected payload shape (loopback receiver) | e2e | 🔨 |
+| Scenario                                                                                 | Layer       | Status |
+| ---------------------------------------------------------------------------------------- | ----------- | ------ |
+| Turn sends the deterministic attachment → workspace-direct delivery record, hash matches | e2e         | 🔨     |
+| Oversize handling (>25MB refused cleanly)                                                | integration | 🔨     |
+| Webhook fires with expected payload shape (loopback receiver)                            | e2e         | 🔨     |
 
 ## 11. Route integrity (incident regressions)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Loader collapses mixed legacy key forms to ONE route (total preference order) | unit/integration | 🔨 in route-fix lane |
+| Scenario                                                                           | Layer            | Status               |
+| ---------------------------------------------------------------------------------- | ---------------- | -------------------- |
+| Loader collapses mixed legacy key forms to ONE route (total preference order)      | unit/integration | 🔨 in route-fix lane |
 | Divergent conversationId rows load via derive+warn, never throw, never drop a chat | unit/integration | 🔨 in route-fix lane |
-| Corrupt-state seed via direct test-DB rows (documented API exception) | integration | 🔨 |
+| Corrupt-state seed via direct test-DB rows (documented API exception)              | integration      | 🔨                   |
 
 ## 12. Channel loop (Slack, dedicated test app)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Real user-pattern message → agent turn → outbound reply in channel | e2e-live | 🏷 |
+| Scenario                                                                                      | Layer    | Status                                                                   |
+| --------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------ |
+| Real user-pattern message → agent turn → outbound reply in channel                            | e2e-live | 🏷                                                                       |
 | Permission block renders (header/context structure); approve callback → tool proceeds + audit | e2e-live | 🏷 (needs real-user or signed-callback fixture — constraint per round-3) |
-| Attachment delivered in channel | e2e-live | 🏷 |
+| Attachment delivered in channel                                                               | e2e-live | 🏷                                                                       |
 
 ## 13. Model matrix & policy gate
 
-| Scenario | Layer | Status |
-|---|---|---|
-| `haiku` + anthropic_sdk turn (required gate) | e2e | 🔨 |
-| `gpt-mini` + deepagents turn | e2e-live | 🏷 |
-| Catalog base/head diff adds changed aliases to live matrix | CI policy job | 🔨 |
-| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨 |
-| `agent-e2e-gate` aggregates + branch protection verified | CI | 🔨 |
+| Scenario                                                                                 | Layer         | Status |
+| ---------------------------------------------------------------------------------------- | ------------- | ------ |
+| `haiku` + anthropic_sdk turn (required gate)                                             | e2e           | 🔨     |
+| `gpt-mini` + deepagents turn                                                             | e2e-live      | 🏷     |
+| Catalog base/head diff adds changed aliases to live matrix                               | CI policy job | 🔨     |
+| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨     |
+| `agent-e2e-gate` aggregates + branch protection verified                                 | CI            | 🔨     |
 
 ## 14. All-tools sweep
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Enumerate effective tool set (internal inspector); every read-only + fixture-backed tool invoked once; call + effect + audit asserted; unreachable granted tool = FAIL | e2e | 🔨 |
-| Authority/lifecycle tools covered by their own scenarios (not blind invocation) | — | design rule |
-| Browser tool against loopback page | e2e | 🔨 (image lacks Chrome — runs in local smoke until media-render ships provisioning) |
+| Scenario                                                                                                                                                               | Layer | Status                                                                              |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------- |
+| Enumerate effective tool set (internal inspector); every read-only + fixture-backed tool invoked once; call + effect + audit asserted; unreachable granted tool = FAIL | e2e   | 🔨                                                                                  |
+| Authority/lifecycle tools covered by their own scenarios (not blind invocation)                                                                                        | —     | design rule                                                                         |
+| Browser tool against loopback page                                                                                                                                     | e2e   | 🔨 (image lacks Chrome — runs in local smoke until media-render ships provisioning) |
 
 ## 15. Multi-agent, delegation & elevated access (user, 2026-07-20)
 
-| Scenario | Layer | Status |
-|---|---|---|
-| **Elevated access loop**: agent hits a denied operation → calls `request_access` (scoped target) → REAL approval path grants → durable grant persisted (revision) → retry succeeds → grant survives restart; denied variant stays denied | e2e (haiku) + integration chain | 🔨 |
-| **Subagent delegation**: turn delegates via `AgentDelegation` to the fixture target agent → delegated turn runs → result returns to the parent turn → both runs + linkage in evidence/audit | e2e (haiku) | 🔨 |
-| Delegated/async task lifecycle plumbing (create → run → complete → result surfaced; failure → clean terminal state) | integration | ✅ partial: ipc-agent-task-lifecycle units; 🔨 durable chain through repos |
-| **Async task**: agent starts async work → turn ends → task completes later → completion notification/result recorded (quiet-until-terminal rule respected) | e2e | 🔨 |
-| **Bash/RunCommand real execution**: agent runs a scoped command in the worker sandbox → output captured in turn → permission decision + audit recorded (beyond the sweep: asserts output round-trip) | e2e (haiku) | 🔨 |
-| **Agents-as-tools**: agent invokes another agent as a TOOL (not delegation) and consumes its structured result | e2e | 🔨 (verify feature state first — agents-as-tools lane; row activates when shipped) |
-| **Two agents, one conversation**: two installed agents with distinct triggers → message for A runs ONLY A; message for B runs ONLY B; no cross-talk; routes stay disambiguated (incident-regression adjacent) | integration (routing) + e2e-live (chat) | 🔨 / 🏷 |
-| Two agents: permission prompt from A answered → grants apply to A only (scope isolation across co-resident agents) | integration | 🔨 |
+| Scenario                                                                                                                                                                                                                                 | Layer                                   | Status                                                                             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Elevated access loop**: agent hits a denied operation → calls `request_access` (scoped target) → REAL approval path grants → durable grant persisted (revision) → retry succeeds → grant survives restart; denied variant stays denied | e2e (haiku) + integration chain         | 🔨                                                                                 |
+| **Subagent delegation**: turn delegates via `AgentDelegation` to the fixture target agent → delegated turn runs → result returns to the parent turn → both runs + linkage in evidence/audit                                              | e2e (haiku)                             | 🔨                                                                                 |
+| Delegated/async task lifecycle plumbing (create → run → complete → result surfaced; failure → clean terminal state)                                                                                                                      | integration                             | ✅ partial: ipc-agent-task-lifecycle units; 🔨 durable chain through repos         |
+| **Async task**: agent starts async work → turn ends → task completes later → completion notification/result recorded (quiet-until-terminal rule respected)                                                                               | e2e                                     | 🔨                                                                                 |
+| **Bash/RunCommand real execution**: agent runs a scoped command in the worker sandbox → output captured in turn → permission decision + audit recorded (beyond the sweep: asserts output round-trip)                                     | e2e (haiku)                             | 🔨                                                                                 |
+| **Agents-as-tools**: agent invokes another agent as a TOOL (not delegation) and consumes its structured result                                                                                                                           | e2e                                     | 🔨 (verify feature state first — agents-as-tools lane; row activates when shipped) |
+| **Two agents, one conversation**: two installed agents with distinct triggers → message for A runs ONLY A; message for B runs ONLY B; no cross-talk; routes stay disambiguated (incident-regression adjacent)                            | integration (routing) + e2e-live (chat) | 🔨 / 🏷                                                                            |
+| Two agents: permission prompt from A answered → grants apply to A only (scope isolation across co-resident agents)                                                                                                                       | integration                             | 🔨                                                                                 |
 
 ## 16. Security & recovery
 
-| Scenario | Layer | Status |
-|---|---|---|
-| Skill+MCP selections survive restart; allow_once does NOT | e2e | 🔨 |
-| Logs + evidence credential-scrubbed (whole run grep) | e2e | 🔨 |
-| Fork PRs never see secrets (workflow config review) | CI review | 🔨 |
-| i-have-adhd zero references (scoped guard, fragment-built token) | unit | 🔨 |
+| Scenario                                                         | Layer     | Status |
+| ---------------------------------------------------------------- | --------- | ------ |
+| Skill+MCP selections survive restart; allow_once does NOT        | e2e       | 🔨     |
+| Logs + evidence credential-scrubbed (whole run grep)             | e2e       | 🔨     |
+| Fork PRs never see secrets (workflow config review)              | CI review | 🔨     |
+| i-have-adhd zero references (scoped guard, fragment-built token) | unit      | 🔨     |
 
 ## 17. Orphan suites (never ran in CI — adopt deliberately)
 
-| Suite | Status |
-|---|---|
-| live-waiting-admission.postgres.integration | 💤 excluded-by-name; adopt = delete one exclude line |
-| pattern-candidate-atomic-claim.postgres.integration | 💤 same |
-| proactive-surfacing-opt-in.postgres.integration | 💤 same |
-| toolchain-bake-reconciler.postgres.integration | 💤 same |
-| worker-coordination.postgres.integration | 💤 same (known flaky-under-load heartbeat test) |
+| Suite                                               | Status                                               |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| live-waiting-admission.postgres.integration         | 💤 excluded-by-name; adopt = delete one exclude line |
+| pattern-candidate-atomic-claim.postgres.integration | 💤 same                                              |
+| proactive-surfacing-opt-in.postgres.integration     | 💤 same                                              |
+| toolchain-bake-reconciler.postgres.integration      | 💤 same                                              |
+| worker-coordination.postgres.integration            | 💤 same (known flaky-under-load heartbeat test)      |
 
 ## Add new scenarios below
 
 | Feature | Scenario | Layer | Notes |
-|---|---|---|---|
-| | | | |
+| ------- | -------- | ----- | ----- |
+|         |          |       |       |

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test:integration:postgres:hot-path": "node .codex/scripts/require-postgres-integration-env.mjs && npm run build:contracts && GANTRY_POSTGRES_HOT_PATH=1 vitest run -c vitest.integration.postgres.hot-path.config.ts",
     "test:e2e": "npm run build:contracts && vitest run -c vitest.e2e.config.ts",
     "test:e2e:postgres": "node .codex/scripts/require-postgres-integration-env.mjs && npm run build:contracts && vitest run -c vitest.e2e.postgres.config.ts",
+    "test:e2e:agent:hermetic": "node .codex/scripts/require-postgres-integration-env.mjs && npm run build:contracts && vitest run -c vitest.agent-e2e.config.ts",
     "test:watch": "npm run build:contracts && vitest -c vitest.config.ts"
   },
   "dependencies": {

--- a/vitest.agent-e2e.config.ts
+++ b/vitest.agent-e2e.config.ts
@@ -1,0 +1,9 @@
+import { makeVitestConfig } from './vitest.shared.js';
+
+// Packaged-runtime agent E2E gate scenarios (hermetic lane). Serial: every
+// scenario boots the built runtime against its own disposable database.
+// Requires GANTRY_TEST_DATABASE_URL (throwaway admin URL) + a built dist/.
+export default makeVitestConfig({
+  include: ['apps/core/test/agent-e2e/scenarios/**/*.agent-e2e.test.ts'],
+  fileParallelism: false,
+});


### PR DESCRIPTION
The packaged-runtime harness (matrix §1): fresh GANTRY_HOME per run with refuse-to-run isolation guards (never ~/gantry, never the live DB), disposable per-run database (vector+pg_trgm), generated per-run secrets with env hygiene (TZ=UTC, model creds unset), dual mode (local-process from dist / docker CI image), bounded readiness, restart(), evidence bundles with secret redaction.

First hermetic scenario: boot -> healthz/readyz + migrations asserted -> create agent via API -> restart -> agent still projected -> teardown clean (3/3 locally, ~6s). Isolation-guard unit tests 5/5. New lane test:e2e:agent:hermetic wired into CI.

No model credential needed for this scenario; the haiku-turn scenario builds on this harness next (agentId targeting landed in #241).