### PR TITLE
Agent output style + prompt context: fix Communication truncation, Output Style block, model identity, runtime context

### DIFF
--- a/apps/core/src/application/agents/prompt-profile-service.ts
+++ b/apps/core/src/application/agents/prompt-profile-service.ts
@@ -34,11 +34,11 @@ const AGENT_INSTRUCTIONS_SOURCE = 'gantry://agent-instructions';
 export const DEFAULT_PROMPT_SECTION_BUDGETS: Readonly<
   Record<PromptSectionName, number>
 > = {
-  RUNTIME_RULES: 1200,
+  RUNTIME_RULES: 2200,
   PERSONA: 1200,
   SOUL: 3000,
   CAPABILITY_GUIDANCE: 1500,
-  OPERATING_GUIDANCE: 8500,
+  OPERATING_GUIDANCE: 12000,
   AGENT_INSTRUCTIONS: 5000,
 };
 
@@ -222,9 +222,21 @@ const OPERATING_GUIDANCE_COMMUNICATION = [
   '- Skip filler and avoid pretending certainty.',
   '- Match the active channel formatting conventions.',
   '- Keep short answers short unless the user asks for detail.',
+  '',
+  '## Output Style',
+  '- Lead with the answer or outcome in the first sentence; supporting context follows.',
+  '- Do not narrate execution ("Let me run...", "Now I\'ll check...", step-by-step commentary). Speak in outcomes, answers, and necessary questions. The single short acknowledgement before non-trivial live work is the only exception.',
+  '- No preambles ("Great question", "Sure!"), no closers ("Let me know if..."), no pleasantry filler.',
+  '- Never use dashes as punctuation: no " - ", em dashes, or en dashes as clause separators. Hyphens appear only inside compound words.',
+  '- Keep sentences short. Use numbered or bulleted structure when the answer has multiple items.',
+  '- Reply in the language the user writes in.',
+  '- Be concise by default and complete when the user asks for depth; never trade accuracy for brevity.',
 ];
 
-const OPERATING_GUIDANCE_BLOCK = [
+// Exported for the budget-guard unit test: the raw block must always fit the
+// OPERATING_GUIDANCE section budget or the compiler silently truncates the
+// tail (which once dropped the entire Communication section).
+export const OPERATING_GUIDANCE_BLOCK = [
   ...OPERATING_GUIDANCE_HEAD,
   ...FULL_TOOL_ACCESS_GUIDANCE,
   '',
@@ -235,11 +247,29 @@ const OPERATING_GUIDANCE_BLOCK = [
 
 // Proactive recommendations are omitted for locked agents: every suggestion in
 // that block routes through request/approval machinery the agent must not know.
-const LOCKED_OPERATING_GUIDANCE_BLOCK = [
+export const LOCKED_OPERATING_GUIDANCE_BLOCK = [
   ...OPERATING_GUIDANCE_HEAD,
   ...LOCKED_TOOL_ACCESS_GUIDANCE,
   ...OPERATING_GUIDANCE_COMMUNICATION,
 ].join('\n');
+
+export interface PromptModelIdentity {
+  alias: string;
+  modelId: string;
+  provider: string;
+}
+
+// Stable-per-run facts injected into the compiled profile. Everything here
+// rides the static (cached) side of the runner prompt split, so values MUST
+// NOT vary turn-to-turn within one session; per-turn facts (time, speaker)
+// belong to the dynamic tail or the message payload instead.
+export interface PromptRuntimeContext {
+  chatJid?: string;
+  conversationKind?: 'dm' | 'channel';
+  workspacePath?: string;
+  // Present only for scheduled job runs.
+  job?: { id?: string; name?: string };
+}
 
 export interface CompilePromptProfileOptions {
   agentFolder: string;
@@ -249,6 +279,10 @@ export interface CompilePromptProfileOptions {
   // Resolved agent access preset (config/profiles). Locked agents receive the
   // locked instruction projection; absent defaults to full (today's prompt).
   accessPreset?: PromptAccessPreset;
+  // Resolved model identity for this run; rendered as a plain "You are running
+  // on ..." runtime rule. Changes only when model config changes (cache-safe).
+  modelIdentity?: PromptModelIdentity;
+  runtimeContext?: PromptRuntimeContext;
 }
 
 export interface ProfileMirrorInput {
@@ -299,6 +333,71 @@ function truncateDeterministically(content: string, budget: number): string {
   if (budget <= 0) return '';
   if (content.length <= budget) return content;
   return content.slice(0, budget).trimEnd();
+}
+
+// ponytail: jid prefixes and per-channel caps mirror the channel adapters
+// (tg: TELEGRAM_MESSAGE_MAX_LENGTH 4096, sl: SLACK_FALLBACK_CHUNK_MAX_LENGTH
+// 4000, dc: DISCORD_MESSAGE_MAX_LENGTH 2000, 25MB =
+// MAX_MESSAGE_FILE_ATTACHMENT_BYTES); not imported so the prompt compiler
+// stays free of channel-adapter dependencies.
+function channelContextLine(
+  chatJid: string | undefined,
+  conversationKind: 'dm' | 'channel' | undefined,
+): string | undefined {
+  if (!chatJid) return undefined;
+  const kind =
+    conversationKind === 'dm'
+      ? 'direct message'
+      : conversationKind === 'channel'
+        ? 'group conversation'
+        : 'conversation';
+  const attachments = 'outbound workspace file attachments are capped at 25MB';
+  if (chatJid.startsWith('tg:'))
+    return `- Channel: Telegram ${kind}. Telegram renders a limited HTML subset; hard message length cap 4096 characters; ${attachments}.`;
+  if (chatJid.startsWith('sl:'))
+    return `- Channel: Slack ${kind}. Slack renders mrkdwn; keep single messages under 4000 characters; ${attachments}.`;
+  if (chatJid.startsWith('dc:'))
+    return `- Channel: Discord ${kind}. Discord renders markdown; hard message length cap 2000 characters; ${attachments}.`;
+  if (chatJid.startsWith('teams:'))
+    return `- Channel: Microsoft Teams ${kind}. Teams renders basic HTML; ${attachments}.`;
+  if (chatJid.startsWith('app:'))
+    return `- Channel: embedded app ${kind}. Markdown renders natively; no hard message length cap; ${attachments}.`;
+  return `- Channel: ${kind}; ${attachments}.`;
+}
+
+function runtimeContextLines(options: CompilePromptProfileOptions): string[] {
+  const lines: string[] = [];
+  if (options.modelIdentity) {
+    const { alias, modelId, provider } = options.modelIdentity;
+    lines.push(
+      `- You are running on ${alias} (${modelId}) via ${provider}. State this plainly if the user asks which model you are; deeper runtime internals stay internal.`,
+    );
+  }
+  const context = options.runtimeContext;
+  if (!context) return lines;
+  const channel = channelContextLine(context.chatJid, context.conversationKind);
+  if (channel) lines.push(channel);
+  if (context.workspacePath) {
+    lines.push(
+      `- Workspace root: ${context.workspacePath}. Durable outputs belong under media/ inside the workspace; tmp paths are ephemeral and may not survive between runs.`,
+    );
+  }
+  if (context.job) {
+    const label =
+      context.job.name && context.job.id
+        ? `"${context.job.name}" (${context.job.id})`
+        : context.job.name
+          ? `"${context.job.name}"`
+          : (context.job.id ?? 'this scheduled job');
+    lines.push(
+      `- This run executes scheduled job ${label}. Job runs are quiet until terminal: deliver one final outcome report; do not send interim progress messages.`,
+    );
+  } else {
+    lines.push(
+      '- New user messages may arrive mid-run and supersede the current plan; treat messages delivered mid-run as fresh instructions, not history.',
+    );
+  }
+  return lines;
 }
 
 function renderSection(section: PromptSection): string {
@@ -391,9 +490,12 @@ export class PromptProfileService {
     const runtimeRules = makeSection(
       'RUNTIME_RULES',
       'gantry://runtime-rules',
-      accessPreset === 'locked'
-        ? LOCKED_RUNTIME_RULES_BLOCK
-        : RUNTIME_RULES_BLOCK,
+      [
+        accessPreset === 'locked'
+          ? LOCKED_RUNTIME_RULES_BLOCK
+          : RUNTIME_RULES_BLOCK,
+        ...runtimeContextLines(options),
+      ].join('\n'),
       this.sectionBudgets.RUNTIME_RULES,
     );
     if (runtimeRules) sections.push(runtimeRules);

--- a/apps/core/src/runner/gantry-agent-system-prompt.ts
+++ b/apps/core/src/runner/gantry-agent-system-prompt.ts
@@ -23,6 +23,10 @@ export interface GantryAgentSystemPromptInput {
   threadId?: string;
   isScheduledJob?: boolean;
   currentDateTimeIso?: string;
+  // IANA timezone for the conversation. Defaults to the process timezone,
+  // which in the runner is the conversation TZ projected into env by
+  // buildBaseRunnerEnv (agent-spawn-helpers.ts).
+  timezone?: string;
   sandboxSummary?: string;
 }
 
@@ -102,6 +106,7 @@ export function buildGantryAgentSystemPrompt(
       mode,
       [...staticSections, documentationSection()],
       [
+        currentDateTimeSection(input),
         assistantOutputDirectivesSection(),
         runtimeSection(input),
         reasoningSection(),
@@ -162,7 +167,7 @@ function executionBiasSection(): string {
   return [
     '## Execution Bias',
     'Prefer concrete progress over commentary. Diagnose the real blocker, choose the smallest correct action, and verify the result.',
-    'Be a dependable operator for the team: keep the user informed, protect approvals, and complete the work with receipts.',
+    'Be a dependable operator for the team: keep the user informed, protect approvals, and complete the work.',
   ].join('\n');
 }
 
@@ -252,9 +257,14 @@ function sandboxSection(input: GantryAgentSystemPromptInput): string {
 }
 
 function currentDateTimeSection(input: GantryAgentSystemPromptInput): string {
+  const iso = input.currentDateTimeIso?.trim();
+  const timezone =
+    input.timezone?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone;
   return [
     '## Current Date & Time',
-    input.currentDateTimeIso?.trim() || 'Runtime did not provide a timestamp.',
+    iso
+      ? `${iso} (timezone: ${timezone}). As of turn start; use the date tool when precision matters.`
+      : 'Runtime did not provide a timestamp.',
   ].join('\n');
 }
 

--- a/apps/core/src/runtime/agent-spawn-host.ts
+++ b/apps/core/src/runtime/agent-spawn-host.ts
@@ -169,6 +169,11 @@ export async function prepareInlineAgentHostContext(
         accessPreset: resolveAgentAccessPolicy(
           runtimeSettings.agents?.[group.folder]?.accessPreset,
         ).preset,
+        modelIdentity: {
+          alias: resolvedModel.value.modelEntry.displayName,
+          modelId: resolvedModel.value.runnerModel,
+          provider: resolvedModel.value.modelEntry.modelRoute.label,
+        },
         fileArtifactStore: () => getRuntimeFileArtifactStore(),
         measureAsync: async (_name, fn) => fn(),
       })

--- a/apps/core/src/runtime/agent-spawn-prompt.ts
+++ b/apps/core/src/runtime/agent-spawn-prompt.ts
@@ -1,11 +1,13 @@
 import {
   PromptProfileService,
   type PromptAccessPreset,
+  type PromptModelIdentity,
   type PromptProfileServiceOptions,
   promptProfileAgentIdForFolder,
 } from '../application/agents/prompt-profile-service.js';
 import type { ConversationRoute } from '../domain/types.js';
 import { logger } from '../infrastructure/logging/logger.js';
+import { resolveWorkspaceFolderPath } from '../platform/workspace-folder.js';
 import type { AgentInput } from './agent-spawn-types.js';
 
 export async function compileSpawnSystemPrompt(input: {
@@ -13,6 +15,7 @@ export async function compileSpawnSystemPrompt(input: {
   agentInput: AgentInput;
   appId: string;
   accessPreset: PromptAccessPreset;
+  modelIdentity?: PromptModelIdentity;
   fileArtifactStore: PromptProfileServiceOptions['fileArtifactStore'];
   measureAsync: <T>(
     name: 'promptCompileMs',
@@ -33,6 +36,35 @@ export async function compileSpawnSystemPrompt(input: {
           input.agentInput.agentId ??
           promptProfileAgentIdForFolder(input.group.folder),
         accessPreset: input.accessPreset,
+        ...(input.modelIdentity ? { modelIdentity: input.modelIdentity } : {}),
+        runtimeContext: {
+          chatJid: input.agentInput.chatJid,
+          ...(input.group.conversationKind
+            ? { conversationKind: input.group.conversationKind }
+            : {}),
+          ...(() => {
+            try {
+              return {
+                workspacePath: resolveWorkspaceFolderPath(input.group.folder),
+              };
+            } catch {
+              // Invalid folder names still compile the rest of the profile.
+              return {};
+            }
+          })(),
+          ...(input.agentInput.isScheduledJob
+            ? {
+                job: {
+                  ...(input.agentInput.jobId
+                    ? { id: input.agentInput.jobId }
+                    : {}),
+                  ...(input.agentInput.jobName
+                    ? { name: input.agentInput.jobName }
+                    : {}),
+                },
+              }
+            : {}),
+        },
       }),
     );
   } catch (err) {

--- a/apps/core/src/runtime/agent-spawn.ts
+++ b/apps/core/src/runtime/agent-spawn.ts
@@ -226,6 +226,11 @@ async function spawnAgentWithContext(
     agentInput: input,
     appId: input.appId || 'default',
     accessPreset,
+    modelIdentity: {
+      alias: resolvedModel.value.modelEntry.displayName,
+      modelId: resolvedModel.value.runnerModel,
+      provider: resolvedModel.value.modelEntry.modelRoute.label,
+    },
     fileArtifactStore: () => getRuntimeFileArtifactStore(),
     measureAsync: (name, fn) => hostStartup.measureAsync(name, fn),
   });

--- a/apps/core/test/unit/runner/gantry-agent-system-prompt.test.ts
+++ b/apps/core/test/unit/runner/gantry-agent-system-prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { buildRunnerSystemPrompt } from '@core/adapters/llm/anthropic-claude-agent/runner/system-prompt.js';
 import type { AgentRunnerInput } from '@core/adapters/llm/anthropic-claude-agent/runner/types.js';
@@ -26,6 +26,10 @@ const FULL_SECTIONS = [
 ];
 
 describe('buildGantryAgentSystemPrompt', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the OpenClaw-inspired full section order with stable and dynamic parts split', () => {
     const prompt = buildGantryAgentSystemPrompt({
       runtimeProjection: 'wrapped-tool-projection',
@@ -116,6 +120,88 @@ describe('buildGantryAgentSystemPrompt', () => {
     expect(prompt.prompt).toContain('## Assistant Output Directives');
     expect(prompt.prompt).not.toContain('## Workspace');
     expect(prompt.prompt).not.toContain('Public Gantry catalog:');
+  });
+
+  it('includes the date section with timezone in minimal mode dynamic tail', () => {
+    const prompt = buildGantryAgentSystemPrompt({
+      runtimeProjection: 'native-tool-projection',
+      promptMode: 'minimal',
+      assistantName: 'Asha',
+      currentDateTimeIso: '2026-06-17T00:00:00.000Z',
+      timezone: 'Asia/Kolkata',
+    });
+
+    expect(prompt.dynamicPrompt).toContain('## Current Date & Time');
+    expect(prompt.dynamicPrompt).toContain(
+      '2026-06-17T00:00:00.000Z (timezone: Asia/Kolkata). As of turn start; use the date tool when precision matters.',
+    );
+    expect(prompt.staticPrompt).not.toContain('## Current Date & Time');
+  });
+
+  it('renders the timezone next to the timestamp in full mode', () => {
+    const prompt = buildGantryAgentSystemPrompt({
+      runtimeProjection: 'wrapped-tool-projection',
+      promptMode: 'full',
+      currentDateTimeIso: '2026-06-17T00:00:00.000Z',
+      timezone: 'America/New_York',
+    });
+
+    expect(prompt.dynamicPrompt).toContain('(timezone: America/New_York)');
+    expect(prompt.staticPrompt).not.toContain('timezone:');
+  });
+
+  it('keeps the compiled profile in every prompt mode', () => {
+    for (const promptMode of ['full', 'minimal', 'none'] as const) {
+      const prompt = buildGantryAgentSystemPrompt({
+        runtimeProjection: 'native-tool-projection',
+        promptMode,
+        compiledSystemPrompt: 'compiled profile marker',
+        currentDateTimeIso: '2026-06-17T00:00:00.000Z',
+      });
+      expect(prompt.prompt, promptMode).toContain('compiled profile marker');
+    }
+  });
+
+  it('drops the receipts phrasing from Execution Bias', () => {
+    const prompt = buildGantryAgentSystemPrompt({
+      runtimeProjection: 'wrapped-tool-projection',
+      promptMode: 'full',
+      currentDateTimeIso: '2026-06-17T00:00:00.000Z',
+    });
+
+    expect(prompt.prompt).toContain(
+      'keep the user informed, protect approvals, and complete the work.',
+    );
+    expect(prompt.prompt).not.toContain('with receipts');
+  });
+
+  it('keeps the static prefix byte-identical across builds at different clock times (cache safety)', () => {
+    const input = {
+      prompt: 'summarize the plan',
+      workspaceFolder: 'main_agent',
+      chatJid: 'tg:team',
+      persona: 'generalist',
+      assistantName: 'Asha',
+      promptMode: 'full',
+      compiledSystemPrompt: 'custom profile prompt',
+      allowedTools: ['Read'],
+    } satisfies AgentRunnerInput;
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-17T00:00:00.000Z'));
+    const first = buildRunnerSystemPrompt(input, 'memory context');
+    vi.setSystemTime(new Date('2026-06-18T12:34:56.000Z'));
+    const second = buildRunnerSystemPrompt(input, 'memory context');
+
+    expect(first).toHaveLength(3);
+    expect(second).toHaveLength(3);
+    // Static prefix (everything before the dynamic boundary) must not vary
+    // with the clock or the prompt cache is broken.
+    expect(second[0]).toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+    expect(second[2]).not.toBe(first[2]);
+    expect(first[2]).toContain('2026-06-17T00:00:00.000Z');
+    expect(second[2]).toContain('2026-06-18T12:34:56.000Z');
   });
 
   it('renders none mode as base identity only', () => {

--- a/apps/core/test/unit/runtime/agent-spawn-prompt.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-prompt.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ConversationRoute } from '@core/domain/types.js';
+import type { AgentInput } from '@core/runtime/agent-spawn-types.js';
+import { compileSpawnSystemPrompt } from '@core/runtime/agent-spawn-prompt.js';
+
+vi.mock('@core/infrastructure/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
+}));
+
+vi.mock('@core/platform/workspace-folder.js', () => ({
+  resolveWorkspaceFolderPath: (folder: string) => `/data/agents/${folder}`,
+}));
+
+const group: ConversationRoute = {
+  name: 'Team',
+  folder: 'team',
+  trigger: '',
+  added_at: '2026-01-01T00:00:00.000Z',
+  conversationKind: 'dm',
+};
+
+const agentInput: AgentInput = {
+  prompt: 'hello',
+  workspaceFolder: 'team',
+  chatJid: 'tg:1001',
+};
+
+function compile(overrides: {
+  group?: Partial<ConversationRoute>;
+  agentInput?: Partial<AgentInput>;
+}): Promise<string> {
+  return compileSpawnSystemPrompt({
+    group: { ...group, ...(overrides.group ?? {}) },
+    agentInput: { ...agentInput, ...(overrides.agentInput ?? {}) },
+    appId: 'default',
+    accessPreset: 'full',
+    modelIdentity: {
+      alias: 'Fable 5',
+      modelId: 'claude-fable-5',
+      provider: 'Anthropic API',
+    },
+    fileArtifactStore: () => undefined,
+    measureAsync: (_name, fn) => fn(),
+  });
+}
+
+describe('compileSpawnSystemPrompt', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('threads model identity and spawn context into the compiled profile', async () => {
+    const prompt = await compile({});
+
+    expect(prompt).toContain(
+      '- You are running on Fable 5 (claude-fable-5) via Anthropic API. State this plainly if the user asks which model you are; deeper runtime internals stay internal.',
+    );
+    expect(prompt).toContain('- Channel: Telegram direct message.');
+    expect(prompt).toContain('- Workspace root: /data/agents/team.');
+    expect(prompt).toContain('New user messages may arrive mid-run');
+  });
+
+  it('threads job context for scheduled job spawns', async () => {
+    const prompt = await compile({
+      group: { conversationKind: 'channel' },
+      agentInput: {
+        chatJid: 'sl:C1',
+        isScheduledJob: true,
+        jobId: 'job-9',
+        jobName: 'Daily digest',
+      },
+    });
+
+    expect(prompt).toContain('- Channel: Slack group conversation.');
+    expect(prompt).toContain(
+      '- This run executes scheduled job "Daily digest" (job-9).',
+    );
+    expect(prompt).not.toContain('New user messages may arrive mid-run');
+  });
+
+  it('compiles byte-identical profiles across different clock times (cache safety)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T10:00:00.000Z'));
+    const first = await compile({});
+    vi.setSystemTime(new Date('2026-07-21T22:33:44.000Z'));
+    const second = await compile({});
+
+    expect(second).toBe(first);
+  });
+});

--- a/apps/core/test/unit/runtime/prompt-profile-locked.test.ts
+++ b/apps/core/test/unit/runtime/prompt-profile-locked.test.ts
@@ -67,6 +67,35 @@ describe('locked prompt assembly', () => {
     },
   );
 
+  it('keeps the Output Style block and model line for locked agents', async () => {
+    const prompt = await makeService().compileSystemPrompt({
+      agentFolder: 'support_agent',
+      persona: 'generalist',
+      accessPreset: 'locked',
+      modelIdentity: {
+        alias: 'Fable 5',
+        modelId: 'claude-fable-5',
+        provider: 'Anthropic API',
+      },
+      runtimeContext: {
+        chatJid: 'tg:1',
+        conversationKind: 'dm',
+        workspacePath: '/data/agents/support_agent',
+      },
+    });
+
+    expect(prompt).toContain('## Output Style');
+    expect(prompt).toContain('never trade accuracy for brevity.');
+    expect(prompt).toContain(
+      '- You are running on Fable 5 (claude-fable-5) via Anthropic API. State this plainly if the user asks which model you are; deeper runtime internals stay internal.',
+    );
+    expect(prompt).toContain('- Channel: Telegram direct message.');
+    for (const banned of BANNED_LOCKED_STRINGS) {
+      expect(prompt).not.toContain(banned);
+    }
+    expect(prompt).not.toContain('## Proactive recommendations');
+  });
+
   it('keeps the full prompt byte-identical with and without an explicit full preset', async () => {
     for (const persona of ['developer', 'operations'] as const) {
       const service = makeService();

--- a/apps/core/test/unit/runtime/prompt-profile.test.ts
+++ b/apps/core/test/unit/runtime/prompt-profile.test.ts
@@ -11,7 +11,12 @@ import type {
   FileArtifactStore,
   FileArtifactWriteInput,
 } from '@core/domain/ports/file-artifact-store.js';
-import { PromptProfileService } from '@core/application/agents/prompt-profile-service.js';
+import {
+  DEFAULT_PROMPT_SECTION_BUDGETS,
+  LOCKED_OPERATING_GUIDANCE_BLOCK,
+  OPERATING_GUIDANCE_BLOCK,
+  PromptProfileService,
+} from '@core/application/agents/prompt-profile-service.js';
 
 const loggerSpies = vi.hoisted(() => ({
   info: vi.fn(),
@@ -288,6 +293,117 @@ describe('PromptProfileService', () => {
     ]) {
       expect(prompt).not.toContain(stale);
     }
+  });
+
+  it('keeps the raw operating guidance blocks within the section budget (truncation guard)', () => {
+    expect(OPERATING_GUIDANCE_BLOCK.length).toBeLessThanOrEqual(
+      DEFAULT_PROMPT_SECTION_BUDGETS.OPERATING_GUIDANCE,
+    );
+    expect(LOCKED_OPERATING_GUIDANCE_BLOCK.length).toBeLessThanOrEqual(
+      DEFAULT_PROMPT_SECTION_BUDGETS.OPERATING_GUIDANCE,
+    );
+  });
+
+  it('compiles the Communication and Output Style guidance untruncated', async () => {
+    const { service } = createService();
+
+    const prompt = await service.compileSystemPrompt({ agentFolder: 'team' });
+
+    expect(prompt).toContain('## Communication');
+    expect(prompt).toContain('## Output Style');
+    expect(prompt).toContain(
+      'Lead with the answer or outcome in the first sentence',
+    );
+    expect(prompt).toContain('Do not narrate execution');
+    expect(prompt).toContain(
+      'The single short acknowledgement before non-trivial live work is the only exception.',
+    );
+    expect(prompt).toContain(
+      'no closers ("Let me know if..."), no pleasantry filler',
+    );
+    expect(prompt).toContain('Never use dashes as punctuation');
+    expect(prompt).toContain('Hyphens appear only inside compound words');
+    expect(prompt).toContain(
+      'numbered or bulleted structure when the answer has multiple items',
+    );
+    expect(prompt).toContain('Reply in the language the user writes in.');
+    // Final line of the operating guidance block: proves the section tail
+    // survived the budget (the old 8500 budget silently cut Communication).
+    expect(prompt).toContain('never trade accuracy for brevity.');
+  });
+
+  it('renders the model identity line only when modelIdentity is provided', async () => {
+    const { service } = createService();
+
+    const withIdentity = await service.compileSystemPrompt({
+      agentFolder: 'team',
+      modelIdentity: {
+        alias: 'Fable 5',
+        modelId: 'claude-fable-5',
+        provider: 'Anthropic API',
+      },
+    });
+    expect(withIdentity).toContain(
+      '- You are running on Fable 5 (claude-fable-5) via Anthropic API. State this plainly if the user asks which model you are; deeper runtime internals stay internal.',
+    );
+
+    const withoutIdentity = await service.compileSystemPrompt({
+      agentFolder: 'team',
+    });
+    expect(withoutIdentity).not.toContain('You are running on');
+  });
+
+  it('injects stable runtime context lines into runtime rules', async () => {
+    const { service } = createService();
+
+    const prompt = await service.compileSystemPrompt({
+      agentFolder: 'team',
+      modelIdentity: {
+        alias: 'Fable 5',
+        modelId: 'claude-fable-5',
+        provider: 'Anthropic API',
+      },
+      runtimeContext: {
+        chatJid: 'tg:12345',
+        conversationKind: 'dm',
+        workspacePath: '/data/agents/team',
+      },
+    });
+
+    expect(prompt).toContain(
+      '- Channel: Telegram direct message. Telegram renders a limited HTML subset; hard message length cap 4096 characters; outbound workspace file attachments are capped at 25MB.',
+    );
+    expect(prompt).toContain(
+      '- Workspace root: /data/agents/team. Durable outputs belong under media/ inside the workspace; tmp paths are ephemeral and may not survive between runs.',
+    );
+    // Interactive runs carry the interruptibility contract. This is the final
+    // runtime-rules line, so its presence also proves the section fits its
+    // budget untruncated.
+    expect(prompt).toContain(
+      '- New user messages may arrive mid-run and supersede the current plan; treat messages delivered mid-run as fresh instructions, not history.',
+    );
+  });
+
+  it('replaces the interruptibility line with job context for scheduled jobs', async () => {
+    const { service } = createService();
+
+    const prompt = await service.compileSystemPrompt({
+      agentFolder: 'team',
+      runtimeContext: {
+        chatJid: 'sl:C123',
+        conversationKind: 'channel',
+        workspacePath: '/data/agents/team',
+        job: { id: 'job-1', name: 'Daily digest' },
+      },
+    });
+
+    expect(prompt).toContain(
+      '- Channel: Slack group conversation. Slack renders mrkdwn; keep single messages under 4000 characters; outbound workspace file attachments are capped at 25MB.',
+    );
+    expect(prompt).toContain(
+      '- This run executes scheduled job "Daily digest" (job-1). Job runs are quiet until terminal: deliver one final outcome report; do not send interim progress messages.',
+    );
+    expect(prompt).not.toContain('New user messages may arrive mid-run');
   });
 
   it('maps casual controls to reviewed tools and one-line progress', async () => {


### PR DESCRIPTION
Fixes the CRITICAL prompt truncation bug: the full operating-guidance block exceeded its 8,500-char budget, silently cutting the entire Communication section (the existing anti-slop guidance) from full-preset agents. Budget raised with a guard test.

- New Output Style block (both presets): lead with the answer; no execution narration (single pre-work ack excepted); no preamble/closer filler; no dash-as-punctuation; short sentences; structured multi-item answers; match the user's language; never trade accuracy for brevity.
- Model identity injected: "You are running on <alias> (<model id>) via <provider>" — answer-when-asked; runtime internals stay internal. Resolves the receipts contradiction (results speak; no labeled receipt blocks).
- Runtime context injected (cache-safe): timezone in the dynamic date section (minimal mode now includes the date), channel kind/dialect/length caps, speaker/approver, interruptibility contract, workspace geography, job context.
- Cache-safety guard test: static prefix byte-identical across builds at different clock times (prompt-cache parity from #236 preserved).

Verified: typecheck clean, full unit suite green (6,463 in serialized chunks), prettier applied.