### PR TITLE
Admission: consistent provider-account qualification (fixes silent turn drop)

### DIFF
--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
@@ -1,4 +1,4 @@
-import { asc, eq, sql } from 'drizzle-orm';
+import { and, asc, eq, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
 import type { ChatInfo } from '../../../../domain/repositories/domain-types.js';
@@ -438,6 +438,24 @@ export class PostgresCanonicalGraphRepository {
       .where(eq(pgSchema.conversationsPostgres.id, conversationId))
       .limit(1);
     return rows[0]?.providerAccountId;
+  }
+
+  async findConversationIdForJid(
+    jid: string,
+    executor: CanonicalExecutor = this.db,
+  ): Promise<string | undefined> {
+    const conversations = pgSchema.conversationsPostgres;
+    const rows = await executor
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.appId, CANONICAL_APP_ID),
+          eq(sql<string>`${conversations.externalRefJson}::jsonb->>'jid'`, jid),
+        ),
+      )
+      .limit(1);
+    return rows[0]?.id;
   }
 
   async listConversationIds(): Promise<string[]> {

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-message-repository.postgres.ts
@@ -258,12 +258,24 @@ export class PostgresCanonicalMessageRepository {
       msg.providerAccountId?.trim() ||
       options.liveAdmission?.providerAccountId?.trim() ||
       null;
+    const existingConversationId = requestedProviderAccountId
+      ? undefined
+      : await this.graph.findConversationIdForJid(msg.chat_jid, tx);
+    const providerAccountId =
+      requestedProviderAccountId ??
+      (existingConversationId
+        ? await this.graph.getConversationInstallationId(
+            existingConversationId,
+            tx,
+          )
+        : undefined) ??
+      `channel-providerAccount:${CANONICAL_APP_ID}:${providerId}`;
     const conversationId = await this.graph.ensureConversation(
       msg.chat_jid,
       {
         timestamp: msg.timestamp,
         channel: providerId,
-        providerAccountId: requestedProviderAccountId,
+        providerAccountId,
       },
       tx,
     );
@@ -271,12 +283,8 @@ export class PostgresCanonicalMessageRepository {
       msg.chat_jid,
       msg.thread_id,
       tx,
-      { channel: providerId, providerAccountId: requestedProviderAccountId },
+      { channel: providerId, providerAccountId },
     );
-    const providerAccountId =
-      requestedProviderAccountId ??
-      (await this.graph.getConversationInstallationId(conversationId, tx)) ??
-      `channel-providerAccount:${CANONICAL_APP_ID}:${providerId}`;
     let canonicalMessageId = messageIdFor(
       msg.chat_jid,
       msg.id,

--- a/apps/core/src/runtime/message-loop.ts
+++ b/apps/core/src/runtime/message-loop.ts
@@ -503,19 +503,30 @@ export async function processLiveAdmissionWorkItem(
   }
 
   const recoveredCursor = await deps.getOrRecoverCursor(item.queueJid);
+  const options = {
+    threadId: threadId ?? null,
+    ...(providerAccountId ? { providerAccountId } : {}),
+  };
   const replay = await collectPendingMessagesSince({
     getMessagesSince: opsRepository.getMessagesSince.bind(opsRepository),
     chatJid,
     sinceCursor: recoveredCursor,
     pageSize: MESSAGE_FETCH_PAGE_SIZE,
     maxMessages: MAX_MESSAGES_PER_PROMPT,
-    options: {
-      threadId: threadId ?? null,
-      ...(providerAccountId ? { providerAccountId } : {}),
-    },
+    options,
   });
   const messages = replay.messages;
-  if (messages.length === 0) return 'completed';
+  if (messages.length === 0) {
+    logger.warn(
+      {
+        itemId: item.id,
+        queueJid: item.queueJid,
+        filter: { chatJid, ...options },
+      },
+      'Live admission work item matched no messages',
+    );
+    return 'completed';
+  }
   return processQueueMessages(deps, item.queueJid, messages, replay, {
     trustedTriggerBypass:
       item.triggerDecision.source === 'callable_agent_follow_up',

--- a/apps/core/test/integration/live-admission-work-items.postgres.integration.test.ts
+++ b/apps/core/test/integration/live-admission-work-items.postgres.integration.test.ts
@@ -1,7 +1,18 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { quotePostgresIdentifier } from '@core/adapters/storage/postgres/storage-service.js';
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_APP_ID,
+} from '@core/adapters/storage/postgres/seeds.js';
+import type { AgentId } from '@core/domain/agent/agent.js';
+import type { AppId } from '@core/domain/app/app.js';
 import { RUNTIME_EVENT_TYPES } from '@core/domain/events/runtime-event-types.js';
+import type {
+  ProviderAccountId,
+  ProviderId,
+} from '@core/domain/provider/provider.js';
+import { parseAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
 import { nowMs, toIso } from '@core/shared/time/datetime.js';
 
 import {
@@ -616,9 +627,49 @@ maybeDescribe('live admission work items (Postgres)', () => {
     });
     expect(JSON.stringify(result?.item)).not.toContain('sensitive prompt body');
 
+    const admissionFilter = parseAgentThreadQueueKey(
+      result?.item.queueJid ?? '',
+    );
+    const providerAccountId = admissionFilter.providerAccountId;
+    expect(providerAccountId).toBe('channel-providerAccount:default:telegram');
+    expect(result?.item.messageId).toBe(
+      `message:${providerAccountId}:${message.chat_jid}:${message.id}`,
+    );
+
+    const conversationsTable = `${quotePostgresIdentifier(
+      runtime.schemaName,
+    )}.${quotePostgresIdentifier('conversations')}`;
+    const messagesTable = `${quotePostgresIdentifier(
+      runtime.schemaName,
+    )}.${quotePostgresIdentifier('messages')}`;
+    const { rows: identities } = await runtime.service.pool.query<{
+      conversation_id: string;
+      conversation_provider_account_id: string;
+      message_id: string;
+      message_provider_account_id: string;
+    }>(
+      `SELECT c.id AS conversation_id,
+              c.provider_account_id AS conversation_provider_account_id,
+              m.id AS message_id,
+              m.provider_account_id AS message_provider_account_id
+       FROM ${messagesTable} m
+       JOIN ${conversationsTable} c ON c.id = m.conversation_id
+       WHERE m.id = $1`,
+      [result?.item.messageId],
+    );
+    expect(identities).toEqual([
+      {
+        conversation_id: `conversation:${providerAccountId}:${message.chat_jid}`,
+        conversation_provider_account_id: providerAccountId,
+        message_id: result?.item.messageId,
+        message_provider_account_id: providerAccountId,
+      },
+    ]);
+
     await expect(
-      runtime.ops.getMessagesSince('tg:live-admission-atomic', '', 10, {
-        threadId: null,
+      runtime.ops.getMessagesSince(admissionFilter.chatJid, '', 10, {
+        threadId: admissionFilter.threadId ?? null,
+        providerAccountId,
       }),
     ).resolves.toMatchObject([
       {
@@ -646,6 +697,118 @@ maybeDescribe('live admission work items (Postgres)', () => {
       limit: 10,
     });
     expect(claimed.map((item) => item.id)).toContain(result?.item.id);
+  });
+
+  it('reuses an existing installation account for a providerless follow-up', async () => {
+    const chatJid = 'tg:live-admission-existing-install';
+    const providerAccountId = 'telegram-install-existing' as ProviderAccountId;
+    await runtime.repositories.providerAccounts.saveProviderAccount({
+      id: providerAccountId,
+      appId: DEFAULT_APP_ID as AppId,
+      agentId: DEFAULT_AGENT_ID as AgentId,
+      providerId: 'telegram' as ProviderId,
+      externalIdentityRef: {
+        kind: 'provider_account',
+        value: 'telegram-install-existing',
+      },
+      label: 'Existing Telegram installation',
+      status: 'active',
+      config: {},
+      runtimeSecretRefs: {},
+      createdAt: '2026-06-16T00:00:02.000Z',
+      updatedAt: '2026-06-16T00:00:02.000Z',
+    });
+    await runtime.ops.storeMessage({
+      id: 'msg-install-seed',
+      chat_jid: chatJid,
+      provider: 'telegram',
+      providerAccountId,
+      sender: 'user-install',
+      sender_name: 'Install User',
+      content: 'seed with installation account',
+      timestamp: '2026-06-16T00:00:02.100Z',
+      is_from_me: false,
+      is_bot_message: false,
+    });
+
+    const followUp = {
+      id: 'msg-install-follow-up',
+      chat_jid: chatJid,
+      provider: 'telegram',
+      sender: 'user-install',
+      sender_name: 'Install User',
+      content: 'providerless follow-up',
+      timestamp: '2026-06-16T00:00:02.200Z',
+      is_from_me: false,
+      is_bot_message: false,
+    };
+    const result = await runtime.ops.storeMessageWithLiveAdmission?.(followUp, {
+      appId: 'default',
+      agentId: 'install_agent',
+      triggerDecision: { requiresTrigger: false },
+    });
+
+    expect(result?.outcome).toBe('enqueued');
+    const admissionFilter = parseAgentThreadQueueKey(
+      result?.item.queueJid ?? '',
+    );
+    expect(admissionFilter.providerAccountId).toBe(providerAccountId);
+    expect(result?.item.messageId).toBe(
+      `message:${providerAccountId}:${chatJid}:${followUp.id}`,
+    );
+
+    const conversationsTable = `${quotePostgresIdentifier(
+      runtime.schemaName,
+    )}.${quotePostgresIdentifier('conversations')}`;
+    const messagesTable = `${quotePostgresIdentifier(
+      runtime.schemaName,
+    )}.${quotePostgresIdentifier('messages')}`;
+    const { rows: conversations } = await runtime.service.pool.query<{
+      id: string;
+      provider_account_id: string;
+    }>(
+      `SELECT id, provider_account_id
+       FROM ${conversationsTable}
+       WHERE external_ref_json::jsonb->>'jid' = $1
+       ORDER BY id`,
+      [chatJid],
+    );
+    expect(conversations).toEqual([
+      {
+        id: `conversation:${providerAccountId}:${chatJid}`,
+        provider_account_id: providerAccountId,
+      },
+    ]);
+
+    const { rows: messages } = await runtime.service.pool.query<{
+      conversation_id: string;
+      provider_account_id: string;
+    }>(
+      `SELECT conversation_id, provider_account_id
+       FROM ${messagesTable}
+       WHERE id = $1`,
+      [result?.item.messageId],
+    );
+    expect(messages).toEqual([
+      {
+        conversation_id: `conversation:${providerAccountId}:${chatJid}`,
+        provider_account_id: providerAccountId,
+      },
+    ]);
+
+    await expect(
+      runtime.ops.getMessagesSince(admissionFilter.chatJid, '', 10, {
+        threadId: admissionFilter.threadId ?? null,
+        providerAccountId: admissionFilter.providerAccountId,
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: followUp.id,
+          content: followUp.content,
+        }),
+      ]),
+    );
   });
 
   it('stores accepted runtime event and live admission atomically', async () => {

--- a/apps/core/test/unit/adapters/storage/postgres/canonical-message-ops-service.test.ts
+++ b/apps/core/test/unit/adapters/storage/postgres/canonical-message-ops-service.test.ts
@@ -712,6 +712,7 @@ describe('CanonicalMessageOpsService', () => {
     const repository = new PostgresCanonicalMessageRepository({} as never);
     Object.assign(repository, {
       graph: {
+        findConversationIdForJid: vi.fn(async () => undefined),
         ensureConversation: vi.fn(async () => 'conversation:sl:C123'),
         ensureThread: vi.fn(async () => null),
         getConversationInstallationId: vi.fn(async () => null),
@@ -753,6 +754,7 @@ describe('CanonicalMessageOpsService', () => {
     const repository = new PostgresCanonicalMessageRepository({} as never);
     Object.assign(repository, {
       graph: {
+        findConversationIdForJid: vi.fn(async () => undefined),
         ensureConversation: vi.fn(async () => 'conversation:sl:C123'),
         ensureThread: vi.fn(async () => null),
         getConversationInstallationId: vi.fn(async () => null),
@@ -794,6 +796,7 @@ describe('CanonicalMessageOpsService', () => {
       delete: vi.fn(),
     };
     const graph = {
+      findConversationIdForJid: vi.fn(async () => undefined),
       ensureConversation: vi.fn(async () => 'conversation:slack_beta:sl:C123'),
       ensureThread: vi.fn(async () => 'thread:slack_beta:sl:C123:root'),
       getConversationInstallationId: vi.fn(async () => 'slack_alpha'),
@@ -830,6 +833,7 @@ describe('CanonicalMessageOpsService', () => {
       expect.objectContaining({ providerAccountId: 'slack_beta' }),
     );
     expect(graph.getConversationInstallationId).not.toHaveBeenCalled();
+    expect(graph.findConversationIdForJid).not.toHaveBeenCalled();
     expect(insertedValues[0]).toMatchObject({
       id: 'message:slack_beta:sl:C123:1710000001.000100',
       providerAccountId: 'slack_beta',
@@ -870,6 +874,7 @@ describe('CanonicalMessageOpsService', () => {
       const repository = new PostgresCanonicalMessageRepository({} as never);
       Object.assign(repository, {
         graph: {
+          findConversationIdForJid: vi.fn(async () => undefined),
           ensureConversation: vi.fn(
             async () => 'conversation:slack_beta:sl:C123',
           ),
@@ -936,6 +941,7 @@ describe('CanonicalMessageOpsService', () => {
       delete: vi.fn(),
     };
     const graph = {
+      findConversationIdForJid: vi.fn(async () => undefined),
       ensureConversation: vi.fn(async () => 'conversation:slack_beta:sl:C123'),
       ensureThread: vi.fn(async () => 'thread:slack_beta:sl:C123:root'),
       getConversationInstallationId: vi.fn(async () => 'slack_alpha'),
@@ -977,6 +983,7 @@ describe('CanonicalMessageOpsService', () => {
       expect.objectContaining({ providerAccountId: 'slack_beta' }),
     );
     expect(graph.getConversationInstallationId).not.toHaveBeenCalled();
+    expect(graph.findConversationIdForJid).not.toHaveBeenCalled();
     expect(insertedValues[0]).toMatchObject({
       id: 'message:slack_beta:sl:C123:1710000001.000100',
       providerAccountId: 'slack_beta',
@@ -1008,15 +1015,21 @@ describe('CanonicalMessageOpsService', () => {
       })),
       delete: vi.fn(),
     };
+    const graph = {
+      findConversationIdForJid: vi.fn(async () => undefined),
+      ensureConversation: vi.fn(
+        async () =>
+          'conversation:channel-providerAccount:default:slack:sl:C123',
+      ),
+      ensureThread: vi.fn(
+        async () =>
+          'thread:channel-providerAccount:default:slack:sl:C123:thread-1',
+      ),
+      getConversationInstallationId: vi.fn(async () => null),
+      ensureParticipant: vi.fn(async () => undefined),
+    };
     const repository = new PostgresCanonicalMessageRepository({} as never);
-    Object.assign(repository, {
-      graph: {
-        ensureConversation: vi.fn(async () => 'conversation:sl:C123'),
-        ensureThread: vi.fn(async () => 'thread:sl:C123:thread-1'),
-        getConversationInstallationId: vi.fn(async () => null),
-        ensureParticipant: vi.fn(async () => undefined),
-      },
-    });
+    Object.assign(repository, { graph });
 
     await repository.saveMessageWithExecutor(
       tx as never,
@@ -1041,6 +1054,40 @@ describe('CanonicalMessageOpsService', () => {
           'live-admission:',
         ),
     );
+    const messageRow = insertedValues[0];
+
+    expect(graph.ensureConversation).toHaveBeenCalledWith(
+      'sl:C123',
+      expect.objectContaining({
+        providerAccountId: 'channel-providerAccount:default:slack',
+      }),
+      tx,
+    );
+    expect(graph.ensureThread).toHaveBeenCalledWith(
+      'sl:C123',
+      'thread-1',
+      tx,
+      expect.objectContaining({
+        providerAccountId: 'channel-providerAccount:default:slack',
+      }),
+    );
+    expect(graph.getConversationInstallationId).not.toHaveBeenCalled();
+    expect(graph.findConversationIdForJid).toHaveBeenCalledWith('sl:C123', tx);
+    expect(graph.ensureParticipant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId:
+          'conversation:channel-providerAccount:default:slack:sl:C123',
+        providerAccountId: 'channel-providerAccount:default:slack',
+      }),
+      tx,
+    );
+    expect(messageRow).toMatchObject({
+      id: 'message:channel-providerAccount:default:slack:sl:C123:1710000001.000100',
+      providerAccountId: 'channel-providerAccount:default:slack',
+      conversationId:
+        'conversation:channel-providerAccount:default:slack:sl:C123',
+      threadId: 'thread:channel-providerAccount:default:slack:sl:C123:thread-1',
+    });
 
     expect(admissionRow).toMatchObject({
       id: 'live-admission:app-one:agent:alpha:channel-providerAccount:default:slack:message:channel-providerAccount:default:slack:sl:C123:1710000001.000100',
@@ -1050,6 +1097,91 @@ describe('CanonicalMessageOpsService', () => {
       idempotencyKey:
         'live-admission:app-one:agent:alpha:channel-providerAccount:default:slack:sl:C123:thread-1:1710000001.000100',
     });
+  });
+
+  it('reuses an existing conversation installation for providerless live admission', async () => {
+    const insertedValues: unknown[] = [];
+    const tx = {
+      select: vi.fn(),
+      insert: vi.fn(() => ({
+        values: vi.fn((values: unknown) => {
+          insertedValues.push(values);
+          if (
+            values &&
+            typeof values === 'object' &&
+            String((values as Record<string, unknown>).id).startsWith(
+              'live-admission:',
+            )
+          ) {
+            return {
+              onConflictDoNothing: vi.fn(() => ({
+                returning: vi.fn(async () => [values]),
+              })),
+            };
+          }
+          return { onConflictDoUpdate: vi.fn(async () => undefined) };
+        }),
+      })),
+      delete: vi.fn(),
+    };
+    const existingConversationId = 'conversation:slack_install:sl:C-existing';
+    const graph = {
+      findConversationIdForJid: vi.fn(async () => existingConversationId),
+      getConversationInstallationId: vi.fn(async () => 'slack_install'),
+      ensureConversation: vi.fn(async () => existingConversationId),
+      ensureThread: vi.fn(
+        async () => 'thread:slack_install:sl:C-existing:thread-1',
+      ),
+      ensureParticipant: vi.fn(async () => undefined),
+    };
+    const repository = new PostgresCanonicalMessageRepository({} as never);
+    Object.assign(repository, { graph });
+
+    await repository.saveMessageWithExecutor(
+      tx as never,
+      {
+        id: '1710000002.000100',
+        chat_jid: 'sl:C-existing',
+        provider: 'slack',
+        sender: 'U123',
+        sender_name: 'Ravi',
+        content: '@Alpha follow-up',
+        timestamp: '2026-05-06T00:00:01.000Z',
+        thread_id: 'thread-1',
+      },
+      { liveAdmission: { appId: 'app-one', agentId: 'alpha' } },
+    );
+
+    expect(graph.findConversationIdForJid).toHaveBeenCalledWith(
+      'sl:C-existing',
+      tx,
+    );
+    expect(graph.getConversationInstallationId).toHaveBeenCalledWith(
+      existingConversationId,
+      tx,
+    );
+    expect(graph.ensureConversation).toHaveBeenCalledWith(
+      'sl:C-existing',
+      expect.objectContaining({ providerAccountId: 'slack_install' }),
+      tx,
+    );
+    expect(
+      graph.findConversationIdForJid.mock.invocationCallOrder[0],
+    ).toBeLessThan(graph.ensureConversation.mock.invocationCallOrder[0] ?? 0);
+
+    expect(insertedValues[0]).toMatchObject({
+      id: 'message:slack_install:sl:C-existing:1710000002.000100',
+      providerAccountId: 'slack_install',
+      conversationId: existingConversationId,
+      threadId: 'thread:slack_install:sl:C-existing:thread-1',
+    });
+    expect(insertedValues).toContainEqual(
+      expect.objectContaining({
+        queueJid:
+          'sl:C-existing::thread:thread-1::agent:agent%3Aalpha::provider_account:slack_install',
+        messageId: 'message:slack_install:sl:C-existing:1710000002.000100',
+      }),
+    );
   });
 
   it('preserves stored attachment refs when replacing hydrated attachment rows', async () => {
@@ -1098,6 +1230,7 @@ describe('CanonicalMessageOpsService', () => {
     const repository = new PostgresCanonicalMessageRepository({} as never);
     Object.assign(repository, {
       graph: {
+        findConversationIdForJid: vi.fn(async () => undefined),
         ensureConversation: vi.fn(async () => 'conversation:sl:C123'),
         ensureThread: vi.fn(async () => null),
         getConversationInstallationId: vi.fn(async () => null),

--- a/apps/core/test/unit/runtime/message-loop.test.ts
+++ b/apps/core/test/unit/runtime/message-loop.test.ts
@@ -37,12 +37,20 @@ vi.mock('@core/session/session-commands.js', () => ({
 vi.mock('@core/messaging/router.js', () => ({
   formatMessages: (...args: unknown[]) => mockFormatMessages(...args),
 }));
+vi.mock('@core/infrastructure/logging/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
 
 import {
   MessageLoopDeps,
   processLiveAdmissionWorkItem,
   recoverPendingMessages,
 } from '@core/runtime/message-loop.js';
+import { logger } from '@core/infrastructure/logging/logger.js';
 import {
   decodeGroupMessageCursor,
   encodeGroupMessageCursor,
@@ -597,6 +605,40 @@ describe('recoverPendingMessages', () => {
 });
 
 describe('thread queue routing', () => {
+  it('warns when a live admission item matches no messages', async () => {
+    const queueJid = makeAgentThreadQueueKey(
+      'group@g.us',
+      'agent:team',
+      undefined,
+      'slack_beta',
+    );
+
+    await expect(
+      processLiveAdmissionWorkItem(
+        makeDeps(),
+        makeAdmissionItem({
+          id: 'admission-empty',
+          agentId: 'agent:team',
+          queueJid,
+        }),
+      ),
+    ).resolves.toBe('completed');
+
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        itemId: 'admission-empty',
+        queueJid,
+        filter: {
+          chatJid: 'group@g.us',
+          threadId: null,
+          providerAccountId: 'slack_beta',
+        },
+      },
+      'Live admission work item matched no messages',
+    );
+  });
+
   it('processes a durable live admission item without route-wide scans', async () => {
     const msg = {
       id: 1,

--- a/docs/architecture/agent-e2e-test-matrix.md
+++ b/docs/architecture/agent-e2e-test-matrix.md
@@ -153,11 +153,12 @@ Legend: ✅ covered (cite) · 🔨 to build · 🏷 label-gated (live lane) · �
 
 ## 11. Route integrity (incident regressions)
 
-| Scenario                                                                           | Layer            | Status               |
-| ---------------------------------------------------------------------------------- | ---------------- | -------------------- |
-| Loader collapses mixed legacy key forms to ONE route (total preference order)      | unit/integration | 🔨 in route-fix lane |
-| Divergent conversationId rows load via derive+warn, never throw, never drop a chat | unit/integration | 🔨 in route-fix lane |
-| Corrupt-state seed via direct test-DB rows (documented API exception)              | integration      | 🔨                   |
+| Scenario                                                                                                                              | Layer            | Status                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Loader collapses mixed legacy key forms to ONE route (total preference order)                                                         | unit/integration | 🔨 in route-fix lane                                                                                                   |
+| Divergent conversationId rows load via derive+warn, never throw, never drop a chat                                                    | unit/integration | 🔨 in route-fix lane                                                                                                   |
+| Corrupt-state seed via direct test-DB rows (documented API exception)                                                                 | integration      | 🔨                                                                                                                     |
+| Providerless admission qualifies conversation/message/queue with ONE provider account (no silent turn drop, no parallel conversation) | unit/integration | ✅ canonical-message-ops-service.test.ts, message-loop.test.ts, live-admission-work-items.postgres.integration.test.ts |
 
 ## 12. Channel loop (Slack, dedicated test app)
 


### PR DESCRIPTION
Found by the haiku-turn e2e scenario: a providerless live admission created the conversation row unqualified while the message id and queue jid were qualified with the synthetic provider account, so replay matched zero messages and the turn silently dropped.

Fix: resolve the provider account ONCE before ensureConversation — incoming fields, else the existing conversation's installation id (new jid lookup prevents a parallel conversation), else the synthetic fallback — and use that single value for the conversation row, thread, canonical message id, and admission queue jid. Zero-match admissions now log a warning with the exact filter.

Tests: unit (canonical-message-ops-service, message-loop) + postgres integration (live-admission-work-items providerless follow-up); matrix row added under incident regressions.