### PR TITLE
Bump shell-quote past new high advisory (audit unblock)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8068,9 +8068,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
Second fresh advisory tonight failing the supply-chain audit for all builds: shell-quote <=1.8.4 (GHSA-395f-4hp3-45gv, high). Lockfile-only bump generated with npm 12 to match CI (3-line diff); audit now reports 0 vulnerabilities.