### PR TITLE
fix runtime events identity drift

### DIFF
--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0104_runtime_events_identity_repair.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0104_runtime_events_identity_repair.sql
@@ -1,40 +1,55 @@
--- Repair runtime_events schemas that have the post-0018 table shape but lost
--- the event_id identity/default during manual drift repair.
+-- Repair generated identity primary keys that lost their generator during
+-- manual drift repair.
 DO $$
 DECLARE
-  next_event_id bigint;
+  identity_primary_key record;
+  target_table regclass;
+  next_value bigint;
   has_identity boolean;
   has_default boolean;
 BEGIN
-  IF to_regclass('runtime_events') IS NULL THEN
-    RETURN;
-  END IF;
+  FOR identity_primary_key IN
+    SELECT *
+    FROM (VALUES
+      ('runtime_events', 'event_id'),
+      ('message_parts', 'id'),
+      ('memory_recall_events', 'id')
+    ) AS identity_primary_keys(table_name, column_name)
+  LOOP
+    target_table := to_regclass(
+      format('%I.%I', current_schema(), identity_primary_key.table_name)
+    );
+    IF target_table IS NULL THEN
+      CONTINUE;
+    END IF;
 
-  SELECT
-    a.attidentity <> '',
-    d.adbin IS NOT NULL
-  INTO has_identity, has_default
-  FROM pg_attribute a
-  LEFT JOIN pg_attrdef d
-    ON d.adrelid = a.attrelid
-   AND d.adnum = a.attnum
-  WHERE a.attrelid = 'runtime_events'::regclass
-    AND a.attname = 'event_id'
-    AND NOT a.attisdropped;
+    SELECT
+      a.attidentity <> '',
+      d.adbin IS NOT NULL
+    INTO has_identity, has_default
+    FROM pg_attribute a
+    LEFT JOIN pg_attrdef d
+      ON d.adrelid = a.attrelid
+     AND d.adnum = a.attnum
+    WHERE a.attrelid = target_table
+      AND a.attname = identity_primary_key.column_name
+      AND NOT a.attisdropped;
 
-  IF NOT FOUND THEN
-    RETURN;
-  END IF;
+    IF NOT FOUND OR has_identity OR has_default THEN
+      CONTINUE;
+    END IF;
 
-  IF has_identity OR has_default THEN
-    RETURN;
-  END IF;
+    EXECUTE format(
+      'SELECT COALESCE(MAX(%I), 0) + 1 FROM %s',
+      identity_primary_key.column_name,
+      target_table
+    ) INTO next_value;
 
-  EXECUTE 'SELECT COALESCE(MAX(event_id), 0) + 1 FROM runtime_events'
-    INTO next_event_id;
-
-  EXECUTE format(
-    'ALTER TABLE runtime_events ALTER COLUMN event_id ADD GENERATED ALWAYS AS IDENTITY (START WITH %s)',
-    next_event_id
-  );
+    EXECUTE format(
+      'ALTER TABLE %s ALTER COLUMN %I ADD GENERATED ALWAYS AS IDENTITY (START WITH %s)',
+      target_table,
+      identity_primary_key.column_name,
+      next_value
+    );
+  END LOOP;
 END $$;

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/0104_runtime_events_identity_repair.sql
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/0104_runtime_events_identity_repair.sql
@@ -1,0 +1,40 @@
+-- Repair runtime_events schemas that have the post-0018 table shape but lost
+-- the event_id identity/default during manual drift repair.
+DO $$
+DECLARE
+  next_event_id bigint;
+  has_identity boolean;
+  has_default boolean;
+BEGIN
+  IF to_regclass('runtime_events') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT
+    a.attidentity <> '',
+    d.adbin IS NOT NULL
+  INTO has_identity, has_default
+  FROM pg_attribute a
+  LEFT JOIN pg_attrdef d
+    ON d.adrelid = a.attrelid
+   AND d.adnum = a.attnum
+  WHERE a.attrelid = 'runtime_events'::regclass
+    AND a.attname = 'event_id'
+    AND NOT a.attisdropped;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF has_identity OR has_default THEN
+    RETURN;
+  END IF;
+
+  EXECUTE 'SELECT COALESCE(MAX(event_id), 0) + 1 FROM runtime_events'
+    INTO next_event_id;
+
+  EXECUTE format(
+    'ALTER TABLE runtime_events ALTER COLUMN event_id ADD GENERATED ALWAYS AS IDENTITY (START WITH %s)',
+    next_event_id
+  );
+END $$;

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/_journal.json
@@ -708,6 +708,13 @@
       "when": 1784430629236,
       "tag": "0103_permission_durable_storage_cutover",
       "breakpoints": true
+    },
+    {
+      "idx": 104,
+      "version": "7",
+      "when": 1784625000000,
+      "tag": "0104_runtime_events_identity_repair",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/adapters/storage/postgres/storage-service.ts
+++ b/apps/core/src/adapters/storage/postgres/storage-service.ts
@@ -36,6 +36,11 @@ const RUNTIME_POSTGRES_POOL_MAX = 20;
 // explicit migrator using PostgresStorageService.migrate().
 export const RUNTIME_MIGRATION_LOCK_NAMESPACE = 1_340_193_180;
 export const RUNTIME_MIGRATION_LOCK_KEY = 2;
+export const GENERATED_ALWAYS_IDENTITY_PRIMARY_KEYS = [
+  { tableName: 'runtime_events', columnName: 'event_id' },
+  { tableName: 'message_parts', columnName: 'id' },
+  { tableName: 'memory_recall_events', columnName: 'id' },
+] as const;
 
 interface LatestPostgresMigration {
   createdAt: number;
@@ -319,7 +324,7 @@ export class PostgresStorageService implements StorageService {
       has_text_search: boolean;
       has_job_queue: boolean;
       has_runtime_events_table: boolean;
-      runtime_events_event_id_generates: boolean;
+      missing_generated_identity_primary_keys: string[] | null;
       has_event_bus_outbox_table: boolean;
       has_event_bus_outbox_runtime_event_unique: boolean;
       missing_runtime_event_indexes: string[] | null;
@@ -346,6 +351,11 @@ export class PostgresStorageService implements StorageService {
         current_schema_name AS (
           SELECT $1::text AS schema_name
         ),
+        required_identity_primary_keys(table_name, column_name) AS (
+          SELECT identity_key."tableName", identity_key."columnName"
+          FROM jsonb_to_recordset($2::jsonb)
+            AS identity_key("tableName" text, "columnName" text)
+        ),
         event_tables AS (
           SELECT
             to_regclass(format('%I.%I', $1::text, 'runtime_events')) AS runtime_events_oid,
@@ -356,17 +366,27 @@ export class PostgresStorageService implements StorageService {
           EXISTS(SELECT 1 FROM pg_extension WHERE extname IN ('pg_trgm', 'pg_search')) AS has_text_search,
           (to_regclass('pgboss.version') IS NOT NULL) AS has_job_queue,
           ((SELECT runtime_events_oid FROM event_tables) IS NOT NULL) AS has_runtime_events_table,
-          EXISTS(
-            SELECT 1
-            FROM event_tables t
-            JOIN pg_attribute a ON a.attrelid = t.runtime_events_oid
+          ARRAY(
+            SELECT format('%s.%s', required.table_name, required.column_name)
+            FROM required_identity_primary_keys required
+            CROSS JOIN current_schema_name csn
+            LEFT JOIN pg_namespace n
+              ON n.nspname = csn.schema_name
+            LEFT JOIN pg_class c
+              ON c.relnamespace = n.oid
+             AND c.relname = required.table_name
+             AND c.relkind IN ('r', 'p')
+            LEFT JOIN pg_attribute a
+              ON a.attrelid = c.oid
+             AND a.attname = required.column_name
+             AND NOT a.attisdropped
             LEFT JOIN pg_attrdef d
               ON d.adrelid = a.attrelid
              AND d.adnum = a.attnum
-            WHERE a.attname = 'event_id'
-              AND NOT a.attisdropped
-              AND (a.attidentity <> '' OR d.adbin IS NOT NULL)
-          ) AS runtime_events_event_id_generates,
+            WHERE a.attnum IS NULL
+               OR (a.attidentity = '' AND d.adbin IS NULL)
+            ORDER BY required.table_name, required.column_name
+          ) AS missing_generated_identity_primary_keys,
           ((SELECT event_bus_outbox_oid FROM event_tables) IS NOT NULL) AS has_event_bus_outbox_table,
           EXISTS(
             SELECT 1
@@ -401,16 +421,22 @@ export class PostgresStorageService implements StorageService {
             )
             ORDER BY r.index_name
           ) AS missing_event_bus_outbox_indexes`,
-      [this.schemaName],
+      [this.schemaName, JSON.stringify(GENERATED_ALWAYS_IDENTITY_PRIMARY_KEYS)],
     );
     const row = caps.rows[0];
     const hasVector = Boolean(row?.has_vector);
     const hasTextSearch = Boolean(row?.has_text_search);
     const hasJobQueue = Boolean(row?.has_job_queue);
     const hasRuntimeEventsTable = Boolean(row?.has_runtime_events_table);
-    const runtimeEventsEventIdGenerates = Boolean(
-      row?.runtime_events_event_id_generates,
-    );
+    const missingGeneratedIdentityPrimaryKeys =
+      row?.missing_generated_identity_primary_keys ?? [];
+    const missingGeneratedIdentityDiagnostics =
+      missingGeneratedIdentityPrimaryKeys
+        .filter(
+          (identityKey) =>
+            hasRuntimeEventsTable || identityKey !== 'runtime_events.event_id',
+        )
+        .map((identityKey) => `${identityKey} identity/default is missing`);
     const hasEventBusOutboxTable = Boolean(row?.has_event_bus_outbox_table);
     const hasEventBusOutboxRuntimeEventUnique = Boolean(
       row?.has_event_bus_outbox_runtime_event_unique,
@@ -420,7 +446,7 @@ export class PostgresStorageService implements StorageService {
       row?.missing_event_bus_outbox_indexes ?? [];
     const hasRuntimeEvents =
       hasRuntimeEventsTable &&
-      runtimeEventsEventIdGenerates &&
+      missingGeneratedIdentityPrimaryKeys.length === 0 &&
       missingRuntimeEventIndexes.length === 0;
     const hasEventBusOutbox =
       hasEventBusOutboxTable &&
@@ -447,9 +473,7 @@ export class PostgresStorageService implements StorageService {
             hasRuntimeEventsTable
               ? undefined
               : 'runtime_events table is missing',
-            hasRuntimeEventsTable && !runtimeEventsEventIdGenerates
-              ? 'runtime_events.event_id identity/default is missing'
-              : undefined,
+            ...missingGeneratedIdentityDiagnostics,
             hasRuntimeEventsTable && missingRuntimeEventIndexes.length
               ? `runtime_events indexes are missing: ${missingRuntimeEventIndexes.join(', ')}`
               : undefined,

--- a/apps/core/src/adapters/storage/postgres/storage-service.ts
+++ b/apps/core/src/adapters/storage/postgres/storage-service.ts
@@ -319,6 +319,7 @@ export class PostgresStorageService implements StorageService {
       has_text_search: boolean;
       has_job_queue: boolean;
       has_runtime_events_table: boolean;
+      runtime_events_event_id_generates: boolean;
       has_event_bus_outbox_table: boolean;
       has_event_bus_outbox_runtime_event_unique: boolean;
       missing_runtime_event_indexes: string[] | null;
@@ -355,6 +356,17 @@ export class PostgresStorageService implements StorageService {
           EXISTS(SELECT 1 FROM pg_extension WHERE extname IN ('pg_trgm', 'pg_search')) AS has_text_search,
           (to_regclass('pgboss.version') IS NOT NULL) AS has_job_queue,
           ((SELECT runtime_events_oid FROM event_tables) IS NOT NULL) AS has_runtime_events_table,
+          EXISTS(
+            SELECT 1
+            FROM event_tables t
+            JOIN pg_attribute a ON a.attrelid = t.runtime_events_oid
+            LEFT JOIN pg_attrdef d
+              ON d.adrelid = a.attrelid
+             AND d.adnum = a.attnum
+            WHERE a.attname = 'event_id'
+              AND NOT a.attisdropped
+              AND (a.attidentity <> '' OR d.adbin IS NOT NULL)
+          ) AS runtime_events_event_id_generates,
           ((SELECT event_bus_outbox_oid FROM event_tables) IS NOT NULL) AS has_event_bus_outbox_table,
           EXISTS(
             SELECT 1
@@ -396,6 +408,9 @@ export class PostgresStorageService implements StorageService {
     const hasTextSearch = Boolean(row?.has_text_search);
     const hasJobQueue = Boolean(row?.has_job_queue);
     const hasRuntimeEventsTable = Boolean(row?.has_runtime_events_table);
+    const runtimeEventsEventIdGenerates = Boolean(
+      row?.runtime_events_event_id_generates,
+    );
     const hasEventBusOutboxTable = Boolean(row?.has_event_bus_outbox_table);
     const hasEventBusOutboxRuntimeEventUnique = Boolean(
       row?.has_event_bus_outbox_runtime_event_unique,
@@ -404,7 +419,9 @@ export class PostgresStorageService implements StorageService {
     const missingEventBusOutboxIndexes =
       row?.missing_event_bus_outbox_indexes ?? [];
     const hasRuntimeEvents =
-      hasRuntimeEventsTable && missingRuntimeEventIndexes.length === 0;
+      hasRuntimeEventsTable &&
+      runtimeEventsEventIdGenerates &&
+      missingRuntimeEventIndexes.length === 0;
     const hasEventBusOutbox =
       hasEventBusOutboxTable &&
       hasEventBusOutboxRuntimeEventUnique &&
@@ -430,6 +447,9 @@ export class PostgresStorageService implements StorageService {
             hasRuntimeEventsTable
               ? undefined
               : 'runtime_events table is missing',
+            hasRuntimeEventsTable && !runtimeEventsEventIdGenerates
+              ? 'runtime_events.event_id identity/default is missing'
+              : undefined,
             hasRuntimeEventsTable && missingRuntimeEventIndexes.length
               ? `runtime_events indexes are missing: ${missingRuntimeEventIndexes.join(', ')}`
               : undefined,

--- a/apps/core/test/integration/generated-identity-repair.postgres.integration.test.ts
+++ b/apps/core/test/integration/generated-identity-repair.postgres.integration.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+
+const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
+
+maybeDescribe('generated identity primary-key repair', () => {
+  let runtime: PostgresIntegrationRuntime;
+
+  beforeAll(async () => {
+    runtime = await createPostgresIntegrationRuntime({
+      schemaPrefix: 'identity_repair',
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await runtime?.cleanup();
+  });
+
+  it('detects drift, repairs it, and leaves the repair unchanged on rerun', async () => {
+    await runtime.service.pool.query(
+      'ALTER TABLE message_parts ALTER COLUMN id DROP IDENTITY IF EXISTS',
+    );
+
+    const drifted = await runtime.service.healthCheck();
+    expect(drifted.runtimeEvents).toBe(false);
+    expect(drifted.runtimeEventsReason).toContain(
+      'message_parts.id identity/default is missing',
+    );
+
+    const migration = fs.readFileSync(
+      path.resolve(
+        'apps/core/src/adapters/storage/postgres/schema/migrations/0104_runtime_events_identity_repair.sql',
+      ),
+      'utf8',
+    );
+    await runtime.service.pool.query(migration);
+
+    const repaired = await runtime.service.healthCheck();
+    expect(repaired.runtimeEvents).toBe(true);
+    expect(repaired.runtimeEventsReason).toBeUndefined();
+
+    const sequenceAfterRepair = await runtime.service.pool.query<{
+      sequence_oid: number | null;
+    }>(
+      "SELECT pg_get_serial_sequence('message_parts', 'id')::regclass::oid AS sequence_oid",
+    );
+    expect(sequenceAfterRepair.rows[0]?.sequence_oid).not.toBeNull();
+
+    await runtime.service.pool.query(migration);
+
+    const sequenceAfterRerun = await runtime.service.pool.query<{
+      sequence_oid: number | null;
+    }>(
+      "SELECT pg_get_serial_sequence('message_parts', 'id')::regclass::oid AS sequence_oid",
+    );
+    expect(sequenceAfterRerun.rows[0]?.sequence_oid).toBe(
+      sequenceAfterRepair.rows[0]?.sequence_oid,
+    );
+  });
+});

--- a/apps/core/test/unit/storage/generated-identity-primary-key-coverage.test.ts
+++ b/apps/core/test/unit/storage/generated-identity-primary-key-coverage.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { is } from 'drizzle-orm';
+import { getTableConfig, PgTable } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import { GENERATED_ALWAYS_IDENTITY_PRIMARY_KEYS } from '@core/adapters/storage/postgres/storage-service.js';
+import * as postgresSchema from '@core/adapters/storage/postgres/schema/schema.js';
+
+function key(tableName: string, columnName: string): string {
+  return `${tableName}.${columnName}`;
+}
+
+function schemaIdentityPrimaryKeys(): string[] {
+  return Object.values(postgresSchema)
+    .filter((value): value is PgTable => is(value, PgTable))
+    .flatMap((table) => {
+      const config = getTableConfig(table);
+      // Drizzle stores inline `.primaryKey()` on column.primary, but
+      // table-level `primaryKey({ columns })` in config.primaryKeys — an
+      // identity column declared the second way would otherwise escape the
+      // guard, leaving future coverage stale while this test stays green.
+      const tableLevelPkColumns = new Set(
+        config.primaryKeys.flatMap((pk) => pk.columns.map((c) => c.name)),
+      );
+      return config.columns
+        .filter(
+          (column) =>
+            column.generatedIdentity?.type === 'always' &&
+            (column.primary || tableLevelPkColumns.has(column.name)),
+        )
+        .map((column) => key(config.name, column.name));
+    })
+    .sort();
+}
+
+function migrationIdentityPrimaryKeys(): string[] {
+  const migration = fs.readFileSync(
+    path.resolve(
+      'apps/core/src/adapters/storage/postgres/schema/migrations/0104_runtime_events_identity_repair.sql',
+    ),
+    'utf8',
+  );
+  const values = migration.match(
+    /FROM \(VALUES(?<values>[\s\S]*?)\) AS identity_primary_keys\(table_name, column_name\)/,
+  )?.groups?.values;
+
+  expect(values).toBeDefined();
+  return [...(values ?? '').matchAll(/\('([^']+)',\s*'([^']+)'\)/g)]
+    .map((match) => key(match[1]!, match[2]!))
+    .sort();
+}
+
+describe('generated identity primary-key coverage', () => {
+  it('covers every schema identity primary key in the repair migration and readiness probe', () => {
+    const schemaKeys = schemaIdentityPrimaryKeys();
+    const probeKeys = GENERATED_ALWAYS_IDENTITY_PRIMARY_KEYS.map((entry) =>
+      key(entry.tableName, entry.columnName),
+    ).sort();
+
+    expect(migrationIdentityPrimaryKeys()).toEqual(schemaKeys);
+    expect(probeKeys).toEqual(schemaKeys);
+  });
+});

--- a/apps/core/test/unit/storage/postgres-migration-journal.test.ts
+++ b/apps/core/test/unit/storage/postgres-migration-journal.test.ts
@@ -23,7 +23,7 @@ describe('Postgres migration journal', () => {
     }
   });
 
-  it('registers the runtime events identity repair', () => {
+  it('registers the generated identity primary-key repair', () => {
     const migrationsDir = path.resolve(
       'apps/core/src/adapters/storage/postgres/schema/migrations',
     );
@@ -41,9 +41,15 @@ describe('Postgres migration journal', () => {
       'utf8',
     );
     expect(migration).toContain(
-      'ALTER COLUMN event_id ADD GENERATED ALWAYS AS IDENTITY',
+      'AS identity_primary_keys(table_name, column_name)',
     );
-    expect(migration).toContain('COALESCE(MAX(event_id), 0) + 1');
+    expect(migration).toContain("('runtime_events', 'event_id')");
+    expect(migration).toContain("('message_parts', 'id')");
+    expect(migration).toContain("('memory_recall_events', 'id')");
+    expect(migration).toContain(
+      'ALTER TABLE %s ALTER COLUMN %I ADD GENERATED ALWAYS AS IDENTITY',
+    );
+    expect(migration).toContain('COALESCE(MAX(%I), 0) + 1');
   });
 
   it('registers the permission prompt relational cutover', () => {

--- a/apps/core/test/unit/storage/postgres-migration-journal.test.ts
+++ b/apps/core/test/unit/storage/postgres-migration-journal.test.ts
@@ -23,6 +23,29 @@ describe('Postgres migration journal', () => {
     }
   });
 
+  it('registers the runtime events identity repair', () => {
+    const migrationsDir = path.resolve(
+      'apps/core/src/adapters/storage/postgres/schema/migrations',
+    );
+    const journal = JSON.parse(
+      fs.readFileSync(path.join(migrationsDir, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(
+      journal.entries.find(
+        (entry) => entry.tag === '0104_runtime_events_identity_repair',
+      ),
+    ).toMatchObject({ idx: 104 });
+
+    const migration = fs.readFileSync(
+      path.join(migrationsDir, '0104_runtime_events_identity_repair.sql'),
+      'utf8',
+    );
+    expect(migration).toContain(
+      'ALTER COLUMN event_id ADD GENERATED ALWAYS AS IDENTITY',
+    );
+    expect(migration).toContain('COALESCE(MAX(event_id), 0) + 1');
+  });
+
   it('registers the permission prompt relational cutover', () => {
     const migrationsDir = path.resolve(
       'apps/core/src/adapters/storage/postgres/schema/migrations',

--- a/apps/core/test/unit/storage/storage-service.test.ts
+++ b/apps/core/test/unit/storage/storage-service.test.ts
@@ -2,6 +2,7 @@ import { readMigrationFiles } from 'drizzle-orm/migrator';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  GENERATED_ALWAYS_IDENTITY_PRIMARY_KEYS,
   PostgresStorageService,
   createStorageService,
   postgresMigrationsFolder,
@@ -142,6 +143,50 @@ describe('storage-service', () => {
     );
 
     expect(query).toHaveBeenCalledOnce();
+    await service.close();
+  });
+
+  it('fails readiness with the exact diagnostic when any identity primary key loses its generator', async () => {
+    const service = new PostgresStorageService(
+      'postgres://user:pass@127.0.0.1:5432/gantry',
+      'gantry',
+    );
+    const query = vi
+      .spyOn(service.pool, 'query')
+      .mockImplementation(async (statement: unknown, params?: unknown[]) => {
+        const sql = String(statement);
+        if (sql === 'SELECT 1') {
+          return { rows: [{}] } as never;
+        }
+        expect(sql).toContain('jsonb_to_recordset($2::jsonb)');
+        expect(params?.[0]).toBe('gantry');
+        expect(JSON.parse(String(params?.[1]))).toEqual(
+          GENERATED_ALWAYS_IDENTITY_PRIMARY_KEYS,
+        );
+        return {
+          rows: [
+            {
+              has_vector: true,
+              has_text_search: true,
+              has_job_queue: true,
+              has_runtime_events_table: true,
+              missing_generated_identity_primary_keys: ['message_parts.id'],
+              has_event_bus_outbox_table: true,
+              has_event_bus_outbox_runtime_event_unique: true,
+              missing_runtime_event_indexes: [],
+              missing_event_bus_outbox_indexes: [],
+            },
+          ],
+        } as never;
+      });
+
+    const capabilities = await service.healthCheck();
+
+    expect(capabilities.runtimeEvents).toBe(false);
+    expect(capabilities.runtimeEventsReason).toBe(
+      'message_parts.id identity/default is missing',
+    );
+    expect(query).toHaveBeenCalledTimes(2);
     await service.close();
   });
 });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

Fixes a Postgres schema drift issue where runtime_events.event_id existed as a plain NOT NULL integer column without an identity/default generator. Runtime code inserts event_id using DEFAULT, so affected deployments were failing to persist audit/diagnostic runtime events.
Changes:
Added migration 0104_runtime_events_identity_repair to restore GENERATED ALWAYS AS IDENTITY on runtime_events.event_id when missing.
Hardened Postgres readiness checks to detect this drift before runtime event writes fail.
Added migration journal test coverage so the repair migration stays registered and visible.

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
