### PR TITLE
test: memory lifecycle + corrupt-route integrity (matrix §8 + §11)

### DIFF
--- a/apps/core/test/integration/memory-lifecycle.postgres.integration.test.ts
+++ b/apps/core/test/integration/memory-lifecycle.postgres.integration.test.ts
@@ -1,0 +1,280 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+
+// The deterministic fallback keeps automatic memory collection and dreaming
+// enabled while disabling all live embedding dependencies.
+vi.mock('@core/config/memory.js', async () => {
+  const actual = await vi.importActual<typeof import('@core/config/memory.js')>(
+    '@core/config/memory.js',
+  );
+  return {
+    ...actual,
+    RUNTIME_MEMORY_ENABLED: true,
+    RUNTIME_MEMORY_DREAMING_ENABLED: true,
+    MEMORY_DREAMING_EMBEDDINGS_ENABLED: false,
+    MEMORY_DREAMING_EMBED_PROVIDER: 'disabled',
+    MEMORY_EMBED_PROVIDER: 'disabled',
+  };
+});
+
+import { _setRuntimeStorageForTest } from '@core/adapters/storage/postgres/runtime-store.js';
+import * as pgSchema from '@core/adapters/storage/postgres/schema/schema.js';
+import { PostgresStorageService } from '@core/adapters/storage/postgres/storage-service.js';
+import { collectDurableMemoryAtBoundary } from '@core/memory/app-memory-session-boundary-collector.js';
+import { AppMemoryService } from '@core/memory/app-memory-service.js';
+import { processMemoryRequest } from '@core/memory/memory-ipc.js';
+import { registerMemoryLlmClient } from '@core/memory/memory-llm-port.js';
+import type { MemoryIpcResponse } from '@gantry/contracts';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+
+const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
+
+const AGENT_FOLDER = 'main_agent';
+const CHAT_JID = 'tg:memory-lifecycle';
+const SEARCH_TOKEN = 'cobalt-orchard-7319';
+const TURN_CONTEXT = {
+  chatJid: CHAT_JID,
+  defaultScope: 'group' as const,
+};
+
+const unconfiguredMemoryLlm = {
+  isConfigured: () => false,
+  query: async () => '[]',
+};
+
+function recalledMemoryIds(response: MemoryIpcResponse): string[] {
+  const data = response.data as
+    | { results?: Array<{ item?: { id?: string } }> }
+    | undefined;
+  return (data?.results ?? [])
+    .map((result) => result.item?.id)
+    .filter((id): id is string => Boolean(id));
+}
+
+async function recallCount(
+  service: PostgresStorageService,
+  itemId: string,
+): Promise<number> {
+  const rows = await service.db
+    .select({ id: pgSchema.memoryRecallEventsPostgres.id })
+    .from(pgSchema.memoryRecallEventsPostgres)
+    .where(eq(pgSchema.memoryRecallEventsPostgres.itemId, itemId));
+  return rows.length;
+}
+
+// Matrix §8 deterministic seam fallback. E2E_ANTHROPIC_API_KEY is not
+// available in this environment, so a reliable real-model gate cannot run.
+// Instead, a real persisted session transcript enters the production boundary
+// collector through a scripted MemoryLlmClient, structured evidence is promoted
+// by the real dreaming service, and later scripted turns use the production
+// memory_search IPC action. This remains distinct from the service-level
+// subject-isolation coverage in memory-write-recall-boundary.postgres.integration.test.ts.
+maybeDescribe('memory turn lifecycle (Postgres scripted-turn seam)', () => {
+  let runtime: PostgresIntegrationRuntime;
+  let restartedService: PostgresStorageService | undefined;
+
+  beforeAll(async () => {
+    runtime = await createPostgresIntegrationRuntime({
+      schemaPrefix: 'memory_lifecycle',
+    });
+    _setRuntimeStorageForTest(runtime.storageRuntime);
+    AppMemoryService.resetForTest();
+    registerMemoryLlmClient(unconfiguredMemoryLlm);
+  }, 60_000);
+
+  afterAll(async () => {
+    registerMemoryLlmClient(unconfiguredMemoryLlm);
+    AppMemoryService.resetForTest();
+    if (runtime) _setRuntimeStorageForTest(runtime.storageRuntime);
+    await restartedService?.close();
+    await runtime?.cleanup();
+  });
+
+  it('collects a channel memory from turn 1, records turn-2 recall, and recalls after restart', async () => {
+    const turnContext = await runtime.ops.getAgentTurnContext({
+      appId: 'default',
+      agentFolder: AGENT_FOLDER,
+      executionProviderId: 'anthropic:claude-agent-sdk' as never,
+      conversationJid: CHAT_JID,
+      conversationKind: 'channel',
+      hydrateMemory: false,
+    });
+    const session = await runtime.repositories.agentSessions.getAgentSession(
+      turnContext.agentSessionId as never,
+    );
+    if (!session?.conversationId) {
+      throw new Error('Expected a durable agent session and conversation.');
+    }
+
+    await runtime.repositories.messages.saveMessage({
+      id: 'message:memory-lifecycle:turn-1-user' as never,
+      appId: session.appId,
+      conversationId: session.conversationId,
+      direction: 'inbound',
+      senderDisplayName: 'Memory Lifecycle User',
+      trust: 'trusted',
+      createdAt: '2026-07-21T00:00:00.000Z' as never,
+      parts: [
+        {
+          kind: 'text',
+          text: `Remember that the durable marker is ${SEARCH_TOKEN}.`,
+        },
+      ],
+      attachments: [],
+    });
+    await runtime.repositories.messages.saveMessage({
+      id: 'message:memory-lifecycle:turn-1-assistant' as never,
+      appId: session.appId,
+      conversationId: session.conversationId,
+      direction: 'outbound',
+      senderDisplayName: 'Gantry',
+      trust: 'system',
+      createdAt: '2026-07-21T00:00:01.000Z' as never,
+      deliveryStatus: 'sent',
+      parts: [{ kind: 'text', text: 'The durable fact was acknowledged.' }],
+      attachments: [],
+    });
+    const persistedTurns =
+      await runtime.repositories.messages.listRecentMessages({
+        conversationId: session.conversationId,
+        threadId: session.threadId,
+        limit: 10,
+      });
+    expect(persistedTurns).toHaveLength(2);
+    expect(persistedTurns.map((message) => message.direction).sort()).toEqual([
+      'inbound',
+      'outbound',
+    ]);
+
+    const extractorQueries: unknown[] = [];
+    registerMemoryLlmClient({
+      isConfigured: () => true,
+      query: async (options) => {
+        extractorQueries.push(options);
+        return JSON.stringify([
+          {
+            kind: 'fact',
+            scope: 'group',
+            key: 'fact:memory-lifecycle-marker',
+            value: `The durable marker is ${SEARCH_TOKEN}.`,
+            confidence: 1,
+            why: `The durable marker is ${SEARCH_TOKEN}.`,
+          },
+        ]);
+      },
+    });
+    const memory = AppMemoryService.getInstance();
+    const collected = await collectDurableMemoryAtBoundary(
+      {
+        agentSessionId: turnContext.agentSessionId,
+        trigger: 'session-end',
+        defaultScope: 'group',
+      },
+      {
+        repositories: runtime.repositories,
+        memory: {
+          recordEvidence: (value) => memory.recordEvidence(value),
+        },
+      },
+    );
+    expect(collected).toEqual({ saved: 1 });
+    expect(extractorQueries).toHaveLength(1);
+
+    const evidenceRows = await runtime.service.db
+      .select()
+      .from(pgSchema.memoryEvidencePostgres);
+    expect(evidenceRows).toHaveLength(1);
+    expect(evidenceRows[0]).toMatchObject({
+      appId: session.appId,
+      agentId: session.agentId,
+      subjectType: 'channel',
+      sourceType: 'session',
+    });
+
+    registerMemoryLlmClient(unconfiguredMemoryLlm);
+    const evidence = evidenceRows[0]!;
+    const dream = await memory.triggerDreaming({
+      appId: evidence.appId,
+      agentId: evidence.agentId,
+      subjectType: evidence.subjectType as 'channel',
+      subjectId: evidence.subjectId,
+      ...(evidence.groupId ? { groupId: evidence.groupId } : {}),
+      ...(evidence.channelId ? { channelId: evidence.channelId } : {}),
+      phase: 'all',
+      dryRun: false,
+    });
+    expect(dream.status).toBe('completed');
+
+    const activeItems = await runtime.service.db
+      .select({
+        id: pgSchema.memoryItemsPostgres.id,
+        agentId: pgSchema.memoryItemsPostgres.agentId,
+        subjectType: pgSchema.memoryItemsPostgres.subjectType,
+        status: pgSchema.memoryItemsPostgres.status,
+      })
+      .from(pgSchema.memoryItemsPostgres)
+      .where(
+        and(
+          eq(pgSchema.memoryItemsPostgres.agentId, session.agentId),
+          eq(pgSchema.memoryItemsPostgres.status, 'active'),
+        ),
+      );
+    expect(activeItems).toHaveLength(1);
+    expect(activeItems[0]).toMatchObject({
+      agentId: session.agentId,
+      subjectType: 'channel',
+      status: 'active',
+    });
+    const itemId = activeItems[0]!.id;
+
+    const turnTwo = await processMemoryRequest(
+      {
+        requestId: 'memory-lifecycle-turn-2-search',
+        action: 'memory_search',
+        payload: { query: SEARCH_TOKEN, limit: 10 },
+        context: TURN_CONTEXT,
+      },
+      AGENT_FOLDER,
+    );
+    expect(turnTwo.ok).toBe(true);
+    expect(recalledMemoryIds(turnTwo)).toContain(itemId);
+    const recallsBeforeRestart = await recallCount(runtime.service, itemId);
+    expect(recallsBeforeRestart).toBeGreaterThan(0);
+
+    restartedService = new PostgresStorageService(
+      process.env.GANTRY_TEST_DATABASE_URL!,
+      runtime.schemaName,
+    );
+    AppMemoryService.resetForTest();
+    _setRuntimeStorageForTest({
+      ...runtime.storageRuntime,
+      service: restartedService,
+    });
+
+    const persistedRows = await restartedService.db
+      .select({ id: pgSchema.memoryItemsPostgres.id })
+      .from(pgSchema.memoryItemsPostgres)
+      .where(eq(pgSchema.memoryItemsPostgres.id, itemId));
+    expect(persistedRows).toEqual([{ id: itemId }]);
+
+    const postRestartTurn = await processMemoryRequest(
+      {
+        requestId: 'memory-lifecycle-post-restart-search',
+        action: 'memory_search',
+        payload: { query: SEARCH_TOKEN, limit: 10 },
+        context: TURN_CONTEXT,
+      },
+      AGENT_FOLDER,
+    );
+    expect(postRestartTurn.ok).toBe(true);
+    expect(recalledMemoryIds(postRestartTurn)).toContain(itemId);
+    expect(await recallCount(restartedService, itemId)).toBeGreaterThan(
+      recallsBeforeRestart,
+    );
+  });
+});

--- a/apps/core/test/integration/route-integrity-corrupt-state.postgres.integration.test.ts
+++ b/apps/core/test/integration/route-integrity-corrupt-state.postgres.integration.test.ts
@@ -1,0 +1,341 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_APP_ID,
+} from '@core/adapters/storage/postgres/seeds.js';
+import { quotePostgresIdentifier } from '@core/adapters/storage/postgres/storage-service.js';
+import { buildLiveAdmissionProcessor } from '@core/app/bootstrap/live-execution.js';
+import type { AgentId } from '@core/domain/agent/agent.js';
+import type { AppId } from '@core/domain/app/app.js';
+import type {
+  ProviderAccountId,
+  ProviderId,
+} from '@core/domain/provider/provider.js';
+import { GroupQueue } from '@core/runtime/group-queue.js';
+import { startLiveAdmissionWorkLoop } from '@core/runtime/live-admission-work-loop.js';
+import { LiveTurnAuthority } from '@core/runtime/live-turn-authority.js';
+import { makeAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+
+const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
+
+maybeDescribe('route integrity corrupt-state recovery (Postgres)', () => {
+  let runtime: PostgresIntegrationRuntime;
+
+  beforeAll(async () => {
+    runtime = await createPostgresIntegrationRuntime({
+      schemaPrefix: 'route_integrity_corrupt',
+    });
+  });
+
+  afterAll(async () => {
+    await runtime?.cleanup();
+  });
+
+  it('collapses corrupt database route aliases and admits exactly one live turn', async () => {
+    const chatJid = 'tg:route-integrity-corrupt';
+    const providerAccountId =
+      'provider-account:route-integrity' as ProviderAccountId;
+    const legacyConversationId = 'legacy-route-integrity-conversation';
+    const canonicalConversationId = `conversation:${providerAccountId}:${chatJid}`;
+    const agentQualifiedRouteKey = makeAgentThreadQueueKey(
+      chatJid,
+      'main_agent',
+    );
+    const fullyQualifiedRouteKey = makeAgentThreadQueueKey(
+      chatJid,
+      DEFAULT_AGENT_ID,
+      undefined,
+      providerAccountId,
+    );
+    const workerInstanceId = 'worker-route-integrity-corrupt';
+    const table = (name: string): string =>
+      `${quotePostgresIdentifier(runtime.schemaName)}.${quotePostgresIdentifier(name)}`;
+
+    await runtime.repositories.providerAccounts.saveProviderAccount({
+      id: providerAccountId,
+      appId: DEFAULT_APP_ID as AppId,
+      agentId: DEFAULT_AGENT_ID as AgentId,
+      providerId: 'telegram' as ProviderId,
+      externalIdentityRef: {
+        kind: 'provider_account',
+        value: providerAccountId,
+      },
+      label: 'Route integrity Telegram account',
+      status: 'active',
+      config: {},
+      runtimeSecretRefs: {},
+      createdAt: '2026-07-21T00:00:00.000Z',
+      updatedAt: '2026-07-21T00:00:00.000Z',
+    });
+
+    // Matrix §11 sanctions direct test-DB corruption here. Repository,
+    // desired-state, admission persistence, and message qualification are
+    // already covered by canonical-binding-repository.test.ts,
+    // settings-desired-state-service.test.ts,
+    // live-admission-work-items.postgres.integration.test.ts, and
+    // canonical-message-ops-service.test.ts; this test alone seeds rows that
+    // bypass those APIs and arrive through the real PostgreSQL loader.
+    await runtime.service.pool.query(
+      `INSERT INTO ${table('conversations')} (
+         id, app_id, provider_account_id, external_ref_json, kind, title,
+         status, created_at, updated_at
+       )
+       VALUES
+         ($1, $2, $3, $4, $5, $6, $7, $8, $8),
+         ($9, $2, $3, $4, $5, $10, $7, $8, $8)`,
+      [
+        canonicalConversationId,
+        DEFAULT_APP_ID,
+        providerAccountId,
+        JSON.stringify({ jid: chatJid }),
+        'group',
+        'Canonical route integrity conversation',
+        'active',
+        '2026-07-21T00:00:00.000Z',
+        legacyConversationId,
+        'Legacy route integrity conversation',
+      ],
+    );
+    await runtime.service.pool.query(
+      `INSERT INTO ${table('conversation_installs')} (
+         id, app_id, agent_id, provider_account_id, conversation_id, thread_id,
+         display_name, status, sender_policy, control_policy, memory_scope,
+         memory_subject_json, permission_policy_ids_json, created_at, updated_at
+       )
+       SELECT seeded.id, $1, $2, $3, seeded.conversation_id, NULL, $4,
+              'active', 'provider_native', 'conversation_approvers',
+              'conversation', $5, '[]', $6, seeded.updated_at
+       FROM (VALUES
+         ($7::text, $8::text, $9::timestamptz),
+         ($10::text, $8::text, $11::timestamptz),
+         ($12::text, $13::text, $14::timestamptz)
+       ) AS seeded(id, conversation_id, updated_at)`,
+      [
+        DEFAULT_APP_ID,
+        DEFAULT_AGENT_ID,
+        providerAccountId,
+        'Route integrity conversation',
+        JSON.stringify({
+          route: { trigger: '@main', requiresTrigger: false },
+        }),
+        '2026-07-21T00:00:00.000Z',
+        `conversation-route:${chatJid}`,
+        legacyConversationId,
+        '2026-07-21T00:03:00.000Z',
+        `conversation-route:${agentQualifiedRouteKey}`,
+        '2026-07-21T00:02:00.000Z',
+        `conversation-route:${fullyQualifiedRouteKey}`,
+        canonicalConversationId,
+        '2026-07-21T00:01:00.000Z',
+      ],
+    );
+
+    const routes = await runtime.ops.getAllConversationRoutes();
+    expect(Object.keys(routes)).toEqual([fullyQualifiedRouteKey]);
+    expect(routes[fullyQualifiedRouteKey]).toMatchObject({
+      folder: 'main_agent',
+      conversationId: canonicalConversationId,
+      providerAccountId,
+      requiresTrigger: false,
+    });
+
+    const admission = await runtime.ops.storeMessageWithLiveAdmission?.(
+      {
+        id: 'route-integrity-message-1',
+        chat_jid: chatJid,
+        provider: 'telegram',
+        sender: 'route-integrity-user',
+        sender_name: 'Route Integrity User',
+        content: 'admit this durable route-integrity turn',
+        timestamp: '2026-07-21T00:04:00.000Z',
+        is_from_me: false,
+        is_bot_message: false,
+      },
+      {
+        appId: DEFAULT_APP_ID,
+        agentId: 'main_agent',
+        triggerDecision: {
+          source: 'channel_persistence',
+          requiresTrigger: false,
+        },
+      },
+    );
+    expect(admission).toMatchObject({
+      outcome: 'enqueued',
+      item: {
+        queueJid: fullyQualifiedRouteKey,
+        conversationId: chatJid,
+        state: 'queued',
+      },
+    });
+    if (!admission) throw new Error('Expected a live admission work item.');
+
+    await runtime.repositories.workerCoordination.registerWorker({
+      id: workerInstanceId,
+      bootNonce: 'route-integrity-corrupt',
+    });
+    const liveTurnAuthority = new LiveTurnAuthority({
+      leaseDeps: {
+        liveTurns: runtime.repositories.liveTurns,
+        coordination: runtime.repositories.workerCoordination,
+        workerInstanceId,
+      },
+      slotCapacity: () => 1,
+      leaseTtlMs: 60_000,
+      ownerPollMs: 60_000,
+    });
+    const queue = new GroupQueue({
+      maxMessageRuns: 1,
+      maxJobRuns: 1,
+      maxRetries: 0,
+      baseRetryMs: 1,
+    });
+    const processGroupMessages = vi.fn(async () => true);
+    const getOrRecoverCursor = async () => '';
+    const processor = buildLiveAdmissionProcessor({
+      liveTurnAuthority,
+      app: {
+        getConversationRoutes: () => routes,
+        processGroupMessages,
+        getOrRecoverCursor,
+        setAgentCursor: () => undefined,
+        saveState: () => undefined,
+      },
+      opsRepository: runtime.ops,
+      executionAdapter: { id: 'anthropic:claude-agent-sdk' },
+      messageFetchPageSize: 50,
+      timezone: 'UTC',
+      enqueueMessageCheck: (queueJid) => queue.enqueueMessageCheck(queueJid),
+      warn: () => undefined,
+    });
+    queue.setProcessMessagesFn(processor);
+
+    const loop = startLiveAdmissionWorkLoop({
+      liveAdmissions: runtime.repositories.liveTurns,
+      appId: DEFAULT_APP_ID,
+      workerInstanceId,
+      messageLoopDeps: {
+        getConversationRoutes: () => routes,
+        getOrRecoverCursor,
+        setAgentCursor: () => undefined,
+        saveState: () => undefined,
+        hasChannel: (_jid, options) =>
+          options?.providerAccountId === providerAccountId,
+        setTyping: async () => undefined,
+        sendProgressUpdate: async () => undefined,
+        queue,
+        opsRepository: runtime.ops,
+      },
+      claimLimit: 1,
+      intervalMs: 60_000,
+      maxBatchesPerWake: 1,
+      warn: () => undefined,
+    });
+
+    try {
+      await vi.waitFor(
+        () => expect(processGroupMessages).toHaveBeenCalledOnce(),
+        { timeout: 10_000, interval: 25 },
+      );
+      await vi.waitFor(
+        async () => {
+          const result = await runtime.service.pool.query<{ state: string }>(
+            `SELECT state FROM ${table('live_admission_work_items')} WHERE id = $1`,
+            [admission.item.id],
+          );
+          expect(result.rows).toEqual([{ state: 'completed' }]);
+        },
+        { timeout: 10_000, interval: 25 },
+      );
+      await vi.waitFor(
+        async () => {
+          const [runResult, liveTurnResult] = await Promise.all([
+            runtime.service.pool.query<{ status: string }>(
+              `SELECT status FROM ${table('agent_runs')}`,
+            ),
+            runtime.service.pool.query<{ state: string }>(
+              `SELECT state FROM ${table('live_turns')}`,
+            ),
+          ]);
+          expect(runResult.rows).toEqual([{ status: 'completed' }]);
+          expect(liveTurnResult.rows).toEqual([{ state: 'completed' }]);
+        },
+        { timeout: 10_000, interval: 25 },
+      );
+
+      const [conversations, sessions, runs, liveTurns] = await Promise.all([
+        runtime.service.pool.query<{ id: string }>(
+          `SELECT id FROM ${table('conversations')}
+           WHERE external_ref_json::jsonb->>'jid' = $1
+           ORDER BY id`,
+          [chatJid],
+        ),
+        runtime.service.pool.query<{
+          id: string;
+          conversation_id: string;
+          status: string;
+        }>(
+          `SELECT id, conversation_id, status
+           FROM ${table('agent_sessions')}
+           WHERE agent_id = $1`,
+          [DEFAULT_AGENT_ID],
+        ),
+        runtime.service.pool.query<{
+          id: string;
+          conversation_id: string;
+          cause: string;
+          status: string;
+        }>(
+          `SELECT id, conversation_id, cause, status
+           FROM ${table('agent_runs')}`,
+        ),
+        runtime.service.pool.query<{
+          run_id: string;
+          conversation_id: string;
+          state: string;
+        }>(
+          `SELECT run_id, conversation_id, state
+           FROM ${table('live_turns')}`,
+        ),
+      ]);
+
+      expect(processGroupMessages).toHaveBeenCalledTimes(1);
+      expect(conversations.rows).toEqual([
+        { id: canonicalConversationId },
+        { id: legacyConversationId },
+      ]);
+      expect(sessions.rows).toEqual([
+        expect.objectContaining({
+          conversation_id: canonicalConversationId,
+          status: 'active',
+        }),
+      ]);
+      expect(runs.rows).toEqual([
+        expect.objectContaining({
+          conversation_id: canonicalConversationId,
+          cause: 'message',
+          status: 'completed',
+        }),
+      ]);
+      expect(liveTurns.rows).toEqual([
+        {
+          run_id: runs.rows[0]?.id,
+          conversation_id: chatJid,
+          state: 'completed',
+        },
+      ]);
+    } finally {
+      await loop.stop({ drainDeadlineMs: 5_000 });
+      await loop.done;
+      await queue.shutdown(5_000);
+      await liveTurnAuthority.shutdown();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Closes 🔨 gaps in E2E matrix §8 (memories) and §11 (route integrity).

## §11 route-integrity-corrupt-state (integration)
Direct-seeds divergent/legacy canonical rows into the test DB (the sanctioned direct-DB exception, cited in-file), then proves the production loader collapses them to ONE route via total preference order (retain-and-warn, never throw, never drop a chat) and that a message for that route still admits + spawns exactly one turn — no silent drop, no parallel conversation. Verified driving the real dedup (loader emits the alias-dropped warning for the seeded legacy row).

## §8 memory-lifecycle (integration, deterministic seam)
Turn-1 durable fact → real boundary collector → evidence row → real dreaming service → active memory item; turn-2 `memory_search` IPC recalls it + records a recall event; survives a fresh-service restart (item persists, post-restart search recalls, recall count increments). Runs through the PRODUCTION collection/dreaming/search services; only the extractor LLM is scripted because `E2E_ANTHROPIC_API_KEY` is unavailable here — the sanctioned below-the-model seam, documented in-file and kept distinct from the existing subject-isolation boundary test.

## Verification
- Both files: 2/2 pass on real Postgres.
- Route + admission suites: 17/17; cited route unit suites: 114/114 (Codex); independently re-ran the 2 new files green.
- `apps/core` typecheck clean; test-only, no source changes.