### PR TITLE
test: jobs lifecycle e2e + fix autonomous denial parser (matrix §9)

### DIFF
--- a/apps/core/src/shared/autonomous-tool-denial.ts
+++ b/apps/core/src/shared/autonomous-tool-denial.ts
@@ -12,9 +12,7 @@ export function parseAutonomousToolDenial(
   );
   if (!prefixMatch || prefixMatch.index === undefined) return null;
   const afterPrefix = value.slice(prefixMatch.index + prefixMatch[0].length);
-  const recoveryBoundary = afterPrefix.search(/\.\s*Recovery:/i);
-  const sentenceBoundary =
-    recoveryBoundary >= 0 ? recoveryBoundary : afterPrefix.search(/\.\s/);
+  const sentenceBoundary = findToolRuleSentenceBoundary(afterPrefix);
   const toolName = (
     sentenceBoundary >= 0 ? afterPrefix.slice(0, sentenceBoundary) : afterPrefix
   )
@@ -27,4 +25,45 @@ export function parseAutonomousToolDenial(
     toolName,
     recoveryAction: recoveryMatch?.[1]?.trim(),
   };
+}
+
+function findToolRuleSentenceBoundary(value: string): number {
+  let parenthesisDepth = 0;
+  let quote: "'" | '"' | '`' | undefined;
+  let escaped = false;
+  for (let index = 0; index < value.length - 1; index += 1) {
+    const character = value[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character;
+      continue;
+    }
+    if (character === '(') {
+      parenthesisDepth += 1;
+      continue;
+    }
+    if (character === ')') {
+      parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+      continue;
+    }
+    if (
+      character === '.' &&
+      parenthesisDepth === 0 &&
+      /\s/.test(value[index + 1]!)
+    ) {
+      return index;
+    }
+  }
+  return -1;
 }

--- a/apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts
+++ b/apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts
@@ -1,0 +1,561 @@
+import fs from 'node:fs';
+import { globSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { Client } from 'pg';
+
+import { AgentE2EApiClient } from '../harness/api-client.js';
+import {
+  startRuntimeHarness,
+  type RuntimeHarness,
+} from '../harness/runtime-harness.js';
+
+const hasDb = Boolean(process.env.GANTRY_TEST_DATABASE_URL?.trim());
+const maybeDescribe = hasDb ? describe : describe.skip;
+const TEST_TIMEOUT_MS = 300_000;
+
+interface StoredJob {
+  jobId: string;
+  status: string;
+  health: {
+    state: string;
+    latestRunId: string | null;
+    latestRunStatus: string | null;
+  };
+}
+
+interface JobEvent {
+  event_type: string;
+  payload: string | null;
+}
+
+function installRuntimeSettings(home: string): void {
+  fs.writeFileSync(
+    path.join(home, 'settings.yaml'),
+    `runtime:
+  deployment_mode: workstation
+  sandbox:
+    provider: sandbox_runtime
+
+storage:
+  postgres:
+    url_env: GANTRY_DATABASE_URL
+    schema: gantry
+`,
+  );
+}
+
+function installHermeticRunnerTools(home: string): string {
+  const binDir = path.join(home, '.local', 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(binDir, 'claude'),
+    `#!${process.execPath}
+const sessionId = '00000000-0000-4000-8000-000000000001';
+let emitted = false;
+let input = '';
+function write(message) {
+  process.stdout.write(JSON.stringify(message) + '\\n');
+}
+function emit() {
+  if (emitted) return;
+  emitted = true;
+  const messages = [
+    {
+      type: 'system',
+      subtype: 'init',
+      apiKeySource: 'temporary',
+      claude_code_version: 'agent-e2e-fake',
+      cwd: process.cwd(),
+      tools: [],
+      mcp_servers: [{ name: 'gantry', status: 'connected' }],
+      model: 'claude-haiku-4-5-20251001',
+      permissionMode: 'default',
+      slash_commands: [],
+      output_style: 'default',
+      skills: [],
+      plugins: [],
+      uuid: '00000000-0000-4000-8000-000000000002',
+      session_id: sessionId,
+    },
+    {
+      type: 'assistant',
+      uuid: '00000000-0000-4000-8000-000000000003',
+      session_id: sessionId,
+      parent_tool_use_id: null,
+      message: {
+        id: 'msg_agent_e2e_job_lifecycle',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-haiku-4-5-20251001',
+        content: [{ type: 'text', text: 'job completed' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      duration_api_ms: 1,
+      is_error: false,
+      num_turns: 1,
+      result: 'job completed',
+      stop_reason: 'end_turn',
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: '00000000-0000-4000-8000-000000000004',
+      session_id: sessionId,
+    },
+  ];
+  for (const message of messages) write(message);
+  setTimeout(() => process.exit(0), 50);
+}
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+  let newline;
+  while ((newline = input.indexOf('\\n')) >= 0) {
+    const line = input.slice(0, newline);
+    input = input.slice(newline + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    if (
+      message.type === 'control_request' &&
+      message.request?.subtype === 'initialize'
+    ) {
+      write({
+        type: 'control_response',
+        response: {
+          subtype: 'success',
+          request_id: message.request_id,
+          response: { commands: [], models: [], agents: [] },
+        },
+      });
+      emit();
+    } else if (
+      message.type === 'control_request' &&
+      message.request?.subtype === 'get_context_usage'
+    ) {
+      write({
+        type: 'control_response',
+        response: {
+          subtype: 'success',
+          request_id: message.request_id,
+          response: {
+            categories: [],
+            totalTokens: 2,
+            maxTokens: 200000,
+            rawMaxTokens: 200000,
+            percentage: 0.001,
+            gridRows: [],
+            model: 'claude-haiku-4-5-20251001',
+            memoryFiles: [],
+            mcpTools: [],
+            agents: [],
+            isAutoCompactEnabled: false,
+          },
+        },
+      });
+      setTimeout(() => process.exit(0), 10);
+    }
+  }
+});
+process.stdin.on('end', emit);
+`,
+  );
+
+  // The hermetic gate runs before CI installs bubblewrap/socat. These
+  // per-scenario shims let the packaged sandbox wrapper start the isolated
+  // deterministic runner without modifying the shared SDK executable. This
+  // scenario proves jobs lifecycle behavior, not sandbox enforcement.
+  fs.writeFileSync(
+    path.join(binDir, 'socat'),
+    `#!${process.execPath}
+const fs = require('node:fs');
+const listen = process.argv.find((arg) => arg.startsWith('UNIX-LISTEN:'));
+const socketPath = listen?.slice('UNIX-LISTEN:'.length).split(',')[0];
+if (socketPath) fs.closeSync(fs.openSync(socketPath, 'w'));
+const finish = () => {
+  if (socketPath) fs.rmSync(socketPath, { force: true });
+  process.exit(0);
+};
+process.on('SIGINT', finish);
+process.on('SIGTERM', finish);
+setInterval(() => {}, 60_000);
+`,
+  );
+  fs.writeFileSync(
+    path.join(binDir, 'rg'),
+    `#!${process.execPath}
+process.exit(0);
+`,
+  );
+  fs.writeFileSync(
+    path.join(binDir, 'bwrap'),
+    `#!${process.execPath}
+const { spawn } = require('node:child_process');
+const marker = process.argv.indexOf('--');
+if (marker < 0 || !process.argv[marker + 1]) {
+  console.error('hermetic bwrap shim: command marker missing');
+  process.exit(2);
+}
+const command = process.argv[marker + 1];
+const args = process.argv.slice(marker + 2);
+const last = args.length - 1;
+if (last >= 0) {
+  args[last] = args[last].replace(
+    /[^\\s'"]*apply-seccomp[^\\s'"]*/g,
+    '/usr/bin/env',
+  );
+}
+const child = spawn(command, args, {
+  stdio: 'inherit',
+  env: { ...process.env, HOME: ${JSON.stringify(home)} },
+});
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => child.kill(signal));
+}
+child.on('error', (error) => {
+  console.error(error);
+  process.exit(1);
+});
+child.on('exit', (code, signal) => {
+  process.exit(signal ? 1 : (code ?? 0));
+});
+`,
+  );
+  for (const executable of ['claude', 'socat', 'rg', 'bwrap']) {
+    fs.chmodSync(path.join(binDir, executable), 0o700);
+  }
+  return binDir;
+}
+
+function payloadRecord(payload: unknown): Record<string, unknown> {
+  return typeof payload === 'string'
+    ? (JSON.parse(payload) as Record<string, unknown>)
+    : ((payload ?? {}) as Record<string, unknown>);
+}
+
+maybeDescribe('agent-e2e job lifecycle (packaged runtime, hermetic)', () => {
+  let harness: RuntimeHarness | undefined;
+  let fakeHome = '';
+  let failed = false;
+
+  afterAll(async () => {
+    if (failed && harness) {
+      console.error(
+        `[job-lifecycle] runtime log tail on failure:\n${harness.logs().slice(-12000)}`,
+      );
+      for (const agentLog of globSync(
+        path.join(fakeHome, 'agents', '*', 'logs', '*.log'),
+      )) {
+        console.error(
+          `[job-lifecycle] ${path.basename(agentLog)} tail:\n${fs.readFileSync(agentLog, 'utf8').slice(-12000)}`,
+        );
+      }
+    }
+    try {
+      await harness?.teardown({ failed });
+    } finally {
+      if (fakeHome && !(failed && process.env.KEEP_EVIDENCE?.trim() === '1')) {
+        fs.rmSync(fakeHome, { recursive: true, force: true });
+      }
+    }
+  }, 60_000);
+
+  it(
+    'pauses, resumes, triggers, completes, delivers, and persists evidence',
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      try {
+        fakeHome = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'gantry-agent-e2e-job-home-'),
+        );
+        installRuntimeSettings(fakeHome);
+        const runnerBin = installHermeticRunnerTools(fakeHome);
+        harness = await startRuntimeHarness({
+          mode: 'local-process',
+          scopes: [
+            'sessions:read',
+            'sessions:write',
+            'agents:admin',
+            'credentials:admin',
+            'jobs:read',
+            'jobs:write',
+          ],
+          env: {
+            GANTRY_HOME: fakeHome,
+            HOME: fakeHome,
+            PATH: `${runnerBin}${path.delimiter}${process.env.PATH ?? '/usr/bin:/bin'}`,
+          },
+        });
+        const api = new AgentE2EApiClient(harness.baseUrl, harness.apiKey);
+
+        const credential = await api.request<{ status: string }>(
+          'PUT',
+          '/v1/credentials/models/anthropic',
+          {
+            body: {
+              authMode: 'api_key',
+              payload: { apiKey: 'sk-ant-api03-agent-e2e-fake' },
+            },
+          },
+        );
+        expect(credential.status).toBe(200);
+        expect(credential.body.status).toBe('active');
+
+        const createdAgent = await api.request<{ id: string }>(
+          'POST',
+          '/v1/agents',
+          {
+            body: {
+              appId: 'default',
+              name: 'agent-e2e-job-lifecycle',
+            },
+          },
+        );
+        expect(createdAgent.status).toBe(201);
+        const agentId = createdAgent.body.id;
+        const workspaceKey = agentId.replace(/^agent:/, '');
+
+        const ensured = await api.request<{
+          sessionId: string;
+          chatJid: string;
+        }>('POST', '/v1/sessions/ensure', {
+          body: {
+            conversationId: 'job-lifecycle-e2e',
+            agentId,
+            title: 'job lifecycle e2e',
+          },
+        });
+        expect(ensured.status).toBe(200);
+
+        const createdJob = await api.request<{
+          jobId: string;
+          status: string;
+        }>('POST', '/v1/jobs', {
+          body: {
+            name: 'agent-e2e job lifecycle',
+            prompt: 'Complete this job successfully.',
+            kind: 'manual',
+            modelAlias: 'haiku',
+            executionContext: {
+              conversationJid: ensured.body.chatJid,
+              threadId: null,
+              workspaceKey,
+              sessionId: ensured.body.sessionId,
+            },
+            notificationRoutes: [
+              {
+                conversationJid: ensured.body.chatJid,
+                threadId: null,
+                label: 'primary',
+              },
+            ],
+          },
+        });
+        expect(createdJob.status).toBe(201);
+        expect(createdJob.body.status).toBe('active');
+        const jobId = createdJob.body.jobId;
+
+        const paused = await api.request('POST', `/v1/jobs/${jobId}/pause`);
+        expect(paused.status).toBe(200);
+        const pausedJob = await api.request<StoredJob>(
+          'GET',
+          `/v1/jobs/${jobId}`,
+        );
+        expect(pausedJob.status).toBe(200);
+        expect(pausedJob.body.status).toBe('paused');
+
+        const rejectedTrigger = await api.request(
+          'POST',
+          `/v1/jobs/${jobId}/trigger`,
+        );
+        expect(rejectedTrigger.status).toBe(409);
+        const pausedEvents = await api.request<{ events: JobEvent[] }>(
+          'GET',
+          `/v1/jobs/${jobId}/events`,
+        );
+        expect(pausedEvents.status).toBe(200);
+        expect(
+          pausedEvents.body.events.some(
+            (event) => event.event_type === 'job.triggered',
+          ),
+        ).toBe(false);
+
+        const resumed = await api.request<{ resumed: boolean }>(
+          'POST',
+          `/v1/jobs/${jobId}/resume`,
+        );
+        expect(resumed.status).toBe(200);
+        expect(resumed.body.resumed).toBe(true);
+        const activeJob = await api.request<StoredJob>(
+          'GET',
+          `/v1/jobs/${jobId}`,
+        );
+        expect(activeJob.status).toBe(200);
+        expect(activeJob.body.status).toBe('active');
+
+        const triggered = await api.request<{ triggerId: string }>(
+          'POST',
+          `/v1/jobs/${jobId}/trigger`,
+        );
+        expect(triggered.status).toBe(202);
+        const triggerId = triggered.body.triggerId;
+        const waited = await api.request<{
+          runId: string;
+          status: string;
+        }>('GET', `/v1/triggers/${triggerId}/wait?timeoutMs=180000`);
+        expect(waited.status).toBe(200);
+        expect(waited.body.status, JSON.stringify(waited.body)).toBe(
+          'completed',
+        );
+        const runId = waited.body.runId;
+
+        type RunResponse = {
+          run_id: string;
+          job_id: string;
+          status: string;
+          ended_at: string | null;
+          notified_at: string | null;
+        };
+        let run = await api.request<RunResponse>('GET', `/v1/runs/${runId}`);
+        const deliveryDeadline = Date.now() + 15_000;
+        while (run.body.notified_at === null && Date.now() < deliveryDeadline) {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          run = await api.request<RunResponse>('GET', `/v1/runs/${runId}`);
+        }
+        expect(run.status).toBe(200);
+        expect(run.body).toMatchObject({
+          run_id: runId,
+          job_id: jobId,
+          status: 'completed',
+          ended_at: expect.any(String),
+          notified_at: expect.any(String),
+        });
+
+        const completedJob = await api.request<StoredJob>(
+          'GET',
+          `/v1/jobs/${jobId}`,
+        );
+        expect(completedJob.status).toBe(200);
+        expect(completedJob.body.health).toMatchObject({
+          state: 'completed',
+          latestRunId: runId,
+          latestRunStatus: 'completed',
+        });
+
+        const jobEvents = await api.request<{ events: JobEvent[] }>(
+          'GET',
+          `/v1/jobs/${jobId}/events`,
+        );
+        expect(jobEvents.status).toBe(200);
+        const eventTypes = jobEvents.body.events.map(
+          (event) => event.event_type,
+        );
+        expect(eventTypes).toEqual(
+          expect.arrayContaining([
+            'job.triggered',
+            'job.run.started',
+            'job.started',
+            'job.completed',
+            'job.run.completed',
+          ]),
+        );
+        expect(
+          payloadRecord(
+            jobEvents.body.events.find(
+              (event) => event.event_type === 'job.completed',
+            )!.payload,
+          ),
+        ).toMatchObject({ delivery_state: 'sent', notified: true });
+
+        const sessionEvents = await api.listEvents(ensured.body.sessionId);
+        expect(
+          sessionEvents.some(
+            (event) => event.eventType === 'session.message.outbound',
+          ),
+        ).toBe(true);
+
+        const client = new Client({ connectionString: harness.databaseUrl });
+        await client.connect();
+        try {
+          const durableRun = await client.query(
+            `SELECT id, job_id, status, ended_at, notified_at
+               FROM gantry.agent_runs
+              WHERE id = $1`,
+            [runId],
+          );
+          expect(durableRun.rows).toEqual([
+            expect.objectContaining({
+              id: runId,
+              job_id: jobId,
+              status: 'completed',
+              ended_at: expect.any(Date),
+              notified_at: expect.any(Date),
+            }),
+          ]);
+
+          const durableLease = await client.query(
+            'SELECT status FROM gantry.run_leases WHERE run_id = $1',
+            [runId],
+          );
+          expect(durableLease.rows).toEqual([{ status: 'completed' }]);
+
+          const durableTrigger = await client.query(
+            'SELECT status, run_id FROM gantry.job_triggers WHERE id = $1',
+            [triggerId],
+          );
+          expect(durableTrigger.rows).toEqual([
+            { status: 'completed', run_id: runId },
+          ]);
+
+          const durableEvents = await client.query<{
+            event_type: string;
+            payload_json: unknown;
+          }>(
+            `SELECT event_type, payload_json
+               FROM gantry.runtime_events
+              WHERE job_id = $1 OR (session_id = $2 AND event_type = 'session.message.outbound')
+              ORDER BY event_id`,
+            [jobId, ensured.body.sessionId],
+          );
+          expect(durableEvents.rows.map((event) => event.event_type)).toEqual(
+            expect.arrayContaining([
+              'job.triggered',
+              'job.run.started',
+              'job.started',
+              'job.completed',
+              'job.run.completed',
+              'session.message.outbound',
+            ]),
+          );
+          expect(
+            payloadRecord(
+              durableEvents.rows.find(
+                (event) => event.event_type === 'job.completed',
+              )!.payload_json,
+            ),
+          ).toMatchObject({ delivery_state: 'sent', notified: true });
+        } finally {
+          await client.end();
+        }
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
+    },
+  );
+});

--- a/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
+++ b/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
@@ -1,0 +1,477 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const configMocks = vi.hoisted(() => ({ schedulerDatabaseUrl: '' }));
+const pgBossMocks = vi.hoisted(() => ({ schema: '' }));
+
+vi.mock('pg-boss', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('pg-boss')>();
+
+  class IsolatedPgBoss extends actual.PgBoss {
+    constructor(options: string | import('pg-boss').ConstructorOptions) {
+      super(
+        typeof options === 'string'
+          ? { connectionString: options, schema: pgBossMocks.schema }
+          : { ...options, schema: pgBossMocks.schema },
+      );
+    }
+  }
+
+  return { ...actual, PgBoss: IsolatedPgBoss };
+});
+
+vi.mock('@core/config/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@core/config/index.js')>();
+  return {
+    ...actual,
+    get STORAGE_POSTGRES_URL() {
+      return configMocks.schedulerDatabaseUrl;
+    },
+  };
+});
+
+import { _setRuntimeStorageForTest } from '@core/adapters/storage/postgres/runtime-store.js';
+import { quotePostgresIdentifier } from '@core/adapters/storage/postgres/storage-service.js';
+import type { JobUpsertInput } from '@core/domain/repositories/ops-repo.js';
+import type { ConversationRoute } from '@core/domain/types.js';
+import { PgBossSchedulerEngine } from '@core/infrastructure/pgboss/scheduler-engine.js';
+import { configureRunSlotBackend } from '@core/jobs/concurrency.js';
+import { _resetSchedulerLoopForTests, runJob } from '@core/jobs/scheduler.js';
+import { registerWorkerInstance } from '@core/jobs/worker-identity.js';
+import type { AgentOutput } from '@core/runtime/agent-spawn.js';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+import { createRuntimeFlowHarness } from '../harness/runtime-flow-harness.js';
+
+const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
+const now = '2026-07-21T00:00:00.000Z';
+
+function makeJob(id: string, patch: Partial<JobUpsertInput> = {}) {
+  return {
+    id,
+    name: `Job ${id}`,
+    prompt: 'Run the deterministic lifecycle test',
+    schedule_type: 'interval',
+    schedule_value: '60000',
+    status: 'active',
+    session_id: null,
+    thread_id: 'thread-job-lifecycle',
+    execution_context: {
+      conversationJid: 'tg:job-lifecycle',
+      threadId: 'thread-job-lifecycle',
+      workspaceKey: 'job_lifecycle_agent',
+      sessionId: null,
+    },
+    notification_routes: [
+      {
+        conversationJid: 'tg:job-lifecycle',
+        threadId: 'thread-job-lifecycle',
+        label: 'primary',
+      },
+    ],
+    workspace_key: 'job_lifecycle_agent',
+    created_by: 'human',
+    created_at: now,
+    updated_at: now,
+    next_run: now,
+    silent: true,
+    timeout_ms: 30_000,
+    max_retries: 3,
+    retry_backoff_ms: 1,
+    max_consecutive_failures: 5,
+    ...patch,
+  } satisfies JobUpsertInput;
+}
+
+function makeConversationRoute(): ConversationRoute {
+  return {
+    name: 'Job Lifecycle Agent',
+    folder: 'job_lifecycle_agent',
+    trigger: '',
+    added_at: now,
+    requiresTrigger: false,
+    conversationKind: 'channel',
+  };
+}
+
+maybeDescribe('job lifecycle (Postgres)', () => {
+  let runtime: PostgresIntegrationRuntime;
+  let schedulerEngine: PgBossSchedulerEngine | undefined;
+
+  beforeAll(async () => {
+    runtime = await createPostgresIntegrationRuntime({
+      schemaPrefix: 'job_lifecycle',
+    });
+    _setRuntimeStorageForTest(runtime.storageRuntime);
+    configMocks.schedulerDatabaseUrl = process.env.GANTRY_TEST_DATABASE_URL!;
+    pgBossMocks.schema = `pgboss_job_${process.pid}_${randomUUID().replaceAll('-', '').slice(0, 12)}`;
+  }, 60_000);
+
+  afterAll(async () => {
+    await schedulerEngine?.stop();
+    try {
+      await runtime.service.pool.query(
+        `DROP SCHEMA IF EXISTS ${quotePostgresIdentifier(pgBossMocks.schema)} CASCADE`,
+      );
+    } finally {
+      await runtime.cleanup();
+    }
+  });
+
+  beforeEach(async () => {
+    _resetSchedulerLoopForTests();
+    const workerInstanceId = await registerWorkerInstance(
+      runtime.repositories.workerCoordination,
+    );
+    configureRunSlotBackend({
+      repository: runtime.repositories.workerCoordination,
+      workerInstanceId,
+    });
+  });
+
+  afterEach(async () => {
+    await schedulerEngine?.stop();
+    schedulerEngine = undefined;
+  });
+
+  it('exhausts retries into dead-letter with terminal runtime evidence', async () => {
+    const harness = createRuntimeFlowHarness({
+      runnerResult: {
+        status: 'error',
+        error: 'planned retry exhaustion',
+      },
+    });
+    const job = makeJob('job:integration:retry-exhaustion', {
+      max_retries: 1,
+      max_consecutive_failures: 99,
+      next_run: new Date(Date.now() - 1_000).toISOString(),
+    });
+    let resolveTerminal!: () => void;
+    const terminal = new Promise<void>((resolve) => {
+      resolveTerminal = resolve;
+    });
+    const deps = {
+      processRole: 'all' as const,
+      hasLiveAdmissionBacklog: async () => false,
+      conversationRoutes: () => ({
+        'tg:job-lifecycle': makeConversationRoute(),
+      }),
+      queue: {} as never,
+      onProcess: () => {},
+      sendMessage: harness.channel.sendMessage,
+      opsRepository: runtime.ops,
+      runAgent: harness.runner.runAgent as never,
+      runnerSandboxProvider: {} as never,
+      onSchedulerChanged: (jobId?: string) => {
+        if (jobId === job.id && harness.runner.calls.length >= 2) {
+          resolveTerminal();
+        }
+      },
+    };
+    await runtime.ops.upsertJob(job);
+    schedulerEngine = new PgBossSchedulerEngine(deps, {
+      registerSystemJobs: async () => undefined,
+      runJob,
+      sweepCompletedOneTimeJobs: async () => false,
+    });
+    await schedulerEngine.start();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        terminal,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error('scheduler did not exhaust retries')),
+            30_000,
+          );
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+
+    const runs = await runtime.ops.listJobRuns(job.id);
+    expect(runs).toHaveLength(2);
+    expect(runs.filter((run) => run.status === 'failed')).toHaveLength(1);
+    expect(runs.filter((run) => run.status === 'dead_lettered')).toHaveLength(
+      1,
+    );
+    expect(runs.every((run) => run.ended_at !== null)).toBe(true);
+    expect(runs.some((run) => run.status === 'running')).toBe(false);
+    const leases = await runtime.service.pool.query<{
+      run_id: string;
+      status: string;
+    }>(
+      `SELECT run_id, status
+         FROM ${quotePostgresIdentifier(runtime.schemaName)}.run_leases
+        WHERE run_id = ANY($1::text[])
+        ORDER BY run_id`,
+      [runs.map((run) => run.run_id)],
+    );
+    expect(leases.rows).toHaveLength(2);
+    expect(leases.rows.every((lease) => lease.status === 'failed')).toBe(true);
+
+    const deadLetterRun = runs.find((run) => run.status === 'dead_lettered')!;
+    await expect(runtime.ops.listDeadLetterRuns()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          run_id: deadLetterRun.run_id,
+          job_id: job.id,
+          status: 'dead_lettered',
+        }),
+      ]),
+    );
+    await expect(runtime.ops.getJobById(job.id)).resolves.toMatchObject({
+      status: 'dead_lettered',
+      consecutive_failures: 2,
+      next_run: null,
+      lease_run_id: null,
+      lease_expires_at: null,
+    });
+
+    const events = await runtime.ops.listRecentJobEvents(20, {
+      job_id: job.id,
+      run_id: deadLetterRun.run_id,
+    });
+    expect(events.map((event) => event.event_type)).toEqual(
+      expect.arrayContaining([
+        'run.dead_lettered',
+        'job.failed',
+        'job.run.failed',
+      ]),
+    );
+    const terminalEvent = events.find(
+      (event) => event.event_type === 'job.run.failed',
+    );
+    expect(JSON.parse(terminalEvent?.payload ?? '{}')).toMatchObject({
+      status: 'dead_lettered',
+    });
+  });
+
+  it('terminates and audits an autonomous ungranted-tool dead-end', async () => {
+    const harness = createRuntimeFlowHarness();
+    const permissionRoot = mkdtempSync(
+      join(tmpdir(), 'gantry-job-permission-'),
+    );
+    const ipcDir = join(permissionRoot, 'ipc');
+    vi.stubEnv('GANTRY_WORKSPACE_GROUP_DIR', join(permissionRoot, 'group'));
+    vi.stubEnv('GANTRY_WORKSPACE_EXTRA_DIR', join(permissionRoot, 'extra'));
+    vi.stubEnv('GANTRY_IPC_DIR', ipcDir);
+    vi.stubEnv('GANTRY_IPC_INPUT_DIR', join(ipcDir, 'input'));
+    vi.stubEnv('GANTRY_IPC_AUTH_TOKEN', 'job-lifecycle-test-secret');
+    vi.stubEnv('GANTRY_AUTONOMOUS_PERMISSION_TIMEOUT_MS', '0');
+    vi.stubEnv('GANTRY_JOB_ID', 'job:integration:ungranted-tool');
+    vi.resetModules();
+    const { createCanUseToolCallback } =
+      await import('@core/adapters/llm/anthropic-claude-agent/runner/tool-permission-gate.js');
+    const runnerInputs: Record<string, unknown>[] = [];
+    const runnerFrames: AgentOutput[] = [];
+    let permissionDecision: Awaited<
+      ReturnType<ReturnType<typeof createCanUseToolCallback>>
+    >;
+    const runAgent = async (
+      _group: ConversationRoute,
+      input: Record<string, unknown>,
+      _onProcess: unknown,
+      onOutput?: (output: AgentOutput) => void | Promise<void>,
+    ): Promise<AgentOutput> => {
+      runnerInputs.push(input);
+      const canUseTool = createCanUseToolCallback({
+        agentInput: {
+          prompt: String(input.prompt),
+          appId: String(input.appId),
+          agentId: String(input.agentId),
+          runId: String(input.runId),
+          isScheduledJob: input.isScheduledJob === true,
+          jobId: String(input.jobId),
+          chatJid: String(input.chatJid),
+          threadId: String(input.threadId),
+          workspaceFolder: basename(ipcDir),
+          permissionMode: 'default',
+          allowedTools: Array.isArray(input.toolPolicyRules)
+            ? (input.toolPolicyRules as string[])
+            : [],
+        },
+        sdkEnv: {},
+        workspaceFolder: basename(ipcDir),
+        memoryBlock: '',
+        capabilities: {
+          allowedTools: [],
+          alwaysAllowedTools: [],
+          permissionMode: 'default',
+        },
+        primeToolAttempts: [],
+        getNewSessionId: () => undefined,
+        emitInteractionBoundary: () => undefined,
+        recordToolActivity: () => undefined,
+      });
+      const outputSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation((value: unknown) => {
+          if (typeof value !== 'string' || !value.startsWith('{"status"')) {
+            return;
+          }
+          const output = JSON.parse(value) as AgentOutput;
+          if (output.runtimeEvents?.length) runnerFrames.push(output);
+        });
+      try {
+        permissionDecision = await canUseTool(
+          'Bash',
+          { command: 'npm test -- unit' },
+          {
+            title: 'Run command',
+            displayName: 'Bash',
+            description: 'Run the job command',
+            decisionReason: 'The scheduled job needs this command',
+            suggestions: [],
+            toolUseID: 'tool-use-job-lifecycle',
+            signal: new AbortController().signal,
+          },
+        );
+      } finally {
+        outputSpy.mockRestore();
+      }
+      for (const frame of runnerFrames) await onOutput?.(frame);
+      return { status: 'success', result: 'blocked' };
+    };
+    const job = makeJob('job:integration:ungranted-tool');
+    await runtime.ops.upsertJob(job);
+
+    try {
+      await runJob(
+        (await runtime.ops.getJobById(job.id))!,
+        {
+          conversationRoutes: () => ({
+            'tg:job-lifecycle': makeConversationRoute(),
+          }),
+          queue: {} as never,
+          onProcess: () => {},
+          sendMessage: harness.channel.sendMessage,
+          opsRepository: runtime.ops,
+          runAgent: runAgent as never,
+          runnerSandboxProvider: {} as never,
+        },
+        'tg:job-lifecycle',
+      );
+
+      const permissionRequestsDir = join(ipcDir, 'permission-requests');
+      const requestFiles = readdirSync(permissionRequestsDir);
+      expect(requestFiles).toHaveLength(1);
+      expect(
+        JSON.parse(
+          readFileSync(join(permissionRequestsDir, requestFiles[0]!), 'utf8'),
+        ),
+      ).toMatchObject({
+        jobId: job.id,
+        toolName: 'RunCommand',
+        unattended: true,
+      });
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(permissionRoot, { recursive: true, force: true });
+    }
+
+    expect(runnerInputs).toHaveLength(1);
+    expect(runnerInputs[0]).toMatchObject({
+      isScheduledJob: true,
+      jobId: job.id,
+      toolPolicyRules: [],
+    });
+    expect(permissionDecision).toMatchObject({
+      behavior: 'deny',
+      interrupt: true,
+      message: expect.stringContaining(
+        'Tool not on autonomous run allowlist: RunCommand',
+      ),
+    });
+    expect(
+      runnerFrames
+        .flatMap((frame) => frame.runtimeEvents ?? [])
+        .map((event) => [event.eventType, event.payload]),
+    ).toEqual(
+      expect.arrayContaining([
+        [
+          'job.tool_activity',
+          expect.objectContaining({
+            phase: 'permission_wait',
+            tool: 'RunCommand',
+            recovery_action: expect.stringContaining('request_access'),
+          }),
+        ],
+        [
+          'job.tool_activity',
+          expect.objectContaining({
+            phase: 'permission_denied',
+            tool: 'RunCommand',
+          }),
+        ],
+      ]),
+    );
+    const runs = await runtime.ops.listJobRuns(job.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      status: 'failed',
+      ended_at: expect.any(String),
+      error_summary: expect.stringContaining(
+        'Tool not on autonomous run allowlist: RunCommand',
+      ),
+    });
+    expect(runs.some((run) => run.status === 'running')).toBe(false);
+    const leases = await runtime.service.pool.query<{ status: string }>(
+      `SELECT status
+         FROM ${quotePostgresIdentifier(runtime.schemaName)}.run_leases
+        WHERE run_id = $1`,
+      [runs[0]!.run_id],
+    );
+    expect(leases.rows).toEqual([{ status: 'failed' }]);
+    await expect(runtime.ops.getJobById(job.id)).resolves.toMatchObject({
+      status: 'paused',
+      pause_reason: 'Setup required',
+      setup_state: expect.objectContaining({
+        state: 'missing_capability',
+      }),
+      next_run: null,
+      lease_run_id: null,
+      lease_expires_at: null,
+    });
+
+    const events = await runtime.ops.listRecentJobEvents(20, {
+      job_id: job.id,
+    });
+    expect(events.map((event) => event.event_type)).toEqual(
+      expect.arrayContaining([
+        'run.failed',
+        'job.setup_required',
+        'job.tool_denied',
+        'job.failed',
+        'job.run.failed',
+      ]),
+    );
+    const deniedEvent = events.find(
+      (event) => event.event_type === 'job.tool_denied',
+    );
+    expect(JSON.parse(deniedEvent?.payload ?? '{}')).toMatchObject({
+      denied_tool: 'RunCommand',
+      recovery_kind: 'persistent_capability',
+      recovery_action: expect.stringContaining('request_access'),
+    });
+  });
+});


### PR DESCRIPTION
Closes 🔨 gaps in E2E matrix §9 (jobs), plus one root-cause source fix surfaced by the coverage.

## Coverage
- **Retry exhaustion → dead-letter**: forced-failure job exhausts retries → dead-letter, terminal events, failed leases, no zombie run.
- **Autonomous tool dead-end**: real permission-gate denial inside a job run → unattended IPC request, audit events, clean terminal settlement (no hang).
- **API e2e**: create → pause → resume → trigger → completion → delivery → durable evidence (the API twin of agent-job-smoke.sh).
- `jobs-runs-memory-flow` triaged: non-reproducible flake (70/70 repeated + 35/35 randomized passed) — no edit warranted.

## Source fix (root cause)
`autonomous-tool-denial.ts`: the denial parser used `search(/\.\s/)` to end the tool name, which truncated at the first `. ` even inside a `RunCommand(...)` scope — so scoped commands containing punctuation (e.g. `gog sheets update *`) parsed wrong. Replaced with `findToolRuleSentenceBoundary`, a scanner that honors parenthesis depth + quotes/escapes. Direct unit coverage in autonomous-tool-denial.test.ts.

## Verification (independently re-run)
- Typecheck clean; denial unit 4/4; job-lifecycle postgres integration 2/2 on real pg; hermetic local-process agent-e2e 4 passed (2 credential-gated Haiku skipped).