### PR TITLE
test: runtime boot + onboarding e2e; harness isolation guard (matrix §1 + §2)

### DIFF
--- a/apps/core/test/agent-e2e/harness/runtime-harness.ts
+++ b/apps/core/test/agent-e2e/harness/runtime-harness.ts
@@ -41,6 +41,8 @@ export type RuntimeHarnessMode = 'local-process' | 'docker';
 export interface RuntimeHarnessOptions {
   /** Scopes carried by the run's generated control API key. */
   scopes?: string[];
+  /** Optional fresh, non-existent home path; the harness creates/removes it. */
+  runtimeHome?: string;
   /** Selected via AGENT_E2E_RUNTIME_MODE by default; local-process otherwise. */
   mode?: RuntimeHarnessMode;
   /** docker mode: image ref/digest (default env AGENT_E2E_RUNTIME_IMAGE). */
@@ -179,10 +181,15 @@ async function createRunDatabase(adminUrl: string): Promise<{
     await client.query(`CREATE DATABASE ${quoteIdent(databaseName)}`);
   });
   const databaseUrl = perRunDatabaseUrl(adminUrl, databaseName);
-  await withAdminClient(databaseUrl, async (client) => {
-    await client.query('CREATE EXTENSION IF NOT EXISTS vector');
-    await client.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
-  });
+  try {
+    await withAdminClient(databaseUrl, async (client) => {
+      await client.query('CREATE EXTENSION IF NOT EXISTS vector');
+      await client.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+    });
+  } catch (error) {
+    await dropRunDatabase(adminUrl, databaseName).catch(() => undefined);
+    throw error;
+  }
   return { databaseName, databaseUrl };
 }
 
@@ -235,17 +242,44 @@ export async function startRuntimeHarness(
       ? 'docker'
       : 'local-process');
   const adminUrl = requireAdminDatabaseUrl();
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'gantry-agent-e2e-'));
+  const requestedHome = options.runtimeHome?.trim();
+  const guardedHome = requestedHome
+    ? path.resolve(requestedHome)
+    : path.join(os.tmpdir(), 'gantry-agent-e2e-isolation-probe');
 
-  // Guard the admin URL before any connection, and the per-run URL after.
-  assertIsolatedRuntimeTarget({ runtimeHome: home, databaseUrl: adminUrl });
-  const { databaseName, databaseUrl } = await createRunDatabase(adminUrl);
-  assertIsolatedRuntimeTarget({ runtimeHome: home, databaseUrl });
+  // Refuse an explicit real home or live admin DB before creating a temp home,
+  // connecting to Postgres, or spawning a runtime.
+  assertIsolatedRuntimeTarget({
+    runtimeHome: guardedHome,
+    databaseUrl: adminUrl,
+  });
+  const port = await pickFreePort();
+  const home = requestedHome
+    ? guardedHome
+    : fs.mkdtempSync(path.join(os.tmpdir(), 'gantry-agent-e2e-'));
+  if (requestedHome) {
+    fs.mkdirSync(home, { mode: 0o700 });
+  }
+
+  // Guard the generated per-run URL before handing it to the runtime.
+  let databaseName: string | undefined;
+  let databaseUrl: string | undefined;
+  try {
+    const database = await createRunDatabase(adminUrl);
+    databaseName = database.databaseName;
+    databaseUrl = database.databaseUrl;
+    assertIsolatedRuntimeTarget({ runtimeHome: home, databaseUrl });
+  } catch (error) {
+    if (databaseName) {
+      await dropRunDatabase(adminUrl, databaseName).catch(() => undefined);
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+    throw error;
+  }
 
   const apiKey = randomBytes(32).toString('hex');
   const secretEncryptionKey = randomBytes(32).toString('base64');
   const ipcAuthSecret = randomBytes(32).toString('hex');
-  const port = await pickFreePort();
   const baseUrl = `http://127.0.0.1:${port}`;
   const controlKeysJson = JSON.stringify([
     {

--- a/apps/core/test/agent-e2e/scenarios/onboarding.agent-e2e.test.ts
+++ b/apps/core/test/agent-e2e/scenarios/onboarding.agent-e2e.test.ts
@@ -1,0 +1,292 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { Client } from 'pg';
+
+import { AgentE2EApiClient } from '../harness/api-client.js';
+import {
+  startRuntimeHarness,
+  type RuntimeHarness,
+} from '../harness/runtime-harness.js';
+
+const hasDb = Boolean(process.env.GANTRY_TEST_DATABASE_URL?.trim());
+const maybeDescribe = hasDb ? describe : describe.skip;
+const BOOT_TIMEOUT_MS = 300_000;
+const AGENT_FOLDER = 'e2e_boot_onboarding';
+const AGENT_ID = `agent:${AGENT_FOLDER}`;
+const AGENT_NAME = 'E2E Boot Onboarding';
+const PROVIDER_ACCOUNT_ID = 'control:default';
+const CONVERSATION_KEY = `${AGENT_FOLDER}_conversation`;
+const ADDED_AT = '2026-07-21T00:00:00.000Z';
+
+interface DesiredStateResponse {
+  revision: number;
+  settings: Record<string, unknown> | null;
+  updatedAt: string | null;
+}
+
+interface CapabilityResponse {
+  id: string;
+  version: string;
+}
+
+interface AgentResponse {
+  id: string;
+  name: string;
+  status: string;
+}
+
+interface ConversationInstallResponse {
+  id: string;
+  agentId: string;
+  providerAccountId: string;
+  conversationId: string;
+  status: string;
+}
+
+interface AgentAccessResponse {
+  agentId: string;
+  selections: CapabilityResponse[];
+}
+
+interface ModelPreviewResponse {
+  target: string;
+  scope: string;
+}
+
+function recordAt(
+  document: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const value = document[key];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Desired-state document is missing object ${key}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+async function durableProjection(
+  databaseUrl: string,
+  expectedRevision: number,
+): Promise<void> {
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    const revision = await client.query<{ revision: number }>(
+      'SELECT max(revision)::int AS revision FROM "gantry"."settings_revisions" WHERE app_id = $1',
+      ['default'],
+    );
+    expect(revision.rows[0]?.revision).toBe(expectedRevision);
+
+    const projection = await client.query(
+      `SELECT a.id AS agent_id,
+              pa.id AS provider_account_id,
+              c.id AS conversation_id,
+              ci.id AS install_id,
+              atb.id AS tool_binding_id
+         FROM "gantry"."agents" a
+         JOIN "gantry"."provider_accounts" pa
+           ON pa.app_id = a.app_id AND pa.agent_id = a.id
+         JOIN "gantry"."conversations" c
+           ON c.app_id = a.app_id AND c.provider_account_id = pa.id
+         JOIN "gantry"."conversation_installs" ci
+           ON ci.app_id = a.app_id
+          AND ci.agent_id = a.id
+          AND ci.provider_account_id = pa.id
+          AND ci.conversation_id = c.id
+          AND ci.status = 'active'
+         JOIN "gantry"."agent_tool_bindings" atb
+           ON atb.app_id = a.app_id
+          AND atb.agent_id = a.id
+          AND atb.status = 'active'
+        WHERE a.id = $1 AND a.status = 'active' AND pa.id = $2`,
+      [AGENT_ID, PROVIDER_ACCOUNT_ID],
+    );
+    expect(projection.rowCount).toBeGreaterThan(0);
+    expect(projection.rows[0]).toMatchObject({
+      agent_id: AGENT_ID,
+      provider_account_id: PROVIDER_ACCOUNT_ID,
+    });
+  } finally {
+    await client.end();
+  }
+}
+
+maybeDescribe('agent-e2e onboarding (public desired-state API)', () => {
+  let harness: RuntimeHarness | undefined;
+  let sawFailure = false;
+
+  afterAll(async () => {
+    await harness?.teardown({ failed: sawFailure });
+  });
+
+  it(
+    'appends a revision and reconstitutes the agent, binding, and grant after restart',
+    { timeout: BOOT_TIMEOUT_MS },
+    async () => {
+      try {
+        harness = await startRuntimeHarness({
+          scopes: [
+            'sessions:read',
+            'sessions:write',
+            'agents:admin',
+            'conversations:read',
+            'conversations:admin',
+          ],
+        });
+        const api = new AgentE2EApiClient(harness.baseUrl, harness.apiKey);
+
+        const baseline = await api.request<DesiredStateResponse>(
+          'GET',
+          '/v1/settings/desired-state',
+        );
+        expect(baseline.status).toBe(200);
+        expect(Number.isInteger(baseline.body.revision)).toBe(true);
+        expect(baseline.body.settings).not.toBeNull();
+
+        const catalog = await api.request<{
+          capabilities: CapabilityResponse[];
+        }>('GET', '/v1/capabilities');
+        expect(catalog.status).toBe(200);
+        expect(Array.isArray(catalog.body.capabilities)).toBe(true);
+        const catalogCapability = catalog.body.capabilities.find(
+          (entry) => entry.id.length > 0 && entry.version.length > 0,
+        );
+        expect(
+          catalogCapability,
+          'a persistent built-in capability',
+        ).toBeDefined();
+        if (!catalogCapability) throw new Error('Capability catalog is empty');
+        const capability = {
+          id: catalogCapability.id,
+          version: catalogCapability.version,
+        };
+
+        const settings = structuredClone(
+          baseline.body.settings as Record<string, unknown>,
+        );
+        recordAt(settings, 'providers').app = { enabled: true };
+        recordAt(settings, 'provider_accounts')[PROVIDER_ACCOUNT_ID] = {
+          agent: AGENT_FOLDER,
+          provider: 'app',
+          label: AGENT_NAME,
+          runtime_secret_refs: {},
+        };
+        recordAt(settings, 'agents')[AGENT_FOLDER] = {
+          name: AGENT_NAME,
+          access: {
+            preset: 'full',
+            sources: { skills: [], mcp_servers: [], tools: [] },
+            selections: [capability],
+          },
+        };
+        recordAt(settings, 'conversations')[CONVERSATION_KEY] = {
+          provider_account: PROVIDER_ACCOUNT_ID,
+          external_id: `default:${AGENT_FOLDER}`,
+          kind: 'group',
+          display_name: AGENT_NAME,
+          sender_policy: { allow: '*', mode: 'trigger' },
+          control_approvers: [],
+          installed_agents: {
+            [AGENT_FOLDER]: {
+              provider_account: PROVIDER_ACCOUNT_ID,
+              status: 'active',
+              added_at: ADDED_AT,
+              memory_scope: 'conversation',
+              requires_trigger: false,
+            },
+          },
+        };
+
+        const written = await api.request<{ revision: number }>(
+          'PUT',
+          '/v1/settings/desired-state',
+          {
+            body: {
+              settings,
+              expectedRevision: baseline.body.revision,
+              note: 'agent-e2e onboarding',
+            },
+          },
+        );
+        expect(written.status, JSON.stringify(written.body)).toBe(200);
+        expect(written.body.revision).toBeGreaterThan(baseline.body.revision);
+
+        const createdAgent = await api.request<AgentResponse>(
+          'GET',
+          `/v1/agents/${encodeURIComponent(AGENT_ID)}`,
+        );
+        expect(createdAgent.status).toBe(200);
+        expect(createdAgent.body).toMatchObject({
+          id: AGENT_ID,
+          name: AGENT_NAME,
+          status: 'active',
+        });
+
+        await durableProjection(harness.databaseUrl, written.body.revision);
+        await harness.restart();
+
+        const replayedState = await api.request<DesiredStateResponse>(
+          'GET',
+          '/v1/settings/desired-state',
+        );
+        expect(replayedState.status).toBe(200);
+        expect(replayedState.body.revision).toBe(written.body.revision);
+
+        const replayedAgent = await api.request<AgentResponse>(
+          'GET',
+          `/v1/agents/${encodeURIComponent(AGENT_ID)}`,
+        );
+        expect(replayedAgent.status).toBe(200);
+        expect(replayedAgent.body).toMatchObject({
+          id: AGENT_ID,
+          name: AGENT_NAME,
+          status: 'active',
+        });
+
+        const installs = await api.request<{
+          conversationInstalls: ConversationInstallResponse[];
+        }>(
+          'GET',
+          `/v1/agents/${encodeURIComponent(AGENT_ID)}/conversation-installs`,
+        );
+        expect(installs.status).toBe(200);
+        expect(installs.body.conversationInstalls).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              agentId: AGENT_ID,
+              providerAccountId: PROVIDER_ACCOUNT_ID,
+              status: 'active',
+            }),
+          ]),
+        );
+
+        const access = await api.request<AgentAccessResponse>(
+          'GET',
+          `/v1/agents/${encodeURIComponent(AGENT_ID)}/access`,
+        );
+        expect(access.status).toBe(200);
+        expect(access.body.agentId).toBe(AGENT_ID);
+        expect(access.body.selections).toEqual(
+          expect.arrayContaining([capability]),
+        );
+
+        const liveRoute = await api.request<ModelPreviewResponse>(
+          'POST',
+          '/v1/models/preview',
+          {
+            body: { target: 'chat', workspaceKey: AGENT_FOLDER },
+          },
+        );
+        expect(liveRoute.status, JSON.stringify(liveRoute.body)).toBe(200);
+        expect(liveRoute.body).toMatchObject({
+          target: 'chat',
+          scope: AGENT_FOLDER,
+        });
+
+        await durableProjection(harness.databaseUrl, written.body.revision);
+      } catch (error) {
+        sawFailure = true;
+        throw error;
+      }
+    },
+  );
+});

--- a/apps/core/test/agent-e2e/scenarios/runtime-boot.agent-e2e.test.ts
+++ b/apps/core/test/agent-e2e/scenarios/runtime-boot.agent-e2e.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { Client } from 'pg';
+
+import {
+  startRuntimeHarness,
+  type RuntimeHarness,
+} from '../harness/runtime-harness.js';
+
+const hasDb = Boolean(process.env.GANTRY_TEST_DATABASE_URL?.trim());
+const maybeDescribe = hasDb ? describe : describe.skip;
+const BOOT_TIMEOUT_MS = 300_000;
+
+maybeDescribe('agent-e2e runtime boot (fresh state, hermetic)', () => {
+  let harness: RuntimeHarness | undefined;
+  let sawFailure = false;
+
+  afterAll(async () => {
+    await harness?.teardown({ failed: sawFailure });
+  });
+
+  it(
+    'boots a fresh runtime healthy with current migrations',
+    { timeout: BOOT_TIMEOUT_MS },
+    async () => {
+      try {
+        harness = await startRuntimeHarness();
+
+        const health = await fetch(`${harness.baseUrl}/healthz`);
+        expect(health.status).toBe(200);
+
+        const ready = await fetch(`${harness.baseUrl}/readyz`);
+        expect(ready.status).toBe(200);
+        await expect(ready.json()).resolves.toMatchObject({
+          status: 'ready',
+          checks: { database: 'pass', migrations: 'pass' },
+        });
+
+        const client = new Client({ connectionString: harness.databaseUrl });
+        await client.connect();
+        try {
+          const applied = await client.query<{ applied: number }>(
+            'SELECT count(*)::int AS applied FROM "gantry"."__drizzle_migrations"',
+          );
+          expect(applied.rows[0]?.applied).toBeGreaterThan(0);
+        } finally {
+          await client.end();
+        }
+      } catch (error) {
+        sawFailure = true;
+        throw error;
+      }
+    },
+  );
+});

--- a/apps/core/test/integration/onboarding-scope.integration.test.ts
+++ b/apps/core/test/integration/onboarding-scope.integration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentE2EApiClient } from '../agent-e2e/harness/api-client.js';
+import { startTestControlServer } from '../harness/control-http-server.js';
+
+interface ErrorResponse {
+  error: {
+    code: string;
+    message: string;
+    retryable: boolean;
+    requestId: string;
+  };
+}
+
+describe('onboarding API scope enforcement integration', () => {
+  it('returns 403 when a sessions-only key attempts agent creation', async () => {
+    const server = await startTestControlServer({
+      token: 'sessions-only-onboarding-key',
+      appId: 'default',
+      scopes: ['sessions:read', 'sessions:write'],
+    });
+    const api = new AgentE2EApiClient(server.baseUrl, server.token);
+
+    try {
+      const response = await api.request<ErrorResponse>('POST', '/v1/agents', {
+        body: { appId: 'default', name: 'Forbidden onboarding agent' },
+      });
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'API key is missing required scope agents:admin',
+        retryable: false,
+      });
+      expect(response.body.error.requestId).toEqual(expect.any(String));
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/apps/core/test/unit/agent-e2e/runtime-harness-guard.test.ts
+++ b/apps/core/test/unit/agent-e2e/runtime-harness-guard.test.ts
@@ -5,17 +5,20 @@
 import os from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   assertIsolatedRuntimeTarget,
   realRuntimeHome,
+  startRuntimeHarness,
 } from '../../agent-e2e/harness/runtime-harness.js';
 
 const SAFE_DB_URL = 'postgres://user:pass@127.0.0.1:5432/gantry_e2e_abc123';
 const SAFE_HOME = path.join(os.tmpdir(), 'gantry-agent-e2e-guard-test');
 
 describe('agent-e2e runtime harness isolation guard', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
   it('accepts a disposable home + per-run database', () => {
     expect(() =>
       assertIsolatedRuntimeTarget({
@@ -64,5 +67,24 @@ describe('agent-e2e runtime harness isolation guard', () => {
         databaseUrl: 'not a url',
       }),
     ).toThrow(/not a valid URL/);
+  });
+
+  it('refuses the real runtime home through harness startup before spawning', async () => {
+    vi.stubEnv('GANTRY_TEST_DATABASE_URL', SAFE_DB_URL);
+
+    await expect(
+      startRuntimeHarness({ runtimeHome: realRuntimeHome() }),
+    ).rejects.toThrow(/live runtime home/);
+  });
+
+  it('refuses the live database through harness startup before spawning', async () => {
+    vi.stubEnv(
+      'GANTRY_TEST_DATABASE_URL',
+      'postgres://user:pass@127.0.0.1:5432/gantry',
+    );
+
+    await expect(
+      startRuntimeHarness({ runtimeHome: SAFE_HOME }),
+    ).rejects.toThrow(/live `gantry` database/);
   });
 });


### PR DESCRIPTION
Closes 🔨 gaps in E2E matrix §1 (boot) and §2 (onboarding). Test + harness only, no production source.

## Coverage
- **runtime-boot** (e2e): fresh GANTRY_HOME + disposable DB, health/readiness, migrations current.
- **onboarding** (e2e): public desired-state API → revision appended → durable projection → binding/grant replay → live route after restart.
- **onboarding-scope** (integration): sessions-only key → 403 on agent creation.
- **harness isolation guard** (unit self-test): startRuntimeHarness/assertIsolatedRuntimeTarget refuse the real home or the live DB.
- Additive harness helper (`runtimeHome`, private perms, startup-failure cleanup) — signatures stable so read-only consumer lanes are unaffected.

Deferred as scoped: haiku model routing (needs live key → live lane) and `sessions/ensure` agentId (blocked on ponytail). Docker image mode stays the CI-only row.

## Verification (independently re-run, local-process mode)
- Typecheck clean; harness guards 7/7; agent-e2e 5/5 **including the existing boot-restart (no harness regression)**; scope integration green — all vs real pg 5433.