### PR TITLE
test: delegated task lifecycle + multi-agent capability isolation (matrix §15)

### DIFF
--- a/apps/core/test/integration/agent-delegation-task-lifecycle.postgres.integration.test.ts
+++ b/apps/core/test/integration/agent-delegation-task-lifecycle.postgres.integration.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { PostgresAsyncTaskRepository } from '@core/adapters/storage/postgres/repositories/async-task-repository.postgres.js';
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_APP_ID,
+} from '@core/adapters/storage/postgres/seeds.js';
+import { AsyncCommandTaskService } from '@core/jobs/async-command-task-service.js';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+
+const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
+const CONVERSATION_ID = 'conversation:delegation-integration';
+const TARGET_AGENT_ID = 'agent:delegation_reviewer';
+const TARGET_AGENT_FOLDER = 'delegation_reviewer';
+const PAYLOAD_ENCRYPTION_KEY = Buffer.alloc(32, 23).toString('base64');
+
+// Complements the in-memory IPC proof "delegates an async child run to a bound
+// target agent" in ipc-agent-task-lifecycle-handlers.test.ts.
+maybeDescribe('delegated agent task lifecycle (Postgres)', () => {
+  let runtime: PostgresIntegrationRuntime;
+
+  beforeAll(async () => {
+    vi.stubEnv('SECRET_ENCRYPTION_KEY', PAYLOAD_ENCRYPTION_KEY);
+    runtime = await createPostgresIntegrationRuntime({
+      schemaPrefix: 'agent_delegation_lifecycle',
+    });
+    const now = '2026-07-21T00:00:00.000Z';
+    await runtime.repositories.agents.saveAgent({
+      id: TARGET_AGENT_ID as never,
+      appId: DEFAULT_APP_ID as never,
+      name: 'Delegation Reviewer',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      if (runtime) await runtime.cleanup();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('persists a delegated task completion and linkage across repository instances', async () => {
+    const service = new AsyncCommandTaskService(
+      runtime.repositories.asyncTasks,
+      { run: async () => ({}) },
+    );
+    const started = await service.startDelegatedAgent({
+      appId: DEFAULT_APP_ID,
+      agentId: DEFAULT_AGENT_ID,
+      conversationId: CONVERSATION_ID,
+      objective: 'Research durable delegation',
+      targetAgentId: TARGET_AGENT_ID,
+      authorityToolName: 'AgentDelegation',
+      workspaceFolder: TARGET_AGENT_FOLDER,
+      run: async () => ({ outputSummary: 'Durable delegated result.' }),
+    });
+
+    expect(started.ok).toBe(true);
+    if (!started.ok) throw new Error(started.message);
+    expect(started.task).toMatchObject({
+      kind: 'delegated_agent',
+      status: 'queued',
+    });
+    await expect(started.completion.wait(5_000)).resolves.toMatchObject({
+      taskId: started.task.id,
+      status: 'completed',
+      result: 'Durable delegated result.',
+    });
+
+    const freshRepository = new PostgresAsyncTaskRepository(runtime.service.db);
+    const freshService = new AsyncCommandTaskService(freshRepository, {
+      run: async () => ({}),
+    });
+    await expect(
+      freshService.getScoped({
+        taskId: started.task.id,
+        appId: DEFAULT_APP_ID,
+        agentId: DEFAULT_AGENT_ID,
+        conversationId: CONVERSATION_ID,
+      }),
+    ).resolves.toMatchObject({
+      id: started.task.id,
+      status: 'completed',
+      outputSummary: 'Durable delegated result.',
+      terminalAt: expect.any(String),
+      allowedActions: ['get', 'list'],
+    });
+    await expect(
+      freshRepository.getTask(started.task.id),
+    ).resolves.toMatchObject({
+      conversationId: CONVERSATION_ID,
+      authoritySnapshotJson: {
+        toolName: 'AgentDelegation',
+        maxDepth: 1,
+      },
+      privateCorrelationJson: {
+        targetAgentId: TARGET_AGENT_ID,
+        workspaceFolder: TARGET_AGENT_FOLDER,
+      },
+    });
+  });
+
+  it('persists a delegated task failure as an immutable terminal result across repository instances', async () => {
+    const service = new AsyncCommandTaskService(
+      runtime.repositories.asyncTasks,
+      { run: async () => ({}) },
+    );
+    const started = await service.startDelegatedAgent({
+      appId: DEFAULT_APP_ID,
+      agentId: DEFAULT_AGENT_ID,
+      conversationId: CONVERSATION_ID,
+      objective: 'Review durable delegation',
+      targetAgentId: TARGET_AGENT_ID,
+      authorityToolName: 'AgentDelegation',
+      workspaceFolder: TARGET_AGENT_FOLDER,
+      run: async () => ({
+        outputSummary: 'Reviewed two sources.',
+        errorSummary: 'Delegated review failed.',
+        failure: {
+          type: 'execution',
+          attemptedAction: 'Review durable delegation',
+          partialResult: 'Reviewed two sources.',
+        },
+      }),
+    });
+
+    expect(started.ok).toBe(true);
+    if (!started.ok) throw new Error(started.message);
+    await expect(started.completion.wait(5_000)).resolves.toMatchObject({
+      taskId: started.task.id,
+      status: 'failed',
+    });
+
+    const freshRepository = new PostgresAsyncTaskRepository(runtime.service.db);
+    const freshService = new AsyncCommandTaskService(freshRepository, {
+      run: async () => ({}),
+    });
+    const persisted = await freshRepository.getTask(started.task.id);
+    expect(persisted).toMatchObject({
+      status: 'failed',
+      terminalAt: expect.any(String),
+      privateCorrelationJson: {
+        targetAgentId: TARGET_AGENT_ID,
+        failure: {
+          type: 'execution',
+          attemptedAction: 'Review durable delegation',
+          partialResult: 'Reviewed two sources.',
+        },
+      },
+    });
+    await expect(
+      freshService.getScoped({
+        taskId: started.task.id,
+        appId: DEFAULT_APP_ID,
+        agentId: DEFAULT_AGENT_ID,
+        conversationId: CONVERSATION_ID,
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failure: {
+        type: 'execution',
+        attemptedAction: 'Review durable delegation',
+        partialResult: 'Reviewed two sources.',
+      },
+      allowedActions: ['get', 'list'],
+    });
+    expect(persisted).not.toBeNull();
+    if (!persisted) return;
+    await expect(
+      freshRepository.transitionTask({
+        taskId: persisted.id,
+        leaseToken: persisted.leaseToken,
+        fencingVersion: persisted.fencingVersion,
+        status: 'completed',
+        now: '2026-07-21T00:00:01.000Z',
+        terminalAt: '2026-07-21T00:00:01.000Z',
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/core/test/integration/multi-agent-capability-isolation.postgres.integration.test.ts
+++ b/apps/core/test/integration/multi-agent-capability-isolation.postgres.integration.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SettingsDesiredStateService } from '@core/config/settings/desired-state-service.js';
+import {
+  createDefaultRuntimeSettings,
+  ensureConfiguredAgent,
+} from '@core/config/settings/runtime-settings.js';
+import type { AgentId } from '@core/domain/agent/agent.js';
+import type { AppId } from '@core/domain/app/app.js';
+import { resolveConfiguredToolPolicy } from '@core/runtime/configured-agent-tools.js';
+import {
+  semanticCapabilityInputSchema,
+  type SemanticCapabilityDefinition,
+} from '@core/shared/semantic-capabilities.js';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+
+const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
+const APP_ID = 'default' as AppId;
+const AGENT_A_FOLDER = 'capability_agent_a';
+const AGENT_B_FOLDER = 'capability_agent_b';
+const AGENT_A_ID = `agent:${AGENT_A_FOLDER}` as AgentId;
+const AGENT_B_ID = `agent:${AGENT_B_FOLDER}` as AgentId;
+
+// Reuses the desired-state-to-policy projection seam from
+// capability-lifecycle.postgres.integration.test.ts.
+maybeDescribe('multi-agent capability isolation (Postgres)', () => {
+  let runtime: PostgresIntegrationRuntime;
+
+  beforeAll(async () => {
+    runtime = await createPostgresIntegrationRuntime({
+      schemaPrefix: 'multi_agent_capability_isolation',
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (runtime) await runtime.cleanup();
+  });
+
+  it('keeps a desired-state capability grant scoped to one co-resident agent', async () => {
+    const now = '2026-07-21T00:00:00.000Z';
+    const capability: SemanticCapabilityDefinition = {
+      capabilityId: 'acme.records.append',
+      displayName: 'Acme records append',
+      category: 'Acme',
+      risk: 'write',
+      can: 'Append reviewed records through configured access.',
+      cannot: 'Read unrelated records or receive raw credentials.',
+      credentialSource: 'configured_access',
+      implementationBindings: [
+        {
+          kind: 'tool_rule',
+          rule: 'RunCommand(/opt/acme/bin/acme records append *)',
+        },
+      ],
+      preflight: { kind: 'none' },
+    };
+    await runtime.repositories.tools.saveTool({
+      id: `tool:capability:${capability.capabilityId}` as never,
+      appId: APP_ID,
+      name: `capability:${capability.capabilityId}`,
+      kind: 'host',
+      provider: 'gantry',
+      displayName: capability.displayName,
+      category: 'productivity',
+      risk: 'high',
+      selectable: true,
+      status: 'active',
+      adapterRef: `capability/${capability.capabilityId}`,
+      inputSchema: semanticCapabilityInputSchema(capability),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const settings = createDefaultRuntimeSettings();
+    settings.desiredState.authoritative = true;
+    ensureConfiguredAgent(settings, {
+      agentId: AGENT_A_FOLDER,
+      agentName: 'Capability Agent A',
+      agentFolder: AGENT_A_FOLDER,
+    });
+    ensureConfiguredAgent(settings, {
+      agentId: AGENT_B_FOLDER,
+      agentName: 'Capability Agent B',
+      agentFolder: AGENT_B_FOLDER,
+    });
+    settings.agents[AGENT_A_FOLDER]!.capabilities = [
+      { id: capability.capabilityId, version: '1' },
+    ];
+
+    const reconciled = await new SettingsDesiredStateService({
+      ops: runtime.ops,
+      repositories: runtime.repositories,
+      clock: { now: () => now },
+    }).reconcile(settings);
+    expect(reconciled.invalidReferences).toEqual([]);
+
+    const project = (agentId: AgentId) =>
+      resolveConfiguredToolPolicy({
+        repository: runtime.repositories.tools,
+        appId: APP_ID,
+        agentId,
+      });
+    const [agentAPolicy, agentBPolicy] = await Promise.all([
+      project(AGENT_A_ID),
+      project(AGENT_B_ID),
+    ]);
+    const grantedRules = [
+      `capability:${capability.capabilityId}`,
+      'RunCommand(/opt/acme/bin/acme records append *)',
+    ];
+
+    expect(agentAPolicy.toolPolicyRules).toEqual(grantedRules);
+    expect(agentBPolicy.toolPolicyRules).toEqual([]);
+    expect(agentAPolicy.runtimeAccess).toEqual([
+      expect.objectContaining({
+        selectedCapabilityId: capability.capabilityId,
+        sourceType: 'builtin_tool',
+        runtimeToolRules: ['RunCommand(/opt/acme/bin/acme records append *)'],
+      }),
+    ]);
+    expect(agentBPolicy.runtimeAccess).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds Postgres integration coverage for E2E matrix §15 (multi-agent, delegation) — the deterministic integration rows. Two new test files, no production source changes.

**Scenarios (behavioral assertions only):**
1. **Delegated task lifecycle — durable across repository instances**: `startDelegatedAgent` → completion persists; re-read through a FRESH `PostgresAsyncTaskRepository` returns the completed task with its authority snapshot + private correlation linkage + scoped `allowedActions`. Failure variant persists as an **immutable terminal result** — a re-`transitionTask` to `completed` returns null (terminal-state immutability via lease/fencing). Complements the in-memory IPC unit proof in `ipc-agent-task-lifecycle-handlers.test.ts`.
2. **Two co-resident agents, grant scope isolation**: a desired-state capability granted to agent A projects the scoped rule for A and an **empty** policy for B — grant does not leak across co-resident agents. Reuses the desired-state→policy projection seam from `capability-lifecycle.postgres.integration.test.ts`.

Deferred (kept to ponytail-minimum): the optional routing-disambiguation row.

**Verify:** `tsc --noEmit` clean; both files → 3/3 pass vs real Postgres; cited IPC unit suite 12/12.