### PR TITLE
feat(observability): reconstruct tool-execution spans (Anthropic + OpenAI)

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-observability.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-observability.ts
@@ -72,7 +72,10 @@ export function resolveGatewayTap(
 ): GatewayStreamTap | undefined {
   try {
     return observation?.isStreaming
-      ? observation.streamTapFor(response.headers.get('content-type'))
+      ? observation.streamTapFor(
+          response.headers.get('content-type'),
+          response.status,
+        )
       : undefined;
   } catch {
     return undefined;

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway.ts
@@ -524,17 +524,12 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
       res.setHeader(key, value);
     });
     const tap = resolveGatewayTap(observation, response);
+    let pipeError: unknown;
     try {
-      const pipePromise = pipeUpstreamBody(response, res, tap);
-      if (auditPromise) {
-        const [, pipeResult] = await Promise.allSettled([
-          auditPromise,
-          pipePromise,
-        ]);
-        if (pipeResult.status === 'rejected') throw pipeResult.reason;
-      } else {
-        await pipePromise;
-      }
+      await pipeUpstreamBody(response, res, tap);
+      // Finalize streamed tool calls as soon as the response is complete. The
+      // runner can submit the next tool-result request before a slow audit
+      // sink settles, and that request must find the pending tool span.
       if (observation?.isStreaming) observation.finish({ status });
     } catch (error) {
       if (observation?.isStreaming)
@@ -542,8 +537,10 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
           status,
           errorMessage: error instanceof Error ? error.message : String(error),
         });
-      throw error;
+      pipeError = error;
     }
+    if (auditPromise) await auditPromise;
+    if (pipeError) throw pipeError;
   }
   private async publishGatewayUseAudit(
     tokenRecord: GatewayTokenRecord,

--- a/apps/core/src/adapters/llm/observability/genai-spans.ts
+++ b/apps/core/src/adapters/llm/observability/genai-spans.ts
@@ -7,18 +7,22 @@ import {
   ATTR_COMPLETION,
   ATTR_PROMPT,
   boundedContent,
-  boundedJsonArray,
   MAX_ATTRIBUTE_CHARS,
   TRACE_CONTENT_MAX_CHARS,
   childContextFor,
   contentCaptureEnabled,
   getTurnSpan,
+  registerDelegationToolSpan,
+  registerTurnSpanEndCallback,
+  settleDelegationToolSpan,
   tracer,
 } from '../../../infrastructure/observability/tracing.js';
 import {
   createSseAccumulator,
   createSseFrameSplitter,
   isOpenAiUsageOnlyFrame,
+  type SseAccumulatorResult,
+  type SseToolCall,
   type SseStreamKind,
 } from './sse-accumulator.js';
 
@@ -44,6 +48,7 @@ export interface GatewayCallObservation {
   // a plain-JSON error body back, which the frame-aligned tap must not touch.
   streamTapFor: (
     contentType: string | null | undefined,
+    status?: number,
   ) => GatewayStreamTap | undefined;
   finish: (input: {
     status: number;
@@ -98,9 +103,326 @@ const PROVIDER_SYSTEM_MAP: Record<string, string> = {
   vertex: 'gcp.vertex_ai',
   gemini: 'gcp.gemini',
 };
+const PROVIDER_NAME_MAP: Record<string, string> = {
+  ...PROVIDER_SYSTEM_MAP,
+  xai: 'x_ai',
+};
+
+const ATTR_INPUT_MESSAGES = 'gen_ai.input.messages';
+const ATTR_OUTPUT_MESSAGES = 'gen_ai.output.messages';
+const TRUNCATION_SUFFIX = '…[truncated]';
+const MAX_TOOL_CALLS = 128;
+
+interface ToolCall extends SseToolCall {
+  id: string;
+  name: string;
+  choiceIndex?: number;
+  complete: boolean;
+}
+
+interface ToolResult {
+  id: string;
+  content: unknown;
+  status: 'success' | 'error' | 'unknown';
+}
+
+interface PendingToolSpan {
+  span: Span;
+  startedAt: number;
+  delegation: boolean;
+  unregisterTurnEnd: () => void;
+}
+
+let pendingTracer: ReturnType<typeof tracer>;
+const pendingToolsByRun = new Map<string, Map<string, PendingToolSpan>>();
+
+function boundedTraceValue(
+  value: unknown,
+  stringLimit: number,
+  arrayLimit: number,
+  depth = 0,
+): unknown {
+  if (typeof value === 'string') {
+    return value.length > stringLimit
+      ? `${value.slice(0, stringLimit)}${TRUNCATION_SUFFIX}`
+      : value;
+  }
+  if (
+    value === null ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (depth >= 8) return TRUNCATION_SUFFIX;
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, arrayLimit)
+      .map((entry) =>
+        boundedTraceValue(entry, stringLimit, arrayLimit, depth + 1),
+      );
+  }
+  if (typeof value !== 'object') return String(value ?? '');
+  const result: Record<string, unknown> = {};
+  let count = 0;
+  for (const key in value) {
+    if (!Object.hasOwn(value, key)) continue;
+    if (count >= 64) break;
+    result[key] = boundedTraceValue(
+      (value as Record<string, unknown>)[key],
+      stringLimit,
+      arrayLimit,
+      depth + 1,
+    );
+    count += 1;
+  }
+  return result;
+}
+
+function boundedMessageJson(
+  messages: Record<string, unknown>[],
+  schema: 'legacy' | 'current-input' | 'current-output',
+): string {
+  let stringLimit = TRACE_CONTENT_MAX_CHARS;
+  let arrayLimit = 64;
+  let messageLimit = Math.min(MAX_TOOL_CALLS, messages.length);
+  for (;;) {
+    const bounded = messages
+      .slice(-messageLimit)
+      .map((message) => boundedTraceValue(message, stringLimit, arrayLimit));
+    const serialized = JSON.stringify(bounded);
+    if (serialized.length <= MAX_ATTRIBUTE_CHARS) return serialized;
+    if (stringLimit > 256) stringLimit = Math.floor(stringLimit / 2);
+    else if (arrayLimit > 1) arrayLimit = Math.floor(arrayLimit / 2);
+    else if (messageLimit > 1) messageLimit = Math.floor(messageLimit / 2);
+    else {
+      if (schema === 'legacy') {
+        return JSON.stringify([
+          { role: 'unknown', content: TRUNCATION_SUFFIX },
+        ]);
+      }
+      return JSON.stringify([
+        {
+          role: 'unknown',
+          parts: [{ type: 'text', content: TRUNCATION_SUFFIX }],
+          ...(schema === 'current-output'
+            ? {
+                finish_reason:
+                  typeof messages.at(-1)?.finish_reason === 'string'
+                    ? messages.at(-1)!.finish_reason
+                    : 'error',
+              }
+            : {}),
+        },
+      ]);
+    }
+  }
+}
+
+function visibleAnthropicBlocks(content: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(content)) return [];
+  const visible: Record<string, unknown>[] = [];
+  for (const value of content) {
+    if (visible.length >= MAX_TOOL_CALLS) break;
+    if (!value || typeof value !== 'object') continue;
+    const block = value as Record<string, unknown>;
+    if (block.type === 'text' && typeof block.text === 'string') {
+      visible.push({ ...block, type: 'text', text: block.text });
+    } else if (
+      block.type === 'tool_use' &&
+      typeof block.id === 'string' &&
+      typeof block.name === 'string'
+    ) {
+      visible.push({
+        ...block,
+        type: 'tool_use',
+        id: block.id,
+        name: block.name,
+      });
+    } else if (
+      block.type === 'tool_result' &&
+      typeof block.tool_use_id === 'string'
+    ) {
+      visible.push({
+        ...block,
+        type: 'tool_result',
+        tool_use_id: block.tool_use_id,
+      });
+    } else if (
+      typeof block.type === 'string' &&
+      block.type !== 'thinking' &&
+      block.type !== 'redacted_thinking'
+    ) {
+      visible.push({ ...block });
+    }
+  }
+  return visible;
+}
+
+function visibleOpenAiParts(content: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(content)) return [];
+  const visible: Record<string, unknown>[] = [];
+  for (const value of content) {
+    if (visible.length >= MAX_TOOL_CALLS) break;
+    if (!value || typeof value !== 'object') continue;
+    const part = value as Record<string, unknown>;
+    if (
+      ![
+        'text',
+        'image_url',
+        'input_audio',
+        'audio',
+        'file',
+        'refusal',
+      ].includes(String(part.type))
+    ) {
+      continue;
+    }
+    visible.push({ ...part });
+  }
+  return visible;
+}
+
+function legacyMessages(
+  kind: SseStreamKind | undefined,
+  messages: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  if (kind !== 'anthropic' && kind !== 'openai') return messages;
+  return messages.map((message) => {
+    const legacy = { ...message };
+    delete legacy.finish_reason;
+    delete legacy.index;
+    return {
+      ...legacy,
+      ...(Array.isArray(message.content)
+        ? {
+            content:
+              kind === 'anthropic'
+                ? visibleAnthropicBlocks(message.content)
+                : visibleOpenAiParts(message.content),
+          }
+        : {}),
+    };
+  });
+}
+
+function normalizedMessages(
+  kind: SseStreamKind | undefined,
+  messages: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  const normalized: Record<string, unknown>[] = [];
+  for (const message of messages) {
+    const role = typeof message.role === 'string' ? message.role : 'unknown';
+    const parts: Record<string, unknown>[] = [];
+    if (kind === 'anthropic' && Array.isArray(message.content)) {
+      for (const block of visibleAnthropicBlocks(message.content)) {
+        if (block.type === 'text') {
+          parts.push({ type: 'text', content: block.text });
+        } else if (block.type === 'tool_use') {
+          parts.push({
+            type: 'tool_call',
+            id: block.id,
+            name: block.name,
+            arguments: block.input ?? {},
+          });
+        } else if (block.type === 'tool_result') {
+          parts.push({
+            type: 'tool_call_response',
+            id: block.tool_use_id,
+            response: block.content ?? '',
+          });
+        } else {
+          parts.push(block);
+        }
+      }
+    } else if (role === 'tool' && typeof message.tool_call_id === 'string') {
+      parts.push({
+        type: 'tool_call_response',
+        id: message.tool_call_id,
+        response:
+          message.content === undefined ? '' : parsedJson(message.content),
+      });
+    } else {
+      if (typeof message.content === 'string') {
+        parts.push({ type: 'text', content: message.content });
+      } else if (Array.isArray(message.content)) {
+        for (const part of visibleOpenAiParts(message.content)) {
+          if (part.type === 'text' && typeof part.text === 'string') {
+            parts.push({ type: 'text', content: part.text });
+          } else {
+            parts.push(part);
+          }
+        }
+      }
+      if (Array.isArray(message.tool_calls)) {
+        for (const value of message.tool_calls.slice(0, MAX_TOOL_CALLS)) {
+          if (!value || typeof value !== 'object') continue;
+          const toolCall = value as Record<string, unknown>;
+          const fn = toolCall.function as Record<string, unknown> | undefined;
+          if (typeof toolCall.id !== 'string' || typeof fn?.name !== 'string') {
+            continue;
+          }
+          parts.push({
+            type: 'tool_call',
+            id: toolCall.id,
+            name: fn.name,
+            arguments: parsedJson(fn.arguments) ?? {},
+          });
+        }
+      }
+      if (typeof message.refusal === 'string') {
+        parts.push({ type: 'refusal', refusal: message.refusal });
+      }
+    }
+    if (parts.length === 0) continue;
+    normalized.push({
+      role: parts.every((part) => part.type === 'tool_call_response')
+        ? 'tool'
+        : role,
+      parts,
+      ...(typeof message.index === 'number' ? { index: message.index } : {}),
+      ...(typeof message.finish_reason === 'string'
+        ? { finish_reason: message.finish_reason }
+        : {}),
+    });
+  }
+  return normalized;
+}
+
+function setMessageAttributes(
+  span: Span,
+  legacyKey: string,
+  currentKey: string,
+  messages: Record<string, unknown>[],
+  kind: SseStreamKind | undefined,
+): void {
+  span.setAttribute(
+    legacyKey,
+    boundedMessageJson(legacyMessages(kind, messages), 'legacy'),
+  );
+  const current = normalizedMessages(kind, messages);
+  const schemaComplete =
+    currentKey !== ATTR_OUTPUT_MESSAGES ||
+    current.every((message) => typeof message.finish_reason === 'string');
+  if (current.length > 0 && schemaComplete) {
+    span.setAttribute(
+      currentKey,
+      boundedMessageJson(
+        current,
+        currentKey === ATTR_OUTPUT_MESSAGES
+          ? 'current-output'
+          : 'current-input',
+      ),
+    );
+  }
+}
 
 function providerSystemFor(providerId: string): string {
   return PROVIDER_SYSTEM_MAP[providerId] ?? providerId;
+}
+
+function providerNameFor(providerId: string): string {
+  return PROVIDER_NAME_MAP[providerId] ?? providerId;
 }
 
 function numeric(value: unknown): number | undefined {
@@ -109,81 +431,245 @@ function numeric(value: unknown): number | undefined {
     : undefined;
 }
 
-function promptJson(request: Record<string, unknown>): string | undefined {
+function promptMessages(
+  request: Record<string, unknown>,
+): Record<string, unknown>[] {
   const messages = Array.isArray(request.messages)
     ? (request.messages as Record<string, unknown>[])
     : [];
-  // Walk from the end (most recent messages) under a raw-char budget so a
-  // request with millions of tiny messages never materializes millions of
-  // entries — the serializer's 32k output limit is enforced afterwards.
-  const entries: { role: string; content: string }[] = [];
-  let budget = MAX_ATTRIBUTE_CHARS;
-  for (let index = messages.length - 1; index >= 0 && budget > 0; index -= 1) {
-    const message = messages[index];
-    if (message === null || typeof message !== 'object') continue;
-    const role = typeof message.role === 'string' ? message.role : 'unknown';
-    const content =
-      typeof message.content === 'string'
-        ? message.content
-        : JSON.stringify(message.content ?? '');
-    const entry = { role, content: boundedContent(content) };
-    entries.push(entry);
-    budget -= entry.content.length + 32;
-  }
-  entries.reverse();
   const system = request.system;
+  const hasSystem = typeof system === 'string' || Array.isArray(system);
+  const entries: Record<string, unknown>[] = messages
+    .slice(hasSystem ? -63 : -64)
+    .filter(
+      (message): message is Record<string, unknown> =>
+        message !== null && typeof message === 'object',
+    )
+    .map((message) => ({
+      role: typeof message.role === 'string' ? message.role : 'unknown',
+      ...(message.content !== undefined ? { content: message.content } : {}),
+      ...(message.tool_calls !== undefined
+        ? { tool_calls: message.tool_calls }
+        : {}),
+      ...(message.tool_call_id !== undefined
+        ? { tool_call_id: message.tool_call_id }
+        : {}),
+      ...(message.name !== undefined ? { name: message.name } : {}),
+      ...(message.refusal !== undefined ? { refusal: message.refusal } : {}),
+    }));
   if (typeof system === 'string') {
-    entries.unshift({ role: 'system', content: boundedContent(system) });
+    entries.unshift({ role: 'system', content: system });
   } else if (Array.isArray(system)) {
-    entries.unshift({
-      role: 'system',
-      content: boundedContent(JSON.stringify(system)),
-    });
+    entries.unshift({ role: 'system', content: system });
   }
-  return entries.length > 0 ? boundedJsonArray(entries) : undefined;
+  return entries;
 }
 
-function completionJson(content: string): string {
-  return boundedJsonArray([
-    { role: 'assistant', content: boundedContent(content) },
-  ]);
+function parsedJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
 }
 
-function responseCompletionText(
+function responseAssistantMessages(
   kind: SseStreamKind | undefined,
   response: Record<string, unknown>,
-): string | undefined {
+): Record<string, unknown>[] {
   if (kind === 'anthropic' && Array.isArray(response.content)) {
-    // Accumulate only up to the trace budget — joining every block of an
-    // unbounded provider response would allocate freely on the hot path.
-    let text = '';
-    for (const block of response.content as Record<string, unknown>[]) {
-      if (block.type === 'text' && typeof block.text === 'string') {
-        text += block.text;
-        if (text.length > TRACE_CONTENT_MAX_CHARS) {
-          return text.slice(0, TRACE_CONTENT_MAX_CHARS + 1);
-        }
+    const blocks = visibleAnthropicBlocks(response.content);
+    if (blocks.length === 0) return [];
+    if (blocks.every((block) => block.type === 'text')) {
+      let text = '';
+      for (const block of blocks) {
+        if (block.type !== 'text' || typeof block.text !== 'string') continue;
+        const remaining = TRACE_CONTENT_MAX_CHARS + 1 - text.length;
+        if (remaining <= 0) break;
+        text += block.text.slice(0, remaining);
       }
+      if (!text) return [];
+      return [
+        {
+          role: 'assistant',
+          content: boundedContent(text),
+          ...(typeof response.stop_reason === 'string'
+            ? { finish_reason: response.stop_reason }
+            : {}),
+        },
+      ];
     }
-    return text || boundedContent(JSON.stringify(response.content));
+    return [
+      {
+        role: 'assistant',
+        content: blocks,
+        ...(typeof response.stop_reason === 'string'
+          ? { finish_reason: response.stop_reason }
+          : {}),
+      },
+    ];
   }
   if (kind === 'openai') {
-    const choice = (
-      response.choices as Record<string, unknown>[] | undefined
-    )?.[0];
-    const message = choice?.message as { content?: unknown } | undefined;
-    if (typeof message?.content === 'string') return message.content;
+    const messages: Record<string, unknown>[] = [];
+    for (const [position, choice] of (
+      (response.choices as Record<string, unknown>[] | undefined) ?? []
+    )
+      .slice(0, MAX_TOOL_CALLS)
+      .entries()) {
+      const message = choice.message;
+      if (!message || typeof message !== 'object') continue;
+      const record = message as Record<string, unknown>;
+      messages.push({
+        ...(record.content !== undefined ? { content: record.content } : {}),
+        ...(record.tool_calls !== undefined
+          ? { tool_calls: record.tool_calls }
+          : {}),
+        ...(record.name !== undefined ? { name: record.name } : {}),
+        ...(record.refusal !== undefined ? { refusal: record.refusal } : {}),
+        role: typeof record.role === 'string' ? record.role : 'assistant',
+        index: numeric(choice.index) ?? position,
+        ...(typeof choice.finish_reason === 'string'
+          ? { finish_reason: choice.finish_reason }
+          : {}),
+      });
+    }
+    return messages;
   }
-  return undefined;
+  return [];
 }
 
-function setUsageAttributes(span: Span, usage: Record<string, unknown>): void {
+function responseToolCalls(
+  kind: SseStreamKind | undefined,
+  response: Record<string, unknown>,
+): ToolCall[] {
+  if (kind === 'anthropic' && Array.isArray(response.content)) {
+    const calls: ToolCall[] = [];
+    for (const block of response.content as Record<string, unknown>[]) {
+      if (calls.length >= MAX_TOOL_CALLS) break;
+      if (
+        block.type !== 'tool_use' ||
+        typeof block.id !== 'string' ||
+        typeof block.name !== 'string'
+      ) {
+        continue;
+      }
+      calls.push({
+        id: boundedToolIdentity(block.id),
+        name: boundedToolIdentity(block.name),
+        arguments: boundedToolValue(block.input),
+        complete: response.stop_reason === 'tool_use',
+      });
+    }
+    return calls;
+  }
+  if (kind !== 'openai') return [];
+  const calls: ToolCall[] = [];
+  for (const [position, choice] of (
+    (response.choices as Record<string, unknown>[] | undefined) ?? []
+  )
+    .slice(0, MAX_TOOL_CALLS)
+    .entries()) {
+    const message = choice.message as Record<string, unknown> | undefined;
+    if (!Array.isArray(message?.tool_calls)) continue;
+    const choiceIndex = numeric(choice.index) ?? position;
+    for (const toolCall of message.tool_calls as Record<string, unknown>[]) {
+      if (calls.length >= MAX_TOOL_CALLS) return calls;
+      const fn = toolCall.function as Record<string, unknown> | undefined;
+      if (typeof toolCall.id !== 'string' || typeof fn?.name !== 'string') {
+        continue;
+      }
+      calls.push({
+        id: boundedToolIdentity(toolCall.id),
+        name: boundedToolIdentity(fn.name),
+        arguments: boundedToolValue(parsedJson(fn.arguments)),
+        choiceIndex,
+        complete: choice.finish_reason === 'tool_calls',
+      });
+    }
+  }
+  return calls;
+}
+
+function requestToolResults(
+  kind: SseStreamKind | undefined,
+  request: Record<string, unknown>,
+): ToolResult[] {
+  if (!Array.isArray(request.messages)) return [];
+  const results: ToolResult[] = [];
+  for (
+    let index = request.messages.length - 1;
+    index >= 0 && results.length < MAX_TOOL_CALLS;
+    index -= 1
+  ) {
+    const value = request.messages[index];
+    if (!value || typeof value !== 'object') continue;
+    const message = value as Record<string, unknown>;
+    if (kind === 'anthropic' && Array.isArray(message.content)) {
+      for (
+        let blockIndex = message.content.length - 1;
+        blockIndex >= 0 && results.length < MAX_TOOL_CALLS;
+        blockIndex -= 1
+      ) {
+        const value = message.content[blockIndex];
+        if (!value || typeof value !== 'object') continue;
+        const block = value as Record<string, unknown>;
+        if (
+          block.type !== 'tool_result' ||
+          typeof block.tool_use_id !== 'string'
+        ) {
+          continue;
+        }
+        results.push({
+          id: boundedToolIdentity(block.tool_use_id),
+          content: block.content,
+          status: block.is_error === true ? 'error' : 'success',
+        });
+      }
+    } else if (
+      kind === 'openai' &&
+      message.role === 'tool' &&
+      typeof message.tool_call_id === 'string'
+    ) {
+      const content = parsedJson(message.content);
+      const resultRecord =
+        content && typeof content === 'object'
+          ? (content as Record<string, unknown>)
+          : undefined;
+      const errorMarker =
+        message.is_error ?? resultRecord?.is_error ?? resultRecord?.isError;
+      results.push({
+        id: boundedToolIdentity(message.tool_call_id),
+        content,
+        status:
+          errorMarker === true
+            ? 'error'
+            : errorMarker === false
+              ? 'success'
+              : 'unknown',
+      });
+    }
+  }
+  return results.reverse();
+}
+
+function setUsageAttributes(
+  span: Span,
+  usage: Record<string, unknown>,
+  kind: SseStreamKind | undefined,
+): void {
   const input = numeric(usage.input_tokens) ?? numeric(usage.prompt_tokens);
   const output =
     numeric(usage.output_tokens) ?? numeric(usage.completion_tokens);
-  if (input !== undefined) {
-    span.setAttribute('gen_ai.usage.input_tokens', input);
-  }
+  const cacheRead = numeric(usage.cache_read_input_tokens);
+  const cacheWrite = numeric(usage.cache_creation_input_tokens);
+  if (input !== undefined)
+    span.setAttribute(
+      'gen_ai.usage.input_tokens',
+      kind === 'anthropic'
+        ? input + (cacheRead ?? 0) + (cacheWrite ?? 0)
+        : input,
+    );
   if (output !== undefined) {
     span.setAttribute('gen_ai.usage.output_tokens', output);
   }
@@ -191,13 +677,13 @@ function setUsageAttributes(span: Span, usage: Record<string, unknown>): void {
   if (total !== undefined) {
     span.setAttribute('gen_ai.usage.total_tokens', total);
   }
-  const cacheRead = numeric(usage.cache_read_input_tokens);
   if (cacheRead !== undefined) {
     span.setAttribute('gen_ai.usage.cache_read_input_tokens', cacheRead);
+    span.setAttribute('gen_ai.usage.cache_read.input_tokens', cacheRead);
   }
-  const cacheWrite = numeric(usage.cache_creation_input_tokens);
   if (cacheWrite !== undefined) {
     span.setAttribute('gen_ai.usage.cache_creation_input_tokens', cacheWrite);
+    span.setAttribute('gen_ai.usage.cache_creation.input_tokens', cacheWrite);
   }
   const details = usage.prompt_tokens_details as
     | Record<string, unknown>
@@ -211,12 +697,28 @@ function setUsageAttributes(span: Span, usage: Record<string, unknown>): void {
 function setNormalizedUsageAttributes(
   span: Span,
   usage: NormalizedModelUsage,
+  kind: SseStreamKind | undefined,
+  rawUsage?: Record<string, unknown>,
 ): void {
-  span.setAttribute('gen_ai.usage.input_tokens', usage.inputTokens);
+  const rawInput = numeric(rawUsage?.input_tokens);
+  const rawCacheRead = numeric(rawUsage?.cache_read_input_tokens);
+  const rawCacheWrite = numeric(rawUsage?.cache_creation_input_tokens);
+  span.setAttribute(
+    'gen_ai.usage.input_tokens',
+    kind === 'anthropic'
+      ? (rawInput ?? usage.inputTokens) +
+          (rawCacheRead ?? usage.cacheReadTokens) +
+          (rawCacheWrite ?? usage.cacheWriteTokens)
+      : usage.inputTokens,
+  );
   span.setAttribute('gen_ai.usage.output_tokens', usage.outputTokens);
   if (usage.cacheReadTokens > 0) {
     span.setAttribute(
       'gen_ai.usage.cache_read_input_tokens',
+      usage.cacheReadTokens,
+    );
+    span.setAttribute(
+      'gen_ai.usage.cache_read.input_tokens',
       usage.cacheReadTokens,
     );
   }
@@ -225,7 +727,328 @@ function setNormalizedUsageAttributes(
       'gen_ai.usage.cache_creation_input_tokens',
       usage.cacheWriteTokens,
     );
+    span.setAttribute(
+      'gen_ai.usage.cache_creation.input_tokens',
+      usage.cacheWriteTokens,
+    );
   }
+}
+
+function boundedToolValue(value: unknown): unknown {
+  let stringLimit = TRACE_CONTENT_MAX_CHARS;
+  let arrayLimit = 64;
+  for (;;) {
+    const bounded = boundedTraceValue(value ?? null, stringLimit, arrayLimit);
+    if (JSON.stringify(bounded).length <= TRACE_CONTENT_MAX_CHARS) {
+      return bounded;
+    }
+    if (stringLimit > 256) stringLimit = Math.floor(stringLimit / 2);
+    else if (arrayLimit > 1) arrayLimit = Math.floor(arrayLimit / 2);
+    else return { truncated: true };
+  }
+}
+
+function boundedToolJson(value: unknown): string {
+  return JSON.stringify(boundedToolValue(value));
+}
+
+function boundedToolIdentity(value: string): string {
+  return value.length <= TRACE_CONTENT_MAX_CHARS
+    ? value
+    : `${value.slice(
+        0,
+        TRACE_CONTENT_MAX_CHARS - TRUNCATION_SUFFIX.length,
+      )}${TRUNCATION_SUFFIX}`;
+}
+
+function toolPayload(value: unknown): string {
+  return typeof value === 'string'
+    ? boundedContent(value)
+    : boundedToolJson(value);
+}
+
+function toolMetadata(call: ToolCall): {
+  transport: 'local' | 'mcp' | 'delegation';
+  server?: string;
+} {
+  const gantryName = call.name.startsWith('mcp__gantry__')
+    ? call.name.slice('mcp__gantry__'.length)
+    : call.name;
+  if (
+    gantryName === 'delegate_task' ||
+    gantryName === 'AgentDelegation' ||
+    gantryName === 'Agent' ||
+    gantryName.startsWith('delegate_to_')
+  ) {
+    return { transport: 'delegation' };
+  }
+  if (gantryName === 'mcp_call_tool' || gantryName === 'async_mcp_call') {
+    const args =
+      call.arguments && typeof call.arguments === 'object'
+        ? (call.arguments as Record<string, unknown>)
+        : undefined;
+    return {
+      transport: 'mcp',
+      ...(call.mcpServer
+        ? { server: call.mcpServer }
+        : typeof args?.serverName === 'string'
+          ? { server: args.serverName }
+          : {}),
+    };
+  }
+  const mcp = /^mcp__([A-Za-z0-9_-]+)__/.exec(call.name);
+  return mcp ? { transport: 'mcp', server: mcp[1] } : { transport: 'local' };
+}
+
+function delegationObjective(call: ToolCall): string | undefined {
+  const value = call.arguments ?? call.correlationArguments;
+  if (!value || typeof value !== 'object') return undefined;
+  const args = value as Record<string, unknown>;
+  for (const key of ['objective', 'task', 'prompt']) {
+    if (typeof args[key] === 'string' && args[key].trim()) {
+      return args[key].trim();
+    }
+  }
+  return undefined;
+}
+
+function delegationTaskId(value: unknown, depth = 0): string | undefined {
+  if (depth > 6 || value === null || value === undefined) return undefined;
+  if (typeof value === 'string') {
+    return /\btask_[A-Za-z0-9][A-Za-z0-9_-]{0,159}\b/.exec(value)?.[0];
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value.slice(0, 64)) {
+      const found = delegationTaskId(entry, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (typeof value !== 'object') return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of ['taskId', 'id']) {
+    const candidate = record[key];
+    if (
+      typeof candidate === 'string' &&
+      /^task_[A-Za-z0-9][A-Za-z0-9_-]{0,159}$/.test(candidate)
+    ) {
+      return candidate;
+    }
+  }
+  for (const entry of Object.values(record).slice(0, 64)) {
+    const found = delegationTaskId(entry, depth + 1);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function finishPendingToolSpans(
+  runId: string,
+  kind: SseStreamKind | undefined,
+  request: Record<string, unknown>,
+  captureContent: boolean,
+): void {
+  const pending = pendingToolsByRun.get(runId);
+  if (!pending) return;
+  for (const result of requestToolResults(kind, request)) {
+    const active = pending.get(result.id);
+    if (!active) continue;
+    pending.delete(result.id);
+    try {
+      active.unregisterTurnEnd();
+      if (active.delegation) {
+        settleDelegationToolSpan({
+          runId,
+          callId: result.id,
+          taskId:
+            result.status === 'error'
+              ? undefined
+              : delegationTaskId(result.content),
+        });
+      }
+      active.span.setAttribute(
+        'gantry.tool.latency_ms',
+        Math.max(0, Date.now() - active.startedAt),
+      );
+      active.span.setAttribute('gantry.tool.status', result.status);
+      if (captureContent) {
+        active.span.setAttribute(
+          'gen_ai.tool.call.result',
+          toolPayload(result.content),
+        );
+      }
+      if (result.status === 'error') {
+        active.span.setAttribute('error.type', 'tool_error');
+        active.span.setStatus({ code: SpanStatusCode.ERROR });
+      } else if (result.status === 'success') {
+        active.span.setStatus({ code: SpanStatusCode.OK });
+      }
+    } catch {
+      // fail-open
+    } finally {
+      try {
+        active.span.end();
+      } catch {
+        // fail-open
+      }
+    }
+  }
+  if (pending.size === 0) pendingToolsByRun.delete(runId);
+}
+
+function startPendingToolSpans(input: {
+  runId: string;
+  parent: Span;
+  activeTracer: NonNullable<ReturnType<typeof tracer>>;
+  toolCalls: ToolCall[];
+  captureContent: boolean;
+}): void {
+  if (input.toolCalls.length === 0) return;
+  const pending =
+    pendingToolsByRun.get(input.runId) ?? new Map<string, PendingToolSpan>();
+  pendingToolsByRun.set(input.runId, pending);
+  for (const call of input.toolCalls) {
+    if (pending.has(call.id)) continue;
+    try {
+      const metadata = toolMetadata(call);
+      const span = input.activeTracer.startSpan(
+        `execute_tool ${call.name.slice(0, 128)}`,
+        {
+          attributes: {
+            'gen_ai.operation.name': 'execute_tool',
+            'gen_ai.tool.name': call.name,
+            'gen_ai.tool.call.id': call.id,
+            'gen_ai.tool.type': 'function',
+            'gantry.tool.transport': metadata.transport,
+            'gantry.tool.timing': 'reconstructed',
+            'gantry.run_id': input.runId,
+            ...(call.choiceIndex !== undefined
+              ? { 'gen_ai.response.choice.index': call.choiceIndex }
+              : {}),
+            ...(metadata.server
+              ? { 'gantry.mcp.server': metadata.server }
+              : {}),
+            ...(input.captureContent && call.arguments !== undefined
+              ? {
+                  'gen_ai.tool.call.arguments': toolPayload(call.arguments),
+                }
+              : {}),
+          },
+        },
+        childContextFor(input.parent),
+      );
+      if (metadata.transport === 'delegation') {
+        registerDelegationToolSpan({
+          runId: input.runId,
+          callId: call.id,
+          objective: delegationObjective(call),
+          span,
+        });
+      }
+      pending.set(call.id, {
+        unregisterTurnEnd: () => {},
+        span,
+        startedAt: Date.now(),
+        delegation: metadata.transport === 'delegation',
+      });
+      const active = pending.get(call.id)!;
+      active.unregisterTurnEnd = registerTurnSpanEndCallback(
+        input.runId,
+        () => {
+          pending.delete(call.id);
+          if (pending.size === 0) pendingToolsByRun.delete(input.runId);
+          if (active.delegation) {
+            settleDelegationToolSpan({
+              runId: input.runId,
+              callId: call.id,
+            });
+          }
+          try {
+            active.span.setAttribute(
+              'gantry.tool.latency_ms',
+              Math.max(0, Date.now() - active.startedAt),
+            );
+            active.span.setAttribute('gantry.tool.status', 'error');
+            active.span.setAttribute('error.type', 'tool_result_missing');
+            active.span.setStatus({ code: SpanStatusCode.ERROR });
+          } catch {
+            // fail-open
+          } finally {
+            try {
+              active.span.end();
+            } catch {
+              // fail-open
+            }
+          }
+        },
+      );
+    } catch {
+      // fail-open
+    }
+  }
+}
+
+function failPendingToolSpans(
+  runId: string,
+  callIds: ReadonlySet<string>,
+): void {
+  const pending = pendingToolsByRun.get(runId);
+  if (!pending) return;
+  for (const callId of callIds) {
+    const active = pending.get(callId);
+    if (!active) continue;
+    pending.delete(callId);
+    active.unregisterTurnEnd();
+    if (active.delegation) settleDelegationToolSpan({ runId, callId });
+    try {
+      active.span.setAttribute(
+        'gantry.tool.latency_ms',
+        Math.max(0, Date.now() - active.startedAt),
+      );
+      active.span.setAttribute('gantry.tool.status', 'error');
+      active.span.setAttribute('error.type', 'tool_response_failed');
+      active.span.setStatus({ code: SpanStatusCode.ERROR });
+    } catch {
+      // fail-open
+    } finally {
+      try {
+        active.span.end();
+      } catch {
+        // fail-open
+      }
+    }
+  }
+  if (pending.size === 0) pendingToolsByRun.delete(runId);
+}
+
+function isCompleteToolCallResponse(
+  kind: SseStreamKind | undefined,
+  finishReason: string | undefined,
+): boolean {
+  return (
+    (kind === 'anthropic' && finishReason === 'tool_use') ||
+    (kind === 'openai' && finishReason === 'tool_calls')
+  );
+}
+
+function streamedToolCalls(
+  kind: SseStreamKind | undefined,
+  streamed: SseAccumulatorResult,
+): ToolCall[] {
+  return (streamed.toolCalls ?? []).flatMap((call) =>
+    typeof call.id === 'string' && typeof call.name === 'string'
+      ? [
+          {
+            ...call,
+            id: call.id,
+            name: call.name,
+            complete:
+              call.complete ??
+              isCompleteToolCallResponse(kind, streamed.finishReason),
+          },
+        ]
+      : [],
+  );
 }
 
 function injectIncludeUsage(
@@ -258,6 +1081,10 @@ export function observeGatewayCall(input: {
 }): GatewayCallObservation | undefined {
   const activeTracer = tracer();
   if (!activeTracer) return undefined;
+  if (pendingTracer !== activeTracer) {
+    pendingTracer = activeTracer;
+    pendingToolsByRun.clear();
+  }
   let startedSpan: Span | undefined;
   try {
     let request: Record<string, unknown> = {};
@@ -284,6 +1111,9 @@ export function observeGatewayCall(input: {
 
     const runId =
       input.token.runId === undefined ? undefined : String(input.token.runId);
+    if (runId) {
+      finishPendingToolSpans(runId, kind, request, captureContent);
+    }
     const parent = runId ? getTurnSpan(runId) : undefined;
     // Span names bypass the attribute length limit; model comes from an
     // untrusted request body.
@@ -292,6 +1122,7 @@ export function observeGatewayCall(input: {
       {
         attributes: {
           'gen_ai.operation.name': 'chat',
+          'gen_ai.provider.name': providerNameFor(input.providerId),
           'gen_ai.system': providerSystemFor(input.providerId),
           ...(requestModel ? { 'gen_ai.request.model': requestModel } : {}),
           ...(numeric(request.max_tokens) !== undefined
@@ -343,8 +1174,16 @@ export function observeGatewayCall(input: {
       }
     }
     if (captureContent) {
-      const prompt = promptJson(request);
-      if (prompt) span.setAttribute(ATTR_PROMPT, prompt);
+      const messages = promptMessages(request);
+      if (messages.length > 0) {
+        setMessageAttributes(
+          span,
+          ATTR_PROMPT,
+          ATTR_INPUT_MESSAGES,
+          messages,
+          kind,
+        );
+      }
     }
 
     const accumulator =
@@ -353,6 +1192,39 @@ export function observeGatewayCall(input: {
         : undefined;
     let tapUsed = false;
     let sawFirstChunk = false;
+    let streamStatus: number | undefined;
+    const earlyRegisteredToolCallIds = new Set<string>();
+
+    const registerCompletedStreamToolCalls = () => {
+      if (!accumulator?.takeToolCallsReady()) return;
+      if (
+        !runId ||
+        streamStatus === undefined ||
+        streamStatus < 200 ||
+        streamStatus >= 300
+      ) {
+        return;
+      }
+      const streamed = accumulator.result();
+      if (streamed.errorMessage) return;
+      const liveParent = getTurnSpan(runId);
+      if (!liveParent) return;
+      const complete = streamedToolCalls(kind, streamed).filter(
+        (call) => call.complete && !earlyRegisteredToolCallIds.has(call.id),
+      );
+      if (complete.length === 0) return;
+      startPendingToolSpans({
+        runId,
+        parent: liveParent,
+        activeTracer,
+        toolCalls: complete,
+        captureContent,
+      });
+      const pending = pendingToolsByRun.get(runId);
+      for (const call of complete) {
+        if (pending?.has(call.id)) earlyRegisteredToolCallIds.add(call.id);
+      }
+    };
 
     const markFirstChunk = () => {
       if (!sawFirstChunk) {
@@ -377,6 +1249,7 @@ export function observeGatewayCall(input: {
             markFirstChunk();
             try {
               accumulator?.push(chunk);
+              registerCompletedStreamToolCalls();
             } catch {
               // fail-open
             }
@@ -385,6 +1258,7 @@ export function observeGatewayCall(input: {
           flush: () => {
             try {
               accumulator?.push(Buffer.from('\n\n'));
+              registerCompletedStreamToolCalls();
             } catch {
               // fail-open
             }
@@ -401,6 +1275,7 @@ export function observeGatewayCall(input: {
         const out: string[] = [];
         for (const frame of frames) {
           accumulator.pushFrame(frame);
+          registerCompletedStreamToolCalls();
           if (!isOpenAiUsageOnlyFrame(frame)) out.push(`${frame}\n\n`);
         }
         if (splitter.overflowed()) {
@@ -439,15 +1314,33 @@ export function observeGatewayCall(input: {
         span.setAttribute('http.response.status_code', result.status);
         let usage: Record<string, unknown> | undefined;
         let responseModel: string | undefined;
-        let completionText: string | undefined;
-        let finishReason: string | undefined;
+        let assistantMessages: Record<string, unknown>[] = [];
+        let toolCalls: ToolCall[] = [];
+        let finishReasons: string[] = [];
         let streamErrorMessage: string | undefined;
         if (tapUsed && accumulator) {
           const streamed = accumulator.result();
           usage = streamed.usage;
           responseModel = streamed.model;
-          completionText = streamed.completionText;
-          finishReason = streamed.finishReason;
+          toolCalls = streamedToolCalls(kind, streamed);
+          if (streamed.assistantMessages) {
+            assistantMessages = streamed.assistantMessages;
+          } else if (streamed.assistantMessage) {
+            assistantMessages = [streamed.assistantMessage];
+          } else if (streamed.completionText) {
+            assistantMessages = [
+              {
+                role: 'assistant',
+                content: streamed.completionText,
+                ...(streamed.finishReason
+                  ? { finish_reason: streamed.finishReason }
+                  : {}),
+              },
+            ];
+          }
+          finishReasons =
+            streamed.finishReasons ??
+            (streamed.finishReason ? [streamed.finishReason] : []);
           streamErrorMessage = streamed.errorMessage;
         } else if (
           result.responseJson &&
@@ -460,18 +1353,23 @@ export function observeGatewayCall(input: {
               : undefined;
           responseModel =
             typeof response.model === 'string' ? response.model : undefined;
-          completionText = captureContent
-            ? responseCompletionText(kind, response)
-            : undefined;
-          finishReason =
-            typeof response.stop_reason === 'string'
-              ? response.stop_reason
-              : typeof (
-                    response.choices as Record<string, unknown>[] | undefined
-                  )?.[0]?.finish_reason === 'string'
-                ? ((response.choices as Record<string, unknown>[])[0]
-                    .finish_reason as string)
-                : undefined;
+          assistantMessages = captureContent
+            ? responseAssistantMessages(kind, response)
+            : [];
+          toolCalls = responseToolCalls(kind, response);
+          if (typeof response.stop_reason === 'string') {
+            finishReasons = [response.stop_reason];
+          } else {
+            finishReasons = (
+              (response.choices as Record<string, unknown>[] | undefined) ?? []
+            )
+              .slice(0, MAX_TOOL_CALLS)
+              .flatMap((choice) =>
+                typeof choice.finish_reason === 'string'
+                  ? [choice.finish_reason]
+                  : [],
+              );
+          }
           if (typeof response.id === 'string') {
             span.setAttribute('gen_ai.response.id', response.id);
           }
@@ -479,10 +1377,10 @@ export function observeGatewayCall(input: {
         if (responseModel) {
           span.setAttribute('gen_ai.response.model', responseModel);
         }
-        if (finishReason) {
-          span.setAttribute('gen_ai.response.finish_reasons', [finishReason]);
+        if (finishReasons.length > 0) {
+          span.setAttribute('gen_ai.response.finish_reasons', finishReasons);
         }
-        if (usage) setUsageAttributes(span, usage);
+        if (usage) setUsageAttributes(span, usage, kind);
         const normalized =
           result.normalizedUsage ??
           (usage
@@ -491,16 +1389,24 @@ export function observeGatewayCall(input: {
                 fallbackModel: responseModel ?? requestModel,
               })
             : undefined);
-        if (normalized) setNormalizedUsageAttributes(span, normalized);
+        if (normalized) {
+          setNormalizedUsageAttributes(span, normalized, kind, usage);
+        }
         if (typeof normalized?.estimatedCostUsd === 'number') {
           span.setAttribute('gen_ai.usage.cost', normalized.estimatedCostUsd);
         }
-        if (captureContent && completionText) {
-          span.setAttribute(ATTR_COMPLETION, completionJson(completionText));
+        if (captureContent && assistantMessages.length > 0) {
+          setMessageAttributes(
+            span,
+            ATTR_COMPLETION,
+            ATTR_OUTPUT_MESSAGES,
+            assistantMessages,
+            kind,
+          );
         }
-        // streamErrorMessage is provider-sourced and may echo request
-        // content; with content capture off, record a stable label instead.
-        // result.errorMessage is host/gateway-sourced (timeouts, statusText).
+        // Provider and transport errors can arrive after valid-looking tool
+        // fragments. Only a successful terminal tool-call response means a
+        // tool execution could actually follow on the next request.
         const providerError = streamErrorMessage
           ? captureContent
             ? boundedContent(streamErrorMessage)
@@ -509,6 +1415,32 @@ export function observeGatewayCall(input: {
         const errorMessage = result.errorMessage
           ? boundedContent(result.errorMessage)
           : providerError;
+        if (runId && errorMessage && earlyRegisteredToolCallIds.size > 0) {
+          failPendingToolSpans(runId, earlyRegisteredToolCallIds);
+        }
+        const liveParent = runId ? getTurnSpan(runId) : undefined;
+        const completeToolCalls = toolCalls.filter(
+          (call) => call.complete && !earlyRegisteredToolCallIds.has(call.id),
+        );
+        if (
+          runId &&
+          liveParent &&
+          result.status >= 200 &&
+          result.status < 300 &&
+          !errorMessage &&
+          completeToolCalls.length > 0
+        ) {
+          startPendingToolSpans({
+            runId,
+            parent: liveParent,
+            activeTracer,
+            toolCalls: completeToolCalls,
+            captureContent,
+          });
+        }
+        // streamErrorMessage is provider-sourced and may echo request
+        // content; with content capture off, record a stable label instead.
+        // result.errorMessage is host/gateway-sourced (timeouts, statusText).
         if (result.status >= 400 || errorMessage) {
           span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
           if (errorMessage) {
@@ -530,7 +1462,7 @@ export function observeGatewayCall(input: {
     return {
       requestBody,
       isStreaming,
-      streamTapFor: (contentType) => {
+      streamTapFor: (contentType, status) => {
         // Media types are case-insensitive (e.g. Text/Event-Stream).
         if (
           !isStreaming ||
@@ -538,6 +1470,7 @@ export function observeGatewayCall(input: {
         ) {
           return undefined;
         }
+        if (status !== undefined) streamStatus = status;
         cachedTap ??= buildStreamTap();
         return cachedTap;
       },

--- a/apps/core/src/adapters/llm/observability/sse-accumulator.ts
+++ b/apps/core/src/adapters/llm/observability/sse-accumulator.ts
@@ -1,14 +1,49 @@
 import { StringDecoder } from 'node:string_decoder';
 
+import { TRACE_CONTENT_MAX_CHARS } from '../../../infrastructure/observability/tracing.js';
+
 export type SseStreamKind = 'anthropic' | 'openai';
 
 const MAX_COMPLETION_CHARS = 256 * 1024;
+const MAX_TOOL_PAYLOAD_CHARS = 16 * 1024;
+const MAX_AGGREGATE_TOOL_ARGUMENT_CHARS = 1024 * 1024;
+const MAX_TOOL_IDENTITY_CHARS = TRACE_CONTENT_MAX_CHARS;
+const MAX_TOOL_CALLS = 128;
+const MAX_OPENAI_CHOICES = 128;
+const TRUNCATED_SUFFIX = '…[truncated]';
+
+export interface SseToolCall {
+  id?: string;
+  name?: string;
+  arguments?: unknown;
+  mcpServer?: string;
+  choiceIndex?: number;
+  complete?: boolean;
+  // Bounded, in-process-only hint used to correlate parallel delegation when
+  // content export is disabled. Never written to span attributes/messages.
+  correlationArguments?: unknown;
+}
+
+export interface SseAssistantMessage {
+  [key: string]: unknown;
+  role: 'assistant';
+  content?: unknown;
+  tool_calls?: Array<{
+    id?: string;
+    type: 'function';
+    function: { name?: string; arguments?: unknown };
+  }>;
+}
 
 export interface SseAccumulatorResult {
   model?: string;
   usage?: Record<string, unknown>;
   completionText?: string;
+  toolCalls?: SseToolCall[];
+  assistantMessage?: SseAssistantMessage;
+  assistantMessages?: SseAssistantMessage[];
   finishReason?: string;
+  finishReasons?: string[];
   // Providers can fail mid-stream behind an HTTP 200 (top-level `error`
   // chunk / `error` event); spans must not export those as successes.
   errorMessage?: string;
@@ -118,7 +153,116 @@ export function isOpenAiUsageOnlyFrame(frame: string): boolean {
 export interface SseAccumulator {
   push: (chunk: Buffer) => void;
   pushFrame: (frame: string) => void;
+  takeToolCallsReady: () => boolean;
   result: () => SseAccumulatorResult;
+}
+
+interface PendingToolCall {
+  order: number;
+  id?: string;
+  name?: string;
+  initialArguments?: unknown;
+  argumentText: string;
+  argumentCapped: boolean;
+  sawArgumentDelta: boolean;
+}
+
+interface OpenAiChoiceState {
+  index: number;
+  completionText: string;
+  completionCapped: boolean;
+  refusalText: string;
+  finishReason?: string;
+  pendingToolCalls: Map<number, PendingToolCall>;
+}
+
+function boundedToolValue(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
+}
+
+function boundedStructuredValue(
+  value: unknown,
+  stringLimit: number,
+  arrayLimit: number,
+  depth = 0,
+): unknown {
+  if (typeof value === 'string') {
+    return boundedToolValue(value, stringLimit);
+  }
+  if (
+    value === null ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (depth >= 8) return TRUNCATED_SUFFIX;
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, arrayLimit)
+      .map((entry) =>
+        boundedStructuredValue(entry, stringLimit, arrayLimit, depth + 1),
+      );
+  }
+  if (typeof value !== 'object') return String(value ?? '');
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).slice(
+    0,
+    64,
+  )) {
+    result[key] = boundedStructuredValue(
+      (value as Record<string, unknown>)[key],
+      stringLimit,
+      arrayLimit,
+      depth + 1,
+    );
+  }
+  return result;
+}
+
+function boundedStructuredArguments(value: unknown): unknown {
+  let stringLimit = MAX_TOOL_PAYLOAD_CHARS;
+  let arrayLimit = 64;
+  for (;;) {
+    const bounded = boundedStructuredValue(value, stringLimit, arrayLimit);
+    if (JSON.stringify(bounded).length <= MAX_TOOL_PAYLOAD_CHARS) {
+      return bounded;
+    }
+    if (stringLimit > 256) stringLimit = Math.floor(stringLimit / 2);
+    else if (arrayLimit > 1) arrayLimit = Math.floor(arrayLimit / 2);
+    else return { truncated: true };
+  }
+}
+
+function structuredArguments(value: string): unknown {
+  try {
+    return boundedStructuredArguments(JSON.parse(value) as unknown);
+  } catch {
+    return boundedToolValue(value, MAX_TOOL_PAYLOAD_CHARS);
+  }
+}
+
+function initialArguments(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  try {
+    return boundedStructuredArguments(value);
+  } catch {
+    return boundedToolValue(String(value), MAX_TOOL_PAYLOAD_CHARS);
+  }
+}
+
+function isDelegationTool(name: string | undefined): boolean {
+  if (!name) return false;
+  const gantryName = name.startsWith('mcp__gantry__')
+    ? name.slice('mcp__gantry__'.length)
+    : name;
+  return (
+    gantryName === 'delegate_task' ||
+    gantryName === 'AgentDelegation' ||
+    gantryName === 'Agent' ||
+    gantryName.startsWith('delegate_to_')
+  );
 }
 
 export function createSseAccumulator(
@@ -135,6 +279,13 @@ export function createSseAccumulator(
   let errorMessage: string | undefined;
   const usage: Record<string, unknown> = {};
   let sawUsage = false;
+  const pendingToolCalls = new Map<number, PendingToolCall>();
+  const openAiChoices = new Map<number, OpenAiChoiceState>();
+  const anthropicTextBlocks = new Map<number, string>();
+  let retainedToolArgumentChars = 0;
+  let retainedToolCalls = 0;
+  let retainedOpenAiContentChars = 0;
+  let toolCallsReady = false;
 
   const captureError = (value: unknown) => {
     if (errorMessage || value === null || typeof value !== 'object') return;
@@ -145,13 +296,214 @@ export function createSseAccumulator(
     errorMessage = parts.length > 0 ? parts.join(': ') : 'stream error';
   };
 
-  const appendText = (text: string) => {
-    if (!captureContent || completionCapped) return;
+  const appendText = (text: string): string => {
+    if (!captureContent || completionCapped) return '';
+    const before = completionText.length;
     completionText += text;
     if (completionText.length > MAX_COMPLETION_CHARS) {
       completionText = completionText.slice(0, MAX_COMPLETION_CHARS);
       completionCapped = true;
     }
+    return completionText.slice(before);
+  };
+
+  const appendChoiceText = (choice: OpenAiChoiceState, text: string) => {
+    if (!captureContent || choice.completionCapped) return;
+    const available = MAX_COMPLETION_CHARS - retainedOpenAiContentChars;
+    if (available <= 0) {
+      choice.completionCapped = true;
+      return;
+    }
+    const retained = text.slice(0, available);
+    choice.completionText += retained;
+    retainedOpenAiContentChars += retained.length;
+    if (retained.length < text.length) choice.completionCapped = true;
+  };
+
+  const appendChoiceRefusal = (choice: OpenAiChoiceState, text: string) => {
+    if (!captureContent) return;
+    const available = MAX_COMPLETION_CHARS - retainedOpenAiContentChars;
+    if (available <= 0) return;
+    const retained = text.slice(0, available);
+    choice.refusalText += retained;
+    retainedOpenAiContentChars += retained.length;
+  };
+
+  const toolIndex = (value: unknown, fallback: number): number =>
+    typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+      ? value
+      : fallback;
+
+  const getToolCall = (
+    calls: Map<number, PendingToolCall>,
+    index: number,
+  ): PendingToolCall | undefined => {
+    const current = calls.get(index);
+    if (current) return current;
+    if (retainedToolCalls >= MAX_TOOL_CALLS) return undefined;
+    const created: PendingToolCall = {
+      order: index,
+      argumentText: '',
+      argumentCapped: false,
+      sawArgumentDelta: false,
+    };
+    calls.set(index, created);
+    retainedToolCalls += 1;
+    return created;
+  };
+
+  const appendIdentity = (
+    current: string | undefined,
+    fragment: unknown,
+  ): string | undefined => {
+    if (typeof fragment !== 'string') return current;
+    return boundedToolValue(
+      `${current ?? ''}${fragment}`,
+      MAX_TOOL_IDENTITY_CHARS,
+    );
+  };
+
+  const appendArguments = (call: PendingToolCall, fragment: unknown) => {
+    if (typeof fragment !== 'string' || fragment.length === 0) return;
+    call.sawArgumentDelta = true;
+    if (call.argumentCapped) return;
+    const available =
+      MAX_AGGREGATE_TOOL_ARGUMENT_CHARS - retainedToolArgumentChars;
+    if (available <= 0) {
+      call.argumentCapped = true;
+      return;
+    }
+    if (fragment.length <= available) {
+      call.argumentText += fragment;
+      retainedToolArgumentChars += fragment.length;
+      return;
+    }
+    const suffix = TRUNCATED_SUFFIX.slice(0, available);
+    const contentLength = Math.max(0, available - suffix.length);
+    call.argumentText += `${fragment.slice(0, contentLength)}${suffix}`;
+    retainedToolArgumentChars += available;
+    call.argumentCapped = true;
+  };
+
+  const completedToolCall = (
+    call: PendingToolCall,
+    choice?: OpenAiChoiceState,
+  ): SseToolCall => {
+    const parsedArguments = call.sawArgumentDelta
+      ? call.argumentCapped && !call.argumentText
+        ? { truncated: true }
+        : structuredArguments(call.argumentText)
+      : call.initialArguments;
+    const args = captureContent ? parsedArguments : undefined;
+    const mcpServer =
+      parsedArguments &&
+      typeof parsedArguments === 'object' &&
+      typeof (parsedArguments as Record<string, unknown>).serverName ===
+        'string'
+        ? ((parsedArguments as Record<string, unknown>).serverName as string)
+        : undefined;
+    return {
+      ...(call.id ? { id: call.id } : {}),
+      ...(call.name ? { name: call.name } : {}),
+      ...(args !== undefined ? { arguments: args } : {}),
+      ...(mcpServer ? { mcpServer } : {}),
+      ...(!captureContent && isDelegationTool(call.name)
+        ? { correlationArguments: parsedArguments }
+        : {}),
+      ...(choice
+        ? {
+            choiceIndex: choice.index,
+            complete: choice.finishReason === 'tool_calls',
+          }
+        : {}),
+    };
+  };
+
+  const sortedOpenAiChoices = (): OpenAiChoiceState[] =>
+    [...openAiChoices.values()].sort((left, right) => left.index - right.index);
+
+  const completedToolCalls = (): SseToolCall[] =>
+    kind === 'openai'
+      ? sortedOpenAiChoices().flatMap((choice) =>
+          [...choice.pendingToolCalls.values()]
+            .sort((left, right) => left.order - right.order)
+            .map((call) => completedToolCall(call, choice)),
+        )
+      : [...pendingToolCalls.values()]
+          .sort((left, right) => left.order - right.order)
+          .map((call) => completedToolCall(call));
+
+  const anthropicAssistantMessage = (
+    toolCalls: SseToolCall[],
+  ): SseAssistantMessage | undefined => {
+    if (!captureContent) return undefined;
+    if (toolCalls.length === 0) return undefined;
+    const blocks = [
+      ...[...anthropicTextBlocks.entries()].map(([order, text]) => ({
+        order,
+        block: { type: 'text', text },
+      })),
+      ...[...pendingToolCalls.values()].map((call) => {
+        const completed = completedToolCall(call);
+        return {
+          order: call.order,
+          block: {
+            type: 'tool_use',
+            ...(call.id ? { id: call.id } : {}),
+            ...(call.name ? { name: call.name } : {}),
+            ...(completed.arguments !== undefined
+              ? { input: completed.arguments }
+              : {}),
+          },
+        };
+      }),
+    ]
+      .sort((left, right) => left.order - right.order)
+      .map(({ block }) => block);
+    return blocks.length > 0
+      ? {
+          role: 'assistant',
+          content: blocks,
+          ...(finishReason ? { finish_reason: finishReason } : {}),
+        }
+      : undefined;
+  };
+
+  const openAiAssistantMessage = (
+    choice: OpenAiChoiceState,
+  ): SseAssistantMessage | undefined => {
+    if (!captureContent) return undefined;
+    const toolCalls = [...choice.pendingToolCalls.values()]
+      .sort((left, right) => left.order - right.order)
+      .map((call) => completedToolCall(call, choice));
+    if (
+      !choice.completionText &&
+      toolCalls.length === 0 &&
+      !choice.refusalText
+    ) {
+      return undefined;
+    }
+    return {
+      role: 'assistant',
+      content: choice.completionText || null,
+      index: choice.index,
+      ...(choice.finishReason ? { finish_reason: choice.finishReason } : {}),
+      ...(choice.refusalText ? { refusal: choice.refusalText } : {}),
+      ...(toolCalls.length > 0 || choice.refusalText
+        ? {
+            tool_calls: toolCalls.map((call) => ({
+              ...(call.id ? { id: call.id } : {}),
+              type: 'function' as const,
+              function: {
+                ...(call.name ? { name: call.name } : {}),
+                ...(call.arguments !== undefined
+                  ? { arguments: call.arguments }
+                  : {}),
+              },
+            })),
+          }
+        : {}),
+    };
   };
 
   // Only recognized usage fields are retained — merging arbitrary provider
@@ -211,10 +563,43 @@ export function createSseAccumulator(
       mergeUsage(message?.usage);
       return;
     }
+    if (event.type === 'content_block_start') {
+      const index = toolIndex(event.index, pendingToolCalls.size);
+      const block = event.content_block as Record<string, unknown> | undefined;
+      if (block?.type === 'text') {
+        const captured =
+          typeof block.text === 'string' ? appendText(block.text) : '';
+        if (captured && anthropicTextBlocks.size < MAX_TOOL_CALLS) {
+          anthropicTextBlocks.set(index, captured);
+        }
+      } else if (block?.type === 'tool_use') {
+        const call = getToolCall(pendingToolCalls, index);
+        if (call) {
+          call.id = appendIdentity(undefined, block.id);
+          call.name = appendIdentity(undefined, block.name);
+          call.initialArguments = initialArguments(block.input);
+        }
+      }
+      return;
+    }
     if (event.type === 'content_block_delta') {
-      const delta = event.delta as { type?: string; text?: string } | undefined;
+      const index = toolIndex(event.index, pendingToolCalls.size);
+      const delta = event.delta as
+        | { type?: string; text?: string; partial_json?: string }
+        | undefined;
       if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
-        appendText(delta.text);
+        const captured = appendText(delta.text);
+        if (
+          captured &&
+          (anthropicTextBlocks.has(index) ||
+            anthropicTextBlocks.size < MAX_TOOL_CALLS)
+        ) {
+          const text = `${anthropicTextBlocks.get(index) ?? ''}${captured}`;
+          anthropicTextBlocks.set(index, text);
+        }
+      } else if (delta?.type === 'input_json_delta') {
+        const call = getToolCall(pendingToolCalls, index);
+        if (call) appendArguments(call, delta.partial_json);
       }
       return;
     }
@@ -223,6 +608,7 @@ export function createSseAccumulator(
       const delta = event.delta as { stop_reason?: string } | undefined;
       if (typeof delta?.stop_reason === 'string') {
         finishReason = delta.stop_reason;
+        if (finishReason === 'tool_use') toolCallsReady = true;
       }
     }
   };
@@ -233,14 +619,53 @@ export function createSseAccumulator(
     }
     if (typeof event.model === 'string') model = event.model;
     mergeUsage(event.usage);
-    const choice = (
-      event.choices as Record<string, unknown>[] | undefined
-    )?.[0];
-    if (!choice) return;
-    const delta = choice.delta as { content?: unknown } | undefined;
-    if (typeof delta?.content === 'string') appendText(delta.content);
-    if (typeof choice.finish_reason === 'string') {
-      finishReason = choice.finish_reason;
+    const choices = Array.isArray(event.choices)
+      ? (event.choices as unknown[]).slice(0, MAX_TOOL_CALLS)
+      : [];
+    for (const [position, value] of choices.entries()) {
+      if (value === null || typeof value !== 'object') continue;
+      const choice = value as Record<string, unknown>;
+      const index = toolIndex(choice.index, position);
+      let choiceState = openAiChoices.get(index);
+      if (!choiceState) {
+        if (openAiChoices.size >= MAX_OPENAI_CHOICES) continue;
+        choiceState = {
+          index,
+          completionText: '',
+          completionCapped: false,
+          refusalText: '',
+          pendingToolCalls: new Map(),
+        };
+        openAiChoices.set(index, choiceState);
+      }
+      const delta = choice.delta as
+        | { content?: unknown; refusal?: unknown; tool_calls?: unknown }
+        | undefined;
+      if (typeof delta?.content === 'string') {
+        appendChoiceText(choiceState, delta.content);
+      }
+      if (typeof delta?.refusal === 'string') {
+        appendChoiceRefusal(choiceState, delta.refusal);
+      }
+      if (Array.isArray(delta?.tool_calls)) {
+        for (const [toolPosition, toolValue] of delta.tool_calls.entries()) {
+          if (toolValue === null || typeof toolValue !== 'object') continue;
+          const fragment = toolValue as Record<string, unknown>;
+          const call = getToolCall(
+            choiceState.pendingToolCalls,
+            toolIndex(fragment.index, toolPosition),
+          );
+          if (!call) continue;
+          call.id = appendIdentity(call.id, fragment.id);
+          const fn = fragment.function as Record<string, unknown> | undefined;
+          call.name = appendIdentity(call.name, fn?.name);
+          appendArguments(call, fn?.arguments);
+        }
+      }
+      if (typeof choice.finish_reason === 'string') {
+        choiceState.finishReason = choice.finish_reason;
+        if (choiceState.finishReason === 'tool_calls') toolCallsReady = true;
+      }
     }
   };
 
@@ -279,12 +704,57 @@ export function createSseAccumulator(
       }
     },
     pushFrame,
-    result: () => ({
-      ...(model ? { model } : {}),
-      ...(sawUsage ? { usage } : {}),
-      ...(completionText ? { completionText } : {}),
-      ...(finishReason ? { finishReason } : {}),
-      ...(errorMessage ? { errorMessage } : {}),
-    }),
+    takeToolCallsReady: () => {
+      const ready = toolCallsReady;
+      toolCallsReady = false;
+      return ready;
+    },
+    result: () => {
+      const toolCalls = completedToolCalls();
+      if (kind === 'openai') {
+        const choices = sortedOpenAiChoices();
+        const messages = choices.flatMap((choice) => {
+          const message = openAiAssistantMessage(choice);
+          return message ? [message] : [];
+        });
+        const finishReasons = choices.flatMap((choice) =>
+          choice.finishReason ? [choice.finishReason] : [],
+        );
+        const onlyChoice = choices.length === 1 ? choices[0] : undefined;
+        const onlyMessage = messages.length === 1 ? messages[0] : undefined;
+        return {
+          ...(model ? { model } : {}),
+          ...(sawUsage ? { usage } : {}),
+          ...(onlyChoice?.completionText
+            ? { completionText: onlyChoice.completionText }
+            : {}),
+          ...(toolCalls.length > 0 ? { toolCalls } : {}),
+          ...(onlyMessage &&
+          (onlyChoice?.pendingToolCalls.size || onlyChoice?.refusalText)
+            ? { assistantMessage: onlyMessage }
+            : {}),
+          ...(choices.length > 1 && messages.length > 0
+            ? { assistantMessages: messages }
+            : {}),
+          ...(onlyChoice?.finishReason
+            ? { finishReason: onlyChoice.finishReason }
+            : {}),
+          ...(choices.length > 1 && finishReasons.length > 0
+            ? { finishReasons }
+            : {}),
+          ...(errorMessage ? { errorMessage } : {}),
+        };
+      }
+      const message = anthropicAssistantMessage(toolCalls);
+      return {
+        ...(model ? { model } : {}),
+        ...(sawUsage ? { usage } : {}),
+        ...(completionText ? { completionText } : {}),
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        ...(message ? { assistantMessage: message } : {}),
+        ...(finishReason ? { finishReason } : {}),
+        ...(errorMessage ? { errorMessage } : {}),
+      };
+    },
   };
 }

--- a/apps/core/src/infrastructure/observability/spawn-log-context.ts
+++ b/apps/core/src/infrastructure/observability/spawn-log-context.ts
@@ -7,6 +7,7 @@ import {
 interface SpawnLogTurnInput {
   runId?: string;
   parentRunId?: string;
+  parentTaskId?: string;
   appId?: string;
   agentId?: string;
   chatJid?: string;

--- a/apps/core/src/infrastructure/observability/spawn-turn-tracker.ts
+++ b/apps/core/src/infrastructure/observability/spawn-turn-tracker.ts
@@ -5,6 +5,7 @@ import {
   contentCaptureEnabled,
   getTurnSpan,
   startTurnSpan,
+  takeDelegationToolSpan,
   tracingEnabled,
   TRACE_CONTENT_MAX_CHARS,
 } from './tracing.js';
@@ -16,6 +17,7 @@ import { updateLogContext } from '../logging/logger.js';
 interface TurnInputLike {
   runId?: string;
   parentRunId?: string;
+  parentTaskId?: string;
   appId?: string;
   agentId?: string;
   chatJid?: string;
@@ -53,10 +55,17 @@ export function createSpawnTurnTracker<F extends TurnFrameLike>(
   onOutput: ((frame: F) => Promise<void>) | undefined,
 ): SpawnTurnTracker<F> {
   const correlationId = input.runId ?? `credential-run:${randomUUID()}`;
+  const delegationParent = input.parentRunId
+    ? takeDelegationToolSpan({
+        parentRunId: input.parentRunId,
+        parentTaskId: input.parentTaskId,
+        prompt: input.prompt,
+      })
+    : undefined;
   const openTurnSpan = (continuation?: boolean) => {
-    const parentSpan = input.parentRunId
-      ? getTurnSpan(input.parentRunId)
-      : undefined;
+    const parentSpan =
+      (!continuation ? delegationParent : undefined) ??
+      (input.parentRunId ? getTurnSpan(input.parentRunId) : undefined);
     return startTurnSpan(
       {
         runId: correlationId,

--- a/apps/core/src/infrastructure/observability/tracing.ts
+++ b/apps/core/src/infrastructure/observability/tracing.ts
@@ -51,6 +51,58 @@ interface TracingState {
 
 let state: TracingState | undefined;
 const turnSpans = new Map<string, Span>();
+const turnSpanEndCallbacks = new Map<string, Set<() => void>>();
+const DELEGATION_PARENT_TTL_MS = 30 * 60_000;
+const MAX_DELEGATION_PARENTS = 1024;
+
+interface DelegationParent {
+  key: string;
+  runId: string;
+  callId: string;
+  objective?: string;
+  taskId?: string;
+  span: Span;
+  expiresAt: number;
+}
+
+const delegationParentsByCall = new Map<string, DelegationParent>();
+const delegationParentsByTask = new Map<string, DelegationParent>();
+
+function removeDelegationParent(entry: DelegationParent): void {
+  if (delegationParentsByCall.get(entry.key) === entry) {
+    delegationParentsByCall.delete(entry.key);
+  }
+  const taskKey = entry.taskId ? `${entry.runId}\0${entry.taskId}` : undefined;
+  if (taskKey && delegationParentsByTask.get(taskKey) === entry) {
+    delegationParentsByTask.delete(taskKey);
+  }
+}
+
+function pruneDelegationParents(): void {
+  const now = Date.now();
+  for (const entry of delegationParentsByCall.values()) {
+    if (entry.expiresAt <= now) removeDelegationParent(entry);
+  }
+  while (delegationParentsByCall.size > MAX_DELEGATION_PARENTS) {
+    const oldest = delegationParentsByCall.values().next().value as
+      | DelegationParent
+      | undefined;
+    if (!oldest) break;
+    removeDelegationParent(oldest);
+  }
+}
+
+function finishTurnChildren(runId: string): void {
+  const callbacks = turnSpanEndCallbacks.get(runId);
+  turnSpanEndCallbacks.delete(runId);
+  for (const callback of callbacks ?? []) {
+    try {
+      callback();
+    } catch {
+      // fail-open
+    }
+  }
+}
 
 export function parseOtlpHeaders(
   raw: string | undefined,
@@ -115,8 +167,12 @@ export function initTracing(
 
 export async function shutdownTracing(): Promise<void> {
   const current = state;
+  for (const runId of turnSpanEndCallbacks.keys()) finishTurnChildren(runId);
   state = undefined;
   turnSpans.clear();
+  turnSpanEndCallbacks.clear();
+  delegationParentsByCall.clear();
+  delegationParentsByTask.clear();
   if (!current) return;
   try {
     await current.provider.shutdown();
@@ -139,6 +195,87 @@ export function tracer(): Tracer | undefined {
 
 export function getTurnSpan(runId: string): Span | undefined {
   return turnSpans.get(runId);
+}
+
+export function registerDelegationToolSpan(input: {
+  runId: string;
+  callId: string;
+  objective?: string;
+  span: Span;
+}): void {
+  if (!state || !turnSpans.has(input.runId)) return;
+  pruneDelegationParents();
+  const key = `${input.runId}\0${input.callId}`;
+  const existing = delegationParentsByCall.get(key);
+  if (existing) removeDelegationParent(existing);
+  delegationParentsByCall.set(key, {
+    key,
+    runId: input.runId,
+    callId: input.callId,
+    ...(input.objective?.trim() ? { objective: input.objective.trim() } : {}),
+    span: input.span,
+    expiresAt: Date.now() + DELEGATION_PARENT_TTL_MS,
+  });
+  pruneDelegationParents();
+}
+
+export function settleDelegationToolSpan(input: {
+  runId: string;
+  callId: string;
+  taskId?: string;
+}): void {
+  pruneDelegationParents();
+  const entry = delegationParentsByCall.get(`${input.runId}\0${input.callId}`);
+  if (!entry) return;
+  if (!input.taskId) {
+    removeDelegationParent(entry);
+    return;
+  }
+  entry.taskId = input.taskId;
+  delegationParentsByTask.set(`${entry.runId}\0${input.taskId}`, entry);
+}
+
+export function takeDelegationToolSpan(input: {
+  parentRunId: string;
+  parentTaskId?: string;
+  prompt: string;
+}): Span | undefined {
+  pruneDelegationParents();
+  let entry = input.parentTaskId
+    ? delegationParentsByTask.get(`${input.parentRunId}\0${input.parentTaskId}`)
+    : undefined;
+  if (!entry) {
+    const candidates = [...delegationParentsByCall.values()].filter(
+      (candidate) => candidate.runId === input.parentRunId,
+    );
+    const objectiveMatches = candidates.filter(
+      (candidate) =>
+        candidate.objective && input.prompt.includes(candidate.objective),
+    );
+    entry =
+      objectiveMatches.length === 1
+        ? objectiveMatches[0]
+        : candidates.length === 1
+          ? candidates[0]
+          : undefined;
+  }
+  if (!entry) return undefined;
+  removeDelegationParent(entry);
+  return entry.span;
+}
+
+export function registerTurnSpanEndCallback(
+  runId: string,
+  callback: () => void,
+): () => void {
+  if (!state || !turnSpans.has(runId)) return () => {};
+  const callbacks = turnSpanEndCallbacks.get(runId) ?? new Set<() => void>();
+  callbacks.add(callback);
+  turnSpanEndCallbacks.set(runId, callbacks);
+  return () => {
+    callbacks.delete(callback);
+    if (callbacks.size === 0) turnSpanEndCallbacks.delete(runId);
+  };
 }
 
 export function boundedContent(value: string): string {
@@ -273,6 +410,7 @@ export function startTurnSpan(
       end: (outcome, error) => {
         if (ended) return;
         ended = true;
+        finishTurnChildren(input.runId);
         turnSpans.delete(input.runId);
         try {
           span.setAttribute('gantry.turn_outcome', outcome);

--- a/apps/core/test/unit/core/gantry-model-gateway-tracing.test.ts
+++ b/apps/core/test/unit/core/gantry-model-gateway-tracing.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { GantryModelGatewayBroker } from '@core/adapters/llm/anthropic-claude-agent/gantry-model-gateway.js';
 import type { AppId } from '@core/domain/app/app.js';
+import type { RuntimeEventPublishInput } from '@core/domain/events/events.js';
 import type {
   ModelCredential,
   ModelCredentialMetadata,
@@ -123,9 +124,11 @@ function request(input: {
 async function gateway(input: {
   providerId: 'anthropic' | 'openai';
   runId?: string;
+  audit?: (event: RuntimeEventPublishInput) => Promise<unknown> | unknown;
 }): Promise<{ url: string; token: string }> {
   const broker = new GantryModelGatewayBroker(
     new CredentialRepository(input.providerId),
+    input.audit ? { audit: input.audit } : undefined,
   );
   brokers.push(broker);
   const injection = await broker.getInjection({
@@ -217,13 +220,350 @@ describe('Gantry Model Gateway tracing', () => {
     expect(chat.spanContext().traceId).toBe(parent.spanContext().traceId);
     expect(chat.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
     expect(chat.attributes).toMatchObject({
-      'gen_ai.usage.input_tokens': 12,
+      'gen_ai.usage.input_tokens': 17,
       'gen_ai.usage.output_tokens': 4,
       'gen_ai.usage.cache_read_input_tokens': 3,
       'gen_ai.usage.cache_creation_input_tokens': 2,
       'gen_ai.usage.cost': expect.any(Number),
     });
     expect(chat.attributes['gen_ai.usage.cost']).toBeGreaterThan(0);
+  });
+
+  it('reconstructs an Anthropic tool span across consecutive gateway requests', async () => {
+    const exporter = new InMemorySpanExporter();
+    tracing(exporter);
+    const runId = 'run:gateway-anthropic-tool';
+    const turn = startTurnSpan({ runId, agentName: 'Anthropic Tool Agent' });
+    const toolResponse = Buffer.from(
+      JSON.stringify({
+        model: 'claude-sonnet-4-6',
+        stop_reason: 'tool_use',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'anthropic-call',
+            name: 'mcp__github__search_code',
+            input: { query: 'otel' },
+          },
+        ],
+      }),
+    );
+    const finalResponse = Buffer.from(
+      JSON.stringify({
+        model: 'claude-sonnet-4-6',
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: 'Done' }],
+      }),
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(toolResponse, {
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(finalResponse, {
+            headers: { 'content-type': 'application/json' },
+          }),
+        ),
+    );
+    const endpoint = await gateway({ providerId: 'anthropic', runId });
+
+    expect(
+      await request({
+        ...endpoint,
+        body: Buffer.from(
+          JSON.stringify({
+            model: 'claude-sonnet-4-6',
+            messages: [{ role: 'user', content: 'Search' }],
+          }),
+        ),
+      }),
+    ).toEqual({ status: 200, body: toolResponse });
+    expect(
+      await request({
+        ...endpoint,
+        body: Buffer.from(
+          JSON.stringify({
+            model: 'claude-sonnet-4-6',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'tool_result',
+                    tool_use_id: 'anthropic-call',
+                    content: [{ type: 'text', text: 'match' }],
+                  },
+                ],
+              },
+            ],
+          }),
+        ),
+      }),
+    ).toEqual({ status: 200, body: finalResponse });
+    turn.end('success');
+
+    const spans = exporter.getFinishedSpans();
+    const parent = spans.find(
+      (span) => span.attributes['gen_ai.operation.name'] === 'invoke_agent',
+    )!;
+    const tool = spans.find(
+      (span) => span.attributes['gen_ai.operation.name'] === 'execute_tool',
+    )!;
+    expect(tool.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
+    expect(tool.attributes).toMatchObject({
+      'gen_ai.tool.name': 'mcp__github__search_code',
+      'gen_ai.tool.call.id': 'anthropic-call',
+      'gantry.tool.transport': 'mcp',
+      'gantry.mcp.server': 'github',
+      'gen_ai.tool.call.arguments': JSON.stringify({ query: 'otel' }),
+      'gen_ai.tool.call.result': JSON.stringify([
+        { type: 'text', text: 'match' },
+      ]),
+      'gantry.tool.status': 'success',
+    });
+    const toolChat = spans.find(
+      (span) =>
+        typeof span.attributes['gen_ai.output.messages'] === 'string' &&
+        String(span.attributes['gen_ai.output.messages']).includes(
+          'anthropic-call',
+        ),
+    )!;
+    const output = JSON.parse(
+      String(toolChat.attributes['gen_ai.output.messages']),
+    ) as Array<{ parts: unknown[] }>;
+    expect(output[0]?.parts).toEqual([
+      {
+        type: 'tool_call',
+        id: 'anthropic-call',
+        name: 'mcp__github__search_code',
+        arguments: { query: 'otel' },
+      },
+    ]);
+    const legacyOutput = JSON.parse(
+      String(toolChat.attributes['gen_ai.completion']),
+    ) as Array<{ content: unknown }>;
+    expect(Array.isArray(legacyOutput[0]?.content)).toBe(true);
+  });
+
+  it('captures streamed OpenAI tool calls and closes them on the next request', async () => {
+    const exporter = new InMemorySpanExporter();
+    tracing(exporter);
+    const runId = 'run:gateway-openai-tool';
+    const turn = startTurnSpan({ runId, agentName: 'OpenAI Tool Agent' });
+    const toolStream =
+      frame({
+        model: 'gpt-5.5',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'openai-',
+                  function: {
+                    name: 'mcp_call_',
+                    arguments: '{"serverName":"linear",',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }) +
+      frame({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call',
+                  function: {
+                    name: 'tool',
+                    arguments: '"toolName":"search_issues"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      }) +
+      frame('[DONE]');
+    const finalResponse = Buffer.from(
+      JSON.stringify({
+        model: 'gpt-5.5',
+        choices: [
+          {
+            finish_reason: 'stop',
+            message: { role: 'assistant', content: 'Done' },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(streamedResponse([toolStream]))
+        .mockResolvedValueOnce(
+          new Response(finalResponse, {
+            headers: { 'content-type': 'application/json' },
+          }),
+        ),
+    );
+    const endpoint = await gateway({ providerId: 'openai', runId });
+
+    expect(
+      await request({
+        ...endpoint,
+        body: Buffer.from(
+          JSON.stringify({
+            model: 'gpt-5.5',
+            stream: true,
+            stream_options: { include_usage: true },
+            messages: [{ role: 'user', content: 'Search' }],
+          }),
+        ),
+      }),
+    ).toEqual({ status: 200, body: Buffer.from(toolStream) });
+    expect(
+      await request({
+        ...endpoint,
+        body: Buffer.from(
+          JSON.stringify({
+            model: 'gpt-5.5',
+            messages: [
+              {
+                role: 'tool',
+                tool_call_id: 'openai-call',
+                content: JSON.stringify({ issues: [1] }),
+              },
+            ],
+          }),
+        ),
+      }),
+    ).toEqual({ status: 200, body: finalResponse });
+    turn.end('success');
+
+    const tool = exporter
+      .getFinishedSpans()
+      .find(
+        (span) => span.attributes['gen_ai.operation.name'] === 'execute_tool',
+      )!;
+    expect(tool.attributes).toMatchObject({
+      'gen_ai.tool.name': 'mcp_call_tool',
+      'gen_ai.tool.call.id': 'openai-call',
+      'gantry.tool.transport': 'mcp',
+      'gantry.mcp.server': 'linear',
+      'gen_ai.tool.call.arguments': JSON.stringify({
+        serverName: 'linear',
+        toolName: 'search_issues',
+      }),
+      'gen_ai.tool.call.result': JSON.stringify({ issues: [1] }),
+      'gantry.tool.status': 'unknown',
+    });
+  });
+
+  it('registers streamed tool calls before a slow usage audit settles', async () => {
+    const exporter = new InMemorySpanExporter();
+    tracing(exporter);
+    const runId = 'run:gateway-delayed-audit';
+    const turn = startTurnSpan({ runId, agentName: 'Delayed Audit Agent' });
+    let releaseAudit!: () => void;
+    const delayedAudit = new Promise<void>((resolve) => {
+      releaseAudit = resolve;
+    });
+    let forwardedAudits = 0;
+    const audit = (event: RuntimeEventPublishInput) => {
+      if (event.payload.outcome !== 'forwarded') return undefined;
+      forwardedAudits += 1;
+      return forwardedAudits === 1 ? delayedAudit : undefined;
+    };
+    const toolStream =
+      frame({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'delayed-audit-call',
+                  function: { name: 'Read', arguments: '{"path":"/tmp/a"}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      }) + frame('[DONE]');
+    const finalResponse = Buffer.from(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: 'stop',
+            message: { role: 'assistant', content: 'Done' },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(streamedResponse([toolStream]))
+        .mockResolvedValueOnce(
+          new Response(finalResponse, {
+            headers: { 'content-type': 'application/json' },
+          }),
+        ),
+    );
+    const endpoint = await gateway({ providerId: 'openai', runId, audit });
+
+    await request({
+      ...endpoint,
+      body: Buffer.from(
+        JSON.stringify({
+          model: 'gpt-5.5',
+          stream: true,
+          stream_options: { include_usage: true },
+          messages: [{ role: 'user', content: 'Read' }],
+        }),
+      ),
+    });
+    await request({
+      ...endpoint,
+      body: Buffer.from(
+        JSON.stringify({
+          model: 'gpt-5.5',
+          messages: [
+            {
+              role: 'tool',
+              tool_call_id: 'delayed-audit-call',
+              content: 'read result',
+            },
+          ],
+        }),
+      ),
+    });
+    releaseAudit();
+    turn.end('success');
+
+    const tool = exporter
+      .getFinishedSpans()
+      .find(
+        (span) => span.attributes['gen_ai.operation.name'] === 'execute_tool',
+      );
+    expect(tool?.attributes).toMatchObject({
+      'gen_ai.tool.call.id': 'delayed-audit-call',
+      'gantry.tool.status': 'unknown',
+      'gen_ai.tool.call.result': 'read result',
+    });
   });
 
   it('preserves chunked Anthropic SSE bytes and records streamed usage', async () => {
@@ -280,7 +620,7 @@ describe('Gantry Model Gateway tracing', () => {
 
     expect(result).toEqual({ status: 200, body: Buffer.from(source) });
     expect(chatSpan(exporter).attributes).toMatchObject({
-      'gen_ai.usage.input_tokens': 11,
+      'gen_ai.usage.input_tokens': 17,
       'gen_ai.usage.output_tokens': 3,
       'gen_ai.usage.cache_read_input_tokens': 4,
       'gen_ai.usage.cache_creation_input_tokens': 2,

--- a/apps/core/test/unit/core/observability-genai-spans.test.ts
+++ b/apps/core/test/unit/core/observability-genai-spans.test.ts
@@ -19,6 +19,7 @@ import {
   shutdownTracing,
   startTurnSpan,
 } from '@core/infrastructure/observability/tracing.js';
+import { createSpawnTurnTracker } from '@core/infrastructure/observability/spawn-turn-tracker.js';
 
 const OPENAI_URL = new URL('https://llm.example/v1/chat/completions');
 const MESSAGES_URL = new URL('https://llm.example/v1/messages');
@@ -61,6 +62,14 @@ function chatSpan(exporter: InMemorySpanExporter): ReadableSpan {
     );
   expect(span).toBeDefined();
   return span!;
+}
+
+function toolSpans(exporter: InMemorySpanExporter): ReadableSpan[] {
+  return exporter
+    .getFinishedSpans()
+    .filter(
+      (span) => span.attributes['gen_ai.operation.name'] === 'execute_tool',
+    );
 }
 
 function frame(data: unknown, newline = '\n'): string {
@@ -150,14 +159,18 @@ describe('observeGatewayCall', () => {
 
     const attributes = chatSpan(exporter).attributes;
     expect(attributes).toMatchObject({
+      'gen_ai.provider.name': 'fixture-provider',
+      'gen_ai.system': 'fixture-provider',
       'gen_ai.request.model': 'request-model',
       'gen_ai.response.model': 'response-model',
       'gen_ai.response.id': 'response-id',
       'gen_ai.response.finish_reasons': ['end_turn'],
-      'gen_ai.usage.input_tokens': 12,
+      'gen_ai.usage.input_tokens': 20,
       'gen_ai.usage.output_tokens': 7,
       'gen_ai.usage.cache_read_input_tokens': 5,
       'gen_ai.usage.cache_creation_input_tokens': 3,
+      'gen_ai.usage.cache_read.input_tokens': 5,
+      'gen_ai.usage.cache_creation.input_tokens': 3,
     });
     expect(JSON.parse(String(attributes['gen_ai.prompt']))).toEqual([
       { role: 'system', content: 'System fixture' },
@@ -166,6 +179,38 @@ describe('observeGatewayCall', () => {
     expect(JSON.parse(String(attributes['gen_ai.completion']))).toEqual([
       { role: 'assistant', content: 'Completion fixture' },
     ]);
+    expect(JSON.parse(String(attributes['gen_ai.input.messages']))).toEqual([
+      {
+        role: 'system',
+        parts: [{ type: 'text', content: 'System fixture' }],
+      },
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'Prompt fixture' }],
+      },
+    ]);
+    expect(JSON.parse(String(attributes['gen_ai.output.messages']))).toEqual([
+      {
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'Completion fixture' }],
+        finish_reason: 'end_turn',
+      },
+    ]);
+  });
+
+  it('dual-emits the current and legacy xAI provider identifiers', () => {
+    const exporter = init();
+    const observation = observe({
+      providerId: 'xai',
+      request: { model: 'grok-4', messages: [] },
+    });
+
+    observation.finish({ status: 200, responseJson: {} });
+
+    expect(chatSpan(exporter).attributes).toMatchObject({
+      'gen_ai.provider.name': 'x_ai',
+      'gen_ai.system': 'xai',
+    });
   });
 
   it('maps OpenAI response attributes including cached tokens', () => {
@@ -213,6 +258,1311 @@ describe('observeGatewayCall', () => {
     expect(JSON.parse(String(attributes['gen_ai.completion']))).toEqual([
       { role: 'assistant', content: 'Completion fixture' },
     ]);
+    expect(JSON.parse(String(attributes['gen_ai.input.messages']))).toEqual([
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'Prompt fixture' }],
+      },
+    ]);
+    expect(JSON.parse(String(attributes['gen_ai.output.messages']))).toEqual([
+      {
+        role: 'assistant',
+        index: 0,
+        parts: [{ type: 'text', content: 'Completion fixture' }],
+        finish_reason: 'stop',
+      },
+    ]);
+  });
+
+  it('preserves the Anthropic system prompt at the message cap', () => {
+    const exporter = init();
+    const observation = observe({
+      upstreamUrl: MESSAGES_URL,
+      request: {
+        model: 'request-model',
+        system: 'Keep this system prompt',
+        messages: Array.from({ length: 64 }, (_, index) => ({
+          role: 'user',
+          content: `message-${index}`,
+        })),
+      },
+    });
+    observation.finish({ status: 200, responseJson: {} });
+
+    const attributes = chatSpan(exporter).attributes;
+    const legacy = JSON.parse(String(attributes['gen_ai.prompt'])) as Array<{
+      role: string;
+      content: string;
+    }>;
+    const current = JSON.parse(
+      String(attributes['gen_ai.input.messages']),
+    ) as Array<{ role: string; parts: unknown[] }>;
+    expect(legacy).toHaveLength(64);
+    expect(legacy[0]).toEqual({
+      role: 'system',
+      content: 'Keep this system prompt',
+    });
+    expect(legacy[1]?.content).toBe('message-1');
+    expect(current[0]).toEqual({
+      role: 'system',
+      parts: [{ type: 'text', content: 'Keep this system prompt' }],
+    });
+  });
+
+  it('preserves Anthropic media blocks while omitting private reasoning blocks', () => {
+    const exporter = init();
+    const observation = observe({
+      upstreamUrl: MESSAGES_URL,
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'thinking', thinking: 'private reasoning' },
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'aGVsbG8=',
+                },
+              },
+              {
+                type: 'document',
+                source: { type: 'text', data: 'document contents' },
+              },
+              { type: 'redacted_thinking', data: 'private redaction' },
+            ],
+          },
+        ],
+      },
+    });
+    observation.finish({
+      status: 200,
+      responseJson: {
+        stop_reason: 'end_turn',
+        content: [
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'server-tool-1',
+            content: [{ type: 'web_search_result', title: 'Visible result' }],
+          },
+        ],
+      },
+    });
+
+    const attributes = chatSpan(exporter).attributes;
+    const legacy = String(attributes['gen_ai.prompt']);
+    const current = String(attributes['gen_ai.input.messages']);
+    expect(legacy).toContain('image/png');
+    expect(legacy).toContain('document contents');
+    expect(current).toContain('image/png');
+    expect(current).toContain('document contents');
+    expect(legacy).not.toContain('private reasoning');
+    expect(legacy).not.toContain('private redaction');
+    expect(current).not.toContain('private reasoning');
+    expect(current).not.toContain('private redaction');
+    expect(String(attributes['gen_ai.completion'])).toContain('Visible result');
+    expect(String(attributes['gen_ai.output.messages'])).toContain(
+      'Visible result',
+    );
+  });
+
+  it('preserves visible OpenAI multimodal and refusal parts', () => {
+    const exporter = init();
+    const observation = observe({
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.test/image.png' },
+              },
+              {
+                type: 'input_audio',
+                input_audio: { data: 'YXVkaW8=', format: 'wav' },
+              },
+              { type: 'file', file: { file_id: 'file-visible' } },
+              { type: 'refusal', refusal: 'visible input refusal' },
+              { type: 'reasoning', content: 'private input reasoning' },
+            ],
+          },
+        ],
+      },
+    });
+    observation.finish({
+      status: 200,
+      responseJson: {
+        choices: [
+          {
+            finish_reason: 'stop',
+            message: {
+              role: 'assistant',
+              content: [
+                { type: 'refusal', refusal: 'visible output refusal' },
+                { type: 'reasoning', content: 'private output reasoning' },
+              ],
+              refusal: 'top-level refusal',
+            },
+          },
+        ],
+      },
+    });
+
+    const attributes = chatSpan(exporter).attributes;
+    for (const key of ['gen_ai.prompt', 'gen_ai.input.messages']) {
+      const value = String(attributes[key]);
+      expect(value).toContain('https://example.test/image.png');
+      expect(value).toContain('YXVkaW8=');
+      expect(value).toContain('file-visible');
+      expect(value).toContain('visible input refusal');
+      expect(value).not.toContain('private input reasoning');
+    }
+    for (const key of ['gen_ai.completion', 'gen_ai.output.messages']) {
+      const value = String(attributes[key]);
+      expect(value).toContain('visible output refusal');
+      expect(value).toContain('top-level refusal');
+      expect(value).not.toContain('private output reasoning');
+    }
+  });
+
+  it('reconstructs parallel Anthropic tools and nests delegation under its tool span', () => {
+    const exporter = init();
+    const runId = 'run-anthropic-tools';
+    const turn = startTurnSpan({ runId, agentName: 'Tool Parent' });
+    const first = observe({
+      runId,
+      upstreamUrl: MESSAGES_URL,
+      request: {
+        model: 'request-model',
+        messages: [{ role: 'user', content: 'Use the tools' }],
+      },
+    });
+    const assistantContent = [
+      {
+        type: 'tool_use',
+        id: 'tool-local',
+        name: 'Read',
+        input: { path: '/tmp/a' },
+      },
+      {
+        type: 'tool_use',
+        id: 'tool-mcp',
+        name: 'mcp__github__search_code',
+        input: { query: 'trace' },
+      },
+      {
+        type: 'tool_use',
+        id: 'tool-delegate',
+        name: 'delegate_task',
+        input: { objective: 'Inspect the trace' },
+      },
+    ];
+    first.finish({
+      status: 200,
+      responseJson: {
+        model: 'response-model',
+        stop_reason: 'tool_use',
+        content: [
+          { type: 'thinking', thinking: 'private chain of thought' },
+          ...assistantContent,
+        ],
+      },
+    });
+
+    const delegationReceipt =
+      'Queued: task_trace_inspector\n{"id":"task_trace_inspector"}';
+    const second = observe({
+      runId,
+      upstreamUrl: MESSAGES_URL,
+      request: {
+        model: 'request-model',
+        messages: [
+          { role: 'assistant', content: assistantContent },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-local',
+                content: 'read failed',
+                is_error: true,
+              },
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-mcp',
+                content: [{ type: 'text', text: 'match' }],
+              },
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-delegate',
+                content: delegationReceipt,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const delegated = createSpawnTurnTracker(
+      'Trace Inspector',
+      {
+        runId: 'run-delegated-tool',
+        parentRunId: runId,
+        parentTaskId: 'task_trace_inspector',
+        prompt: 'Inspect the trace',
+      },
+      undefined,
+    );
+    delegated.finish({ status: 'success', result: 'nested result' });
+    second.finish({
+      status: 200,
+      responseJson: { content: [{ type: 'text', text: 'Done' }] },
+    });
+    turn.end('success');
+
+    const spans = exporter.getFinishedSpans();
+    const parent = spans.find(
+      (span) =>
+        span.attributes['gantry.run_id'] === runId &&
+        span.attributes['gen_ai.operation.name'] === 'invoke_agent',
+    )!;
+    const tools = toolSpans(exporter);
+    expect(tools).toHaveLength(3);
+    for (const tool of tools) {
+      expect(tool.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
+      expect(tool.attributes).toMatchObject({
+        'gen_ai.tool.type': 'function',
+        'gantry.tool.timing': 'reconstructed',
+        'gantry.run_id': runId,
+        'gantry.tool.latency_ms': expect.any(Number),
+      });
+    }
+    const local = tools.find(
+      (span) => span.attributes['gen_ai.tool.call.id'] === 'tool-local',
+    )!;
+    expect(local.attributes).toMatchObject({
+      'gen_ai.tool.name': 'Read',
+      'gantry.tool.transport': 'local',
+      'gantry.tool.status': 'error',
+      'gen_ai.tool.call.arguments': JSON.stringify({ path: '/tmp/a' }),
+      'gen_ai.tool.call.result': 'read failed',
+      'error.type': 'tool_error',
+    });
+    expect(local.status.code).toBe(2);
+    const mcp = tools.find(
+      (span) => span.attributes['gen_ai.tool.call.id'] === 'tool-mcp',
+    )!;
+    expect(mcp.attributes).toMatchObject({
+      'gen_ai.tool.name': 'mcp__github__search_code',
+      'gantry.tool.transport': 'mcp',
+      'gantry.mcp.server': 'github',
+      'gantry.tool.status': 'success',
+      'gen_ai.tool.call.result': JSON.stringify([
+        { type: 'text', text: 'match' },
+      ]),
+    });
+    const delegate = tools.find(
+      (span) => span.attributes['gen_ai.tool.call.id'] === 'tool-delegate',
+    )!;
+    expect(delegate.attributes['gantry.tool.transport']).toBe('delegation');
+    const child = spans.find(
+      (span) => span.attributes['gantry.run_id'] === 'run-delegated-tool',
+    )!;
+    expect(child.parentSpanContext?.spanId).toBe(delegate.spanContext().spanId);
+
+    const structuredOutput = spans.find(
+      (span) =>
+        typeof span.attributes['gen_ai.output.messages'] === 'string' &&
+        String(span.attributes['gen_ai.output.messages']).includes(
+          'tool-local',
+        ),
+    )!;
+    const output = JSON.parse(
+      String(structuredOutput.attributes['gen_ai.output.messages']),
+    ) as Array<{ parts: unknown; finish_reason?: string }>;
+    expect(output).toEqual([
+      {
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool_call',
+            id: 'tool-local',
+            name: 'Read',
+            arguments: { path: '/tmp/a' },
+          },
+          {
+            type: 'tool_call',
+            id: 'tool-mcp',
+            name: 'mcp__github__search_code',
+            arguments: { query: 'trace' },
+          },
+          {
+            type: 'tool_call',
+            id: 'tool-delegate',
+            name: 'delegate_task',
+            arguments: { objective: 'Inspect the trace' },
+          },
+        ],
+        finish_reason: 'tool_use',
+      },
+    ]);
+    expect(
+      String(structuredOutput.attributes['gen_ai.completion']),
+    ).not.toContain('private chain of thought');
+    expect(
+      JSON.parse(String(structuredOutput.attributes['gen_ai.completion'])),
+    ).toEqual([{ role: 'assistant', content: assistantContent }]);
+    const structuredInput = spans.find(
+      (span) =>
+        typeof span.attributes['gen_ai.input.messages'] === 'string' &&
+        String(span.attributes['gen_ai.input.messages']).includes(
+          'tool_call_response',
+        ),
+    )!;
+    const prompt = JSON.parse(
+      String(structuredInput.attributes['gen_ai.input.messages']),
+    ) as Array<{ role: string; parts: unknown[] }>;
+    expect(prompt[1]).toEqual({
+      role: 'tool',
+      parts: [
+        {
+          type: 'tool_call_response',
+          id: 'tool-local',
+          response: 'read failed',
+        },
+        {
+          type: 'tool_call_response',
+          id: 'tool-mcp',
+          response: [{ type: 'text', text: 'match' }],
+        },
+        {
+          type: 'tool_call_response',
+          id: 'tool-delegate',
+          response: delegationReceipt,
+        },
+      ],
+    });
+    expect(
+      Array.isArray(
+        (
+          JSON.parse(
+            String(structuredInput.attributes['gen_ai.prompt']),
+          ) as Array<{
+            content: unknown;
+          }>
+        )[1]?.content,
+      ),
+    ).toBe(true);
+  });
+
+  it('reconstructs OpenAI tool calls and derives MCP proxy metadata', () => {
+    const exporter = init();
+    const runId = 'run-openai-tools';
+    const turn = startTurnSpan({ runId, agentName: 'OpenAI Tool Parent' });
+    const first = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: [{ role: 'user', content: 'Search' }],
+      },
+    });
+    first.finish({
+      status: 200,
+      responseJson: {
+        choices: [
+          {
+            finish_reason: 'tool_calls',
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call-openai',
+                  type: 'function',
+                  function: {
+                    name: 'mcp_call_tool',
+                    arguments: JSON.stringify({
+                      serverName: 'linear',
+                      toolName: 'search_issues',
+                      arguments: { query: 'otel' },
+                    }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const second = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'tool',
+            tool_call_id: 'call-openai',
+            content: JSON.stringify({ issues: [1, 2] }),
+          },
+        ],
+      },
+    });
+    second.finish({ status: 200, responseJson: { choices: [] } });
+    turn.end('success');
+
+    const tool = toolSpans(exporter)[0]!;
+    expect(tool.attributes).toMatchObject({
+      'gen_ai.tool.name': 'mcp_call_tool',
+      'gen_ai.tool.call.id': 'call-openai',
+      'gen_ai.tool.type': 'function',
+      'gantry.tool.transport': 'mcp',
+      'gantry.mcp.server': 'linear',
+      'gantry.tool.status': 'unknown',
+      'gen_ai.tool.call.arguments': JSON.stringify({
+        serverName: 'linear',
+        toolName: 'search_issues',
+        arguments: { query: 'otel' },
+      }),
+      'gen_ai.tool.call.result': JSON.stringify({ issues: [1, 2] }),
+    });
+    expect(tool.status.code).toBe(0);
+  });
+
+  it('records every OpenAI choice and scopes reconstructed tools by choice', () => {
+    const exporter = init();
+    const runId = 'run-openai-multi-choice';
+    const turn = startTurnSpan({ runId, agentName: 'Multi Choice Parent' });
+    const first = observe({
+      runId,
+      request: { model: 'request-model', messages: [] },
+    });
+    first.finish({
+      status: 200,
+      responseJson: {
+        choices: [
+          {
+            index: 0,
+            finish_reason: 'tool_calls',
+            message: {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  id: 'choice-zero-tool',
+                  function: { name: 'Read', arguments: '{"path":"a"}' },
+                },
+              ],
+            },
+          },
+          {
+            index: 1,
+            finish_reason: 'tool_calls',
+            message: {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  id: 'choice-one-tool',
+                  function: { name: 'Read', arguments: '{"path":"b"}' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const second = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: [
+          { role: 'tool', tool_call_id: 'choice-zero-tool', content: 'a' },
+          { role: 'tool', tool_call_id: 'choice-one-tool', content: 'b' },
+        ],
+      },
+    });
+    second.finish({ status: 200, responseJson: { choices: [] } });
+    turn.end('success');
+
+    const spans = exporter.getFinishedSpans();
+    const outputSpan = spans.find(
+      (span) =>
+        typeof span.attributes['gen_ai.output.messages'] === 'string' &&
+        String(span.attributes['gen_ai.output.messages']).includes(
+          'choice-one-tool',
+        ),
+    )!;
+    const output = JSON.parse(
+      String(outputSpan.attributes['gen_ai.output.messages']),
+    ) as Array<{ index: number }>;
+    expect(output.map((message) => message.index)).toEqual([0, 1]);
+    expect(outputSpan.attributes['gen_ai.response.finish_reasons']).toEqual([
+      'tool_calls',
+      'tool_calls',
+    ]);
+    expect(
+      toolSpans(exporter).map(
+        (span) => span.attributes['gen_ai.response.choice.index'],
+      ),
+    ).toEqual([0, 1]);
+  });
+
+  it('settles more than 64 parallel OpenAI tool-result messages', () => {
+    const exporter = init();
+    const runId = 'run-openai-high-fanout';
+    const turn = startTurnSpan({ runId, agentName: 'High Fanout Parent' });
+    const first = observe({
+      runId,
+      request: { model: 'request-model', messages: [] },
+    });
+    first.finish({
+      status: 200,
+      responseJson: {
+        choices: [
+          {
+            finish_reason: 'tool_calls',
+            message: {
+              role: 'assistant',
+              tool_calls: Array.from({ length: 80 }, (_, index) => ({
+                id: `fanout-${index}`,
+                function: {
+                  name: 'Read',
+                  arguments: JSON.stringify({ index }),
+                },
+              })),
+            },
+          },
+        ],
+      },
+    });
+    const second = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: Array.from({ length: 80 }, (_, index) => ({
+          role: 'tool',
+          tool_call_id: `fanout-${index}`,
+          content: JSON.stringify({ index }),
+        })),
+      },
+    });
+    second.finish({ status: 200, responseJson: { choices: [] } });
+    turn.end('success');
+
+    const tools = toolSpans(exporter);
+    expect(tools).toHaveLength(80);
+    expect(
+      tools.every(
+        (span) =>
+          span.attributes['gantry.tool.status'] === 'unknown' &&
+          span.attributes['error.type'] === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it.each(['anthropic', 'openai'] as const)(
+    'bounds non-streaming %s tool data before registry retention',
+    (kind) => {
+      const exporter = init();
+      const runId = `run-bounded-${kind}-tool`;
+      const turn = startTurnSpan({ runId, agentName: 'Bounded Tool Parent' });
+      const upstreamUrl = kind === 'anthropic' ? MESSAGES_URL : OPENAI_URL;
+      const rawId = `call-${'i'.repeat(20_000)}`;
+      const rawName = `Read-${'n'.repeat(20_000)}`;
+      const first = observe({
+        runId,
+        upstreamUrl,
+        request: { model: 'request-model', messages: [] },
+      });
+      first.finish({
+        status: 200,
+        responseJson:
+          kind === 'anthropic'
+            ? {
+                stop_reason: 'tool_use',
+                content: [
+                  {
+                    type: 'tool_use',
+                    id: rawId,
+                    name: rawName,
+                    input: { query: 'q'.repeat(20_000) },
+                  },
+                ],
+              }
+            : {
+                choices: [
+                  {
+                    finish_reason: 'tool_calls',
+                    message: {
+                      role: 'assistant',
+                      tool_calls: [
+                        {
+                          id: rawId,
+                          function: {
+                            name: rawName,
+                            arguments: JSON.stringify({
+                              query: 'q'.repeat(20_000),
+                            }),
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+      });
+      const second = observe({
+        runId,
+        upstreamUrl,
+        request: {
+          model: 'request-model',
+          messages:
+            kind === 'anthropic'
+              ? [
+                  {
+                    role: 'user',
+                    content: [
+                      {
+                        type: 'tool_result',
+                        tool_use_id: rawId,
+                        content: 'done',
+                      },
+                    ],
+                  },
+                ]
+              : [
+                  {
+                    role: 'tool',
+                    tool_call_id: rawId,
+                    content: 'done',
+                  },
+                ],
+        },
+      });
+      second.finish({ status: 200, responseJson: {} });
+      turn.end('success');
+
+      const tool = toolSpans(exporter)[0]!;
+      expect(String(tool.attributes['gen_ai.tool.call.id'])).toHaveLength(
+        16_000,
+      );
+      expect(String(tool.attributes['gen_ai.tool.name'])).toHaveLength(16_000);
+      expect(String(tool.attributes['gen_ai.tool.call.id'])).toMatch(
+        /…\[truncated\]$/,
+      );
+      expect(
+        String(tool.attributes['gen_ai.tool.call.arguments']).length,
+      ).toBeLessThanOrEqual(16_000);
+      expect(tool.attributes['gantry.tool.status']).toBe(
+        kind === 'anthropic' ? 'success' : 'unknown',
+      );
+    },
+  );
+
+  it('keeps delegated children under the turn when parallel delegation is ambiguous', () => {
+    const exporter = init();
+    const runId = 'run-parallel-delegation';
+    const turn = startTurnSpan({ runId, agentName: 'Delegation Parent' });
+    const first = observe({
+      runId,
+      upstreamUrl: MESSAGES_URL,
+      request: {
+        model: 'request-model',
+        messages: [{ role: 'user', content: 'Delegate twice' }],
+      },
+    });
+    first.finish({
+      status: 200,
+      responseJson: {
+        stop_reason: 'tool_use',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'delegate-one',
+            name: 'delegate_task',
+            input: { objective: 'First' },
+          },
+          {
+            type: 'tool_use',
+            id: 'delegate-two',
+            name: 'delegate_task',
+            input: { objective: 'Second' },
+          },
+        ],
+      },
+    });
+
+    const delegated = createSpawnTurnTracker(
+      'Ambiguous Child',
+      {
+        runId: 'run-ambiguous-child',
+        parentRunId: runId,
+        prompt: 'Do one of the queued tasks',
+      },
+      undefined,
+    );
+    delegated.finish({ status: 'success', result: 'done' });
+
+    const second = observe({
+      runId,
+      upstreamUrl: MESSAGES_URL,
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'delegate-one',
+                content: 'first done',
+              },
+              {
+                type: 'tool_result',
+                tool_use_id: 'delegate-two',
+                content: 'second done',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    second.finish({
+      status: 200,
+      responseJson: { content: [{ type: 'text', text: 'Done' }] },
+    });
+    turn.end('success');
+
+    const spans = exporter.getFinishedSpans();
+    const parent = spans.find(
+      (span) =>
+        span.attributes['gantry.run_id'] === runId &&
+        span.attributes['gen_ai.operation.name'] === 'invoke_agent',
+    )!;
+    const child = spans.find(
+      (span) => span.attributes['gantry.run_id'] === 'run-ambiguous-child',
+    )!;
+    expect(child.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
+    expect(toolSpans(exporter)).toHaveLength(2);
+  });
+
+  it('correlates parallel streamed delegations without exporting captured arguments', () => {
+    const exporter = init(false);
+    const runId = 'run-private-parallel-delegation';
+    const turn = startTurnSpan({ runId, agentName: 'Private Delegator' });
+    const observation = observe({
+      runId,
+      request: { model: 'request-model', stream: true, messages: [] },
+    });
+    const tap = observation.streamTapFor('text/event-stream')!;
+    tap.transform(
+      Buffer.from(
+        frame({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'private-delegate-one',
+                    function: {
+                      name: 'delegate_task',
+                      arguments: '{"objective":"Inspect alpha"}',
+                    },
+                  },
+                  {
+                    index: 1,
+                    id: 'private-delegate-two',
+                    function: {
+                      name: 'delegate_task',
+                      arguments: '{"objective":"Inspect beta"}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        }) + frame('[DONE]'),
+      ),
+    );
+    tap.flush();
+    observation.finish({ status: 200 });
+
+    const alpha = createSpawnTurnTracker(
+      'Alpha Inspector',
+      {
+        runId: 'run-private-alpha',
+        parentRunId: runId,
+        prompt: 'Inspect alpha',
+      },
+      undefined,
+    );
+    alpha.finish({ status: 'success', result: 'done' });
+    const beta = createSpawnTurnTracker(
+      'Beta Inspector',
+      {
+        runId: 'run-private-beta',
+        parentRunId: runId,
+        prompt: 'Inspect beta',
+      },
+      undefined,
+    );
+    beta.finish({ status: 'success', result: 'done' });
+    turn.end('success');
+
+    const spans = exporter.getFinishedSpans();
+    const tools = toolSpans(exporter);
+    const toolOne = tools.find(
+      (span) =>
+        span.attributes['gen_ai.tool.call.id'] === 'private-delegate-one',
+    )!;
+    const toolTwo = tools.find(
+      (span) =>
+        span.attributes['gen_ai.tool.call.id'] === 'private-delegate-two',
+    )!;
+    expect(
+      spans.find(
+        (span) => span.attributes['gantry.run_id'] === 'run-private-alpha',
+      )?.parentSpanContext?.spanId,
+    ).toBe(toolOne.spanContext().spanId);
+    expect(
+      spans.find(
+        (span) => span.attributes['gantry.run_id'] === 'run-private-beta',
+      )?.parentSpanContext?.spanId,
+    ).toBe(toolTwo.spanContext().spanId);
+    expect(toolOne.attributes['gen_ai.tool.call.arguments']).toBeUndefined();
+    expect(toolTwo.attributes['gen_ai.tool.call.arguments']).toBeUndefined();
+  });
+
+  it('registers a streamed tool before returning its terminal SSE bytes', () => {
+    const exporter = init();
+    const runId = 'run-terminal-sse-race';
+    const turn = startTurnSpan({ runId, agentName: 'Terminal SSE Parent' });
+    const first = observe({
+      runId,
+      request: { model: 'request-model', stream: true, messages: [] },
+    });
+    const terminal = Buffer.from(
+      frame({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'terminal-race-call',
+                  function: { name: 'Read', arguments: '{"path":"/tmp/a"}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      }) + frame('[DONE]'),
+    );
+    expect(
+      first.streamTapFor('text/event-stream', 200)?.transform(terminal),
+    ).toEqual(terminal);
+
+    // Model the runner reacting as soon as it receives the terminal bytes,
+    // before the first response pipeline calls finish().
+    const second = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'tool',
+            tool_call_id: 'terminal-race-call',
+            content: 'read result',
+          },
+        ],
+      },
+    });
+    second.finish({ status: 200, responseJson: { choices: [] } });
+    first.finish({ status: 200 });
+    turn.end('success');
+
+    const tools = toolSpans(exporter);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.attributes).toMatchObject({
+      'gen_ai.tool.call.id': 'terminal-race-call',
+      'gantry.tool.status': 'unknown',
+      'gen_ai.tool.call.result': 'read result',
+    });
+  });
+
+  it('pairs oversized streamed tool IDs with canonically bounded results', () => {
+    const exporter = init();
+    const runId = 'run-oversized-stream-id';
+    const rawId = `stream-${'i'.repeat(20_000)}`;
+    const turn = startTurnSpan({ runId, agentName: 'Bounded Stream Parent' });
+    const first = observe({
+      runId,
+      request: { model: 'request-model', stream: true, messages: [] },
+    });
+    first.streamTapFor('text/event-stream', 200)?.transform(
+      Buffer.from(
+        frame({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: rawId,
+                    function: { name: 'Read', arguments: '{}' },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        }) + frame('[DONE]'),
+      ),
+    );
+    const second = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: [
+          { role: 'tool', tool_call_id: rawId, content: 'stream result' },
+        ],
+      },
+    });
+    second.finish({ status: 200, responseJson: { choices: [] } });
+    first.finish({ status: 200 });
+    turn.end('success');
+
+    const tool = toolSpans(exporter)[0]!;
+    expect(String(tool.attributes['gen_ai.tool.call.id'])).toHaveLength(16_000);
+    expect(tool.attributes).toMatchObject({
+      'gantry.tool.status': 'unknown',
+      'gen_ai.tool.call.result': 'stream result',
+    });
+  });
+
+  it('keeps tool identity, transport, timing, and status when capture is disabled', () => {
+    const exporter = init(false);
+    const runId = 'run-private-tool';
+    const turn = startTurnSpan({ runId, agentName: 'Private Tool Parent' });
+    const first = observe({
+      runId,
+      request: { model: 'request-model', messages: [] },
+    });
+    first.finish({
+      status: 200,
+      responseJson: {
+        choices: [
+          {
+            finish_reason: 'tool_calls',
+            message: {
+              tool_calls: [
+                {
+                  id: 'private-call',
+                  function: {
+                    name: 'Write',
+                    arguments: '{"secret":"argument"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const second = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'tool',
+            tool_call_id: 'private-call',
+            content: '{"secret":"result"}',
+          },
+        ],
+      },
+    });
+    second.finish({ status: 200, responseJson: { choices: [] } });
+    turn.end('success');
+
+    const tool = toolSpans(exporter)[0]!;
+    expect(tool.attributes).toMatchObject({
+      'gen_ai.tool.name': 'Write',
+      'gen_ai.tool.call.id': 'private-call',
+      'gantry.tool.transport': 'local',
+      'gantry.tool.status': 'unknown',
+      'gantry.tool.timing': 'reconstructed',
+      'gantry.tool.latency_ms': expect.any(Number),
+    });
+    expect(tool.attributes['gen_ai.tool.call.arguments']).toBeUndefined();
+    expect(tool.attributes['gen_ai.tool.call.result']).toBeUndefined();
+    expect(tool.status.code).toBe(0);
+  });
+
+  it('keeps truncated structured tool arguments and results valid JSON', () => {
+    const exporter = init();
+    const runId = 'run-large-tool-payload';
+    const turn = startTurnSpan({ runId, agentName: 'Large Tool Parent' });
+    const first = observe({
+      runId,
+      request: { model: 'request-model', messages: [] },
+    });
+    first.finish({
+      status: 200,
+      responseJson: {
+        choices: [
+          {
+            finish_reason: 'tool_calls',
+            message: {
+              tool_calls: [
+                {
+                  id: 'large-call',
+                  function: {
+                    name: 'Search',
+                    arguments: JSON.stringify({ query: 'x'.repeat(20_000) }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const second = observe({
+      runId,
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'tool',
+            tool_call_id: 'large-call',
+            content: JSON.stringify({ output: 'y'.repeat(20_000) }),
+          },
+        ],
+      },
+    });
+    second.finish({ status: 200, responseJson: { choices: [] } });
+    turn.end('success');
+
+    const attributes = toolSpans(exporter)[0]!.attributes;
+    const args = String(attributes['gen_ai.tool.call.arguments']);
+    const result = String(attributes['gen_ai.tool.call.result']);
+    expect(args.length).toBeLessThanOrEqual(16_000);
+    expect(result.length).toBeLessThanOrEqual(16_000);
+    expect(JSON.parse(args)).toMatchObject({
+      query: expect.stringMatching(/…\[truncated\]$/),
+    });
+    expect(JSON.parse(result)).toMatchObject({
+      output: expect.stringMatching(/…\[truncated\]$/),
+    });
+  });
+
+  it('does not reconstruct tool spans after the turn has already ended', () => {
+    const exporter = init();
+    const runId = 'run-ended-before-response';
+    const turn = startTurnSpan({ runId, agentName: 'Cancelled Tool Parent' });
+    const observation = observe({
+      runId,
+      upstreamUrl: MESSAGES_URL,
+      request: { model: 'request-model', messages: [] },
+    });
+    turn.end('cancelled');
+    observation.finish({
+      status: 200,
+      responseJson: {
+        stop_reason: 'tool_use',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'late-tool',
+            name: 'Read',
+            input: { path: '/tmp/late' },
+          },
+        ],
+      },
+    });
+
+    const restartedTurn = startTurnSpan({
+      runId,
+      agentName: 'Restarted Tool Parent',
+    });
+    const followUp = observe({
+      runId,
+      upstreamUrl: MESSAGES_URL,
+      request: {
+        model: 'request-model',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'late-tool',
+                content: 'late result',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    followUp.finish({ status: 200, responseJson: {} });
+    restartedTurn.end('success');
+
+    expect(toolSpans(exporter)).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      'provider stream error',
+      frame({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'phantom-tool',
+                  function: { name: 'Read', arguments: '{}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      }) + frame({ error: { message: 'stream failed' } }),
+    ],
+    [
+      'incomplete stream',
+      frame({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'phantom-tool',
+                  function: { name: 'Read', arguments: '{}' },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      }),
+    ],
+  ])('does not reconstruct tool spans from a %s', (_scenario, stream) => {
+    const exporter = init();
+    const runId = `run-${_scenario.replaceAll(' ', '-')}`;
+    const turn = startTurnSpan({ runId, agentName: 'Streaming Tool Parent' });
+    const observation = observe({
+      runId,
+      request: { model: 'request-model', stream: true, messages: [] },
+    });
+    const tap = observation.streamTapFor('text/event-stream')!;
+    tap.transform(Buffer.from(stream));
+    tap.flush();
+    observation.finish({ status: 200 });
+    turn.end('success');
+
+    expect(toolSpans(exporter)).toHaveLength(0);
+  });
+
+  it('suppresses schema-incomplete current output messages but keeps legacy content', () => {
+    const exporter = init();
+    const observation = observe({
+      request: { model: 'request-model', stream: true, messages: [] },
+    });
+    const tap = observation.streamTapFor('text/event-stream')!;
+    tap.transform(
+      Buffer.from(
+        frame({ choices: [{ delta: { content: 'partial output' } }] }),
+      ),
+    );
+    tap.flush();
+    observation.finish({ status: 200 });
+
+    const attributes = chatSpan(exporter).attributes;
+    expect(attributes['gen_ai.completion']).toBe(
+      JSON.stringify([{ role: 'assistant', content: 'partial output' }]),
+    );
+    expect(attributes['gen_ai.output.messages']).toBeUndefined();
+  });
+
+  it('does not assign one streamed choice finish reason to an incomplete choice', () => {
+    const exporter = init();
+    const observation = observe({
+      request: { model: 'request-model', stream: true, messages: [] },
+    });
+    const tap = observation.streamTapFor('text/event-stream')!;
+    tap.transform(
+      Buffer.from(
+        frame({
+          choices: [
+            {
+              index: 0,
+              delta: { content: 'complete choice' },
+              finish_reason: 'stop',
+            },
+            {
+              index: 1,
+              delta: { content: 'partial choice' },
+              finish_reason: null,
+            },
+          ],
+        }),
+      ),
+    );
+    tap.flush();
+    observation.finish({ status: 200 });
+
+    const attributes = chatSpan(exporter).attributes;
+    expect(String(attributes['gen_ai.completion'])).toContain(
+      'complete choice',
+    );
+    expect(String(attributes['gen_ai.completion'])).toContain('partial choice');
+    expect(attributes['gen_ai.output.messages']).toBeUndefined();
+  });
+
+  it('ends an unmatched reconstructed tool span when its turn ends', () => {
+    const exporter = init(false);
+    const runId = 'run-unmatched-tool';
+    const turn = startTurnSpan({ runId, agentName: 'Interrupted Tool Parent' });
+    const observation = observe({
+      runId,
+      upstreamUrl: MESSAGES_URL,
+      request: { model: 'request-model', messages: [] },
+    });
+    observation.finish({
+      status: 200,
+      responseJson: {
+        stop_reason: 'tool_use',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'unmatched-tool',
+            name: 'Read',
+            input: { path: '/tmp/a' },
+          },
+        ],
+      },
+    });
+
+    turn.end('error', 'tool execution interrupted');
+
+    const tool = toolSpans(exporter)[0]!;
+    expect(tool.attributes).toMatchObject({
+      'gen_ai.tool.name': 'Read',
+      'gantry.tool.transport': 'local',
+      'gantry.tool.status': 'error',
+      'gantry.tool.latency_ms': expect.any(Number),
+      'error.type': 'tool_result_missing',
+    });
+    expect(tool.status.code).toBe(2);
   });
 
   it('keeps token attributes but omits content when capture is disabled', () => {
@@ -265,7 +1615,7 @@ describe('observeGatewayCall', () => {
     });
 
     expect(chatSpan(exporter).attributes).toMatchObject({
-      'gen_ai.usage.input_tokens': 100,
+      'gen_ai.usage.input_tokens': 150,
       'gen_ai.usage.output_tokens': 20,
       'gen_ai.usage.cache_read_input_tokens': 40,
       'gen_ai.usage.cache_creation_input_tokens': 10,
@@ -301,6 +1651,70 @@ describe('observeGatewayCall', () => {
     expect(completion[0]?.content).toHaveLength(16_012);
     expect(prompt[0]?.content).toMatch(/…\[truncated\]$/);
     expect(completion[0]?.content).toMatch(/…\[truncated\]$/);
+  });
+
+  it('keeps current output schema valid in the message overflow fallback', () => {
+    const exporter = init();
+    const wideChild = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `child-${index}`,
+        'x'.repeat(1_000),
+      ]),
+    );
+    const widePayload = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [`branch-${index}`, wideChild]),
+    );
+    const observation = observe({
+      upstreamUrl: MESSAGES_URL,
+      request: { model: 'request-model', messages: [] },
+    });
+
+    observation.finish({
+      status: 200,
+      responseJson: {
+        stop_reason: 'end_turn',
+        content: [{ type: 'provider_payload', payload: widePayload }],
+      },
+    });
+
+    expect(
+      JSON.parse(
+        String(chatSpan(exporter).attributes['gen_ai.output.messages']),
+      ),
+    ).toEqual([
+      {
+        role: 'unknown',
+        parts: [{ type: 'text', content: '…[truncated]' }],
+        finish_reason: 'end_turn',
+      },
+    ]);
+  });
+
+  it('marks truncated all-text Anthropic completions explicitly', () => {
+    const exporter = init();
+    const observation = observe({
+      upstreamUrl: MESSAGES_URL,
+      request: { model: 'request-model', messages: [] },
+    });
+    observation.finish({
+      status: 200,
+      responseJson: {
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: 'x'.repeat(20_000) }],
+      },
+    });
+
+    const attributes = chatSpan(exporter).attributes;
+    const legacy = JSON.parse(
+      String(attributes['gen_ai.completion']),
+    ) as Array<{
+      content: string;
+    }>;
+    const current = JSON.parse(
+      String(attributes['gen_ai.output.messages']),
+    ) as Array<{ parts: Array<{ content: string }> }>;
+    expect(legacy[0]?.content).toMatch(/…\[truncated\]$/);
+    expect(current[0]?.parts[0]?.content).toMatch(/…\[truncated\]$/);
   });
 
   it('keeps oversized multi-message prompts valid within the attribute cap', () => {
@@ -640,6 +2054,387 @@ describe('SSE accumulation', () => {
       completionText: 'Hi',
       finishReason: 'stop',
     });
+
+    const refusal = createSseAccumulator('openai', true);
+    refusal.push(
+      Buffer.from(
+        frame({
+          choices: [
+            { delta: { refusal: 'Cannot comply' }, finish_reason: 'stop' },
+          ],
+        }),
+      ),
+    );
+    expect(refusal.result()).toEqual({
+      assistantMessage: {
+        role: 'assistant',
+        content: null,
+        index: 0,
+        finish_reason: 'stop',
+        refusal: 'Cannot comply',
+        tool_calls: [],
+      },
+      finishReason: 'stop',
+    });
+  });
+
+  it('keeps OpenAI streaming choices and tool fragments isolated by choice index', () => {
+    const accumulator = createSseAccumulator('openai', true);
+    accumulator.push(
+      Buffer.from(
+        frame({
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call-a',
+                    function: { name: 'Read', arguments: '{"path":' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+            {
+              index: 1,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call-b',
+                    function: { name: 'Search', arguments: '{"query":' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        }) +
+          frame({
+            choices: [
+              {
+                index: 1,
+                delta: {
+                  tool_calls: [
+                    { index: 0, function: { arguments: '"trace"}' } },
+                  ],
+                },
+                finish_reason: 'stop',
+              },
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    { index: 0, function: { arguments: '"/tmp/a"}' } },
+                  ],
+                },
+                finish_reason: 'tool_calls',
+              },
+            ],
+          }),
+      ),
+    );
+
+    expect(accumulator.result()).toMatchObject({
+      finishReasons: ['tool_calls', 'stop'],
+      toolCalls: [
+        {
+          id: 'call-a',
+          name: 'Read',
+          arguments: { path: '/tmp/a' },
+          choiceIndex: 0,
+          complete: true,
+        },
+        {
+          id: 'call-b',
+          name: 'Search',
+          arguments: { query: 'trace' },
+          choiceIndex: 1,
+          complete: false,
+        },
+      ],
+      assistantMessages: [
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              id: 'call-a',
+              function: { name: 'Read', arguments: { path: '/tmp/a' } },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              id: 'call-b',
+              function: { name: 'Search', arguments: { query: 'trace' } },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('bounds distinct OpenAI stream choices and their aggregate content across frames', () => {
+    const accumulator = createSseAccumulator('openai', true);
+    for (let index = 0; index < 180; index += 1) {
+      accumulator.push(
+        Buffer.from(
+          frame({
+            choices: [
+              {
+                index,
+                delta: { content: 'x'.repeat(4_096) },
+                finish_reason: 'stop',
+              },
+            ],
+          }),
+        ),
+      );
+    }
+
+    const result = accumulator.result();
+    expect(result.finishReasons).toHaveLength(128);
+    expect(result.assistantMessages).toHaveLength(64);
+    const retainedChars = result.assistantMessages!.reduce(
+      (total, message) =>
+        total +
+        (typeof message.content === 'string' ? message.content.length : 0),
+      0,
+    );
+    expect(retainedChars).toBe(256 * 1024);
+    expect(result.assistantMessages?.at(-1)).toMatchObject({
+      index: 63,
+      finish_reason: 'stop',
+    });
+  });
+
+  it('retains Anthropic and OpenAI streaming tool identities and structured arguments', () => {
+    const anthropic = createSseAccumulator('anthropic', true);
+    anthropic.push(
+      Buffer.from(
+        frame({
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'tool_use',
+            id: 'anthropic-tool',
+            name: 'Read',
+            input: {},
+          },
+        }) +
+          frame({
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'input_json_delta', partial_json: '{"path":' },
+          }) +
+          frame({
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'input_json_delta', partial_json: '"/tmp/a"}' },
+          }),
+      ),
+    );
+    expect(anthropic.result()).toMatchObject({
+      toolCalls: [
+        {
+          id: 'anthropic-tool',
+          name: 'Read',
+          arguments: { path: '/tmp/a' },
+        },
+      ],
+      assistantMessage: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'anthropic-tool',
+            name: 'Read',
+            input: { path: '/tmp/a' },
+          },
+        ],
+      },
+    });
+
+    const openai = createSseAccumulator('openai', true);
+    openai.push(
+      Buffer.from(
+        frame({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_',
+                    function: { name: 'mcp_', arguments: '{"serverName":' },
+                  },
+                ],
+              },
+            },
+          ],
+        }) +
+          frame({
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'stream',
+                      function: { name: 'call_tool', arguments: '"github"}' },
+                    },
+                  ],
+                },
+                finish_reason: 'tool_calls',
+              },
+            ],
+          }),
+      ),
+    );
+    expect(openai.result()).toMatchObject({
+      finishReason: 'tool_calls',
+      toolCalls: [
+        {
+          id: 'call_stream',
+          name: 'mcp_call_tool',
+          arguments: { serverName: 'github' },
+        },
+      ],
+      assistantMessage: {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_stream',
+            function: {
+              name: 'mcp_call_tool',
+              arguments: { serverName: 'github' },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('retains streaming tool identity but drops arguments when capture is disabled', () => {
+    const accumulator = createSseAccumulator('openai', false);
+    accumulator.push(
+      Buffer.from(
+        frame({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'private-id',
+                    function: {
+                      name: 'mcp_call_tool',
+                      arguments: '{"serverName":"private-mcp","secret":true}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        }),
+      ),
+    );
+    expect(accumulator.result()).toEqual({
+      toolCalls: [
+        {
+          id: 'private-id',
+          name: 'mcp_call_tool',
+          mcpServer: 'private-mcp',
+          choiceIndex: 0,
+          complete: true,
+        },
+      ],
+      finishReason: 'tool_calls',
+    });
+  });
+
+  it('parses large streamed tool arguments before structurally bounding them', () => {
+    const accumulator = createSseAccumulator('openai', true);
+    accumulator.push(
+      Buffer.from(
+        frame({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'large-streamed-tool',
+                    function: {
+                      name: 'mcp_call_tool',
+                      arguments: JSON.stringify({
+                        serverName: 'github',
+                        query: 'x'.repeat(20_000),
+                      }),
+                    },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = accumulator.result();
+    const args = result.toolCalls?.[0]?.arguments as
+      | Record<string, unknown>
+      | undefined;
+    expect(result.toolCalls?.[0]?.mcpServer).toBe('github');
+    expect(args?.serverName).toBe('github');
+    expect(args?.query).toEqual(expect.stringMatching(/…\[truncated\]$/));
+    expect(JSON.stringify(args).length).toBeLessThanOrEqual(16 * 1024);
+  });
+
+  it('shares one bounded raw-argument budget across streamed tool calls', () => {
+    const accumulator = createSseAccumulator('openai', true);
+    for (let index = 0; index < 3; index += 1) {
+      accumulator.push(
+        Buffer.from(
+          frame({
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index,
+                      id: `aggregate-${index}`,
+                      function: {
+                        name: 'Search',
+                        arguments: JSON.stringify({
+                          query: String(index).repeat(400_000),
+                        }),
+                      },
+                    },
+                  ],
+                },
+                finish_reason: index === 2 ? 'tool_calls' : null,
+              },
+            ],
+          }),
+        ),
+      );
+    }
+
+    const calls = accumulator.result().toolCalls!;
+    expect(calls).toHaveLength(3);
+    expect(typeof calls[0]?.arguments).toBe('object');
+    expect(typeof calls[1]?.arguments).toBe('object');
+    expect(calls[2]?.arguments).toEqual(
+      expect.stringMatching(/…\[truncated\]$/),
+    );
   });
 
   it('stops after malformed data without throwing or losing prior data', () => {

--- a/apps/core/test/unit/core/observability-tracing.test.ts
+++ b/apps/core/test/unit/core/observability-tracing.test.ts
@@ -7,11 +7,15 @@ import {
   ATTR_PROMPT,
   TRACE_CONTENT_MAX_CHARS,
   boundedContent,
+  childContextFor,
   getTurnSpan,
   initTracing,
   parseOtlpHeaders,
+  registerDelegationToolSpan,
+  settleDelegationToolSpan,
   shutdownTracing,
   startTurnSpan,
+  tracer,
   tracingEnabled,
 } from '@core/infrastructure/observability/tracing.js';
 import { createSpawnTurnTracker } from '@core/infrastructure/observability/spawn-turn-tracker.js';
@@ -150,6 +154,83 @@ describe('observability tracing', () => {
     );
     expect(childSpan.attributes['gantry.parent_run_id']).toBe('run-parent');
     expect(rootSpan.parentSpanContext).toBeUndefined();
+  });
+
+  it('parents the matching delegated task under its tool span', () => {
+    const exporter = new InMemorySpanExporter();
+    initTracing(
+      { enabled: true, captureContent: false, sampleRate: 1 },
+      exporter,
+    );
+    const parent = startTurnSpan({
+      runId: 'run-parent',
+      agentName: 'Parent Agent',
+    });
+    const parentSpan = getTurnSpan('run-parent')!;
+    const toolSpan = tracer()!.startSpan(
+      'execute_tool delegate_task',
+      { attributes: { 'gen_ai.operation.name': 'execute_tool' } },
+      childContextFor(parentSpan),
+    );
+    registerDelegationToolSpan({
+      runId: 'run-parent',
+      callId: 'delegate-call',
+      objective: 'delegated work',
+      span: toolSpan,
+    });
+    settleDelegationToolSpan({
+      runId: 'run-parent',
+      callId: 'delegate-call',
+      taskId: 'task_delegated',
+    });
+    toolSpan.end();
+
+    const delegated = createSpawnTurnTracker(
+      'Delegated Agent',
+      {
+        runId: 'run-delegated',
+        parentRunId: 'run-parent',
+        parentTaskId: 'task_delegated',
+        prompt: 'delegated work',
+      },
+      undefined,
+    );
+    delegated.finish({ status: 'success', result: 'done' });
+
+    const unrelated = createSpawnTurnTracker(
+      'Unrelated Child',
+      {
+        runId: 'run-unrelated',
+        parentRunId: 'run-parent',
+        prompt: 'more work',
+      },
+      undefined,
+    );
+    unrelated.finish({ status: 'success', result: 'done' });
+    parent.end('success');
+
+    const spans = exporter.getFinishedSpans();
+    const finishedParentSpan = spans.find(
+      (span) => span.attributes['gantry.run_id'] === 'run-parent',
+    )!;
+    const finishedToolSpan = spans.find(
+      (span) => span.name === 'execute_tool delegate_task',
+    )!;
+    const delegatedSpan = spans.find(
+      (span) => span.attributes['gantry.run_id'] === 'run-delegated',
+    )!;
+    const unrelatedSpan = spans.find(
+      (span) => span.attributes['gantry.run_id'] === 'run-unrelated',
+    )!;
+    expect(finishedToolSpan.parentSpanContext?.spanId).toBe(
+      finishedParentSpan.spanContext().spanId,
+    );
+    expect(delegatedSpan.parentSpanContext?.spanId).toBe(
+      finishedToolSpan.spanContext().spanId,
+    );
+    expect(unrelatedSpan.parentSpanContext?.spanId).toBe(
+      finishedParentSpan.spanContext().spanId,
+    );
   });
 
   it('does not capture turn content when captureContent is false', () => {


### PR DESCRIPTION
Makes tool calls, MCP calls, and delegation **first-class spans** in the OTel/GenAI traces (LangSmith/Langfuse-viewable), instead of being buried in `gen_ai.prompt`/`completion` content. Flag-gated behind existing `observability.enabled` (pure no-op when off).

**What ships:**
- **Gateway reconstruction** — pairs `tool_use`/`tool_call` (completion N) with `tool_result`/`role:tool` (request N+1) from the message stream the gateway already parses, for BOTH lanes: Anthropic `/v1/messages` and OpenAI `/chat/completions` (the OpenAI path previously dropped tool data entirely). No subprocess instrumentation.
- **`execute_tool {name}` child spans** under the turn span with `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name/call.id/type`, plus `gantry.tool.transport = local|mcp|delegation` and `gantry.mcp.server` (derived from `mcp__<server>__<tool>`).
- **Content-gated** args/result capture (`capture_content`); structured GenAI messages preserved (stops the double-encoding); legacy attrs dual-emitted for back-compat.
- **Delegation nesting** — a delegated subagent's `invoke_agent` span nests under the parent's `execute_tool(delegate)` span.
- Parallel `tool_use` batches marked `gantry.tool.timing=reconstructed` (shared window, not claimed as measured).

**Reconstructed trace (InMemorySpanExporter):**
```
invoke_agent Trace Dump Agent
├─ chat claude-sonnet-4-6
├─ execute_tool mcp__github__search_code  transport=mcp mcp.server=github status=success
│     arguments={"query":"otel spans"}  result=[{"type":"text","text":"3 matches"}]
└─ chat claude-sonnet-4-6
```

**Verify:** typecheck clean; observability lane **71/71** + full gateway suite green (**122/122** across the 4 relevant files); existing 37 obs tests remain green; fail-open proven (a throwing exporter/audit never affects the proxied byte stream). Strictly the 10 observability files.

Deferred: hosted LangSmith smoke (no creds available in the sandbox); exact per-MCP latency from the host proxy (later enrichment).