### PR TITLE
docs: PRs must open with the plain-language goal, not the diff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,4 +106,4 @@ A task is not PR-ready until all of these exist:
 - Review runs as ONE autoreview pass in Codex — never inline, never nested reviewers.
 - Keep the template repo independent of any client-specific source repo.
 - Do not keep long policy blocks in `AGENTS.md`; move them into docs.
-- PRs: orchestrator may push story branches + raise PRs once `pr_ready` (one per story); merging stays human-gated; runtime-behavior PRs carry their agent-e2e delta (or state why not). Policy: `docs/review-instructions.md`.
+- PRs: orchestrator may push story branches + raise PRs once `pr_ready` (one per story); merging stays human-gated; every PR body opens with the plain-language goal/why before the technical delta; runtime-behavior PRs carry their agent-e2e delta (or state why not). Policy: `docs/review-instructions.md`.

--- a/docs/review-instructions.md
+++ b/docs/review-instructions.md
@@ -23,3 +23,20 @@ When removing debt, delete the matching exception in the same change. If the che
   coverage for it; matrix rows in `docs/architecture/agent-e2e-test-matrix.md`
   flip with test-file citations. A PR with no e2e delta states why in its
   body. The agent-e2e gate is the merge bar.
+
+## PR description clarity (client directive 2026-07-23)
+
+A PR is read by people who weren't in the build. Every PR body opens with a
+plain-language section, BEFORE any technical detail, so a reader understands
+the total goal — not just the diff. Required structure:
+
+1. **What & why** — the feature/program in 2-3 sentences a non-builder
+   understands (name the program, not just the story key); what it does for
+   users and why it exists.
+2. **What this PR delivers** — this slice in the arc, plainly.
+3. **Technical detail** — stages, key changes.
+4. **Evidence** — verify/review/test results.
+5. **E2E delta** — the agent-e2e change, or why none is needed.
+
+Never open a PR with stage jargon (e.g. "land S2 emission + S3a batch-core")
+that assumes context the reader lacks.


### PR DESCRIPTION
## What & why
When someone opens a PR, they should immediately understand **what the feature is and why it exists** — even if they weren't part of building it. Our recent PRs led with stage jargon ("land S2 emission + S3a batch-core") that only makes sense to whoever wrote it. This adds a standing rule so every PR reads clearly to any reviewer.

## What this PR delivers
A required PR-body structure, codified in the repo contract:
1. **What & why** — the feature/program in 2–3 plain sentences (name the program, not just the story key)
2. **What this PR delivers** — this slice in the arc
3. **Technical detail** — stages, key changes
4. **Evidence** — verify/review/test results
5. **E2E delta** — the agent-e2e change, or why none is needed

This PR body follows its own rule as the worked example.

## Technical detail
- `AGENTS.md` PR line now requires "every PR body opens with the plain-language goal/why before the technical delta" (kept within the 110-line cap).
- Full structure lives in `docs/review-instructions.md` under "PR description clarity".

## Evidence
AGENTS hygiene check passes; docs-only change.

## E2E delta
None — documentation only, no runtime behavior.