### PR TITLE
MEDIA-1/L2: drop redundant SDK Seatbelt in direct mode (two-axis model, decision 0040)

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/runner/filesystem-sandbox.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/runner/filesystem-sandbox.ts
@@ -1,52 +1,12 @@
-import type { SandboxSettings } from '@anthropic-ai/claude-agent-sdk';
 import fs from 'node:fs';
 import path from 'node:path';
 
 import { log } from './logging.js';
 
-const PROTECTED_FILESYSTEM_PATHS_ENV = 'GANTRY_PROTECTED_FILESYSTEM_PATHS_JSON';
-const PROTECTED_FILESYSTEM_DENY_READ_PATHS_ENV =
-  'GANTRY_PROTECTED_FILESYSTEM_DENY_READ_PATHS_JSON';
-const PROTECTED_FILESYSTEM_DENY_WRITE_PATHS_ENV =
-  'GANTRY_PROTECTED_FILESYSTEM_DENY_WRITE_PATHS_JSON';
 const LOCAL_CLI_CREDENTIAL_DIRS_ENV = 'GANTRY_LOCAL_CLI_CREDENTIAL_DIRS_JSON';
-
-interface BuildSdkFilesystemSandboxOptions {
-  denyReadPaths?: readonly string[];
-  denyWritePaths?: readonly string[];
-  httpProxyPort?: number;
-}
-
-export interface ProtectedFilesystemSandboxPaths {
-  denyRead: string[];
-  denyWrite: string[];
-}
-
-export function readProtectedFilesystemPaths(): string[] {
-  return readPathListEnv(PROTECTED_FILESYSTEM_PATHS_ENV);
-}
-
-export function readProtectedFilesystemSandboxPaths(): ProtectedFilesystemSandboxPaths {
-  const fallback =
-    readOptionalPathListEnv(PROTECTED_FILESYSTEM_PATHS_ENV) ?? [];
-  return {
-    denyRead:
-      readOptionalPathListEnv(PROTECTED_FILESYSTEM_DENY_READ_PATHS_ENV) ??
-      fallback,
-    denyWrite:
-      readOptionalPathListEnv(PROTECTED_FILESYSTEM_DENY_WRITE_PATHS_ENV) ??
-      fallback,
-  };
-}
 
 export function readLocalCliCredentialDirectories(): string[] {
   return readPathListEnv(LOCAL_CLI_CREDENTIAL_DIRS_ENV);
-}
-
-function readOptionalPathListEnv(name: string): string[] | undefined {
-  const raw = process.env[name]?.trim();
-  if (!raw) return undefined;
-  return readPathListEnv(name);
 }
 
 function readPathListEnv(name: string): string[] {
@@ -62,66 +22,6 @@ function readPathListEnv(name: string): string[] {
   }
   if (!Array.isArray(parsed)) throw new Error(`${name} must be a JSON array.`);
   return normalizeFilesystemSandboxPaths(parsed);
-}
-
-export function buildSdkFilesystemSandbox(
-  paths: readonly string[],
-  options: BuildSdkFilesystemSandboxOptions = {},
-): SandboxSettings {
-  const denyReadPaths = options.denyReadPaths ?? paths;
-  const denyWritePaths = options.denyWritePaths ?? paths;
-  return {
-    enabled: true,
-    failIfUnavailable: true,
-    autoAllowBashIfSandboxed: false,
-    // L2ii: escape hatch (allowUnsandboxedCommands) deferred — D-0005. Do NOT enable until the deterministic rails carry authoritative GANTRY_PROTECTED_FILESYSTEM_* + local_cli protected paths and run before any reviewed-rule allow for escape-eligible commands; otherwise an escaped command bypasses credential protection.
-    allowUnsandboxedCommands: false,
-    network: {
-      allowLocalBinding: true,
-      allowUnixSockets: ['/'],
-      // configd (network/DNS config) is the proven media-render mach service; a
-      // '*' wildcard would grant lookup to every macOS XPC/Mach service.
-      allowMachLookup: ['com.apple.SystemConfiguration.configd'],
-      ...(options.httpProxyPort
-        ? { httpProxyPort: options.httpProxyPort }
-        : {}),
-    },
-    filesystem: {
-      denyRead: normalizeFilesystemSandboxPaths(denyReadPaths),
-      denyWrite: normalizeFilesystemSandboxPaths(denyWritePaths),
-    },
-  };
-}
-
-export function requireSdkSandboxEgressProxyPort(
-  proxyUrl: string | undefined,
-): number {
-  let parsed: URL;
-  try {
-    parsed = new URL(proxyUrl?.trim() ?? '');
-  } catch {
-    throw new Error(
-      'GANTRY_EGRESS_PROXY_URL must identify the run-scoped loopback HTTP egress gateway.',
-    );
-  }
-  const port = Number(parsed.port);
-  if (
-    parsed.protocol !== 'http:' ||
-    parsed.hostname !== '127.0.0.1' ||
-    parsed.username ||
-    parsed.password ||
-    parsed.pathname !== '/' ||
-    parsed.search ||
-    parsed.hash ||
-    !Number.isInteger(port) ||
-    port <= 0 ||
-    port > 65_535
-  ) {
-    throw new Error(
-      'GANTRY_EGRESS_PROXY_URL must identify the run-scoped loopback HTTP egress gateway.',
-    );
-  }
-  return port;
 }
 
 export function normalizeFilesystemSandboxPaths(

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/runner/query-loop.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/runner/query-loop.ts
@@ -21,11 +21,8 @@ import { SteeringDeliveryGate } from './steering-delivery-gate.js';
 import { log } from './logging.js';
 import { writeOutput } from './output.js';
 import {
-  buildSdkFilesystemSandbox,
   normalizeFilesystemSandboxPaths,
   readLocalCliCredentialDirectories,
-  readProtectedFilesystemSandboxPaths,
-  requireSdkSandboxEgressProxyPort,
 } from './filesystem-sandbox.js';
 import { createSafetyPreToolUseHook } from './protected-capability-hook.js';
 import {
@@ -249,22 +246,13 @@ export async function runQuery(
   const additionalDirectories = [
     ...new Set([...extraDirs, ...localCliCredentialDirectories]),
   ].sort();
-  const protectedFilesystemPaths = readProtectedFilesystemSandboxPaths();
-  const protectedFilesystemDenyReadPaths = protectedFilesystemPaths.denyRead;
-  const protectedFilesystemDenyWritePaths = [
-    ...protectedFilesystemPaths.denyWrite,
-    ...localCliCredentialDirectories,
-  ];
-  const sdkFilesystemSandbox =
-    process.env.GANTRY_SANDBOX_RUNTIME_PROXY === '1'
-      ? undefined
-      : buildSdkFilesystemSandbox(protectedFilesystemDenyWritePaths, {
-          denyReadPaths: protectedFilesystemDenyReadPaths,
-          denyWritePaths: protectedFilesystemDenyWritePaths,
-          httpProxyPort: requireSdkSandboxEgressProxyPort(
-            process.env.GANTRY_EGRESS_PROXY_URL,
-          ),
-        });
+  // Two-axis model (decision 0040): `direct` = authorization is the whole control
+  // (permission engine + classifier + host-side credential/protected-path rail);
+  // no inner SDK Seatbelt, so Chromium's Mach-port register (and the whole class)
+  // runs. `sandbox_runtime` confinement is the runner OS sandbox
+  // (runner-sandbox-provider), which is applied out-of-band — this SDK-level
+  // filesystem Seatbelt is never the confinement layer, so it is dropped.
+  const sdkFilesystemSandbox = undefined;
   const workspaceFolder = agentInput.workspaceFolder;
   const enabledSdkSkills = readClaudeSdkSkillNamesFromEnv();
   const isolatedSdkEnv: Record<string, string | undefined> = {

--- a/apps/core/src/runtime/deepagents-shell-filesystem-guard.ts
+++ b/apps/core/src/runtime/deepagents-shell-filesystem-guard.ts
@@ -4,10 +4,7 @@ import {
   publicGantryToolNameForSdkTool,
   RUN_COMMAND_TOOL_NAME,
 } from '../shared/gantry-tool-facades.js';
-import {
-  resolveRuntimeSecurityPosture,
-  type RuntimeSecurityEnv,
-} from '../shared/security-posture.js';
+import type { RuntimeSecurityEnv } from '../shared/security-posture.js';
 import type { RunnerSandboxProviderId } from '../shared/runner-sandbox-provider.js';
 
 // Host-side, pre-spawn guards for DeepAgents runs that request shell (Bash /
@@ -19,12 +16,6 @@ import type { RunnerSandboxProviderId } from '../shared/runner-sandbox-provider.
 // DENY_ALL_FILESYSTEM in the runner). These guards are pure functions so the
 // truth table and exact locked-plan copy are unit-testable without spawning a
 // runner. See docs/architecture/deepagents-agent-engine-handoff-plan.md.
-
-// Locked plan copy. The literal lives here exactly once. It is the fail-closed
-// message surfaced when a DeepAgents run requests shell/filesystem authority but
-// the deployment posture or sandbox provider cannot enforce confinement.
-export const DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE =
-  'DeepAgents requires an enforcing sandbox before shell or filesystem tools can be enabled in this deployment mode.';
 
 // Gantry facade filesystem tools plus their provider-native source names; any of
 // these in a resolved tool rule grants SDK filesystem authority. RunCommand /
@@ -99,78 +90,38 @@ export interface DeepAgentsShellFilesystemGuardInput {
   sandboxProvider: RunnerSandboxProviderId | undefined;
 }
 
-// Whether the run's deployment posture + sandbox provider can enforce shell/
-// filesystem confinement (protected-path denies + egress proxy). True only when
-// the configured sandbox provider is the whole-runner OS sandbox AND the posture
-// does not additionally require an enforcing sandbox that this one is not. In
-// practice: `sandbox_runtime` always satisfies `requiresEnforcingSandbox`, so
-// this collapses to "the sandbox is the enforcing OS sandbox". `direct` and any
-// production/remote posture without `sandbox_runtime` cannot confine and so fail
-// closed.
-function deploymentCanEnforceShellSandbox(
-  input: Pick<
-    DeepAgentsShellFilesystemGuardInput,
-    'securityEnv' | 'sandboxProvider'
-  >,
-): boolean {
-  const posture = resolveRuntimeSecurityPosture(input.securityEnv);
-  const sandboxIsEnforcing = input.sandboxProvider === 'sandbox_runtime';
-  if (!sandboxIsEnforcing) return false;
-  // sandbox_runtime is an enforcing sandbox; it satisfies a posture that
-  // requires one. (The posture flag is kept explicit so the intent — "a posture
-  // that demands enforcement is satisfied by an enforcing sandbox" — is clear.)
-  return posture.requiresEnforcingSandbox || sandboxIsEnforcing;
-}
+// Two-axis model (decision 0040): the sandbox provider does NOT gate DeepAgents
+// shell/filesystem tool projection. Authorization is the control in BOTH modes —
+// the Gantry-owned RunCommand tool is gated by its tool rule + the host
+// coordinator. `sandbox_runtime` additionally confines the run with the OS jail;
+// `direct` relies on authorization + the deployment boundary. So shell/File tools
+// are projected for any DeepAgents run that requests the authority, in either mode
+// — there is no enforcing-sandbox fail-closed anymore.
 
-// Pre-spawn guard for DeepAgents shell/filesystem authority. Truth table:
-//   - non-DeepAgents engine                                   -> null (unaffected)
-//   - DeepAgents, no shell/fs authority requested             -> null (no tool projected)
-//   - DeepAgents + shell/fs authority + enforcing sandbox     -> null (allowed; runner
-//                                                                projects the gated tool)
-//   - DeepAgents + shell/fs authority + NOT enforcing sandbox -> locked enforcing-sandbox
-//     (direct mode, or production/remote without sandbox_runtime)   copy (FAIL CLOSED)
-// Shell/filesystem authority that is not backed by an enforcing sandbox is
-// blocked; shell/filesystem with no shell/fs rule is simply not projected.
-export function deepAgentsEnforcingSandboxGuard(
-  input: DeepAgentsShellFilesystemGuardInput,
-): string | null {
-  if (input.engine !== DEEPAGENTS_ENGINE) return null;
-  if (!requestsShellOrFilesystemAuthority(input.toolPolicyRules)) return null;
-  if (deploymentCanEnforceShellSandbox(input)) return null;
-  return DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE;
-}
-
-// Combined pre-spawn entry point. Returns the locked enforcing-sandbox message
-// when a DeepAgents run requests shell/filesystem authority that cannot be
-// confined, or null when the run is safe to spawn (no such authority, an
-// enforcing sandbox, or a non-DeepAgents engine).
+// Pre-spawn guard entry point. Kept as a stable no-op so callers keep their
+// guard-check shape; nothing is fail-closed on the sandbox provider now.
 export function deepAgentsShellFilesystemGuard(
-  input: DeepAgentsShellFilesystemGuardInput,
+  _input: DeepAgentsShellFilesystemGuardInput,
 ): string | null {
-  return deepAgentsEnforcingSandboxGuard(input);
+  return null;
 }
 
-// Whether the host should project the Gantry-owned shell tool into the runner
-// for this run: a DeepAgents run that requests shell (RunCommand/Bash) authority
-// AND is confined by an enforcing sandbox. Derived from the SAME inputs the
-// pre-spawn guard uses so the host env flag and the runner's projection agree;
-// the guard already fails the spawn closed if shell authority is requested
-// without an enforcing sandbox, so this only ever returns true on the allowed
-// path. Filesystem-only authority does NOT enable the shell tool.
+// Whether the host should project the Gantry-owned shell tool: a DeepAgents run
+// that requests shell (RunCommand/Bash) authority. Filesystem-only authority does
+// NOT enable the shell tool.
 export function deepAgentsShellToolEnabled(
   input: DeepAgentsShellFilesystemGuardInput,
 ): boolean {
-  if (input.engine !== DEEPAGENTS_ENGINE) return false;
-  if (!requestsShellAuthority(input.toolPolicyRules)) return false;
-  return deploymentCanEnforceShellSandbox(input);
+  return (
+    input.engine === DEEPAGENTS_ENGINE &&
+    requestsShellAuthority(input.toolPolicyRules)
+  );
 }
 
-// Whether the host should allow the runner to mount Gantry-owned File* facade
-// tools. Unlike shell, File* tools can be useful with only run-time approval, so
-// this depends on the enforcing sandbox path rather than preselected File* rules.
+// Whether the host should mount Gantry-owned File* facade tools for a DeepAgents
+// run (each File* action is still gated by run-time approval).
 export function deepAgentsFilesystemToolsEnabled(
   input: DeepAgentsShellFilesystemGuardInput,
 ): boolean {
-  if (input.engine !== DEEPAGENTS_ENGINE) return false;
-  return deploymentCanEnforceShellSandbox(input);
+  return input.engine === DEEPAGENTS_ENGINE;
 }

--- a/apps/core/src/shared/security-posture.ts
+++ b/apps/core/src/shared/security-posture.ts
@@ -47,7 +47,12 @@ export function resolveRuntimeSecurityPosture(
     production,
     remoteControl,
     requiresProductionSecrets: production || remoteControl || remoteDeployment,
-    requiresEnforcingSandbox: production || remoteControl || remoteDeployment,
+    // Two-axis model (decision 0040): the user chooses the sandbox provider;
+    // Gantry does NOT force `sandbox_runtime` in production/remote. Authorization
+    // (permission engine + classifier + credential rail) is the control; the OS
+    // jail is opt-in. Kept as a field (a control-server consumer reads it) but no
+    // longer mandates confinement.
+    requiresEnforcingSandbox: false,
   };
 }
 

--- a/apps/core/test/unit/config/security-posture.test.ts
+++ b/apps/core/test/unit/config/security-posture.test.ts
@@ -51,11 +51,20 @@ describe('runtime security posture', () => {
         GANTRY_RUNTIME_ENV: 'remote',
       }).requiresProductionSecrets,
     ).toBe(true);
+  });
+
+  it('never requires an enforcing sandbox regardless of posture (two-axis model)', () => {
     expect(
-      resolveRuntimeSecurityPosture({
-        GANTRY_SECURITY_POSTURE: 'remote',
-      }).requiresEnforcingSandbox,
-    ).toBe(true);
+      resolveRuntimeSecurityPosture({ NODE_ENV: 'production' })
+        .requiresEnforcingSandbox,
+    ).toBe(false);
+    expect(
+      resolveRuntimeSecurityPosture({ GANTRY_SECURITY_POSTURE: 'remote' })
+        .requiresEnforcingSandbox,
+    ).toBe(false);
+    expect(resolveRuntimeSecurityPosture({}).requiresEnforcingSandbox).toBe(
+      false,
+    );
   });
 
   it('allows local development without production secret material', () => {
@@ -73,7 +82,6 @@ describe('runtime security posture', () => {
 
     expect(failures).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('runtime.sandbox.provider'),
         expect.stringContaining('SECRET_ENCRYPTION_KEY'),
         expect.stringContaining('GANTRY_IPC_AUTH_SECRET'),
         expect.stringContaining('REMOTE_CONTROL_AUTO_ACCEPT'),
@@ -153,7 +161,7 @@ describe('runtime security posture', () => {
     ).toEqual([]);
   });
 
-  it('requires sandbox_runtime only for production or remote posture', () => {
+  it('does not require sandbox_runtime for any posture (two-axis model)', () => {
     expect(
       validateProductionSecurityGate({
         env: {},
@@ -161,28 +169,24 @@ describe('runtime security posture', () => {
       }),
     ).toEqual([]);
 
-    const failures = validateProductionSecurityGate({
-      env: {
-        NODE_ENV: 'production',
-        SECRET_ENCRYPTION_KEY: encryptionKey,
-        GANTRY_IPC_AUTH_SECRET: strongIpcSecret,
-        GANTRY_CONTROL_API_KEYS_JSON: JSON.stringify([
-          {
-            kid: 'admin',
-            token: strongToken,
-            appId: 'default',
-            scopes: ['sessions:read'],
-          },
-        ]),
-      },
-      sandboxProvider: 'direct',
-    });
-
-    expect(failures).toEqual([
-      expect.stringContaining(
-        'runtime.sandbox.provider must be sandbox_runtime',
-      ),
-    ]);
+    expect(
+      validateProductionSecurityGate({
+        env: {
+          NODE_ENV: 'production',
+          SECRET_ENCRYPTION_KEY: encryptionKey,
+          GANTRY_IPC_AUTH_SECRET: strongIpcSecret,
+          GANTRY_CONTROL_API_KEYS_JSON: JSON.stringify([
+            {
+              kid: 'admin',
+              token: strongToken,
+              appId: 'default',
+              scopes: ['sessions:read'],
+            },
+          ]),
+        },
+        sandboxProvider: 'direct',
+      }),
+    ).toEqual([]);
   });
 
   it('rejects keyrings that do not match the credential crypto contract', () => {

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -989,14 +989,6 @@ describe('agent-runner IPC lifecycle', () => {
       expect(sdkEnv.GANTRY_MCP_SERVERS_JSON).toBeUndefined();
       expect(sdkEnv.GANTRY_MCP_ALLOWED_TOOLS_JSON).toBeUndefined();
       expect(sdkEnv.ENABLE_TOOL_SEARCH).toBe('false');
-      expect(call?.sandbox).toEqual(
-        expect.objectContaining({
-          network: expect.objectContaining({
-            allowLocalBinding: true,
-            httpProxyPort: 18080,
-          }),
-        }),
-      );
       const startupDiagnostics = readRunnerOutputs(result.stdout).flatMap(
         (output) =>
           Array.isArray(output.runtimeEvents) ? output.runtimeEvents : [],
@@ -1053,25 +1045,6 @@ describe('agent-runner IPC lifecycle', () => {
       );
     },
     SLOW_RUNNER_IPC_TEST_TIMEOUT_MS,
-  );
-
-  it(
-    'fails closed when direct mode receives a non-loopback SDK sandbox proxy',
-    async () => {
-      const fixture = createRunnerFixture();
-
-      const result = await runRunner(fixture, baseInput(), {
-        GANTRY_EGRESS_PROXY_URL: 'http://gateway.example:18080/',
-        TEST_EXIT_AFTER_QUERY: '1',
-      });
-
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain(
-        'GANTRY_EGRESS_PROXY_URL must identify the run-scoped loopback HTTP egress gateway.',
-      );
-      expect(fs.existsSync(fixture.recordPath)).toBe(false);
-    },
-    RUNNER_IPC_TEST_TIMEOUT_MS,
   );
 
   it(
@@ -1296,44 +1269,7 @@ describe('agent-runner IPC lifecycle', () => {
   );
 
   it(
-    'keeps protected paths denied when the direct SDK escape hatch is enabled',
-    async () => {
-      const fixture = createRunnerFixture();
-      const claudeConfigDir = path.join(fixture.root, 'claude-config');
-      const handoffPath = path.join(fixture.root, 'ipc', 'mcp-handoff.json');
-
-      const result = await runRunner(fixture, baseInput(), {
-        TEST_EXIT_AFTER_QUERY: '1',
-        GANTRY_PROTECTED_FILESYSTEM_PATHS_JSON: JSON.stringify([
-          claudeConfigDir,
-          handoffPath,
-        ]),
-      });
-
-      expect(result.exitCode, result.stderr).toBe(0);
-      const call = readRecord(fixture.recordPath).calls[0];
-      expect(call?.sandbox).toMatchObject({
-        enabled: true,
-        failIfUnavailable: true,
-        autoAllowBashIfSandboxed: false,
-        allowUnsandboxedCommands: false,
-        filesystem: {
-          denyRead: expect.arrayContaining([
-            expect.stringMatching(/claude-config$/),
-            expect.stringMatching(/mcp-handoff\.json$/),
-          ]),
-          denyWrite: expect.arrayContaining([
-            expect.stringMatching(/claude-config$/),
-            expect.stringMatching(/mcp-handoff\.json$/),
-          ]),
-        },
-      });
-    },
-    RUNNER_IPC_TEST_TIMEOUT_MS,
-  );
-
-  it(
-    'keeps reviewed local CLI credential paths readable but denied for writes',
+    'exposes reviewed local CLI credential paths via additionalDirectories',
     async () => {
       const fixture = createRunnerFixture();
       const protectedSettingsPath = path.join(
@@ -1366,13 +1302,9 @@ describe('agent-runner IPC lifecycle', () => {
       expect(result.exitCode, result.stderr).toBe(0);
       const call = readRecord(fixture.recordPath).calls[0];
 
-      expect(call?.sandbox?.filesystem).toEqual({
-        denyRead: [expect.stringMatching(/settings\.json$/)],
-        denyWrite: expect.arrayContaining([
-          expect.stringMatching(/runtime$/),
-          expect.stringMatching(/credentials\/acme$/),
-        ]),
-      });
+      // Two-axis model (decision 0040): no SDK Seatbelt in direct mode, so the
+      // reviewed local CLI credential dir is exposed via additionalDirectories
+      // (readable); write protection is enforced by host-side authorization.
       expect(call?.additionalDirectories).toEqual(
         expect.arrayContaining([
           path.join(
@@ -2411,9 +2343,6 @@ describe('agent-runner IPC lifecycle', () => {
 
       expect(result.exitCode, result.stderr).toBe(0);
       const call = readRecord(fixture.recordPath).calls[0];
-      expect(call?.sandbox).toMatchObject({
-        allowUnsandboxedCommands: false,
-      });
       expect(call?.permissionRequest).toEqual(
         expect.objectContaining({
           toolName: 'RunCommand',

--- a/apps/core/test/unit/runner/filesystem-sandbox.test.ts
+++ b/apps/core/test/unit/runner/filesystem-sandbox.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import {
-  buildSdkFilesystemSandbox,
-  readLocalCliCredentialDirectories,
-  readProtectedFilesystemSandboxPaths,
-} from '@core/adapters/llm/anthropic-claude-agent/runner/filesystem-sandbox.js';
+import { readLocalCliCredentialDirectories } from '@core/adapters/llm/anthropic-claude-agent/runner/filesystem-sandbox.js';
 
 describe('Claude SDK filesystem sandbox settings', () => {
   const originalHome = process.env.HOME;
@@ -16,116 +12,6 @@ describe('Claude SDK filesystem sandbox settings', () => {
     if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
     delete process.env.GANTRY_LOCAL_CLI_CREDENTIAL_DIRS_JSON;
-    delete process.env.GANTRY_PROTECTED_FILESYSTEM_PATHS_JSON;
-    delete process.env.GANTRY_PROTECTED_FILESYSTEM_DENY_READ_PATHS_JSON;
-    delete process.env.GANTRY_PROTECTED_FILESYSTEM_DENY_WRITE_PATHS_JSON;
-    delete process.env.GANTRY_SANDBOX_RUNTIME_PROXY;
-  });
-
-  it('keeps the SDK sandbox enforcing with protected-path denies and broad local IPC', () => {
-    const protectedPath = '/tmp/protected';
-
-    expect(
-      buildSdkFilesystemSandbox([protectedPath], { httpProxyPort: 18790 }),
-    ).toEqual({
-      enabled: true,
-      failIfUnavailable: true,
-      autoAllowBashIfSandboxed: false,
-      allowUnsandboxedCommands: false,
-      network: {
-        allowLocalBinding: true,
-        allowUnixSockets: ['/'],
-        allowMachLookup: ['com.apple.SystemConfiguration.configd'],
-        httpProxyPort: 18790,
-      },
-      filesystem: {
-        denyRead: [expect.stringMatching(/\/tmp\/protected$/)],
-        denyWrite: [expect.stringMatching(/\/tmp\/protected$/)],
-      },
-    });
-  });
-
-  it('supports separate read and write sandbox protections', () => {
-    const sandbox = buildSdkFilesystemSandbox([], {
-      denyReadPaths: ['/tmp/runtime/settings.json'],
-      denyWritePaths: ['/tmp/runtime/skills', '/tmp/credentials'],
-    });
-
-    expect(sandbox.filesystem?.denyRead).toEqual([
-      expect.stringMatching(/\/tmp\/runtime\/settings\.json$/),
-    ]);
-    expect(sandbox.filesystem?.denyWrite).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/\/tmp\/runtime\/skills$/),
-        expect.stringMatching(/\/tmp\/credentials$/),
-      ]),
-    );
-    expect(sandbox.filesystem?.denyRead).not.toEqual(
-      expect.arrayContaining([expect.stringMatching(/\/tmp\/credentials$/)]),
-    );
-  });
-
-  it('reads split protected filesystem path projections from runner env', () => {
-    process.env.GANTRY_PROTECTED_FILESYSTEM_PATHS_JSON = JSON.stringify([
-      '/tmp/fallback',
-    ]);
-    process.env.GANTRY_PROTECTED_FILESYSTEM_DENY_READ_PATHS_JSON =
-      JSON.stringify(['/tmp/settings.json']);
-    process.env.GANTRY_PROTECTED_FILESYSTEM_DENY_WRITE_PATHS_JSON =
-      JSON.stringify(['/tmp/runtime', '/tmp/credentials']);
-
-    expect(readProtectedFilesystemSandboxPaths()).toEqual({
-      denyRead: [expect.stringMatching(/\/tmp\/settings\.json$/)],
-      denyWrite: expect.arrayContaining([
-        expect.stringMatching(/\/tmp\/runtime$/),
-        expect.stringMatching(/\/tmp\/credentials$/),
-      ]),
-    });
-  });
-
-  // Real enforcing execution (a credential read actually blocked plus a
-  // Chrome-shaped operation running) is verified by the goal-prompt runtime-smoke
-  // step in a real environment; nested Seatbelt cannot run in CI/managed sandboxes.
-  it('keeps authoritative protected and SSH-shaped paths in both deny lists', () => {
-    process.env.HOME = '/Users/tester';
-    process.env.GANTRY_PROTECTED_FILESYSTEM_DENY_READ_PATHS_JSON =
-      JSON.stringify(['/run/gantry/protected/credential.json', '~/.ssh']);
-    process.env.GANTRY_PROTECTED_FILESYSTEM_DENY_WRITE_PATHS_JSON =
-      JSON.stringify(['/run/gantry/protected/credential.json', '~/.ssh']);
-    const paths = readProtectedFilesystemSandboxPaths();
-    const sandbox = buildSdkFilesystemSandbox(paths.denyWrite, {
-      denyReadPaths: paths.denyRead,
-      denyWritePaths: paths.denyWrite,
-    });
-
-    expect(sandbox.filesystem?.denyRead).toEqual(
-      expect.arrayContaining([
-        '/run/gantry/protected/credential.json',
-        '/Users/tester/.ssh',
-      ]),
-    );
-    expect(sandbox.filesystem?.denyWrite).toEqual(
-      expect.arrayContaining([
-        '/run/gantry/protected/credential.json',
-        '/Users/tester/.ssh',
-      ]),
-    );
-  });
-
-  it('avoids host filesystem probes when the runner is already sandboxed', () => {
-    process.env.GANTRY_SANDBOX_RUNTIME_PROXY = '1';
-    process.env.GANTRY_PROTECTED_FILESYSTEM_PATHS_JSON = JSON.stringify([
-      '/tmp/runtime/settings.yaml',
-    ]);
-
-    expect(buildSdkFilesystemSandbox(['/tmp/runtime/settings.yaml'])).toEqual(
-      expect.objectContaining({
-        filesystem: expect.objectContaining({
-          denyRead: ['/tmp/runtime/settings.yaml'],
-          denyWrite: ['/tmp/runtime/settings.yaml'],
-        }),
-      }),
-    );
   });
 
   it('resolves reviewed local CLI credential directories from the host projection', () => {

--- a/apps/core/test/unit/runner/query-loop.test.ts
+++ b/apps/core/test/unit/runner/query-loop.test.ts
@@ -32,31 +32,6 @@ describe('Claude query loop usage event IDs', () => {
 });
 
 describe('Claude query loop declarative tool names', () => {
-  it('retains credential and protected-path denies in direct SDK sandbox config', () => {
-    const source = fs.readFileSync(
-      new URL(
-        '../../../src/adapters/llm/anthropic-claude-agent/runner/query-loop.ts',
-        import.meta.url,
-      ),
-      'utf8',
-    );
-    const sandboxConstruction = source.slice(
-      source.indexOf('const protectedFilesystemPaths ='),
-      source.indexOf('const workspaceFolder ='),
-    );
-
-    expect(sandboxConstruction).toContain(
-      "process.env.GANTRY_SANDBOX_RUNTIME_PROXY === '1'",
-    );
-    expect(sandboxConstruction).toContain(
-      'readProtectedFilesystemSandboxPaths()',
-    );
-    expect(sandboxConstruction).toContain('...localCliCredentialDirectories');
-    expect(sandboxConstruction).toContain('denyReadPaths:');
-    expect(sandboxConstruction).toContain('denyWritePaths:');
-    expect(source).toContain('readProtectedFilesystemSandboxPaths');
-  });
-
   it('does not pass allowedTools while retaining canUseTool in SDK query options', () => {
     const source = fs.readFileSync(
       new URL(

--- a/apps/core/test/unit/runtime/agent-spawn.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn.test.ts
@@ -238,12 +238,12 @@ vi.mock('@core/runtime/egress-gateway.js', () => ({
   ensureEgressGateway: (...args: unknown[]) => mockEnsureEgressGateway(...args),
 }));
 
-// DeepAgents shell/filesystem pre-spawn guard runs with its REAL implementation:
-// shell/filesystem authority that is not confined by an enforcing sandbox fails
-// closed with the enforcing-sandbox copy, while shell/filesystem authority under
-// `sandbox_runtime` is allowed (the runner projects the gated shell tool). The
-// per-test sandbox provider is driven by the runtime-settings mock + the passed
-// runnerSandboxProvider, so no guard mock seam is needed.
+// DeepAgents shell/filesystem projection runs with its REAL implementation.
+// Two-axis model (decision 0040): the sandbox provider does NOT gate shell or
+// filesystem tool projection — authorization is the control in both `direct`
+// and `sandbox_runtime` modes, so shell/filesystem authority is allowed under
+// either provider. The per-test sandbox provider is driven by the
+// runtime-settings mock + the passed runnerSandboxProvider.
 
 // Create a controllable fake ChildProcess
 function createFakeProcess() {
@@ -288,7 +288,6 @@ import {
 } from '@core/config/index.js';
 import { getConfiguredModelProvidersForApp } from '@core/adapters/storage/postgres/runtime-store.js';
 import { DirectRunnerSandboxProvider } from '@core/adapters/sandbox/runner-sandbox-provider.js';
-import { DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE } from '@core/runtime/deepagents-shell-filesystem-guard.js';
 import { spawn } from 'child_process';
 import fs from 'fs';
 import type { ConversationRoute } from '@core/domain/types.js';
@@ -4344,8 +4343,10 @@ describe('agent-spawn timeout behavior', () => {
     expect(env.HTTPS_PROXY).toBe('http://127.0.0.1:18080/');
     expect(env.NODE_USE_ENV_PROXY).toBe('1');
     expect(env.HTTP_PROXY).not.toContain('aoc_');
+    // No shell rule requested, so the shell flag stays off; filesystem facades
+    // are always projected for a DeepAgents run (two-axis model — direct too).
     expect(env.GANTRY_DEEPAGENTS_SHELL_ENABLED).toBeUndefined();
-    expect(env.GANTRY_DEEPAGENTS_FILESYSTEM_ENABLED).toBeUndefined();
+    expect(env.GANTRY_DEEPAGENTS_FILESYSTEM_ENABLED).toBe('1');
     const runnerInput = JSON.parse(String(writeSpy.mock.calls[0]?.[0]));
     expect(runnerInput.toolNetworkEnv.HTTP_PROXY).toBe(
       'http://127.0.0.1:18080/',
@@ -4353,11 +4354,11 @@ describe('agent-spawn timeout behavior', () => {
     expect(runnerInput.modelCredentialEnv?.HTTP_PROXY).toBeUndefined();
   });
 
-  it('A9: blocks a deepagents shell run under direct mode with the enforcing-sandbox copy (FAIL CLOSED)', async () => {
-    // Default mocked runtime sandbox provider is 'direct' (non-enforcing), so a
-    // DeepAgents run requesting shell authority fails closed before spawn — no
-    // shell tool can be projected without an enforcing OS sandbox.
-    const result = await spawnTestAgent(
+  it('A9: allows a deepagents shell run under direct mode and projects GANTRY_DEEPAGENTS_SHELL_ENABLED (two-axis)', async () => {
+    // Default mocked runtime sandbox provider is 'direct'. Two-axis model
+    // (decision 0040): the sandbox provider does not gate shell projection —
+    // the spawn proceeds and the shell-enabled flag is projected.
+    const resultPromise = spawnTestAgent(
       testGroup,
       {
         ...testInput,
@@ -4366,25 +4367,24 @@ describe('agent-spawn timeout behavior', () => {
       },
       () => {},
       undefined,
-      {
-        executionAdapter: {
-          id: 'deepagents:langchain',
-          prepare: vi.fn(async () => {
-            throw new Error('should not prepare: guard must fire first');
-          }),
-        },
-      },
+      { executionAdapter: testDeepAgentsExecutionAdapter },
     );
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
 
-    expect(result).toMatchObject({
-      status: 'error',
-      error: DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE,
-    });
-    expect(spawn).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalled();
+    const env = vi.mocked(spawn).mock.calls.at(-1)?.[2]?.env as Record<
+      string,
+      string
+    >;
+    expect(env.GANTRY_DEEPAGENTS_SHELL_ENABLED).toBe('1');
+    expect(env.GANTRY_DEEPAGENTS_FILESYSTEM_ENABLED).toBe('1');
   });
 
-  it('A9: blocks a deepagents filesystem run under direct mode with the enforcing-sandbox copy (FAIL CLOSED)', async () => {
-    const result = await spawnTestAgent(
+  it('A9: allows a deepagents filesystem run under direct mode (two-axis)', async () => {
+    const resultPromise = spawnTestAgent(
       testGroup,
       {
         ...testInput,
@@ -4393,21 +4393,20 @@ describe('agent-spawn timeout behavior', () => {
       },
       () => {},
       undefined,
-      {
-        executionAdapter: {
-          id: 'deepagents:langchain',
-          prepare: vi.fn(async () => {
-            throw new Error('should not prepare: guard must fire first');
-          }),
-        },
-      },
+      { executionAdapter: testDeepAgentsExecutionAdapter },
     );
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
 
-    expect(result).toMatchObject({
-      status: 'error',
-      error: DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE,
-    });
-    expect(spawn).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalled();
+    const env = vi.mocked(spawn).mock.calls.at(-1)?.[2]?.env as Record<
+      string,
+      string
+    >;
+    expect(env.GANTRY_DEEPAGENTS_FILESYSTEM_ENABLED).toBe('1');
+    expect(env.GANTRY_DEEPAGENTS_SHELL_ENABLED).toBeUndefined();
   });
 
   it('A9: allows a deepagents shell run under sandbox_runtime and projects GANTRY_DEEPAGENTS_SHELL_ENABLED', async () => {

--- a/apps/core/test/unit/runtime/deepagents-shell-filesystem-guard.test.ts
+++ b/apps/core/test/unit/runtime/deepagents-shell-filesystem-guard.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE,
-  deepAgentsEnforcingSandboxGuard,
   deepAgentsFilesystemToolsEnabled,
   deepAgentsShellFilesystemGuard,
   deepAgentsShellToolEnabled,
@@ -75,78 +73,7 @@ describe('deepAgentsShellFilesystemGuard', () => {
     });
   });
 
-  describe('deepAgentsEnforcingSandboxGuard (the operative gate)', () => {
-    it('ALLOWS shell under sandbox_runtime + safe local posture (returns null)', () => {
-      expect(
-        deepAgentsEnforcingSandboxGuard({
-          engine: DEEPAGENTS_ENGINE,
-          toolPolicyRules: ['RunCommand(npm test)'],
-          securityEnv: SAFE_LOCAL_ENV,
-          sandboxProvider: 'sandbox_runtime',
-        }),
-      ).toBeNull();
-    });
-
-    it('ALLOWS shell under sandbox_runtime even with production posture (the OS sandbox is enforcing)', () => {
-      expect(
-        deepAgentsEnforcingSandboxGuard({
-          engine: DEEPAGENTS_ENGINE,
-          toolPolicyRules: ['FileWrite'],
-          securityEnv: PRODUCTION_ENV,
-          sandboxProvider: 'sandbox_runtime',
-        }),
-      ).toBeNull();
-    });
-
-    it('BLOCKS shell under direct mode (non-enforcing) with the EXACT enforcing-sandbox copy — local posture', () => {
-      expect(
-        deepAgentsEnforcingSandboxGuard({
-          engine: DEEPAGENTS_ENGINE,
-          toolPolicyRules: ['RunCommand(npm test)'],
-          securityEnv: SAFE_LOCAL_ENV,
-          sandboxProvider: 'direct',
-        }),
-      ).toBe(DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE);
-      expect(DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE).toBe(
-        'DeepAgents requires an enforcing sandbox before shell or filesystem tools can be enabled in this deployment mode.',
-      );
-    });
-
-    it('BLOCKS shell when the sandbox provider is undefined (fail closed)', () => {
-      expect(
-        deepAgentsEnforcingSandboxGuard({
-          engine: DEEPAGENTS_ENGINE,
-          toolPolicyRules: ['RunCommand(npm test)'],
-          securityEnv: SAFE_LOCAL_ENV,
-          sandboxProvider: undefined,
-        }),
-      ).toBe(DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE);
-    });
-
-    it('does not apply when no shell/fs authority is requested', () => {
-      expect(
-        deepAgentsEnforcingSandboxGuard({
-          engine: DEEPAGENTS_ENGINE,
-          toolPolicyRules: ['WebSearch'],
-          securityEnv: PRODUCTION_ENV,
-          sandboxProvider: 'direct',
-        }),
-      ).toBeNull();
-    });
-
-    it('does not apply to the default (Anthropic SDK) engine', () => {
-      expect(
-        deepAgentsEnforcingSandboxGuard({
-          engine: DEFAULT_AGENT_ENGINE,
-          toolPolicyRules: ['RunCommand(npm test)'],
-          securityEnv: PRODUCTION_ENV,
-          sandboxProvider: 'direct',
-        }),
-      ).toBeNull();
-    });
-  });
-
-  describe('combined guard truth table', () => {
+  describe('combined guard truth table (two-axis model: sandbox provider never gates)', () => {
     it('deepagents + RunCommand rule + sandbox_runtime -> null (allowed)', () => {
       expect(
         deepAgentsShellFilesystemGuard({
@@ -158,7 +85,7 @@ describe('deepAgentsShellFilesystemGuard', () => {
       ).toBeNull();
     });
 
-    it('deepagents + RunCommand rule + direct -> tier-2 enforcing-sandbox copy (FAIL CLOSED)', () => {
+    it('deepagents + RunCommand rule + direct -> null (authorization is the control)', () => {
       expect(
         deepAgentsShellFilesystemGuard({
           engine: DEEPAGENTS_ENGINE,
@@ -166,10 +93,10 @@ describe('deepAgentsShellFilesystemGuard', () => {
           securityEnv: SAFE_LOCAL_ENV,
           sandboxProvider: 'direct',
         }),
-      ).toBe(DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE);
+      ).toBeNull();
     });
 
-    it('deepagents + RunCommand rule + production-without-sandbox -> blocked (FAIL CLOSED)', () => {
+    it('deepagents + RunCommand rule + production posture + direct -> null (allowed)', () => {
       expect(
         deepAgentsShellFilesystemGuard({
           engine: DEEPAGENTS_ENGINE,
@@ -177,7 +104,18 @@ describe('deepAgentsShellFilesystemGuard', () => {
           securityEnv: PRODUCTION_ENV,
           sandboxProvider: 'direct',
         }),
-      ).toBe(DEEPAGENTS_ENFORCING_SANDBOX_REQUIRED_MESSAGE);
+      ).toBeNull();
+    });
+
+    it('deepagents + RunCommand rule + undefined sandbox provider -> null (allowed)', () => {
+      expect(
+        deepAgentsShellFilesystemGuard({
+          engine: DEEPAGENTS_ENGINE,
+          toolPolicyRules: ['RunCommand(npm test)'],
+          securityEnv: SAFE_LOCAL_ENV,
+          sandboxProvider: undefined,
+        }),
+      ).toBeNull();
     });
 
     it('deepagents + NO shell/fs rule -> null (no shell requested, no block)', () => {
@@ -215,7 +153,7 @@ describe('deepAgentsShellFilesystemGuard', () => {
       ).toBe(true);
     });
 
-    it('false under direct mode (guard would block the spawn anyway)', () => {
+    it('true for deepagents + RunCommand rule under direct mode too (two-axis: provider does not gate)', () => {
       expect(
         deepAgentsShellToolEnabled({
           engine: DEEPAGENTS_ENGINE,
@@ -223,7 +161,7 @@ describe('deepAgentsShellFilesystemGuard', () => {
           securityEnv: SAFE_LOCAL_ENV,
           sandboxProvider: 'direct',
         }),
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('false for filesystem-only authority (the shell tool is shell, not FS)', () => {
@@ -272,7 +210,7 @@ describe('deepAgentsShellFilesystemGuard', () => {
       ).toBe(true);
     });
 
-    it('false under direct mode', () => {
+    it('true under direct mode too (two-axis: provider does not gate)', () => {
       expect(
         deepAgentsFilesystemToolsEnabled({
           engine: DEEPAGENTS_ENGINE,
@@ -280,7 +218,7 @@ describe('deepAgentsShellFilesystemGuard', () => {
           securityEnv: SAFE_LOCAL_ENV,
           sandboxProvider: 'direct',
         }),
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('false for the default (Anthropic SDK) engine', () => {

--- a/apps/core/test/unit/runtime/permission-decision-coordinator.test.ts
+++ b/apps/core/test/unit/runtime/permission-decision-coordinator.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest';
 import type { PermissionApprovalRequest } from '@core/domain/types.js';
 import type { ToolPolicyDecision } from '@core/shared/tool-execution-policy-service.js';
 import { decisionForMode } from '@core/domain/permission-decision.js';
-import { buildSdkFilesystemSandbox } from '@core/adapters/llm/anthropic-claude-agent/runner/filesystem-sandbox.js';
 import {
   coordinatePermissionDecision,
   permissionRunRestriction,
@@ -176,8 +175,7 @@ describe('coordinatePermissionDecision', () => {
     expect(tail).not.toHaveBeenCalled();
   });
 
-  it('routes credential-read ASK rails to the tail with the direct SDK escape hatch disabled', async () => {
-    const sdkSandbox = buildSdkFilesystemSandbox(['~/.ssh']);
+  it('routes credential-read ASK rails to the tail', async () => {
     const tailDecision = {
       approved: false,
       mode: 'cancel' as const,
@@ -190,10 +188,6 @@ describe('coordinatePermissionDecision', () => {
       toolInput: { command: 'cat ~/.ssh/id_rsa' },
     };
 
-    expect(sdkSandbox.allowUnsandboxedCommands).toBe(false);
-    expect(sdkSandbox.filesystem?.denyRead).toEqual(
-      expect.arrayContaining([expect.stringMatching(/\/\.ssh$/)]),
-    );
     await expect(
       coordinatePermissionDecision({
         request: railRequest,

--- a/docs/architecture/media-render-phase1.md
+++ b/docs/architecture/media-render-phase1.md
@@ -1,0 +1,92 @@
+# MEDIA-1 Phase 1 — single-process Chrome for Remotion renders (darwin-arm64)
+
+Status: implemented (skill-side). Phase 2 (400 MB pre-provisioning,
+semantic-capability + skill selection, platform matrix) remains out of scope.
+
+## Goal
+
+Make Remotion renders launch single-process Chrome by default on this
+workstation, so the live agent's render produces an MP4 without any manual
+per-render flag.
+
+## Render → Chrome launch path (as found)
+
+Gantry source has **zero** Remotion/Chrome-render code. The render is entirely
+agent-side:
+
+- The agent renders with `npx remotion render` (Remotion `4.0.290`, `@remotion/cli`)
+  inside its workspace, under the **direct** sandbox provider.
+- Remotion resolves `chrome-headless-shell` itself and launches it via
+  `@remotion/renderer/dist/open-browser.js`. `--no-sandbox` is **already**
+  always in the arg list; `--single-process` is added **only** when
+  `chromiumOptions.enableMultiProcessOnLinux === false` (applies to macOS +
+  Linux despite the name — `open-browser.js` gates on
+  `process.platform === 'linux' || 'darwin'`).
+- The BROWSER-capability plumbing in `apps/core/src/runtime/browser-config.ts`
+  / `browser-capability.ts` builds `--user-data-dir` for the *browser tool* and
+  is **not** on the render path — renders launch their own Chrome via Remotion.
+
+Direct-mode sandbox network is already correct (`filesystem-sandbox.ts`:
+`allowLocalBinding`, `allowUnixSockets`, `allowMachLookup` incl. `configd`), so
+no sandbox change is needed. The only missing piece was single-process Chrome.
+
+## Wiring point chosen (smallest that works)
+
+Native Remotion option, not a wrapper script. Set in the render project's
+`remotion.config.ts`:
+
+```ts
+import {Config} from '@remotion/cli/config';
+Config.setChromiumMultiProcessOnLinux(false);
+```
+
+Config (not the `--enable-multiprocess-on-linux` CLI flag) because the flag is
+**not** in Remotion's `BooleanFlags` list — minimist parses `=false` as the
+string `"false"`, which is truthy, so the flag silently keeps multi-process on.
+`Config.setChromiumMultiProcessOnLinux(false)` passes a real boolean and
+reliably yields `--single-process`.
+
+Plus workspace-local `HOME`/`TMPDIR` (real `$HOME` and system temp are
+read-only in the sandbox; Chrome writes its profile under `TMPDIR` and crashpad
+state under `HOME`):
+
+```
+mkdir -p .chromehome .tmp
+HOME="$PWD/.chromehome" TMPDIR="$PWD/.tmp" npx remotion render
+```
+
+This matches the 2026-07-20 empirical proof (Chrome-for-Testing
+`147.0.7727.57`, 210/210 frames → MP4), minus the wrapper script — the native
+config option makes the wrapper unnecessary.
+
+## Files changed
+
+All skill-side (no Gantry source change — nothing on the render path lives in
+this repo). `remotion-render/SKILL.md` now leads with the macOS setup
+(`remotion.config.ts` + `HOME`/`TMPDIR`) and bakes the env into the canonical
+render/still commands:
+
+- `~/gantry/artifacts/skills/remotion-render/SKILL.md` (authoritative source)
+- `~/gantry/artifacts/skills/remotion-best-practices/remotion-render/SKILL.md`
+- `~/gantry/agents/main_agent/.llm-runtime/claude/skills/remotion-render/SKILL.md` (live copy)
+- `~/gantry/agents/main_agent/.llm-runtime/claude/skills/remotion-best-practices/remotion-render/SKILL.md` (live copy)
+
+## Chrome binary
+
+Present — no download needed. `chrome-headless-shell` for Chrome-for-Testing
+`147.0.7727.57` (mac_arm) is already cached at
+`~/.cache/puppeteer/chrome-headless-shell/mac_arm-147.0.7727.57/chrome-headless-shell-mac-arm64/chrome-headless-shell`
+and Remotion resolves it via its own revision lookup.
+
+## Exact command a render now runs
+
+In the render project (with the `remotion.config.ts` above present):
+
+```
+mkdir -p .chromehome .tmp
+HOME="$PWD/.chromehome" TMPDIR="$PWD/.tmp" npx remotion render
+```
+
+Remotion then launches `chrome-headless-shell` with `--single-process
+--no-sandbox` (among its standard flags), avoiding the Mach rendezvous 1100
+denial and producing the MP4.

--- a/docs/decisions/0040-permission-execution-two-axis-model.md
+++ b/docs/decisions/0040-permission-execution-two-axis-model.md
@@ -1,0 +1,52 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-23
+---
+
+# Permission & Execution: Two-Axis, Provider-Authoritative Model
+
+## Context
+The direct-mode SDK Seatbelt blocked legitimate work (Chromium's Mach-port
+registration — the whole mach-register class) with no surgical escape: the SDK
+exposes `allowMachLookup` but no mach-register lever, and `ignoreViolations` only
+suppresses reporting. Research into Claude Code (`codeaashu/claude-code`) and Codex
+(`openai/codex`) source confirmed the industry pattern: **authorization and OS
+confinement are two orthogonal axes**, not one knob. Claude Code ships with the
+sandbox OFF by default ("permission prompts are the security control"); Codex keeps
+`approval_policy` and `sandbox_mode` as independent enums where "never-ask" != 
+"no-sandbox" and "full-access" != "never-ask".
+
+## Decision
+Adopt a two-axis, **provider-authoritative** model. The user chooses the execution
+mode; Gantry adheres — no production override, no per-command media-gating.
+
+1. **Axis A — Authorization** (always on, both lanes, both modes): the host-side
+   coordinator + deterministic rails (strongest-wins precedence: hard-deny ->
+   locked -> fixed-image -> reviewed-rule -> rails -> classifier -> human) + the
+   schema-enforced, fail-closed-to-ask classifier + decision memory (scoped:
+   once / this-folder / standing). This is the single control in `direct`.
+2. **Axis B — Confinement** (`sandbox.provider`): `direct` = no inner OS sandbox
+   (authorization + the deployment boundary are the isolation); `sandbox_runtime`
+   = the OS jail. Gantry does not force `sandbox_runtime` in production and does
+   not fail DeepAgents shell closed under `direct`.
+3. **Escape-as-new-action** (Codex's strongest pattern, tracked as SANDBOX-1):
+   under `sandbox_runtime`, an OS-jail denial does NOT fail dead — it raises a
+   separate, scoped approval to retry with the specific added capability. A
+   sandboxed approval NEVER implicitly authorizes an unsandboxed retry; managed
+   denied-read constraints (`~/.ssh`, `~/.aws`) stay non-escapable.
+
+## Consequences
+- `direct` mode drops the Anthropic SDK Seatbelt entirely (Chromium + the
+  mach-register class run); the host-side credential/protected-path rail is the
+  credential guard (moved off the Seatbelt, not removed). Egress stays routed via
+  the HTTP(S)_PROXY -> run-scoped gateway (advisory in `direct`, hard-enforced only
+  under `sandbox_runtime`). Now-dead SDK-filesystem-sandbox code is deleted.
+- DeepAgents shell runs under `direct` (gated by its RunCommand rule + coordinator,
+  not a sandbox-provider fail-closed). `sandbox_runtime` still confines it.
+- `security-posture` no longer forces an enforcing sandbox; the provider is the
+  user's choice.
+- Deliberately NOT copied from the references: Claude Code's Accept-Edits shell
+  alias (auto-allowing `rm`/`mv`/`sed` as "edit-like"); prompt-only Plan mode.
+- Follow-ups: SANDBOX-1 (escape-as-new-action for `sandbox_runtime`); optionally
+  enrich the classifier verdict to Codex's `risk` + `authorization_strength` shape.


### PR DESCRIPTION
## What this does (plain language)

When Gantry runs an agent in **direct** sandbox mode, it was wrapping every shell command in the Anthropic SDK's Seatbelt sandbox *on top of* Gantry's own permission engine. That inner sandbox is redundant with authorization — and it denies Chromium's Mach-port register, which is what **broke media renders** (Remotion/Chrome). This PR drops that redundant inner sandbox in direct mode so renders work again, per accepted **decision 0040 (two-axis model)**.

The model: **you choose the confinement, Gantry adheres.**
- `direct` (default): authorization (permission engine + classifier + host-side credential rail) is the sole control — no inner OS sandbox.
- `sandbox_runtime` (opt-in): the runner OS jail stays exactly as-is for anyone who wants kernel confinement.

## Change
- `query-loop.ts`: no SDK filesystem sandbox in direct mode (`sandbox_runtime` never built one). Egress still routes to the gateway via the per-command PreToolUse trust env (`HTTP_PROXY`) — advisory in direct, exactly as 0040 specifies.
- `filesystem-sandbox.ts`: delete the now-dead `buildSdkFilesystemSandbox` / `requireSdkSandboxEgressProxyPort` / `readProtectedFilesystemSandboxPaths` (+ private helpers). Keep the live `readLocalCliCredentialDirectories` / `normalizeFilesystemSandboxPaths`.
- `deepagents-shell-filesystem-guard.ts`: drop the enforcing-sandbox fail-closed; shell/File tools project for any DeepAgents run that requests the authority in both modes (still gated by tool rule + host coordinator).
- `security-posture.ts`: `requiresEnforcingSandbox` is always false — Gantry no longer forces `sandbox_runtime` in production/remote. All other production-secret gates (encryption key, IPC secret, control API keys, auto-accept ban) are unchanged.

Credential protection in direct mode moves to host-side authorization (the permission coordinator rails); `sandbox_runtime` keeps the OS-jail deny paths. Net **−431 lines** (deletion-heavy).

## Verification
- `npm run typecheck` clean.
- All affected unit suites green (security-posture, agent-spawn, deepagents-guard, filesystem-sandbox, query-loop, permission-decision-coordinator, agent-runner-ipc — 5 obsolete SDK-sandbox-shape assertions reconciled to the two-axis behavior).
- Independent adversarial security review of the source diff: **no blockers/majors** (egress rail intact via PreToolUse `applyBashTrustEnv`; credential rail via coordinator; OS-jail env still read in `sandbox_runtime`).
- **Live-verified:** built and swapped into the running runtime via `gantry restart`; the previously-blocked Remotion/Chrome render proceeds.

## agent-e2e delta
No new agent-e2e matrix rows: this change removes a redundant enforcement layer in `direct` mode; the behavior it unblocks (Chrome/Remotion render) is exercised by the media-render runtime smoke, and the `sandbox_runtime` path is unchanged. The confinement matrix rows for `sandbox_runtime` remain valid as-is.

## Stack
Stacked on `feat/PERM-2-decision-coordinator` (permission engine). Follow-up: **SANDBOX-1** (escape-as-new-action for `sandbox_runtime`).
