### PR TITLE
fix(cli): remove agents that have no conversation routes (closes #287)

### DIFF
--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0100_snapshot.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0100_snapshot.json
@@ -98,12 +98,8 @@
           "name": "agent_config_versions_app_id_apps_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -111,12 +107,8 @@
           "name": "agent_config_versions_agent_id_agents_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -124,12 +116,8 @@
           "name": "agent_config_versions_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -137,12 +125,8 @@
           "name": "agent_config_versions_sandbox_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -150,12 +134,8 @@
           "name": "agent_config_versions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -165,10 +145,7 @@
         "agent_config_versions_agent_id_version_unique": {
           "name": "agent_config_versions_agent_id_version_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_id",
-            "version"
-          ]
+          "columns": ["agent_id", "version"]
         }
       },
       "policies": {},
@@ -231,12 +208,8 @@
           "name": "agents_app_id_apps_id_fk",
           "tableFrom": "agents",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -323,12 +296,8 @@
           "name": "llm_profiles_app_id_apps_id_fk",
           "tableFrom": "llm_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -390,9 +359,7 @@
         "apps_slug_unique": {
           "name": "apps_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -500,12 +467,8 @@
           "name": "user_aliases_app_id_apps_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -513,12 +476,8 @@
           "name": "user_aliases_user_id_users_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -608,12 +567,8 @@
           "name": "users_app_id_apps_id_fk",
           "tableFrom": "users",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -889,12 +844,8 @@
           "name": "agent_async_tasks_app_id_apps_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -902,12 +853,8 @@
           "name": "agent_async_tasks_agent_id_agents_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -915,12 +862,8 @@
           "name": "agent_async_tasks_parent_run_id_agent_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "parent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -928,12 +871,8 @@
           "name": "agent_async_tasks_parent_job_id_jobs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "parent_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -941,12 +880,8 @@
           "name": "agent_async_tasks_parent_job_run_id_job_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "job_runs",
-          "columnsFrom": [
-            "parent_job_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1059,12 +994,8 @@
           "name": "brain_dream_decisions_app_id_apps_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1072,12 +1003,8 @@
           "name": "brain_dream_decisions_page_id_brain_pages_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1123,12 +1050,8 @@
           "name": "brain_dream_state_app_id_apps_id_fk",
           "tableFrom": "brain_dream_state",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1301,12 +1224,8 @@
           "name": "brain_edges_app_id_apps_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1314,12 +1233,8 @@
           "name": "brain_edges_from_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "from_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["from_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1327,12 +1242,8 @@
           "name": "brain_edges_to_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "to_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["to_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1340,12 +1251,8 @@
           "name": "brain_edges_evidence_page_id_brain_pages_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "evidence_page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["evidence_page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1464,12 +1371,8 @@
           "name": "brain_entities_app_id_apps_id_fk",
           "tableFrom": "brain_entities",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1638,12 +1541,8 @@
           "name": "brain_page_embeddings_page_id_brain_pages_id_fk",
           "tableFrom": "brain_page_embeddings",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1651,12 +1550,7 @@
       "compositePrimaryKeys": {
         "brain_page_embeddings_pk": {
           "name": "brain_page_embeddings_pk",
-          "columns": [
-            "page_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["page_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -1800,12 +1694,8 @@
           "name": "brain_pages_app_id_apps_id_fk",
           "tableFrom": "brain_pages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1924,12 +1814,8 @@
           "name": "browser_profiles_snapshot_run_id_agent_runs_id_fk",
           "tableFrom": "browser_profiles",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "snapshot_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["snapshot_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2051,12 +1937,8 @@
           "name": "capability_secrets_app_id_apps_id_fk",
           "tableFrom": "capability_secrets",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2116,12 +1998,8 @@
           "name": "control_http_response_routes_session_id_control_http_sessions_session_id_fk",
           "tableFrom": "control_http_response_routes",
           "tableTo": "control_http_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["session_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2129,10 +2007,7 @@
       "compositePrimaryKeys": {
         "control_http_response_routes_session_id_thread_id_pk": {
           "name": "control_http_response_routes_session_id_thread_id_pk",
-          "columns": [
-            "session_id",
-            "thread_id"
-          ]
+          "columns": ["session_id", "thread_id"]
         }
       },
       "uniqueConstraints": {},
@@ -2231,12 +2106,8 @@
           "name": "control_http_sessions_session_id_agent_sessions_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2244,12 +2115,8 @@
           "name": "control_http_sessions_app_id_apps_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2257,12 +2124,8 @@
           "name": "control_http_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2270,12 +2133,8 @@
           "name": "control_http_sessions_agent_id_agents_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2285,10 +2144,7 @@
         "control_http_sessions_app_id_external_conversation_id_key": {
           "name": "control_http_sessions_app_id_external_conversation_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "external_conversation_id"
-          ]
+          "columns": ["app_id", "external_conversation_id"]
         }
       },
       "policies": {},
@@ -2397,12 +2253,8 @@
           "name": "control_http_webhook_deliveries_webhook_id_control_http_webhooks_webhook_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "control_http_webhooks",
-          "columnsFrom": [
-            "webhook_id"
-          ],
-          "columnsTo": [
-            "webhook_id"
-          ],
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["webhook_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2410,12 +2262,8 @@
           "name": "control_http_webhook_deliveries_event_id_runtime_events_event_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2425,10 +2273,7 @@
         "control_http_webhook_deliveries_webhook_id_event_id_key": {
           "name": "control_http_webhook_deliveries_webhook_id_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "webhook_id",
-            "event_id"
-          ]
+          "columns": ["webhook_id", "event_id"]
         }
       },
       "policies": {},
@@ -2544,12 +2389,8 @@
           "name": "control_http_webhooks_app_id_apps_id_fk",
           "tableFrom": "control_http_webhooks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2559,10 +2400,7 @@
         "control_http_webhooks_app_id_name_key": {
           "name": "control_http_webhooks_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -2661,12 +2499,8 @@
           "name": "conversation_approvers_app_id_apps_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2674,12 +2508,8 @@
           "name": "conversation_approvers_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2781,12 +2611,8 @@
           "name": "conversation_participants_app_id_apps_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2794,12 +2620,8 @@
           "name": "conversation_participants_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2807,12 +2629,8 @@
           "name": "conversation_participants_user_id_users_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2901,12 +2719,8 @@
           "name": "conversation_threads_app_id_apps_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2914,12 +2728,8 @@
           "name": "conversation_threads_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3014,12 +2824,8 @@
           "name": "conversations_app_id_apps_id_fk",
           "tableFrom": "conversations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3229,12 +3035,8 @@
           "name": "event_bus_outbox_app_id_apps_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3242,12 +3044,8 @@
           "name": "event_bus_outbox_runtime_event_id_runtime_events_event_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "runtime_event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["runtime_event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3257,9 +3055,7 @@
         "event_bus_outbox_runtime_event_id_key": {
           "name": "event_bus_outbox_runtime_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "runtime_event_id"
-          ]
+          "columns": ["runtime_event_id"]
         }
       },
       "policies": {},
@@ -3635,12 +3431,8 @@
           "name": "runtime_events_app_id_apps_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3648,12 +3440,8 @@
           "name": "runtime_events_agent_id_agents_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -3661,12 +3449,8 @@
           "name": "runtime_events_session_id_agent_sessions_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -3674,12 +3458,8 @@
           "name": "runtime_events_run_id_agent_runs_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3687,12 +3467,8 @@
           "name": "runtime_events_conversation_id_conversations_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -3700,12 +3476,8 @@
           "name": "runtime_events_thread_id_conversation_threads_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -3896,12 +3668,8 @@
           "name": "external_ingress_invocations_app_id_apps_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3909,12 +3677,8 @@
           "name": "external_ingress_invocations_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3924,11 +3688,7 @@
         "external_ingress_invocations_app_id_ingress_id_idempotency_key_key": {
           "name": "external_ingress_invocations_app_id_ingress_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "ingress_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -4020,12 +3780,8 @@
           "name": "external_ingress_nonces_app_id_apps_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4033,12 +3789,8 @@
           "name": "external_ingress_nonces_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4046,11 +3798,7 @@
       "compositePrimaryKeys": {
         "external_ingress_nonces_pk": {
           "name": "external_ingress_nonces_pk",
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "nonce"
-          ]
+          "columns": ["app_id", "ingress_id", "nonce"]
         }
       },
       "uniqueConstraints": {},
@@ -4143,12 +3891,8 @@
           "name": "external_ingresses_app_id_apps_id_fk",
           "tableFrom": "external_ingresses",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4158,10 +3902,7 @@
         "external_ingresses_app_id_name_key": {
           "name": "external_ingresses_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -4350,12 +4091,8 @@
           "name": "file_artifacts_app_id_apps_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4363,12 +4100,8 @@
           "name": "file_artifacts_agent_id_agents_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4376,12 +4109,8 @@
           "name": "file_artifacts_promoted_from_artifact_id_file_artifacts_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "file_artifacts",
-          "columnsFrom": [
-            "promoted_from_artifact_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["promoted_from_artifact_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4544,12 +4273,8 @@
           "name": "runtime_dependencies_app_id_apps_id_fk",
           "tableFrom": "runtime_dependencies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4636,12 +4361,8 @@
           "name": "settings_revisions_app_id_apps_id_fk",
           "tableFrom": "settings_revisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4649,10 +4370,7 @@
       "compositePrimaryKeys": {
         "settings_revisions_pk": {
           "name": "settings_revisions_pk",
-          "columns": [
-            "app_id",
-            "revision"
-          ]
+          "columns": ["app_id", "revision"]
         }
       },
       "uniqueConstraints": {},
@@ -4811,12 +4529,8 @@
           "name": "conversation_installs_app_id_apps_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4824,12 +4538,8 @@
           "name": "conversation_installs_agent_id_agents_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4837,12 +4547,8 @@
           "name": "conversation_installs_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4850,12 +4556,8 @@
           "name": "conversation_installs_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4863,12 +4565,8 @@
           "name": "conversation_installs_thread_id_conversation_threads_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4876,12 +4574,8 @@
           "name": "conversation_installs_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -5045,12 +4739,8 @@
           "name": "provider_accounts_app_id_apps_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5058,12 +4748,8 @@
           "name": "provider_accounts_agent_id_agents_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5071,12 +4757,8 @@
           "name": "provider_accounts_provider_id_providers_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "providers",
-          "columnsFrom": [
-            "provider_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -5192,12 +4874,8 @@
           "name": "job_triggers_app_id_apps_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5205,12 +4883,8 @@
           "name": "job_triggers_job_id_jobs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5218,12 +4892,8 @@
           "name": "job_triggers_run_id_agent_runs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -5513,12 +5183,8 @@
           "name": "jobs_app_id_apps_id_fk",
           "tableFrom": "jobs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5526,12 +5192,8 @@
           "name": "jobs_agent_id_agents_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5539,12 +5201,8 @@
           "name": "jobs_conversation_id_conversations_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -5552,12 +5210,8 @@
           "name": "jobs_thread_id_conversation_threads_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -5565,12 +5219,8 @@
           "name": "jobs_lease_run_id_agent_runs_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "lease_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["lease_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -5686,12 +5336,8 @@
           "name": "job_runs_app_id_apps_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5699,12 +5345,8 @@
           "name": "job_runs_job_id_jobs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5712,12 +5354,8 @@
           "name": "job_runs_agent_run_id_agent_runs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "agent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -6211,12 +5849,8 @@
           "name": "live_turn_commands_live_turn_id_live_turns_id_fk",
           "tableFrom": "live_turn_commands",
           "tableTo": "live_turns",
-          "columnsFrom": [
-            "live_turn_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["live_turn_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6480,12 +6114,8 @@
           "name": "live_turns_run_id_agent_runs_id_fk",
           "tableFrom": "live_turns",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6719,12 +6349,8 @@
           "name": "memory_items_app_id_apps_id_fk",
           "tableFrom": "memory_items",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6816,12 +6442,8 @@
           "name": "message_attachments_message_id_messages_id_fk",
           "tableFrom": "message_attachments",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6884,12 +6506,8 @@
           "name": "message_parts_message_id_messages_id_fk",
           "tableFrom": "message_parts",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6899,10 +6517,7 @@
         "message_parts_message_id_ordinal_unique": {
           "name": "message_parts_message_id_ordinal_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "message_id",
-            "ordinal"
-          ]
+          "columns": ["message_id", "ordinal"]
         }
       },
       "policies": {},
@@ -7123,12 +6738,8 @@
           "name": "messages_app_id_apps_id_fk",
           "tableFrom": "messages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7136,12 +6747,8 @@
           "name": "messages_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "messages",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7149,12 +6756,8 @@
           "name": "messages_conversation_id_conversations_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7162,12 +6765,8 @@
           "name": "messages_thread_id_conversation_threads_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7313,12 +6912,8 @@
           "name": "model_credentials_app_id_apps_id_fk",
           "tableFrom": "model_credentials",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7473,12 +7068,8 @@
           "name": "agent_mcp_server_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7486,12 +7077,8 @@
           "name": "agent_mcp_server_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7499,12 +7086,8 @@
           "name": "agent_mcp_server_bindings_server_id_mcp_servers_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7637,12 +7220,8 @@
           "name": "mcp_server_audit_events_app_id_apps_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7650,12 +7229,8 @@
           "name": "mcp_server_audit_events_agent_id_agents_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7663,12 +7238,8 @@
           "name": "mcp_server_audit_events_server_id_mcp_servers_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7676,12 +7247,8 @@
           "name": "mcp_server_audit_events_binding_id_agent_mcp_server_bindings_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agent_mcp_server_bindings",
-          "columnsFrom": [
-            "binding_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -7889,12 +7456,8 @@
           "name": "mcp_servers_app_id_apps_id_fk",
           "tableFrom": "mcp_servers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8090,12 +7653,8 @@
           "name": "outbound_deliveries_app_id_apps_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8103,12 +7662,8 @@
           "name": "outbound_deliveries_conversation_id_conversations_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8116,12 +7671,8 @@
           "name": "outbound_deliveries_thread_id_conversation_threads_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8129,12 +7680,8 @@
           "name": "outbound_deliveries_agent_id_agents_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -8142,12 +7689,8 @@
           "name": "outbound_deliveries_run_id_agent_runs_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8157,10 +7700,7 @@
         "outbound_deliveries_app_id_idempotency_key_key": {
           "name": "outbound_deliveries_app_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -8210,12 +7750,8 @@
           "name": "outbound_delivery_final_answers_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_final_answers",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8425,12 +7961,8 @@
           "name": "outbound_delivery_items_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_items",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8440,10 +7972,7 @@
         "outbound_delivery_items_delivery_id_ordinal_key": {
           "name": "outbound_delivery_items_delivery_id_ordinal_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "delivery_id",
-            "ordinal"
-          ]
+          "columns": ["delivery_id", "ordinal"]
         }
       },
       "policies": {},
@@ -8532,12 +8061,8 @@
           "name": "outbound_delivery_receipts_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8545,12 +8070,8 @@
           "name": "outbound_delivery_receipts_item_id_outbound_delivery_items_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_delivery_items",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8560,10 +8081,7 @@
         "outbound_delivery_receipts_item_id_idempotency_key_key": {
           "name": "outbound_delivery_receipts_item_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_id",
-            "idempotency_key"
-          ]
+          "columns": ["item_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -8776,12 +8294,8 @@
           "name": "pattern_candidates_app_id_apps_id_fk",
           "tableFrom": "pattern_candidates",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8916,12 +8430,8 @@
           "name": "proactive_surfacing_opt_ins_app_id_apps_id_fk",
           "tableFrom": "proactive_surfacing_opt_ins",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9027,12 +8537,8 @@
           "name": "pending_access_requests_app_id_apps_id_fk",
           "tableFrom": "pending_access_requests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9096,12 +8602,8 @@
           "name": "permission_audit_events_app_id_apps_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9109,12 +8611,8 @@
           "name": "permission_audit_events_decision_id_permission_decisions_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9216,12 +8714,8 @@
           "name": "permission_decisions_app_id_apps_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9229,12 +8723,8 @@
           "name": "permission_decisions_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -9242,12 +8732,8 @@
           "name": "permission_decisions_run_id_agent_runs_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -9255,12 +8741,8 @@
           "name": "permission_decisions_tool_id_tool_catalog_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -9327,12 +8809,8 @@
           "name": "permission_policies_app_id_apps_id_fk",
           "tableFrom": "permission_policies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9404,12 +8882,8 @@
           "name": "permission_rules_app_id_apps_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9417,12 +8891,8 @@
           "name": "permission_rules_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9726,12 +9196,8 @@
           "name": "agent_runs_app_id_apps_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9739,12 +9205,8 @@
           "name": "agent_runs_agent_id_agents_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9752,12 +9214,8 @@
           "name": "agent_runs_config_version_id_agent_config_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_config_versions",
-          "columnsFrom": [
-            "config_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["config_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -9765,12 +9223,8 @@
           "name": "agent_runs_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9778,12 +9232,8 @@
           "name": "agent_runs_conversation_id_conversations_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -9791,12 +9241,8 @@
           "name": "agent_runs_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -9804,12 +9250,8 @@
           "name": "agent_runs_message_id_messages_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -9817,12 +9259,8 @@
           "name": "agent_runs_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -9898,12 +9336,8 @@
           "name": "sandbox_leases_app_id_apps_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9911,12 +9345,8 @@
           "name": "sandbox_leases_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -9924,12 +9354,8 @@
           "name": "sandbox_leases_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9937,12 +9363,8 @@
           "name": "sandbox_leases_permission_decision_id_permission_decisions_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "permission_decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["permission_decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -10032,12 +9454,8 @@
           "name": "sandbox_profiles_app_id_apps_id_fk",
           "tableFrom": "sandbox_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10105,12 +9523,8 @@
           "name": "workspace_snapshots_app_id_apps_id_fk",
           "tableFrom": "workspace_snapshots",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10332,12 +9746,8 @@
           "name": "agent_session_digests_app_id_apps_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10345,12 +9755,8 @@
           "name": "agent_session_digests_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10476,12 +9882,8 @@
           "name": "agent_session_summaries_app_id_apps_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10489,12 +9891,8 @@
           "name": "agent_session_summaries_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10664,12 +10062,8 @@
           "name": "agent_sessions_app_id_apps_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10677,12 +10071,8 @@
           "name": "agent_sessions_agent_id_agents_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10690,12 +10080,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -10703,12 +10089,8 @@
           "name": "agent_sessions_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -10910,12 +10292,8 @@
           "name": "provider_sessions_app_id_apps_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10923,12 +10301,8 @@
           "name": "provider_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10936,12 +10310,8 @@
           "name": "provider_sessions_sandbox_id_sandbox_profiles_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -10949,12 +10319,8 @@
           "name": "provider_sessions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11055,12 +10421,8 @@
           "name": "agent_skill_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11068,12 +10430,8 @@
           "name": "agent_skill_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11081,12 +10439,8 @@
           "name": "agent_skill_bindings_skill_id_skill_catalog_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "skill_catalog",
-          "columnsFrom": [
-            "skill_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11302,12 +10656,8 @@
           "name": "skill_catalog_app_id_apps_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11315,12 +10665,8 @@
           "name": "skill_catalog_agent_id_agents_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -11421,12 +10767,8 @@
           "name": "agent_tool_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11434,12 +10776,8 @@
           "name": "agent_tool_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11447,12 +10785,8 @@
           "name": "agent_tool_bindings_tool_id_tool_catalog_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11622,12 +10956,8 @@
           "name": "agent_tool_sources_app_id_apps_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11635,12 +10965,8 @@
           "name": "agent_tool_sources_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11808,12 +11134,8 @@
           "name": "tool_catalog_app_id_apps_id_fk",
           "tableFrom": "tool_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11978,12 +11300,8 @@
           "name": "pending_interactions_app_id_apps_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11991,12 +11309,8 @@
           "name": "pending_interactions_run_id_agent_runs_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -12163,12 +11477,8 @@
           "name": "run_leases_run_id_agent_runs_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12176,12 +11486,8 @@
           "name": "run_leases_worker_instance_id_worker_instances_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "worker_instances",
-          "columnsFrom": [
-            "worker_instance_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["worker_instance_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12189,10 +11495,7 @@
       "compositePrimaryKeys": {
         "run_leases_pk": {
           "name": "run_leases_pk",
-          "columns": [
-            "run_id",
-            "fencing_version"
-          ]
+          "columns": ["run_id", "fencing_version"]
         }
       },
       "uniqueConstraints": {},
@@ -12350,10 +11653,7 @@
       "compositePrimaryKeys": {
         "run_slots_pk": {
           "name": "run_slots_pk",
-          "columns": [
-            "slot_key",
-            "holder_id"
-          ]
+          "columns": ["slot_key", "holder_id"]
         }
       },
       "uniqueConstraints": {},
@@ -12471,12 +11771,8 @@
           "name": "runner_control_events_run_id_agent_runs_id_fk",
           "tableFrom": "runner_control_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12609,12 +11905,8 @@
           "name": "transient_grants_app_id_apps_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12622,12 +11914,8 @@
           "name": "transient_grants_run_id_agent_runs_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12783,10 +12071,7 @@
       "compositePrimaryKeys": {
         "embedding_cache_pk": {
           "name": "embedding_cache_pk",
-          "columns": [
-            "text_hash",
-            "model"
-          ]
+          "columns": ["text_hash", "model"]
         }
       },
       "uniqueConstraints": {},
@@ -13991,12 +13276,7 @@
       "compositePrimaryKeys": {
         "memory_item_embeddings_pk": {
           "name": "memory_item_embeddings_pk",
-          "columns": [
-            "item_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["item_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -14432,11 +13712,7 @@
       "compositePrimaryKeys": {
         "permission_promotion_counters_pk": {
           "name": "permission_promotion_counters_pk",
-          "columns": [
-            "app_id",
-            "agent_folder",
-            "suggestion_key"
-          ]
+          "columns": ["app_id", "agent_folder", "suggestion_key"]
         }
       },
       "uniqueConstraints": {},

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0101_snapshot.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0101_snapshot.json
@@ -51,10 +51,7 @@
       "compositePrimaryKeys": {
         "embedding_cache_pk": {
           "name": "embedding_cache_pk",
-          "columns": [
-            "text_hash",
-            "model"
-          ]
+          "columns": ["text_hash", "model"]
         }
       },
       "uniqueConstraints": {},
@@ -1259,12 +1256,7 @@
       "compositePrimaryKeys": {
         "memory_item_embeddings_pk": {
           "name": "memory_item_embeddings_pk",
-          "columns": [
-            "item_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["item_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -1700,11 +1692,7 @@
       "compositePrimaryKeys": {
         "permission_promotion_counters_pk": {
           "name": "permission_promotion_counters_pk",
-          "columns": [
-            "app_id",
-            "agent_folder",
-            "suggestion_key"
-          ]
+          "columns": ["app_id", "agent_folder", "suggestion_key"]
         }
       },
       "uniqueConstraints": {},
@@ -1820,9 +1808,7 @@
         "apps_slug_unique": {
           "name": "apps_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -1930,12 +1916,8 @@
           "name": "user_aliases_app_id_apps_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1943,12 +1925,8 @@
           "name": "user_aliases_user_id_users_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2038,12 +2016,8 @@
           "name": "users_app_id_apps_id_fk",
           "tableFrom": "users",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2148,12 +2122,8 @@
           "name": "agent_config_versions_app_id_apps_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2161,12 +2131,8 @@
           "name": "agent_config_versions_agent_id_agents_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2174,12 +2140,8 @@
           "name": "agent_config_versions_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2187,12 +2149,8 @@
           "name": "agent_config_versions_sandbox_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2200,12 +2158,8 @@
           "name": "agent_config_versions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2215,10 +2169,7 @@
         "agent_config_versions_agent_id_version_unique": {
           "name": "agent_config_versions_agent_id_version_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_id",
-            "version"
-          ]
+          "columns": ["agent_id", "version"]
         }
       },
       "policies": {},
@@ -2281,12 +2232,8 @@
           "name": "agents_app_id_apps_id_fk",
           "tableFrom": "agents",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2373,12 +2320,8 @@
           "name": "llm_profiles_app_id_apps_id_fk",
           "tableFrom": "llm_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2654,12 +2597,8 @@
           "name": "agent_async_tasks_app_id_apps_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2667,12 +2606,8 @@
           "name": "agent_async_tasks_agent_id_agents_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2680,12 +2615,8 @@
           "name": "agent_async_tasks_parent_run_id_agent_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "parent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2693,12 +2624,8 @@
           "name": "agent_async_tasks_parent_job_id_jobs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "parent_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2706,12 +2633,8 @@
           "name": "agent_async_tasks_parent_job_run_id_job_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "job_runs",
-          "columnsFrom": [
-            "parent_job_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2824,12 +2747,8 @@
           "name": "brain_dream_decisions_app_id_apps_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2837,12 +2756,8 @@
           "name": "brain_dream_decisions_page_id_brain_pages_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2888,12 +2803,8 @@
           "name": "brain_dream_state_app_id_apps_id_fk",
           "tableFrom": "brain_dream_state",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3066,12 +2977,8 @@
           "name": "brain_edges_app_id_apps_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3079,12 +2986,8 @@
           "name": "brain_edges_from_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "from_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["from_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3092,12 +2995,8 @@
           "name": "brain_edges_to_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "to_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["to_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3105,12 +3004,8 @@
           "name": "brain_edges_evidence_page_id_brain_pages_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "evidence_page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["evidence_page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3229,12 +3124,8 @@
           "name": "brain_entities_app_id_apps_id_fk",
           "tableFrom": "brain_entities",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3403,12 +3294,8 @@
           "name": "brain_page_embeddings_page_id_brain_pages_id_fk",
           "tableFrom": "brain_page_embeddings",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3416,12 +3303,7 @@
       "compositePrimaryKeys": {
         "brain_page_embeddings_pk": {
           "name": "brain_page_embeddings_pk",
-          "columns": [
-            "page_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["page_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -3565,12 +3447,8 @@
           "name": "brain_pages_app_id_apps_id_fk",
           "tableFrom": "brain_pages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3689,12 +3567,8 @@
           "name": "browser_profiles_snapshot_run_id_agent_runs_id_fk",
           "tableFrom": "browser_profiles",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "snapshot_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["snapshot_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -3816,12 +3690,8 @@
           "name": "capability_secrets_app_id_apps_id_fk",
           "tableFrom": "capability_secrets",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3983,12 +3853,8 @@
           "name": "conversation_installs_app_id_apps_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3996,12 +3862,8 @@
           "name": "conversation_installs_agent_id_agents_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4009,12 +3871,8 @@
           "name": "conversation_installs_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4022,12 +3880,8 @@
           "name": "conversation_installs_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4035,12 +3889,8 @@
           "name": "conversation_installs_thread_id_conversation_threads_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4048,12 +3898,8 @@
           "name": "conversation_installs_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4217,12 +4063,8 @@
           "name": "provider_accounts_app_id_apps_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4230,12 +4072,8 @@
           "name": "provider_accounts_agent_id_agents_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4243,12 +4081,8 @@
           "name": "provider_accounts_provider_id_providers_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "providers",
-          "columnsFrom": [
-            "provider_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4390,12 +4224,8 @@
           "name": "conversation_approvers_app_id_apps_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4403,12 +4233,8 @@
           "name": "conversation_approvers_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4510,12 +4336,8 @@
           "name": "conversation_participants_app_id_apps_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4523,12 +4345,8 @@
           "name": "conversation_participants_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4536,12 +4354,8 @@
           "name": "conversation_participants_user_id_users_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4630,12 +4444,8 @@
           "name": "conversation_threads_app_id_apps_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4643,12 +4453,8 @@
           "name": "conversation_threads_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4743,12 +4549,8 @@
           "name": "conversations_app_id_apps_id_fk",
           "tableFrom": "conversations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4808,12 +4610,8 @@
           "name": "control_http_response_routes_session_id_control_http_sessions_session_id_fk",
           "tableFrom": "control_http_response_routes",
           "tableTo": "control_http_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["session_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4821,10 +4619,7 @@
       "compositePrimaryKeys": {
         "control_http_response_routes_session_id_thread_id_pk": {
           "name": "control_http_response_routes_session_id_thread_id_pk",
-          "columns": [
-            "session_id",
-            "thread_id"
-          ]
+          "columns": ["session_id", "thread_id"]
         }
       },
       "uniqueConstraints": {},
@@ -4923,12 +4718,8 @@
           "name": "control_http_sessions_session_id_agent_sessions_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4936,12 +4727,8 @@
           "name": "control_http_sessions_app_id_apps_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4949,12 +4736,8 @@
           "name": "control_http_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4962,12 +4745,8 @@
           "name": "control_http_sessions_agent_id_agents_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4977,10 +4756,7 @@
         "control_http_sessions_app_id_external_conversation_id_key": {
           "name": "control_http_sessions_app_id_external_conversation_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "external_conversation_id"
-          ]
+          "columns": ["app_id", "external_conversation_id"]
         }
       },
       "policies": {},
@@ -5089,12 +4865,8 @@
           "name": "control_http_webhook_deliveries_webhook_id_control_http_webhooks_webhook_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "control_http_webhooks",
-          "columnsFrom": [
-            "webhook_id"
-          ],
-          "columnsTo": [
-            "webhook_id"
-          ],
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["webhook_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5102,12 +4874,8 @@
           "name": "control_http_webhook_deliveries_event_id_runtime_events_event_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5117,10 +4885,7 @@
         "control_http_webhook_deliveries_webhook_id_event_id_key": {
           "name": "control_http_webhook_deliveries_webhook_id_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "webhook_id",
-            "event_id"
-          ]
+          "columns": ["webhook_id", "event_id"]
         }
       },
       "policies": {},
@@ -5236,12 +5001,8 @@
           "name": "control_http_webhooks_app_id_apps_id_fk",
           "tableFrom": "control_http_webhooks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5251,10 +5012,7 @@
         "control_http_webhooks_app_id_name_key": {
           "name": "control_http_webhooks_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -5460,12 +5218,8 @@
           "name": "event_bus_outbox_app_id_apps_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5473,12 +5227,8 @@
           "name": "event_bus_outbox_runtime_event_id_runtime_events_event_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "runtime_event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["runtime_event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5488,9 +5238,7 @@
         "event_bus_outbox_runtime_event_id_key": {
           "name": "event_bus_outbox_runtime_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "runtime_event_id"
-          ]
+          "columns": ["runtime_event_id"]
         }
       },
       "policies": {},
@@ -5866,12 +5614,8 @@
           "name": "runtime_events_app_id_apps_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5879,12 +5623,8 @@
           "name": "runtime_events_agent_id_agents_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5892,12 +5632,8 @@
           "name": "runtime_events_session_id_agent_sessions_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5905,12 +5641,8 @@
           "name": "runtime_events_run_id_agent_runs_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5918,12 +5650,8 @@
           "name": "runtime_events_conversation_id_conversations_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5931,12 +5659,8 @@
           "name": "runtime_events_thread_id_conversation_threads_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6127,12 +5851,8 @@
           "name": "external_ingress_invocations_app_id_apps_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6140,12 +5860,8 @@
           "name": "external_ingress_invocations_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6155,11 +5871,7 @@
         "external_ingress_invocations_app_id_ingress_id_idempotency_key_key": {
           "name": "external_ingress_invocations_app_id_ingress_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "ingress_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -6251,12 +5963,8 @@
           "name": "external_ingress_nonces_app_id_apps_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6264,12 +5972,8 @@
           "name": "external_ingress_nonces_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6277,11 +5981,7 @@
       "compositePrimaryKeys": {
         "external_ingress_nonces_pk": {
           "name": "external_ingress_nonces_pk",
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "nonce"
-          ]
+          "columns": ["app_id", "ingress_id", "nonce"]
         }
       },
       "uniqueConstraints": {},
@@ -6374,12 +6074,8 @@
           "name": "external_ingresses_app_id_apps_id_fk",
           "tableFrom": "external_ingresses",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6389,10 +6085,7 @@
         "external_ingresses_app_id_name_key": {
           "name": "external_ingresses_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -6581,12 +6274,8 @@
           "name": "file_artifacts_app_id_apps_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6594,12 +6283,8 @@
           "name": "file_artifacts_agent_id_agents_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6607,12 +6292,8 @@
           "name": "file_artifacts_promoted_from_artifact_id_file_artifacts_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "file_artifacts",
-          "columnsFrom": [
-            "promoted_from_artifact_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["promoted_from_artifact_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6775,12 +6456,8 @@
           "name": "runtime_dependencies_app_id_apps_id_fk",
           "tableFrom": "runtime_dependencies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6867,12 +6544,8 @@
           "name": "settings_revisions_app_id_apps_id_fk",
           "tableFrom": "settings_revisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6880,10 +6553,7 @@
       "compositePrimaryKeys": {
         "settings_revisions_pk": {
           "name": "settings_revisions_pk",
-          "columns": [
-            "app_id",
-            "revision"
-          ]
+          "columns": ["app_id", "revision"]
         }
       },
       "uniqueConstraints": {},
@@ -6957,12 +6627,8 @@
           "name": "job_triggers_app_id_apps_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6970,12 +6636,8 @@
           "name": "job_triggers_job_id_jobs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6983,12 +6645,8 @@
           "name": "job_triggers_run_id_agent_runs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7278,12 +6936,8 @@
           "name": "jobs_app_id_apps_id_fk",
           "tableFrom": "jobs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7291,12 +6945,8 @@
           "name": "jobs_agent_id_agents_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7304,12 +6954,8 @@
           "name": "jobs_conversation_id_conversations_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7317,12 +6963,8 @@
           "name": "jobs_thread_id_conversation_threads_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7330,12 +6972,8 @@
           "name": "jobs_lease_run_id_agent_runs_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "lease_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["lease_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7451,12 +7089,8 @@
           "name": "job_runs_app_id_apps_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7464,12 +7098,8 @@
           "name": "job_runs_job_id_jobs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7477,12 +7107,8 @@
           "name": "job_runs_agent_run_id_agent_runs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "agent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7976,12 +7602,8 @@
           "name": "live_turn_commands_live_turn_id_live_turns_id_fk",
           "tableFrom": "live_turn_commands",
           "tableTo": "live_turns",
-          "columnsFrom": [
-            "live_turn_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["live_turn_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8245,12 +7867,8 @@
           "name": "live_turns_run_id_agent_runs_id_fk",
           "tableFrom": "live_turns",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8484,12 +8102,8 @@
           "name": "memory_items_app_id_apps_id_fk",
           "tableFrom": "memory_items",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8581,12 +8195,8 @@
           "name": "message_attachments_message_id_messages_id_fk",
           "tableFrom": "message_attachments",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8649,12 +8259,8 @@
           "name": "message_parts_message_id_messages_id_fk",
           "tableFrom": "message_parts",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8664,10 +8270,7 @@
         "message_parts_message_id_ordinal_unique": {
           "name": "message_parts_message_id_ordinal_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "message_id",
-            "ordinal"
-          ]
+          "columns": ["message_id", "ordinal"]
         }
       },
       "policies": {},
@@ -8888,12 +8491,8 @@
           "name": "messages_app_id_apps_id_fk",
           "tableFrom": "messages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8901,12 +8500,8 @@
           "name": "messages_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "messages",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8914,12 +8509,8 @@
           "name": "messages_conversation_id_conversations_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8927,12 +8518,8 @@
           "name": "messages_thread_id_conversation_threads_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9078,12 +8665,8 @@
           "name": "model_credentials_app_id_apps_id_fk",
           "tableFrom": "model_credentials",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9238,12 +8821,8 @@
           "name": "agent_mcp_server_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9251,12 +8830,8 @@
           "name": "agent_mcp_server_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9264,12 +8839,8 @@
           "name": "agent_mcp_server_bindings_server_id_mcp_servers_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9402,12 +8973,8 @@
           "name": "mcp_server_audit_events_app_id_apps_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9415,12 +8982,8 @@
           "name": "mcp_server_audit_events_agent_id_agents_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9428,12 +8991,8 @@
           "name": "mcp_server_audit_events_server_id_mcp_servers_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9441,12 +9000,8 @@
           "name": "mcp_server_audit_events_binding_id_agent_mcp_server_bindings_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agent_mcp_server_bindings",
-          "columnsFrom": [
-            "binding_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9654,12 +9209,8 @@
           "name": "mcp_servers_app_id_apps_id_fk",
           "tableFrom": "mcp_servers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9855,12 +9406,8 @@
           "name": "outbound_deliveries_app_id_apps_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9868,12 +9415,8 @@
           "name": "outbound_deliveries_conversation_id_conversations_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9881,12 +9424,8 @@
           "name": "outbound_deliveries_thread_id_conversation_threads_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9894,12 +9433,8 @@
           "name": "outbound_deliveries_agent_id_agents_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9907,12 +9442,8 @@
           "name": "outbound_deliveries_run_id_agent_runs_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9922,10 +9453,7 @@
         "outbound_deliveries_app_id_idempotency_key_key": {
           "name": "outbound_deliveries_app_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -9975,12 +9503,8 @@
           "name": "outbound_delivery_final_answers_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_final_answers",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10190,12 +9714,8 @@
           "name": "outbound_delivery_items_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_items",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10205,10 +9725,7 @@
         "outbound_delivery_items_delivery_id_ordinal_key": {
           "name": "outbound_delivery_items_delivery_id_ordinal_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "delivery_id",
-            "ordinal"
-          ]
+          "columns": ["delivery_id", "ordinal"]
         }
       },
       "policies": {},
@@ -10297,12 +9814,8 @@
           "name": "outbound_delivery_receipts_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10310,12 +9823,8 @@
           "name": "outbound_delivery_receipts_item_id_outbound_delivery_items_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_delivery_items",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10325,10 +9834,7 @@
         "outbound_delivery_receipts_item_id_idempotency_key_key": {
           "name": "outbound_delivery_receipts_item_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_id",
-            "idempotency_key"
-          ]
+          "columns": ["item_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -10541,12 +10047,8 @@
           "name": "pattern_candidates_app_id_apps_id_fk",
           "tableFrom": "pattern_candidates",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10681,12 +10183,8 @@
           "name": "proactive_surfacing_opt_ins_app_id_apps_id_fk",
           "tableFrom": "proactive_surfacing_opt_ins",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10792,12 +10290,8 @@
           "name": "pending_access_requests_app_id_apps_id_fk",
           "tableFrom": "pending_access_requests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10861,12 +10355,8 @@
           "name": "permission_audit_events_app_id_apps_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10874,12 +10364,8 @@
           "name": "permission_audit_events_decision_id_permission_decisions_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -10981,12 +10467,8 @@
           "name": "permission_decisions_app_id_apps_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10994,12 +10476,8 @@
           "name": "permission_decisions_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11007,12 +10485,8 @@
           "name": "permission_decisions_run_id_agent_runs_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11020,12 +10494,8 @@
           "name": "permission_decisions_tool_id_tool_catalog_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11092,12 +10562,8 @@
           "name": "permission_policies_app_id_apps_id_fk",
           "tableFrom": "permission_policies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11169,12 +10635,8 @@
           "name": "permission_rules_app_id_apps_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11182,12 +10644,8 @@
           "name": "permission_rules_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11491,12 +10949,8 @@
           "name": "agent_runs_app_id_apps_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11504,12 +10958,8 @@
           "name": "agent_runs_agent_id_agents_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11517,12 +10967,8 @@
           "name": "agent_runs_config_version_id_agent_config_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_config_versions",
-          "columnsFrom": [
-            "config_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["config_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11530,12 +10976,8 @@
           "name": "agent_runs_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -11543,12 +10985,8 @@
           "name": "agent_runs_conversation_id_conversations_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11556,12 +10994,8 @@
           "name": "agent_runs_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11569,12 +11003,8 @@
           "name": "agent_runs_message_id_messages_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11582,12 +11012,8 @@
           "name": "agent_runs_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11663,12 +11089,8 @@
           "name": "sandbox_leases_app_id_apps_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11676,12 +11098,8 @@
           "name": "sandbox_leases_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11689,12 +11107,8 @@
           "name": "sandbox_leases_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11702,12 +11116,8 @@
           "name": "sandbox_leases_permission_decision_id_permission_decisions_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "permission_decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["permission_decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11797,12 +11207,8 @@
           "name": "sandbox_profiles_app_id_apps_id_fk",
           "tableFrom": "sandbox_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11870,12 +11276,8 @@
           "name": "workspace_snapshots_app_id_apps_id_fk",
           "tableFrom": "workspace_snapshots",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12097,12 +11499,8 @@
           "name": "agent_session_digests_app_id_apps_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12110,12 +11508,8 @@
           "name": "agent_session_digests_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12241,12 +11635,8 @@
           "name": "agent_session_summaries_app_id_apps_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12254,12 +11644,8 @@
           "name": "agent_session_summaries_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12429,12 +11815,8 @@
           "name": "agent_sessions_app_id_apps_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12442,12 +11824,8 @@
           "name": "agent_sessions_agent_id_agents_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12455,12 +11833,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12468,12 +11842,8 @@
           "name": "agent_sessions_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12675,12 +12045,8 @@
           "name": "provider_sessions_app_id_apps_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12688,12 +12054,8 @@
           "name": "provider_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12701,12 +12063,8 @@
           "name": "provider_sessions_sandbox_id_sandbox_profiles_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12714,12 +12072,8 @@
           "name": "provider_sessions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12820,12 +12174,8 @@
           "name": "agent_skill_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12833,12 +12183,8 @@
           "name": "agent_skill_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12846,12 +12192,8 @@
           "name": "agent_skill_bindings_skill_id_skill_catalog_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "skill_catalog",
-          "columnsFrom": [
-            "skill_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13067,12 +12409,8 @@
           "name": "skill_catalog_app_id_apps_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13080,12 +12418,8 @@
           "name": "skill_catalog_agent_id_agents_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -13186,12 +12520,8 @@
           "name": "agent_tool_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13199,12 +12529,8 @@
           "name": "agent_tool_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13212,12 +12538,8 @@
           "name": "agent_tool_bindings_tool_id_tool_catalog_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13387,12 +12709,8 @@
           "name": "agent_tool_sources_app_id_apps_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13400,12 +12718,8 @@
           "name": "agent_tool_sources_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13573,12 +12887,8 @@
           "name": "tool_catalog_app_id_apps_id_fk",
           "tableFrom": "tool_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13743,12 +13053,8 @@
           "name": "pending_interactions_app_id_apps_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13756,12 +13062,8 @@
           "name": "pending_interactions_run_id_agent_runs_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -13928,12 +13230,8 @@
           "name": "run_leases_run_id_agent_runs_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13941,12 +13239,8 @@
           "name": "run_leases_worker_instance_id_worker_instances_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "worker_instances",
-          "columnsFrom": [
-            "worker_instance_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["worker_instance_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -13954,10 +13248,7 @@
       "compositePrimaryKeys": {
         "run_leases_pk": {
           "name": "run_leases_pk",
-          "columns": [
-            "run_id",
-            "fencing_version"
-          ]
+          "columns": ["run_id", "fencing_version"]
         }
       },
       "uniqueConstraints": {},
@@ -14027,10 +13318,7 @@
       "compositePrimaryKeys": {
         "run_slots_pk": {
           "name": "run_slots_pk",
-          "columns": [
-            "slot_key",
-            "holder_id"
-          ]
+          "columns": ["slot_key", "holder_id"]
         }
       },
       "uniqueConstraints": {},
@@ -14148,12 +13436,8 @@
           "name": "runner_control_events_run_id_agent_runs_id_fk",
           "tableFrom": "runner_control_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -14286,12 +13570,8 @@
           "name": "transient_grants_app_id_apps_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14299,12 +13579,8 @@
           "name": "transient_grants_run_id_agent_runs_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0102_snapshot.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0102_snapshot.json
@@ -51,10 +51,7 @@
       "compositePrimaryKeys": {
         "embedding_cache_pk": {
           "name": "embedding_cache_pk",
-          "columns": [
-            "text_hash",
-            "model"
-          ]
+          "columns": ["text_hash", "model"]
         }
       },
       "uniqueConstraints": {},
@@ -1259,12 +1256,7 @@
       "compositePrimaryKeys": {
         "memory_item_embeddings_pk": {
           "name": "memory_item_embeddings_pk",
-          "columns": [
-            "item_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["item_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -1700,11 +1692,7 @@
       "compositePrimaryKeys": {
         "permission_promotion_counters_pk": {
           "name": "permission_promotion_counters_pk",
-          "columns": [
-            "app_id",
-            "agent_folder",
-            "suggestion_key"
-          ]
+          "columns": ["app_id", "agent_folder", "suggestion_key"]
         }
       },
       "uniqueConstraints": {},
@@ -1820,9 +1808,7 @@
         "apps_slug_unique": {
           "name": "apps_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -1930,12 +1916,8 @@
           "name": "user_aliases_app_id_apps_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1943,12 +1925,8 @@
           "name": "user_aliases_user_id_users_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2038,12 +2016,8 @@
           "name": "users_app_id_apps_id_fk",
           "tableFrom": "users",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2148,12 +2122,8 @@
           "name": "agent_config_versions_app_id_apps_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2161,12 +2131,8 @@
           "name": "agent_config_versions_agent_id_agents_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2174,12 +2140,8 @@
           "name": "agent_config_versions_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2187,12 +2149,8 @@
           "name": "agent_config_versions_sandbox_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2200,12 +2158,8 @@
           "name": "agent_config_versions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2215,10 +2169,7 @@
         "agent_config_versions_agent_id_version_unique": {
           "name": "agent_config_versions_agent_id_version_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_id",
-            "version"
-          ]
+          "columns": ["agent_id", "version"]
         }
       },
       "policies": {},
@@ -2281,12 +2232,8 @@
           "name": "agents_app_id_apps_id_fk",
           "tableFrom": "agents",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2373,12 +2320,8 @@
           "name": "llm_profiles_app_id_apps_id_fk",
           "tableFrom": "llm_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2654,12 +2597,8 @@
           "name": "agent_async_tasks_app_id_apps_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2667,12 +2606,8 @@
           "name": "agent_async_tasks_agent_id_agents_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2680,12 +2615,8 @@
           "name": "agent_async_tasks_parent_run_id_agent_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "parent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2693,12 +2624,8 @@
           "name": "agent_async_tasks_parent_job_id_jobs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "parent_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2706,12 +2633,8 @@
           "name": "agent_async_tasks_parent_job_run_id_job_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "job_runs",
-          "columnsFrom": [
-            "parent_job_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2824,12 +2747,8 @@
           "name": "brain_dream_decisions_app_id_apps_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2837,12 +2756,8 @@
           "name": "brain_dream_decisions_page_id_brain_pages_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2888,12 +2803,8 @@
           "name": "brain_dream_state_app_id_apps_id_fk",
           "tableFrom": "brain_dream_state",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3066,12 +2977,8 @@
           "name": "brain_edges_app_id_apps_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3079,12 +2986,8 @@
           "name": "brain_edges_from_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "from_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["from_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3092,12 +2995,8 @@
           "name": "brain_edges_to_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "to_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["to_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3105,12 +3004,8 @@
           "name": "brain_edges_evidence_page_id_brain_pages_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "evidence_page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["evidence_page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3229,12 +3124,8 @@
           "name": "brain_entities_app_id_apps_id_fk",
           "tableFrom": "brain_entities",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3403,12 +3294,8 @@
           "name": "brain_page_embeddings_page_id_brain_pages_id_fk",
           "tableFrom": "brain_page_embeddings",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3416,12 +3303,7 @@
       "compositePrimaryKeys": {
         "brain_page_embeddings_pk": {
           "name": "brain_page_embeddings_pk",
-          "columns": [
-            "page_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["page_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -3565,12 +3447,8 @@
           "name": "brain_pages_app_id_apps_id_fk",
           "tableFrom": "brain_pages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3689,12 +3567,8 @@
           "name": "browser_profiles_snapshot_run_id_agent_runs_id_fk",
           "tableFrom": "browser_profiles",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "snapshot_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["snapshot_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -3816,12 +3690,8 @@
           "name": "capability_secrets_app_id_apps_id_fk",
           "tableFrom": "capability_secrets",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3983,12 +3853,8 @@
           "name": "conversation_installs_app_id_apps_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3996,12 +3862,8 @@
           "name": "conversation_installs_agent_id_agents_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4009,12 +3871,8 @@
           "name": "conversation_installs_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4022,12 +3880,8 @@
           "name": "conversation_installs_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4035,12 +3889,8 @@
           "name": "conversation_installs_thread_id_conversation_threads_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4048,12 +3898,8 @@
           "name": "conversation_installs_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4217,12 +4063,8 @@
           "name": "provider_accounts_app_id_apps_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4230,12 +4072,8 @@
           "name": "provider_accounts_agent_id_agents_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4243,12 +4081,8 @@
           "name": "provider_accounts_provider_id_providers_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "providers",
-          "columnsFrom": [
-            "provider_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4390,12 +4224,8 @@
           "name": "conversation_approvers_app_id_apps_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4403,12 +4233,8 @@
           "name": "conversation_approvers_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4510,12 +4336,8 @@
           "name": "conversation_participants_app_id_apps_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4523,12 +4345,8 @@
           "name": "conversation_participants_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4536,12 +4354,8 @@
           "name": "conversation_participants_user_id_users_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4630,12 +4444,8 @@
           "name": "conversation_threads_app_id_apps_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4643,12 +4453,8 @@
           "name": "conversation_threads_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4743,12 +4549,8 @@
           "name": "conversations_app_id_apps_id_fk",
           "tableFrom": "conversations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4808,12 +4610,8 @@
           "name": "control_http_response_routes_session_id_control_http_sessions_session_id_fk",
           "tableFrom": "control_http_response_routes",
           "tableTo": "control_http_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["session_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4821,10 +4619,7 @@
       "compositePrimaryKeys": {
         "control_http_response_routes_session_id_thread_id_pk": {
           "name": "control_http_response_routes_session_id_thread_id_pk",
-          "columns": [
-            "session_id",
-            "thread_id"
-          ]
+          "columns": ["session_id", "thread_id"]
         }
       },
       "uniqueConstraints": {},
@@ -4923,12 +4718,8 @@
           "name": "control_http_sessions_session_id_agent_sessions_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4936,12 +4727,8 @@
           "name": "control_http_sessions_app_id_apps_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4949,12 +4736,8 @@
           "name": "control_http_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4962,12 +4745,8 @@
           "name": "control_http_sessions_agent_id_agents_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4977,10 +4756,7 @@
         "control_http_sessions_app_id_external_conversation_id_key": {
           "name": "control_http_sessions_app_id_external_conversation_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "external_conversation_id"
-          ]
+          "columns": ["app_id", "external_conversation_id"]
         }
       },
       "policies": {},
@@ -5089,12 +4865,8 @@
           "name": "control_http_webhook_deliveries_webhook_id_control_http_webhooks_webhook_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "control_http_webhooks",
-          "columnsFrom": [
-            "webhook_id"
-          ],
-          "columnsTo": [
-            "webhook_id"
-          ],
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["webhook_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5102,12 +4874,8 @@
           "name": "control_http_webhook_deliveries_event_id_runtime_events_event_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5117,10 +4885,7 @@
         "control_http_webhook_deliveries_webhook_id_event_id_key": {
           "name": "control_http_webhook_deliveries_webhook_id_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "webhook_id",
-            "event_id"
-          ]
+          "columns": ["webhook_id", "event_id"]
         }
       },
       "policies": {},
@@ -5236,12 +5001,8 @@
           "name": "control_http_webhooks_app_id_apps_id_fk",
           "tableFrom": "control_http_webhooks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5251,10 +5012,7 @@
         "control_http_webhooks_app_id_name_key": {
           "name": "control_http_webhooks_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -5460,12 +5218,8 @@
           "name": "event_bus_outbox_app_id_apps_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5473,12 +5227,8 @@
           "name": "event_bus_outbox_runtime_event_id_runtime_events_event_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "runtime_event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["runtime_event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5488,9 +5238,7 @@
         "event_bus_outbox_runtime_event_id_key": {
           "name": "event_bus_outbox_runtime_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "runtime_event_id"
-          ]
+          "columns": ["runtime_event_id"]
         }
       },
       "policies": {},
@@ -5866,12 +5614,8 @@
           "name": "runtime_events_app_id_apps_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5879,12 +5623,8 @@
           "name": "runtime_events_agent_id_agents_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5892,12 +5632,8 @@
           "name": "runtime_events_session_id_agent_sessions_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5905,12 +5641,8 @@
           "name": "runtime_events_run_id_agent_runs_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5918,12 +5650,8 @@
           "name": "runtime_events_conversation_id_conversations_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5931,12 +5659,8 @@
           "name": "runtime_events_thread_id_conversation_threads_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6127,12 +5851,8 @@
           "name": "external_ingress_invocations_app_id_apps_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6140,12 +5860,8 @@
           "name": "external_ingress_invocations_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6155,11 +5871,7 @@
         "external_ingress_invocations_app_id_ingress_id_idempotency_key_key": {
           "name": "external_ingress_invocations_app_id_ingress_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "ingress_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -6251,12 +5963,8 @@
           "name": "external_ingress_nonces_app_id_apps_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6264,12 +5972,8 @@
           "name": "external_ingress_nonces_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6277,11 +5981,7 @@
       "compositePrimaryKeys": {
         "external_ingress_nonces_pk": {
           "name": "external_ingress_nonces_pk",
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "nonce"
-          ]
+          "columns": ["app_id", "ingress_id", "nonce"]
         }
       },
       "uniqueConstraints": {},
@@ -6374,12 +6074,8 @@
           "name": "external_ingresses_app_id_apps_id_fk",
           "tableFrom": "external_ingresses",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6389,10 +6085,7 @@
         "external_ingresses_app_id_name_key": {
           "name": "external_ingresses_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -6581,12 +6274,8 @@
           "name": "file_artifacts_app_id_apps_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6594,12 +6283,8 @@
           "name": "file_artifacts_agent_id_agents_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6607,12 +6292,8 @@
           "name": "file_artifacts_promoted_from_artifact_id_file_artifacts_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "file_artifacts",
-          "columnsFrom": [
-            "promoted_from_artifact_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["promoted_from_artifact_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6775,12 +6456,8 @@
           "name": "runtime_dependencies_app_id_apps_id_fk",
           "tableFrom": "runtime_dependencies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6867,12 +6544,8 @@
           "name": "settings_revisions_app_id_apps_id_fk",
           "tableFrom": "settings_revisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6880,10 +6553,7 @@
       "compositePrimaryKeys": {
         "settings_revisions_pk": {
           "name": "settings_revisions_pk",
-          "columns": [
-            "app_id",
-            "revision"
-          ]
+          "columns": ["app_id", "revision"]
         }
       },
       "uniqueConstraints": {},
@@ -7026,12 +6696,8 @@
           "name": "group_join_onboarding_provider_account_provider_accounts_id_fk",
           "tableFrom": "group_join_onboarding",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7113,12 +6779,8 @@
           "name": "job_triggers_app_id_apps_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7126,12 +6788,8 @@
           "name": "job_triggers_job_id_jobs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7139,12 +6797,8 @@
           "name": "job_triggers_run_id_agent_runs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7434,12 +7088,8 @@
           "name": "jobs_app_id_apps_id_fk",
           "tableFrom": "jobs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7447,12 +7097,8 @@
           "name": "jobs_agent_id_agents_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7460,12 +7106,8 @@
           "name": "jobs_conversation_id_conversations_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7473,12 +7115,8 @@
           "name": "jobs_thread_id_conversation_threads_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7486,12 +7124,8 @@
           "name": "jobs_lease_run_id_agent_runs_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "lease_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["lease_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7607,12 +7241,8 @@
           "name": "job_runs_app_id_apps_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7620,12 +7250,8 @@
           "name": "job_runs_job_id_jobs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7633,12 +7259,8 @@
           "name": "job_runs_agent_run_id_agent_runs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "agent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -8132,12 +7754,8 @@
           "name": "live_turn_commands_live_turn_id_live_turns_id_fk",
           "tableFrom": "live_turn_commands",
           "tableTo": "live_turns",
-          "columnsFrom": [
-            "live_turn_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["live_turn_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8401,12 +8019,8 @@
           "name": "live_turns_run_id_agent_runs_id_fk",
           "tableFrom": "live_turns",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8640,12 +8254,8 @@
           "name": "memory_items_app_id_apps_id_fk",
           "tableFrom": "memory_items",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8737,12 +8347,8 @@
           "name": "message_attachments_message_id_messages_id_fk",
           "tableFrom": "message_attachments",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8805,12 +8411,8 @@
           "name": "message_parts_message_id_messages_id_fk",
           "tableFrom": "message_parts",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8820,10 +8422,7 @@
         "message_parts_message_id_ordinal_unique": {
           "name": "message_parts_message_id_ordinal_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "message_id",
-            "ordinal"
-          ]
+          "columns": ["message_id", "ordinal"]
         }
       },
       "policies": {},
@@ -9044,12 +8643,8 @@
           "name": "messages_app_id_apps_id_fk",
           "tableFrom": "messages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9057,12 +8652,8 @@
           "name": "messages_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "messages",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9070,12 +8661,8 @@
           "name": "messages_conversation_id_conversations_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9083,12 +8670,8 @@
           "name": "messages_thread_id_conversation_threads_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9234,12 +8817,8 @@
           "name": "model_credentials_app_id_apps_id_fk",
           "tableFrom": "model_credentials",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9394,12 +8973,8 @@
           "name": "agent_mcp_server_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9407,12 +8982,8 @@
           "name": "agent_mcp_server_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9420,12 +8991,8 @@
           "name": "agent_mcp_server_bindings_server_id_mcp_servers_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9558,12 +9125,8 @@
           "name": "mcp_server_audit_events_app_id_apps_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9571,12 +9134,8 @@
           "name": "mcp_server_audit_events_agent_id_agents_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9584,12 +9143,8 @@
           "name": "mcp_server_audit_events_server_id_mcp_servers_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9597,12 +9152,8 @@
           "name": "mcp_server_audit_events_binding_id_agent_mcp_server_bindings_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agent_mcp_server_bindings",
-          "columnsFrom": [
-            "binding_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9810,12 +9361,8 @@
           "name": "mcp_servers_app_id_apps_id_fk",
           "tableFrom": "mcp_servers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10011,12 +9558,8 @@
           "name": "outbound_deliveries_app_id_apps_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10024,12 +9567,8 @@
           "name": "outbound_deliveries_conversation_id_conversations_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10037,12 +9576,8 @@
           "name": "outbound_deliveries_thread_id_conversation_threads_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10050,12 +9585,8 @@
           "name": "outbound_deliveries_agent_id_agents_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -10063,12 +9594,8 @@
           "name": "outbound_deliveries_run_id_agent_runs_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -10078,10 +9605,7 @@
         "outbound_deliveries_app_id_idempotency_key_key": {
           "name": "outbound_deliveries_app_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -10131,12 +9655,8 @@
           "name": "outbound_delivery_final_answers_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_final_answers",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10346,12 +9866,8 @@
           "name": "outbound_delivery_items_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_items",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10361,10 +9877,7 @@
         "outbound_delivery_items_delivery_id_ordinal_key": {
           "name": "outbound_delivery_items_delivery_id_ordinal_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "delivery_id",
-            "ordinal"
-          ]
+          "columns": ["delivery_id", "ordinal"]
         }
       },
       "policies": {},
@@ -10453,12 +9966,8 @@
           "name": "outbound_delivery_receipts_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10466,12 +9975,8 @@
           "name": "outbound_delivery_receipts_item_id_outbound_delivery_items_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_delivery_items",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10481,10 +9986,7 @@
         "outbound_delivery_receipts_item_id_idempotency_key_key": {
           "name": "outbound_delivery_receipts_item_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_id",
-            "idempotency_key"
-          ]
+          "columns": ["item_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -10697,12 +10199,8 @@
           "name": "pattern_candidates_app_id_apps_id_fk",
           "tableFrom": "pattern_candidates",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10837,12 +10335,8 @@
           "name": "proactive_surfacing_opt_ins_app_id_apps_id_fk",
           "tableFrom": "proactive_surfacing_opt_ins",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10948,12 +10442,8 @@
           "name": "pending_access_requests_app_id_apps_id_fk",
           "tableFrom": "pending_access_requests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11017,12 +10507,8 @@
           "name": "permission_audit_events_app_id_apps_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11030,12 +10516,8 @@
           "name": "permission_audit_events_decision_id_permission_decisions_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -11137,12 +10619,8 @@
           "name": "permission_decisions_app_id_apps_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11150,12 +10628,8 @@
           "name": "permission_decisions_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11163,12 +10637,8 @@
           "name": "permission_decisions_run_id_agent_runs_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11176,12 +10646,8 @@
           "name": "permission_decisions_tool_id_tool_catalog_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11248,12 +10714,8 @@
           "name": "permission_policies_app_id_apps_id_fk",
           "tableFrom": "permission_policies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11325,12 +10787,8 @@
           "name": "permission_rules_app_id_apps_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11338,12 +10796,8 @@
           "name": "permission_rules_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11647,12 +11101,8 @@
           "name": "agent_runs_app_id_apps_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11660,12 +11110,8 @@
           "name": "agent_runs_agent_id_agents_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11673,12 +11119,8 @@
           "name": "agent_runs_config_version_id_agent_config_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_config_versions",
-          "columnsFrom": [
-            "config_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["config_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11686,12 +11128,8 @@
           "name": "agent_runs_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -11699,12 +11137,8 @@
           "name": "agent_runs_conversation_id_conversations_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11712,12 +11146,8 @@
           "name": "agent_runs_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11725,12 +11155,8 @@
           "name": "agent_runs_message_id_messages_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11738,12 +11164,8 @@
           "name": "agent_runs_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11819,12 +11241,8 @@
           "name": "sandbox_leases_app_id_apps_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11832,12 +11250,8 @@
           "name": "sandbox_leases_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11845,12 +11259,8 @@
           "name": "sandbox_leases_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11858,12 +11268,8 @@
           "name": "sandbox_leases_permission_decision_id_permission_decisions_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "permission_decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["permission_decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11953,12 +11359,8 @@
           "name": "sandbox_profiles_app_id_apps_id_fk",
           "tableFrom": "sandbox_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12026,12 +11428,8 @@
           "name": "workspace_snapshots_app_id_apps_id_fk",
           "tableFrom": "workspace_snapshots",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12253,12 +11651,8 @@
           "name": "agent_session_digests_app_id_apps_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12266,12 +11660,8 @@
           "name": "agent_session_digests_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12397,12 +11787,8 @@
           "name": "agent_session_summaries_app_id_apps_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12410,12 +11796,8 @@
           "name": "agent_session_summaries_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12585,12 +11967,8 @@
           "name": "agent_sessions_app_id_apps_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12598,12 +11976,8 @@
           "name": "agent_sessions_agent_id_agents_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12611,12 +11985,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12624,12 +11994,8 @@
           "name": "agent_sessions_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12831,12 +12197,8 @@
           "name": "provider_sessions_app_id_apps_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12844,12 +12206,8 @@
           "name": "provider_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12857,12 +12215,8 @@
           "name": "provider_sessions_sandbox_id_sandbox_profiles_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12870,12 +12224,8 @@
           "name": "provider_sessions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12976,12 +12326,8 @@
           "name": "agent_skill_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12989,12 +12335,8 @@
           "name": "agent_skill_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13002,12 +12344,8 @@
           "name": "agent_skill_bindings_skill_id_skill_catalog_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "skill_catalog",
-          "columnsFrom": [
-            "skill_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13223,12 +12561,8 @@
           "name": "skill_catalog_app_id_apps_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13236,12 +12570,8 @@
           "name": "skill_catalog_agent_id_agents_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -13342,12 +12672,8 @@
           "name": "agent_tool_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13355,12 +12681,8 @@
           "name": "agent_tool_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13368,12 +12690,8 @@
           "name": "agent_tool_bindings_tool_id_tool_catalog_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13543,12 +12861,8 @@
           "name": "agent_tool_sources_app_id_apps_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13556,12 +12870,8 @@
           "name": "agent_tool_sources_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13729,12 +13039,8 @@
           "name": "tool_catalog_app_id_apps_id_fk",
           "tableFrom": "tool_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13899,12 +13205,8 @@
           "name": "pending_interactions_app_id_apps_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13912,12 +13214,8 @@
           "name": "pending_interactions_run_id_agent_runs_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -14084,12 +13382,8 @@
           "name": "run_leases_run_id_agent_runs_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14097,12 +13391,8 @@
           "name": "run_leases_worker_instance_id_worker_instances_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "worker_instances",
-          "columnsFrom": [
-            "worker_instance_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["worker_instance_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -14110,10 +13400,7 @@
       "compositePrimaryKeys": {
         "run_leases_pk": {
           "name": "run_leases_pk",
-          "columns": [
-            "run_id",
-            "fencing_version"
-          ]
+          "columns": ["run_id", "fencing_version"]
         }
       },
       "uniqueConstraints": {},
@@ -14183,10 +13470,7 @@
       "compositePrimaryKeys": {
         "run_slots_pk": {
           "name": "run_slots_pk",
-          "columns": [
-            "slot_key",
-            "holder_id"
-          ]
+          "columns": ["slot_key", "holder_id"]
         }
       },
       "uniqueConstraints": {},
@@ -14304,12 +13588,8 @@
           "name": "runner_control_events_run_id_agent_runs_id_fk",
           "tableFrom": "runner_control_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -14442,12 +13722,8 @@
           "name": "transient_grants_app_id_apps_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14455,12 +13731,8 @@
           "name": "transient_grants_run_id_agent_runs_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0105_snapshot.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0105_snapshot.json
@@ -51,10 +51,7 @@
       "compositePrimaryKeys": {
         "embedding_cache_pk": {
           "name": "embedding_cache_pk",
-          "columns": [
-            "text_hash",
-            "model"
-          ]
+          "columns": ["text_hash", "model"]
         }
       },
       "uniqueConstraints": {},
@@ -1259,12 +1256,7 @@
       "compositePrimaryKeys": {
         "memory_item_embeddings_pk": {
           "name": "memory_item_embeddings_pk",
-          "columns": [
-            "item_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["item_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -1700,11 +1692,7 @@
       "compositePrimaryKeys": {
         "permission_promotion_counters_pk": {
           "name": "permission_promotion_counters_pk",
-          "columns": [
-            "app_id",
-            "agent_folder",
-            "suggestion_key"
-          ]
+          "columns": ["app_id", "agent_folder", "suggestion_key"]
         }
       },
       "uniqueConstraints": {},
@@ -1820,9 +1808,7 @@
         "apps_slug_unique": {
           "name": "apps_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -1930,12 +1916,8 @@
           "name": "user_aliases_app_id_apps_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1943,12 +1925,8 @@
           "name": "user_aliases_user_id_users_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2038,12 +2016,8 @@
           "name": "users_app_id_apps_id_fk",
           "tableFrom": "users",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2148,12 +2122,8 @@
           "name": "agent_config_versions_app_id_apps_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2161,12 +2131,8 @@
           "name": "agent_config_versions_agent_id_agents_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2174,12 +2140,8 @@
           "name": "agent_config_versions_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2187,12 +2149,8 @@
           "name": "agent_config_versions_sandbox_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2200,12 +2158,8 @@
           "name": "agent_config_versions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2215,10 +2169,7 @@
         "agent_config_versions_agent_id_version_unique": {
           "name": "agent_config_versions_agent_id_version_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_id",
-            "version"
-          ]
+          "columns": ["agent_id", "version"]
         }
       },
       "policies": {},
@@ -2281,12 +2232,8 @@
           "name": "agents_app_id_apps_id_fk",
           "tableFrom": "agents",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2373,12 +2320,8 @@
           "name": "llm_profiles_app_id_apps_id_fk",
           "tableFrom": "llm_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2654,12 +2597,8 @@
           "name": "agent_async_tasks_app_id_apps_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2667,12 +2606,8 @@
           "name": "agent_async_tasks_agent_id_agents_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2680,12 +2615,8 @@
           "name": "agent_async_tasks_parent_run_id_agent_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "parent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2693,12 +2624,8 @@
           "name": "agent_async_tasks_parent_job_id_jobs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "parent_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2706,12 +2633,8 @@
           "name": "agent_async_tasks_parent_job_run_id_job_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "job_runs",
-          "columnsFrom": [
-            "parent_job_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2824,12 +2747,8 @@
           "name": "brain_dream_decisions_app_id_apps_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2837,12 +2756,8 @@
           "name": "brain_dream_decisions_page_id_brain_pages_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2888,12 +2803,8 @@
           "name": "brain_dream_state_app_id_apps_id_fk",
           "tableFrom": "brain_dream_state",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3066,12 +2977,8 @@
           "name": "brain_edges_app_id_apps_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3079,12 +2986,8 @@
           "name": "brain_edges_from_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "from_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["from_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3092,12 +2995,8 @@
           "name": "brain_edges_to_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "to_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["to_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3105,12 +3004,8 @@
           "name": "brain_edges_evidence_page_id_brain_pages_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "evidence_page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["evidence_page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3229,12 +3124,8 @@
           "name": "brain_entities_app_id_apps_id_fk",
           "tableFrom": "brain_entities",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3403,12 +3294,8 @@
           "name": "brain_page_embeddings_page_id_brain_pages_id_fk",
           "tableFrom": "brain_page_embeddings",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3416,12 +3303,7 @@
       "compositePrimaryKeys": {
         "brain_page_embeddings_pk": {
           "name": "brain_page_embeddings_pk",
-          "columns": [
-            "page_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["page_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -3565,12 +3447,8 @@
           "name": "brain_pages_app_id_apps_id_fk",
           "tableFrom": "brain_pages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3689,12 +3567,8 @@
           "name": "browser_profiles_snapshot_run_id_agent_runs_id_fk",
           "tableFrom": "browser_profiles",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "snapshot_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["snapshot_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -3816,12 +3690,8 @@
           "name": "capability_secrets_app_id_apps_id_fk",
           "tableFrom": "capability_secrets",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3983,12 +3853,8 @@
           "name": "conversation_installs_app_id_apps_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3996,12 +3862,8 @@
           "name": "conversation_installs_agent_id_agents_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4009,12 +3871,8 @@
           "name": "conversation_installs_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4022,12 +3880,8 @@
           "name": "conversation_installs_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4035,12 +3889,8 @@
           "name": "conversation_installs_thread_id_conversation_threads_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4048,12 +3898,8 @@
           "name": "conversation_installs_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4217,12 +4063,8 @@
           "name": "provider_accounts_app_id_apps_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4230,12 +4072,8 @@
           "name": "provider_accounts_agent_id_agents_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4243,12 +4081,8 @@
           "name": "provider_accounts_provider_id_providers_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "providers",
-          "columnsFrom": [
-            "provider_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4390,12 +4224,8 @@
           "name": "conversation_approvers_app_id_apps_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4403,12 +4233,8 @@
           "name": "conversation_approvers_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4510,12 +4336,8 @@
           "name": "conversation_participants_app_id_apps_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4523,12 +4345,8 @@
           "name": "conversation_participants_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4536,12 +4354,8 @@
           "name": "conversation_participants_user_id_users_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4630,12 +4444,8 @@
           "name": "conversation_threads_app_id_apps_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4643,12 +4453,8 @@
           "name": "conversation_threads_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4743,12 +4549,8 @@
           "name": "conversations_app_id_apps_id_fk",
           "tableFrom": "conversations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4808,12 +4610,8 @@
           "name": "control_http_response_routes_session_id_control_http_sessions_session_id_fk",
           "tableFrom": "control_http_response_routes",
           "tableTo": "control_http_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["session_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4821,10 +4619,7 @@
       "compositePrimaryKeys": {
         "control_http_response_routes_session_id_thread_id_pk": {
           "name": "control_http_response_routes_session_id_thread_id_pk",
-          "columns": [
-            "session_id",
-            "thread_id"
-          ]
+          "columns": ["session_id", "thread_id"]
         }
       },
       "uniqueConstraints": {},
@@ -4923,12 +4718,8 @@
           "name": "control_http_sessions_session_id_agent_sessions_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4936,12 +4727,8 @@
           "name": "control_http_sessions_app_id_apps_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4949,12 +4736,8 @@
           "name": "control_http_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4962,12 +4745,8 @@
           "name": "control_http_sessions_agent_id_agents_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4977,10 +4756,7 @@
         "control_http_sessions_app_id_external_conversation_id_key": {
           "name": "control_http_sessions_app_id_external_conversation_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "external_conversation_id"
-          ]
+          "columns": ["app_id", "external_conversation_id"]
         }
       },
       "policies": {},
@@ -5089,12 +4865,8 @@
           "name": "control_http_webhook_deliveries_webhook_id_control_http_webhooks_webhook_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "control_http_webhooks",
-          "columnsFrom": [
-            "webhook_id"
-          ],
-          "columnsTo": [
-            "webhook_id"
-          ],
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["webhook_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5102,12 +4874,8 @@
           "name": "control_http_webhook_deliveries_event_id_runtime_events_event_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5117,10 +4885,7 @@
         "control_http_webhook_deliveries_webhook_id_event_id_key": {
           "name": "control_http_webhook_deliveries_webhook_id_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "webhook_id",
-            "event_id"
-          ]
+          "columns": ["webhook_id", "event_id"]
         }
       },
       "policies": {},
@@ -5236,12 +5001,8 @@
           "name": "control_http_webhooks_app_id_apps_id_fk",
           "tableFrom": "control_http_webhooks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5251,10 +5012,7 @@
         "control_http_webhooks_app_id_name_key": {
           "name": "control_http_webhooks_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -5460,12 +5218,8 @@
           "name": "event_bus_outbox_app_id_apps_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5473,12 +5227,8 @@
           "name": "event_bus_outbox_runtime_event_id_runtime_events_event_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "runtime_event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["runtime_event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5488,9 +5238,7 @@
         "event_bus_outbox_runtime_event_id_key": {
           "name": "event_bus_outbox_runtime_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "runtime_event_id"
-          ]
+          "columns": ["runtime_event_id"]
         }
       },
       "policies": {},
@@ -5866,12 +5614,8 @@
           "name": "runtime_events_app_id_apps_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5879,12 +5623,8 @@
           "name": "runtime_events_agent_id_agents_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5892,12 +5632,8 @@
           "name": "runtime_events_session_id_agent_sessions_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5905,12 +5641,8 @@
           "name": "runtime_events_run_id_agent_runs_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5918,12 +5650,8 @@
           "name": "runtime_events_conversation_id_conversations_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5931,12 +5659,8 @@
           "name": "runtime_events_thread_id_conversation_threads_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6127,12 +5851,8 @@
           "name": "external_ingress_invocations_app_id_apps_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6140,12 +5860,8 @@
           "name": "external_ingress_invocations_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6155,11 +5871,7 @@
         "external_ingress_invocations_app_id_ingress_id_idempotency_key_key": {
           "name": "external_ingress_invocations_app_id_ingress_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "ingress_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -6251,12 +5963,8 @@
           "name": "external_ingress_nonces_app_id_apps_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6264,12 +5972,8 @@
           "name": "external_ingress_nonces_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6277,11 +5981,7 @@
       "compositePrimaryKeys": {
         "external_ingress_nonces_pk": {
           "name": "external_ingress_nonces_pk",
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "nonce"
-          ]
+          "columns": ["app_id", "ingress_id", "nonce"]
         }
       },
       "uniqueConstraints": {},
@@ -6374,12 +6074,8 @@
           "name": "external_ingresses_app_id_apps_id_fk",
           "tableFrom": "external_ingresses",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6389,10 +6085,7 @@
         "external_ingresses_app_id_name_key": {
           "name": "external_ingresses_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -6581,12 +6274,8 @@
           "name": "file_artifacts_app_id_apps_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6594,12 +6283,8 @@
           "name": "file_artifacts_agent_id_agents_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6607,12 +6292,8 @@
           "name": "file_artifacts_promoted_from_artifact_id_file_artifacts_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "file_artifacts",
-          "columnsFrom": [
-            "promoted_from_artifact_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["promoted_from_artifact_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6775,12 +6456,8 @@
           "name": "runtime_dependencies_app_id_apps_id_fk",
           "tableFrom": "runtime_dependencies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6867,12 +6544,8 @@
           "name": "settings_revisions_app_id_apps_id_fk",
           "tableFrom": "settings_revisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6880,10 +6553,7 @@
       "compositePrimaryKeys": {
         "settings_revisions_pk": {
           "name": "settings_revisions_pk",
-          "columns": [
-            "app_id",
-            "revision"
-          ]
+          "columns": ["app_id", "revision"]
         }
       },
       "uniqueConstraints": {},
@@ -7026,12 +6696,8 @@
           "name": "group_join_onboarding_provider_account_provider_accounts_id_fk",
           "tableFrom": "group_join_onboarding",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7113,12 +6779,8 @@
           "name": "job_triggers_app_id_apps_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7126,12 +6788,8 @@
           "name": "job_triggers_job_id_jobs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7139,12 +6797,8 @@
           "name": "job_triggers_run_id_agent_runs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7434,12 +7088,8 @@
           "name": "jobs_app_id_apps_id_fk",
           "tableFrom": "jobs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7447,12 +7097,8 @@
           "name": "jobs_agent_id_agents_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7460,12 +7106,8 @@
           "name": "jobs_conversation_id_conversations_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7473,12 +7115,8 @@
           "name": "jobs_thread_id_conversation_threads_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7486,12 +7124,8 @@
           "name": "jobs_lease_run_id_agent_runs_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "lease_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["lease_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7607,12 +7241,8 @@
           "name": "job_runs_app_id_apps_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7620,12 +7250,8 @@
           "name": "job_runs_job_id_jobs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7633,12 +7259,8 @@
           "name": "job_runs_agent_run_id_agent_runs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "agent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -8132,12 +7754,8 @@
           "name": "live_turn_commands_live_turn_id_live_turns_id_fk",
           "tableFrom": "live_turn_commands",
           "tableTo": "live_turns",
-          "columnsFrom": [
-            "live_turn_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["live_turn_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8401,12 +8019,8 @@
           "name": "live_turns_run_id_agent_runs_id_fk",
           "tableFrom": "live_turns",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8640,12 +8254,8 @@
           "name": "memory_items_app_id_apps_id_fk",
           "tableFrom": "memory_items",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8737,12 +8347,8 @@
           "name": "message_attachments_message_id_messages_id_fk",
           "tableFrom": "message_attachments",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8805,12 +8411,8 @@
           "name": "message_parts_message_id_messages_id_fk",
           "tableFrom": "message_parts",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8820,10 +8422,7 @@
         "message_parts_message_id_ordinal_unique": {
           "name": "message_parts_message_id_ordinal_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "message_id",
-            "ordinal"
-          ]
+          "columns": ["message_id", "ordinal"]
         }
       },
       "policies": {},
@@ -9044,12 +8643,8 @@
           "name": "messages_app_id_apps_id_fk",
           "tableFrom": "messages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9057,12 +8652,8 @@
           "name": "messages_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "messages",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9070,12 +8661,8 @@
           "name": "messages_conversation_id_conversations_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9083,12 +8670,8 @@
           "name": "messages_thread_id_conversation_threads_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9234,12 +8817,8 @@
           "name": "model_credentials_app_id_apps_id_fk",
           "tableFrom": "model_credentials",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9394,12 +8973,8 @@
           "name": "agent_mcp_server_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9407,12 +8982,8 @@
           "name": "agent_mcp_server_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9420,12 +8991,8 @@
           "name": "agent_mcp_server_bindings_server_id_mcp_servers_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9558,12 +9125,8 @@
           "name": "mcp_server_audit_events_app_id_apps_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9571,12 +9134,8 @@
           "name": "mcp_server_audit_events_agent_id_agents_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9584,12 +9143,8 @@
           "name": "mcp_server_audit_events_server_id_mcp_servers_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9597,12 +9152,8 @@
           "name": "mcp_server_audit_events_binding_id_agent_mcp_server_bindings_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agent_mcp_server_bindings",
-          "columnsFrom": [
-            "binding_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9810,12 +9361,8 @@
           "name": "mcp_servers_app_id_apps_id_fk",
           "tableFrom": "mcp_servers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10011,12 +9558,8 @@
           "name": "outbound_deliveries_app_id_apps_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10024,12 +9567,8 @@
           "name": "outbound_deliveries_conversation_id_conversations_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10037,12 +9576,8 @@
           "name": "outbound_deliveries_thread_id_conversation_threads_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10050,12 +9585,8 @@
           "name": "outbound_deliveries_agent_id_agents_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -10063,12 +9594,8 @@
           "name": "outbound_deliveries_run_id_agent_runs_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -10078,10 +9605,7 @@
         "outbound_deliveries_app_id_idempotency_key_key": {
           "name": "outbound_deliveries_app_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -10131,12 +9655,8 @@
           "name": "outbound_delivery_final_answers_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_final_answers",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10346,12 +9866,8 @@
           "name": "outbound_delivery_items_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_items",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10361,10 +9877,7 @@
         "outbound_delivery_items_delivery_id_ordinal_key": {
           "name": "outbound_delivery_items_delivery_id_ordinal_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "delivery_id",
-            "ordinal"
-          ]
+          "columns": ["delivery_id", "ordinal"]
         }
       },
       "policies": {},
@@ -10453,12 +9966,8 @@
           "name": "outbound_delivery_receipts_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10466,12 +9975,8 @@
           "name": "outbound_delivery_receipts_item_id_outbound_delivery_items_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_delivery_items",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10481,10 +9986,7 @@
         "outbound_delivery_receipts_item_id_idempotency_key_key": {
           "name": "outbound_delivery_receipts_item_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_id",
-            "idempotency_key"
-          ]
+          "columns": ["item_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -10561,12 +10063,8 @@
           "name": "observer_deliveries_app_id_apps_id_fk",
           "tableFrom": "observer_deliveries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10619,12 +10117,8 @@
           "name": "observer_insight_cursors_app_id_apps_id_fk",
           "tableFrom": "observer_insight_cursors",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10632,10 +10126,7 @@
       "compositePrimaryKeys": {
         "observer_insight_cursors_pk": {
           "name": "observer_insight_cursors_pk",
-          "columns": [
-            "app_id",
-            "subject"
-          ]
+          "columns": ["app_id", "subject"]
         }
       },
       "uniqueConstraints": {},
@@ -10851,12 +10342,8 @@
           "name": "proactive_insights_app_id_apps_id_fk",
           "tableFrom": "proactive_insights",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10864,12 +10351,8 @@
           "name": "proactive_insights_delivery_id_observer_deliveries_id_fk",
           "tableFrom": "proactive_insights",
           "tableTo": "observer_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -11103,12 +10586,8 @@
           "name": "pattern_candidates_app_id_apps_id_fk",
           "tableFrom": "pattern_candidates",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11243,12 +10722,8 @@
           "name": "proactive_surfacing_opt_ins_app_id_apps_id_fk",
           "tableFrom": "proactive_surfacing_opt_ins",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11354,12 +10829,8 @@
           "name": "pending_access_requests_app_id_apps_id_fk",
           "tableFrom": "pending_access_requests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11423,12 +10894,8 @@
           "name": "permission_audit_events_app_id_apps_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11436,12 +10903,8 @@
           "name": "permission_audit_events_decision_id_permission_decisions_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -11543,12 +11006,8 @@
           "name": "permission_decisions_app_id_apps_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11556,12 +11015,8 @@
           "name": "permission_decisions_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11569,12 +11024,8 @@
           "name": "permission_decisions_run_id_agent_runs_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11582,12 +11033,8 @@
           "name": "permission_decisions_tool_id_tool_catalog_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11654,12 +11101,8 @@
           "name": "permission_policies_app_id_apps_id_fk",
           "tableFrom": "permission_policies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11731,12 +11174,8 @@
           "name": "permission_rules_app_id_apps_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11744,12 +11183,8 @@
           "name": "permission_rules_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12053,12 +11488,8 @@
           "name": "agent_runs_app_id_apps_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12066,12 +11497,8 @@
           "name": "agent_runs_agent_id_agents_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12079,12 +11506,8 @@
           "name": "agent_runs_config_version_id_agent_config_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_config_versions",
-          "columnsFrom": [
-            "config_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["config_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12092,12 +11515,8 @@
           "name": "agent_runs_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -12105,12 +11524,8 @@
           "name": "agent_runs_conversation_id_conversations_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12118,12 +11533,8 @@
           "name": "agent_runs_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12131,12 +11542,8 @@
           "name": "agent_runs_message_id_messages_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12144,12 +11551,8 @@
           "name": "agent_runs_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12225,12 +11628,8 @@
           "name": "sandbox_leases_app_id_apps_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12238,12 +11637,8 @@
           "name": "sandbox_leases_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12251,12 +11646,8 @@
           "name": "sandbox_leases_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12264,12 +11655,8 @@
           "name": "sandbox_leases_permission_decision_id_permission_decisions_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "permission_decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["permission_decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12359,12 +11746,8 @@
           "name": "sandbox_profiles_app_id_apps_id_fk",
           "tableFrom": "sandbox_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12432,12 +11815,8 @@
           "name": "workspace_snapshots_app_id_apps_id_fk",
           "tableFrom": "workspace_snapshots",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12659,12 +12038,8 @@
           "name": "agent_session_digests_app_id_apps_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12672,12 +12047,8 @@
           "name": "agent_session_digests_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12803,12 +12174,8 @@
           "name": "agent_session_summaries_app_id_apps_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12816,12 +12183,8 @@
           "name": "agent_session_summaries_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12991,12 +12354,8 @@
           "name": "agent_sessions_app_id_apps_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13004,12 +12363,8 @@
           "name": "agent_sessions_agent_id_agents_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13017,12 +12372,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -13030,12 +12381,8 @@
           "name": "agent_sessions_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -13237,12 +12584,8 @@
           "name": "provider_sessions_app_id_apps_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13250,12 +12593,8 @@
           "name": "provider_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13263,12 +12602,8 @@
           "name": "provider_sessions_sandbox_id_sandbox_profiles_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -13276,12 +12611,8 @@
           "name": "provider_sessions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -13382,12 +12713,8 @@
           "name": "agent_skill_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13395,12 +12722,8 @@
           "name": "agent_skill_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13408,12 +12731,8 @@
           "name": "agent_skill_bindings_skill_id_skill_catalog_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "skill_catalog",
-          "columnsFrom": [
-            "skill_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13629,12 +12948,8 @@
           "name": "skill_catalog_app_id_apps_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13642,12 +12957,8 @@
           "name": "skill_catalog_agent_id_agents_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -13748,12 +13059,8 @@
           "name": "agent_tool_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13761,12 +13068,8 @@
           "name": "agent_tool_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13774,12 +13077,8 @@
           "name": "agent_tool_bindings_tool_id_tool_catalog_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13949,12 +13248,8 @@
           "name": "agent_tool_sources_app_id_apps_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13962,12 +13257,8 @@
           "name": "agent_tool_sources_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -14135,12 +13426,8 @@
           "name": "tool_catalog_app_id_apps_id_fk",
           "tableFrom": "tool_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -14455,12 +13742,8 @@
           "name": "pending_interactions_app_id_apps_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14468,12 +13751,8 @@
           "name": "pending_interactions_run_id_agent_runs_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -14481,12 +13760,8 @@
           "name": "pending_interactions_envelope_id_permission_prompts_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "permission_prompts",
-          "columnsFrom": [
-            "envelope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["envelope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -14768,12 +14043,8 @@
           "name": "permission_prompts_app_id_apps_id_fk",
           "tableFrom": "permission_prompts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14781,12 +14052,8 @@
           "name": "permission_prompts_parent_envelope_id_permission_prompts_id_fk",
           "tableFrom": "permission_prompts",
           "tableTo": "permission_prompts",
-          "columnsFrom": [
-            "parent_envelope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_envelope_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -14953,12 +14220,8 @@
           "name": "run_leases_run_id_agent_runs_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14966,12 +14229,8 @@
           "name": "run_leases_worker_instance_id_worker_instances_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "worker_instances",
-          "columnsFrom": [
-            "worker_instance_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["worker_instance_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -14979,10 +14238,7 @@
       "compositePrimaryKeys": {
         "run_leases_pk": {
           "name": "run_leases_pk",
-          "columns": [
-            "run_id",
-            "fencing_version"
-          ]
+          "columns": ["run_id", "fencing_version"]
         }
       },
       "uniqueConstraints": {},
@@ -15052,10 +14308,7 @@
       "compositePrimaryKeys": {
         "run_slots_pk": {
           "name": "run_slots_pk",
-          "columns": [
-            "slot_key",
-            "holder_id"
-          ]
+          "columns": ["slot_key", "holder_id"]
         }
       },
       "uniqueConstraints": {},
@@ -15173,12 +14426,8 @@
           "name": "runner_control_events_run_id_agent_runs_id_fk",
           "tableFrom": "runner_control_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -15311,12 +14560,8 @@
           "name": "transient_grants_app_id_apps_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -15324,12 +14569,8 @@
           "name": "transient_grants_run_id_agent_runs_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }

--- a/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0106_snapshot.json
+++ b/apps/core/src/adapters/storage/postgres/schema/migrations/meta/0106_snapshot.json
@@ -51,10 +51,7 @@
       "compositePrimaryKeys": {
         "embedding_cache_pk": {
           "name": "embedding_cache_pk",
-          "columns": [
-            "text_hash",
-            "model"
-          ]
+          "columns": ["text_hash", "model"]
         }
       },
       "uniqueConstraints": {},
@@ -1259,12 +1256,7 @@
       "compositePrimaryKeys": {
         "memory_item_embeddings_pk": {
           "name": "memory_item_embeddings_pk",
-          "columns": [
-            "item_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["item_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -1700,11 +1692,7 @@
       "compositePrimaryKeys": {
         "permission_promotion_counters_pk": {
           "name": "permission_promotion_counters_pk",
-          "columns": [
-            "app_id",
-            "agent_folder",
-            "suggestion_key"
-          ]
+          "columns": ["app_id", "agent_folder", "suggestion_key"]
         }
       },
       "uniqueConstraints": {},
@@ -1820,9 +1808,7 @@
         "apps_slug_unique": {
           "name": "apps_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -1930,12 +1916,8 @@
           "name": "user_aliases_app_id_apps_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1943,12 +1925,8 @@
           "name": "user_aliases_user_id_users_id_fk",
           "tableFrom": "user_aliases",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2038,12 +2016,8 @@
           "name": "users_app_id_apps_id_fk",
           "tableFrom": "users",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2148,12 +2122,8 @@
           "name": "agent_config_versions_app_id_apps_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2161,12 +2131,8 @@
           "name": "agent_config_versions_agent_id_agents_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2174,12 +2140,8 @@
           "name": "agent_config_versions_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2187,12 +2149,8 @@
           "name": "agent_config_versions_sandbox_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2200,12 +2158,8 @@
           "name": "agent_config_versions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "agent_config_versions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2215,10 +2169,7 @@
         "agent_config_versions_agent_id_version_unique": {
           "name": "agent_config_versions_agent_id_version_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_id",
-            "version"
-          ]
+          "columns": ["agent_id", "version"]
         }
       },
       "policies": {},
@@ -2281,12 +2232,8 @@
           "name": "agents_app_id_apps_id_fk",
           "tableFrom": "agents",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2373,12 +2320,8 @@
           "name": "llm_profiles_app_id_apps_id_fk",
           "tableFrom": "llm_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2654,12 +2597,8 @@
           "name": "agent_async_tasks_app_id_apps_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2667,12 +2606,8 @@
           "name": "agent_async_tasks_agent_id_agents_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2680,12 +2615,8 @@
           "name": "agent_async_tasks_parent_run_id_agent_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "parent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2693,12 +2624,8 @@
           "name": "agent_async_tasks_parent_job_id_jobs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "parent_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2706,12 +2633,8 @@
           "name": "agent_async_tasks_parent_job_run_id_job_runs_id_fk",
           "tableFrom": "agent_async_tasks",
           "tableTo": "job_runs",
-          "columnsFrom": [
-            "parent_job_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_job_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2824,12 +2747,8 @@
           "name": "brain_dream_decisions_app_id_apps_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2837,12 +2756,8 @@
           "name": "brain_dream_decisions_page_id_brain_pages_id_fk",
           "tableFrom": "brain_dream_decisions",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2888,12 +2803,8 @@
           "name": "brain_dream_state_app_id_apps_id_fk",
           "tableFrom": "brain_dream_state",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3066,12 +2977,8 @@
           "name": "brain_edges_app_id_apps_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3079,12 +2986,8 @@
           "name": "brain_edges_from_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "from_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["from_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3092,12 +2995,8 @@
           "name": "brain_edges_to_entity_id_brain_entities_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_entities",
-          "columnsFrom": [
-            "to_entity_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["to_entity_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3105,12 +3004,8 @@
           "name": "brain_edges_evidence_page_id_brain_pages_id_fk",
           "tableFrom": "brain_edges",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "evidence_page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["evidence_page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3229,12 +3124,8 @@
           "name": "brain_entities_app_id_apps_id_fk",
           "tableFrom": "brain_entities",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3403,12 +3294,8 @@
           "name": "brain_page_embeddings_page_id_brain_pages_id_fk",
           "tableFrom": "brain_page_embeddings",
           "tableTo": "brain_pages",
-          "columnsFrom": [
-            "page_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["page_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3416,12 +3303,7 @@
       "compositePrimaryKeys": {
         "brain_page_embeddings_pk": {
           "name": "brain_page_embeddings_pk",
-          "columns": [
-            "page_id",
-            "provider",
-            "model",
-            "content_hash"
-          ]
+          "columns": ["page_id", "provider", "model", "content_hash"]
         }
       },
       "uniqueConstraints": {},
@@ -3565,12 +3447,8 @@
           "name": "brain_pages_app_id_apps_id_fk",
           "tableFrom": "brain_pages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3689,12 +3567,8 @@
           "name": "browser_profiles_snapshot_run_id_agent_runs_id_fk",
           "tableFrom": "browser_profiles",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "snapshot_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["snapshot_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -3816,12 +3690,8 @@
           "name": "capability_secrets_app_id_apps_id_fk",
           "tableFrom": "capability_secrets",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4114,12 +3984,8 @@
           "name": "chat_batches_app_id_apps_id_fk",
           "tableFrom": "chat_batches",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4298,12 +4164,8 @@
           "name": "conversation_installs_app_id_apps_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4311,12 +4173,8 @@
           "name": "conversation_installs_agent_id_agents_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4324,12 +4182,8 @@
           "name": "conversation_installs_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4337,12 +4191,8 @@
           "name": "conversation_installs_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4350,12 +4200,8 @@
           "name": "conversation_installs_thread_id_conversation_threads_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4363,12 +4209,8 @@
           "name": "conversation_installs_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "conversation_installs",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4532,12 +4374,8 @@
           "name": "provider_accounts_app_id_apps_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4545,12 +4383,8 @@
           "name": "provider_accounts_agent_id_agents_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4558,12 +4392,8 @@
           "name": "provider_accounts_provider_id_providers_id_fk",
           "tableFrom": "provider_accounts",
           "tableTo": "providers",
-          "columnsFrom": [
-            "provider_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4705,12 +4535,8 @@
           "name": "conversation_approvers_app_id_apps_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4718,12 +4544,8 @@
           "name": "conversation_approvers_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_approvers",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4825,12 +4647,8 @@
           "name": "conversation_participants_app_id_apps_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4838,12 +4656,8 @@
           "name": "conversation_participants_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4851,12 +4665,8 @@
           "name": "conversation_participants_user_id_users_id_fk",
           "tableFrom": "conversation_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4945,12 +4755,8 @@
           "name": "conversation_threads_app_id_apps_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4958,12 +4764,8 @@
           "name": "conversation_threads_conversation_id_conversations_id_fk",
           "tableFrom": "conversation_threads",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5058,12 +4860,8 @@
           "name": "conversations_app_id_apps_id_fk",
           "tableFrom": "conversations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5123,12 +4921,8 @@
           "name": "control_http_response_routes_session_id_control_http_sessions_session_id_fk",
           "tableFrom": "control_http_response_routes",
           "tableTo": "control_http_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["session_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5136,10 +4930,7 @@
       "compositePrimaryKeys": {
         "control_http_response_routes_session_id_thread_id_pk": {
           "name": "control_http_response_routes_session_id_thread_id_pk",
-          "columns": [
-            "session_id",
-            "thread_id"
-          ]
+          "columns": ["session_id", "thread_id"]
         }
       },
       "uniqueConstraints": {},
@@ -5238,12 +5029,8 @@
           "name": "control_http_sessions_session_id_agent_sessions_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5251,12 +5038,8 @@
           "name": "control_http_sessions_app_id_apps_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5264,12 +5047,8 @@
           "name": "control_http_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5277,12 +5056,8 @@
           "name": "control_http_sessions_agent_id_agents_id_fk",
           "tableFrom": "control_http_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5292,10 +5067,7 @@
         "control_http_sessions_app_id_external_conversation_id_key": {
           "name": "control_http_sessions_app_id_external_conversation_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "external_conversation_id"
-          ]
+          "columns": ["app_id", "external_conversation_id"]
         }
       },
       "policies": {},
@@ -5404,12 +5176,8 @@
           "name": "control_http_webhook_deliveries_webhook_id_control_http_webhooks_webhook_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "control_http_webhooks",
-          "columnsFrom": [
-            "webhook_id"
-          ],
-          "columnsTo": [
-            "webhook_id"
-          ],
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["webhook_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5417,12 +5185,8 @@
           "name": "control_http_webhook_deliveries_event_id_runtime_events_event_id_fk",
           "tableFrom": "control_http_webhook_deliveries",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5432,10 +5196,7 @@
         "control_http_webhook_deliveries_webhook_id_event_id_key": {
           "name": "control_http_webhook_deliveries_webhook_id_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "webhook_id",
-            "event_id"
-          ]
+          "columns": ["webhook_id", "event_id"]
         }
       },
       "policies": {},
@@ -5551,12 +5312,8 @@
           "name": "control_http_webhooks_app_id_apps_id_fk",
           "tableFrom": "control_http_webhooks",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5566,10 +5323,7 @@
         "control_http_webhooks_app_id_name_key": {
           "name": "control_http_webhooks_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -5775,12 +5529,8 @@
           "name": "event_bus_outbox_app_id_apps_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5788,12 +5538,8 @@
           "name": "event_bus_outbox_runtime_event_id_runtime_events_event_id_fk",
           "tableFrom": "event_bus_outbox",
           "tableTo": "runtime_events",
-          "columnsFrom": [
-            "runtime_event_id"
-          ],
-          "columnsTo": [
-            "event_id"
-          ],
+          "columnsFrom": ["runtime_event_id"],
+          "columnsTo": ["event_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5803,9 +5549,7 @@
         "event_bus_outbox_runtime_event_id_key": {
           "name": "event_bus_outbox_runtime_event_id_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "runtime_event_id"
-          ]
+          "columns": ["runtime_event_id"]
         }
       },
       "policies": {},
@@ -6181,12 +5925,8 @@
           "name": "runtime_events_app_id_apps_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6194,12 +5934,8 @@
           "name": "runtime_events_agent_id_agents_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -6207,12 +5943,8 @@
           "name": "runtime_events_session_id_agent_sessions_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -6220,12 +5952,8 @@
           "name": "runtime_events_run_id_agent_runs_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6233,12 +5961,8 @@
           "name": "runtime_events_conversation_id_conversations_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -6246,12 +5970,8 @@
           "name": "runtime_events_thread_id_conversation_threads_id_fk",
           "tableFrom": "runtime_events",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -6442,12 +6162,8 @@
           "name": "external_ingress_invocations_app_id_apps_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6455,12 +6171,8 @@
           "name": "external_ingress_invocations_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_invocations",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6470,11 +6182,7 @@
         "external_ingress_invocations_app_id_ingress_id_idempotency_key_key": {
           "name": "external_ingress_invocations_app_id_ingress_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "ingress_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -6566,12 +6274,8 @@
           "name": "external_ingress_nonces_app_id_apps_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6579,12 +6283,8 @@
           "name": "external_ingress_nonces_ingress_id_external_ingresses_ingress_id_fk",
           "tableFrom": "external_ingress_nonces",
           "tableTo": "external_ingresses",
-          "columnsFrom": [
-            "ingress_id"
-          ],
-          "columnsTo": [
-            "ingress_id"
-          ],
+          "columnsFrom": ["ingress_id"],
+          "columnsTo": ["ingress_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6592,11 +6292,7 @@
       "compositePrimaryKeys": {
         "external_ingress_nonces_pk": {
           "name": "external_ingress_nonces_pk",
-          "columns": [
-            "app_id",
-            "ingress_id",
-            "nonce"
-          ]
+          "columns": ["app_id", "ingress_id", "nonce"]
         }
       },
       "uniqueConstraints": {},
@@ -6689,12 +6385,8 @@
           "name": "external_ingresses_app_id_apps_id_fk",
           "tableFrom": "external_ingresses",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6704,10 +6396,7 @@
         "external_ingresses_app_id_name_key": {
           "name": "external_ingresses_app_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "name"
-          ]
+          "columns": ["app_id", "name"]
         }
       },
       "policies": {},
@@ -6896,12 +6585,8 @@
           "name": "file_artifacts_app_id_apps_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6909,12 +6594,8 @@
           "name": "file_artifacts_agent_id_agents_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6922,12 +6603,8 @@
           "name": "file_artifacts_promoted_from_artifact_id_file_artifacts_id_fk",
           "tableFrom": "file_artifacts",
           "tableTo": "file_artifacts",
-          "columnsFrom": [
-            "promoted_from_artifact_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["promoted_from_artifact_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -7090,12 +6767,8 @@
           "name": "runtime_dependencies_app_id_apps_id_fk",
           "tableFrom": "runtime_dependencies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7182,12 +6855,8 @@
           "name": "settings_revisions_app_id_apps_id_fk",
           "tableFrom": "settings_revisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7195,10 +6864,7 @@
       "compositePrimaryKeys": {
         "settings_revisions_pk": {
           "name": "settings_revisions_pk",
-          "columns": [
-            "app_id",
-            "revision"
-          ]
+          "columns": ["app_id", "revision"]
         }
       },
       "uniqueConstraints": {},
@@ -7341,12 +7007,8 @@
           "name": "group_join_onboarding_provider_account_provider_accounts_id_fk",
           "tableFrom": "group_join_onboarding",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7428,12 +7090,8 @@
           "name": "job_triggers_app_id_apps_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7441,12 +7099,8 @@
           "name": "job_triggers_job_id_jobs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7454,12 +7108,8 @@
           "name": "job_triggers_run_id_agent_runs_id_fk",
           "tableFrom": "job_triggers",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7749,12 +7399,8 @@
           "name": "jobs_app_id_apps_id_fk",
           "tableFrom": "jobs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7762,12 +7408,8 @@
           "name": "jobs_agent_id_agents_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7775,12 +7417,8 @@
           "name": "jobs_conversation_id_conversations_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7788,12 +7426,8 @@
           "name": "jobs_thread_id_conversation_threads_id_fk",
           "tableFrom": "jobs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -7801,12 +7435,8 @@
           "name": "jobs_lease_run_id_agent_runs_id_fk",
           "tableFrom": "jobs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "lease_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["lease_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -7922,12 +7552,8 @@
           "name": "job_runs_app_id_apps_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7935,12 +7561,8 @@
           "name": "job_runs_job_id_jobs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7948,12 +7570,8 @@
           "name": "job_runs_agent_run_id_agent_runs_id_fk",
           "tableFrom": "job_runs",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "agent_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -8447,12 +8065,8 @@
           "name": "live_turn_commands_live_turn_id_live_turns_id_fk",
           "tableFrom": "live_turn_commands",
           "tableTo": "live_turns",
-          "columnsFrom": [
-            "live_turn_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["live_turn_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8716,12 +8330,8 @@
           "name": "live_turns_run_id_agent_runs_id_fk",
           "tableFrom": "live_turns",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8955,12 +8565,8 @@
           "name": "memory_items_app_id_apps_id_fk",
           "tableFrom": "memory_items",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9052,12 +8658,8 @@
           "name": "message_attachments_message_id_messages_id_fk",
           "tableFrom": "message_attachments",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9120,12 +8722,8 @@
           "name": "message_parts_message_id_messages_id_fk",
           "tableFrom": "message_parts",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9135,10 +8733,7 @@
         "message_parts_message_id_ordinal_unique": {
           "name": "message_parts_message_id_ordinal_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "message_id",
-            "ordinal"
-          ]
+          "columns": ["message_id", "ordinal"]
         }
       },
       "policies": {},
@@ -9359,12 +8954,8 @@
           "name": "messages_app_id_apps_id_fk",
           "tableFrom": "messages",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9372,12 +8963,8 @@
           "name": "messages_provider_account_id_provider_accounts_id_fk",
           "tableFrom": "messages",
           "tableTo": "provider_accounts",
-          "columnsFrom": [
-            "provider_account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["provider_account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9385,12 +8972,8 @@
           "name": "messages_conversation_id_conversations_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9398,12 +8981,8 @@
           "name": "messages_thread_id_conversation_threads_id_fk",
           "tableFrom": "messages",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9549,12 +9128,8 @@
           "name": "model_credentials_app_id_apps_id_fk",
           "tableFrom": "model_credentials",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9709,12 +9284,8 @@
           "name": "agent_mcp_server_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9722,12 +9293,8 @@
           "name": "agent_mcp_server_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9735,12 +9302,8 @@
           "name": "agent_mcp_server_bindings_server_id_mcp_servers_id_fk",
           "tableFrom": "agent_mcp_server_bindings",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9873,12 +9436,8 @@
           "name": "mcp_server_audit_events_app_id_apps_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9886,12 +9445,8 @@
           "name": "mcp_server_audit_events_agent_id_agents_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9899,12 +9454,8 @@
           "name": "mcp_server_audit_events_server_id_mcp_servers_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "mcp_servers",
-          "columnsFrom": [
-            "server_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -9912,12 +9463,8 @@
           "name": "mcp_server_audit_events_binding_id_agent_mcp_server_bindings_id_fk",
           "tableFrom": "mcp_server_audit_events",
           "tableTo": "agent_mcp_server_bindings",
-          "columnsFrom": [
-            "binding_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["binding_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -10125,12 +9672,8 @@
           "name": "mcp_servers_app_id_apps_id_fk",
           "tableFrom": "mcp_servers",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10326,12 +9869,8 @@
           "name": "outbound_deliveries_app_id_apps_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10339,12 +9878,8 @@
           "name": "outbound_deliveries_conversation_id_conversations_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10352,12 +9887,8 @@
           "name": "outbound_deliveries_thread_id_conversation_threads_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10365,12 +9896,8 @@
           "name": "outbound_deliveries_agent_id_agents_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -10378,12 +9905,8 @@
           "name": "outbound_deliveries_run_id_agent_runs_id_fk",
           "tableFrom": "outbound_deliveries",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -10393,10 +9916,7 @@
         "outbound_deliveries_app_id_idempotency_key_key": {
           "name": "outbound_deliveries_app_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "app_id",
-            "idempotency_key"
-          ]
+          "columns": ["app_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -10446,12 +9966,8 @@
           "name": "outbound_delivery_final_answers_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_final_answers",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10661,12 +10177,8 @@
           "name": "outbound_delivery_items_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_items",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10676,10 +10188,7 @@
         "outbound_delivery_items_delivery_id_ordinal_key": {
           "name": "outbound_delivery_items_delivery_id_ordinal_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "delivery_id",
-            "ordinal"
-          ]
+          "columns": ["delivery_id", "ordinal"]
         }
       },
       "policies": {},
@@ -10768,12 +10277,8 @@
           "name": "outbound_delivery_receipts_delivery_id_outbound_deliveries_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -10781,12 +10286,8 @@
           "name": "outbound_delivery_receipts_item_id_outbound_delivery_items_id_fk",
           "tableFrom": "outbound_delivery_receipts",
           "tableTo": "outbound_delivery_items",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10796,10 +10297,7 @@
         "outbound_delivery_receipts_item_id_idempotency_key_key": {
           "name": "outbound_delivery_receipts_item_id_idempotency_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_id",
-            "idempotency_key"
-          ]
+          "columns": ["item_id", "idempotency_key"]
         }
       },
       "policies": {},
@@ -10876,12 +10374,8 @@
           "name": "observer_deliveries_app_id_apps_id_fk",
           "tableFrom": "observer_deliveries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10934,12 +10428,8 @@
           "name": "observer_insight_cursors_app_id_apps_id_fk",
           "tableFrom": "observer_insight_cursors",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -10947,10 +10437,7 @@
       "compositePrimaryKeys": {
         "observer_insight_cursors_pk": {
           "name": "observer_insight_cursors_pk",
-          "columns": [
-            "app_id",
-            "subject"
-          ]
+          "columns": ["app_id", "subject"]
         }
       },
       "uniqueConstraints": {},
@@ -11166,12 +10653,8 @@
           "name": "proactive_insights_app_id_apps_id_fk",
           "tableFrom": "proactive_insights",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11179,12 +10662,8 @@
           "name": "proactive_insights_delivery_id_observer_deliveries_id_fk",
           "tableFrom": "proactive_insights",
           "tableTo": "observer_deliveries",
-          "columnsFrom": [
-            "delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -11418,12 +10897,8 @@
           "name": "pattern_candidates_app_id_apps_id_fk",
           "tableFrom": "pattern_candidates",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11558,12 +11033,8 @@
           "name": "proactive_surfacing_opt_ins_app_id_apps_id_fk",
           "tableFrom": "proactive_surfacing_opt_ins",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11669,12 +11140,8 @@
           "name": "pending_access_requests_app_id_apps_id_fk",
           "tableFrom": "pending_access_requests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -11738,12 +11205,8 @@
           "name": "permission_audit_events_app_id_apps_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11751,12 +11214,8 @@
           "name": "permission_audit_events_decision_id_permission_decisions_id_fk",
           "tableFrom": "permission_audit_events",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -11858,12 +11317,8 @@
           "name": "permission_decisions_app_id_apps_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -11871,12 +11326,8 @@
           "name": "permission_decisions_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11884,12 +11335,8 @@
           "name": "permission_decisions_run_id_agent_runs_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -11897,12 +11344,8 @@
           "name": "permission_decisions_tool_id_tool_catalog_id_fk",
           "tableFrom": "permission_decisions",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -11969,12 +11412,8 @@
           "name": "permission_policies_app_id_apps_id_fk",
           "tableFrom": "permission_policies",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12046,12 +11485,8 @@
           "name": "permission_rules_app_id_apps_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12059,12 +11494,8 @@
           "name": "permission_rules_policy_id_permission_policies_id_fk",
           "tableFrom": "permission_rules",
           "tableTo": "permission_policies",
-          "columnsFrom": [
-            "policy_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12368,12 +11799,8 @@
           "name": "agent_runs_app_id_apps_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12381,12 +11808,8 @@
           "name": "agent_runs_agent_id_agents_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12394,12 +11817,8 @@
           "name": "agent_runs_config_version_id_agent_config_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_config_versions",
-          "columnsFrom": [
-            "config_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["config_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12407,12 +11826,8 @@
           "name": "agent_runs_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -12420,12 +11835,8 @@
           "name": "agent_runs_conversation_id_conversations_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12433,12 +11844,8 @@
           "name": "agent_runs_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12446,12 +11853,8 @@
           "name": "agent_runs_message_id_messages_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12459,12 +11862,8 @@
           "name": "agent_runs_llm_profile_id_llm_profiles_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "llm_profiles",
-          "columnsFrom": [
-            "llm_profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["llm_profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12540,12 +11939,8 @@
           "name": "sandbox_leases_app_id_apps_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12553,12 +11948,8 @@
           "name": "sandbox_leases_profile_id_sandbox_profiles_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "profile_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -12566,12 +11957,8 @@
           "name": "sandbox_leases_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12579,12 +11966,8 @@
           "name": "sandbox_leases_permission_decision_id_permission_decisions_id_fk",
           "tableFrom": "sandbox_leases",
           "tableTo": "permission_decisions",
-          "columnsFrom": [
-            "permission_decision_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["permission_decision_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -12674,12 +12057,8 @@
           "name": "sandbox_profiles_app_id_apps_id_fk",
           "tableFrom": "sandbox_profiles",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12747,12 +12126,8 @@
           "name": "workspace_snapshots_app_id_apps_id_fk",
           "tableFrom": "workspace_snapshots",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -12974,12 +12349,8 @@
           "name": "agent_session_digests_app_id_apps_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -12987,12 +12358,8 @@
           "name": "agent_session_digests_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_digests",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13118,12 +12485,8 @@
           "name": "agent_session_summaries_app_id_apps_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13131,12 +12494,8 @@
           "name": "agent_session_summaries_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "agent_session_summaries",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13306,12 +12665,8 @@
           "name": "agent_sessions_app_id_apps_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13319,12 +12674,8 @@
           "name": "agent_sessions_agent_id_agents_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13332,12 +12683,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -13345,12 +12692,8 @@
           "name": "agent_sessions_thread_id_conversation_threads_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversation_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -13552,12 +12895,8 @@
           "name": "provider_sessions_app_id_apps_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13565,12 +12904,8 @@
           "name": "provider_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13578,12 +12913,8 @@
           "name": "provider_sessions_sandbox_id_sandbox_profiles_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "sandbox_profiles",
-          "columnsFrom": [
-            "sandbox_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["sandbox_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -13591,12 +12922,8 @@
           "name": "provider_sessions_workspace_snapshot_id_workspace_snapshots_id_fk",
           "tableFrom": "provider_sessions",
           "tableTo": "workspace_snapshots",
-          "columnsFrom": [
-            "workspace_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspace_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -13697,12 +13024,8 @@
           "name": "agent_skill_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13710,12 +13033,8 @@
           "name": "agent_skill_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13723,12 +13042,8 @@
           "name": "agent_skill_bindings_skill_id_skill_catalog_id_fk",
           "tableFrom": "agent_skill_bindings",
           "tableTo": "skill_catalog",
-          "columnsFrom": [
-            "skill_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -13944,12 +13259,8 @@
           "name": "skill_catalog_app_id_apps_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -13957,12 +13268,8 @@
           "name": "skill_catalog_agent_id_agents_id_fk",
           "tableFrom": "skill_catalog",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -14063,12 +13370,8 @@
           "name": "agent_tool_bindings_app_id_apps_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14076,12 +13379,8 @@
           "name": "agent_tool_bindings_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14089,12 +13388,8 @@
           "name": "agent_tool_bindings_tool_id_tool_catalog_id_fk",
           "tableFrom": "agent_tool_bindings",
           "tableTo": "tool_catalog",
-          "columnsFrom": [
-            "tool_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tool_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -14264,12 +13559,8 @@
           "name": "agent_tool_sources_app_id_apps_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14277,12 +13568,8 @@
           "name": "agent_tool_sources_agent_id_agents_id_fk",
           "tableFrom": "agent_tool_sources",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -14450,12 +13737,8 @@
           "name": "tool_catalog_app_id_apps_id_fk",
           "tableFrom": "tool_catalog",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -14770,12 +14053,8 @@
           "name": "pending_interactions_app_id_apps_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -14783,12 +14062,8 @@
           "name": "pending_interactions_run_id_agent_runs_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -14796,12 +14071,8 @@
           "name": "pending_interactions_envelope_id_permission_prompts_id_fk",
           "tableFrom": "pending_interactions",
           "tableTo": "permission_prompts",
-          "columnsFrom": [
-            "envelope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["envelope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -15083,12 +14354,8 @@
           "name": "permission_prompts_app_id_apps_id_fk",
           "tableFrom": "permission_prompts",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -15096,12 +14363,8 @@
           "name": "permission_prompts_parent_envelope_id_permission_prompts_id_fk",
           "tableFrom": "permission_prompts",
           "tableTo": "permission_prompts",
-          "columnsFrom": [
-            "parent_envelope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_envelope_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -15268,12 +14531,8 @@
           "name": "run_leases_run_id_agent_runs_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -15281,12 +14540,8 @@
           "name": "run_leases_worker_instance_id_worker_instances_id_fk",
           "tableFrom": "run_leases",
           "tableTo": "worker_instances",
-          "columnsFrom": [
-            "worker_instance_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["worker_instance_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -15294,10 +14549,7 @@
       "compositePrimaryKeys": {
         "run_leases_pk": {
           "name": "run_leases_pk",
-          "columns": [
-            "run_id",
-            "fencing_version"
-          ]
+          "columns": ["run_id", "fencing_version"]
         }
       },
       "uniqueConstraints": {},
@@ -15367,10 +14619,7 @@
       "compositePrimaryKeys": {
         "run_slots_pk": {
           "name": "run_slots_pk",
-          "columns": [
-            "slot_key",
-            "holder_id"
-          ]
+          "columns": ["slot_key", "holder_id"]
         }
       },
       "uniqueConstraints": {},
@@ -15488,12 +14737,8 @@
           "name": "runner_control_events_run_id_agent_runs_id_fk",
           "tableFrom": "runner_control_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -15626,12 +14871,8 @@
           "name": "transient_grants_app_id_apps_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "apps",
-          "columnsFrom": [
-            "app_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -15639,12 +14880,8 @@
           "name": "transient_grants_run_id_agent_runs_id_fk",
           "tableFrom": "transient_grants",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }

--- a/apps/core/src/cli/group-helpers.ts
+++ b/apps/core/src/cli/group-helpers.ts
@@ -291,7 +291,10 @@ export function resolveRoutelessAgentFolder(input: {
   const folder = selector.startsWith('agent:')
     ? selector.slice('agent:'.length)
     : selector;
-  if (!folder || !input.settings.agents[folder]) return null;
+  // Own-property check: a plain settings object inherits `constructor`,
+  // `toString`, `__proto__` etc., which would otherwise resolve as configured
+  // agents and send a phantom name into destructive pruning.
+  if (!folder || !Object.hasOwn(input.settings.agents, folder)) return null;
   const hasRoutes = Object.values(input.groups).some(
     (group) => group.folder === folder,
   );

--- a/apps/core/src/cli/group-helpers.ts
+++ b/apps/core/src/cli/group-helpers.ts
@@ -21,6 +21,7 @@ import { RuntimeGroupDb, openRuntimeGroupDb } from './runtime-group-db.js';
 import { normalizeTelegramChatJid } from './telegram.js';
 import { providerForJid } from '../channels/provider-registry.js';
 import { parseAgentThreadQueueKey } from '../shared/thread-queue-key.js';
+import { DEFAULT_AGENT_FOLDER } from './main-agent.js';
 
 export { formatAgentHarnessLine } from './group-engine.js';
 
@@ -160,6 +161,7 @@ export async function pruneDesiredStateAgent(input: {
   pruned: boolean;
   providerAccountsPruned: number;
   keptForDelegates?: string[];
+  keptAsDefault?: boolean;
   error?: string;
 }> {
   if (input.remainingRoutes > 0) {
@@ -170,6 +172,12 @@ export async function pruneDesiredStateAgent(input: {
     const previousSettings = structuredClone(settings);
     if (!settings.agents[input.folder]) {
       return { pruned: false, providerAccountsPruned: 0 };
+    }
+    // The default agent underpins runtime startup and reconciliation. Deleting
+    // its definition would leave the default-agent setting dangling, so removal
+    // is refused here for BOTH the route-scoped and route-less callers.
+    if (input.folder === DEFAULT_AGENT_FOLDER) {
+      return { pruned: false, providerAccountsPruned: 0, keptAsDefault: true };
     }
     // Routes are not the only liveness signal: another agent may still list
     // this one as a delegate. Deleting it would break delegation (or leave an

--- a/apps/core/src/cli/group-helpers.ts
+++ b/apps/core/src/cli/group-helpers.ts
@@ -173,9 +173,11 @@ export async function pruneDesiredStateAgent(input: {
     if (!settings.agents[input.folder]) {
       return { pruned: false, providerAccountsPruned: 0 };
     }
-    // The default agent underpins runtime startup and reconciliation. Deleting
-    // its definition would leave the default-agent setting dangling, so removal
-    // is refused here for BOTH the route-scoped and route-less callers.
+    // The default agent's folder is the fixed DEFAULT_AGENT_FOLDER ('main_agent')
+    // -- it is hard-coded across startup/slack/telegram and is never re-pointed
+    // (`gantry agent name` only changes its display name). Deleting its
+    // definition would leave the runtime's default-agent wiring dangling, so
+    // removal is refused for BOTH the route-scoped and route-less callers.
     if (input.folder === DEFAULT_AGENT_FOLDER) {
       return { pruned: false, providerAccountsPruned: 0, keptAsDefault: true };
     }

--- a/apps/core/src/cli/group-helpers.ts
+++ b/apps/core/src/cli/group-helpers.ts
@@ -247,6 +247,13 @@ export async function pruneDesiredStateAgent(input: {
       providerAccountsPruned += 1;
     }
 
+    // Persistence note: when a storage provider is configured (the CLI and the
+    // runtime both do, cli/index.ts:34) this appends a settings revision -- the
+    // boot authority -- and throws if storage is unavailable, so a silent
+    // mirror-only write cannot happen here. Without a provider the file IS the
+    // store, and a file write is correct. `reconciled: false` is therefore not
+    // an error condition; a genuine failure surfaces as a throw and is caught
+    // below.
     await writeDesiredRuntimeSettings({
       runtimeHome: input.runtimeHome,
       settings,
@@ -260,6 +267,35 @@ export async function pruneDesiredStateAgent(input: {
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+/**
+ * Resolve a selector that names an agent with NO conversation routes.
+ *
+ * `resolveGroupSelector` matches only against existing route keys, so an agent
+ * whose last route is already gone is unaddressable by every agent subcommand
+ * -- while its definition lives on in the settings-revision authority and is
+ * re-imported on each boot. Fall back to the desired-state agent set so such an
+ * agent can still be named (and therefore removed).
+ *
+ * Returns null when the selector matches nothing, or when the agent still owns
+ * routes (that case belongs to the normal route-scoped path).
+ */
+export function resolveRoutelessAgentFolder(input: {
+  settings: ReturnType<typeof loadRuntimeSettings>;
+  groups: Record<string, ConversationRoute>;
+  selector: string;
+}): string | null {
+  const selector = input.selector.trim();
+  if (!selector) return null;
+  const folder = selector.startsWith('agent:')
+    ? selector.slice('agent:'.length)
+    : selector;
+  if (!folder || !input.settings.agents[folder]) return null;
+  const hasRoutes = Object.values(input.groups).some(
+    (group) => group.folder === folder,
+  );
+  return hasRoutes ? null : folder;
 }
 
 export async function syncConfiguredConversationBinding(input: {

--- a/apps/core/src/cli/group-remove-routeless.ts
+++ b/apps/core/src/cli/group-remove-routeless.ts
@@ -65,7 +65,7 @@ export async function removeRoutelessAgent(input: {
   }
   if (pruned.keptAsDefault) {
     p.log.error(
-      `Agent ${folder} is the default agent and cannot be removed. Point the default elsewhere first (gantry agent name ...).`,
+      `Agent ${folder} is the default agent (main_agent) and cannot be removed; it underpins runtime startup. Use \`gantry agent name\` to rename it instead.`,
     );
     return 1;
   }

--- a/apps/core/src/cli/group-remove-routeless.ts
+++ b/apps/core/src/cli/group-remove-routeless.ts
@@ -63,6 +63,12 @@ export async function removeRoutelessAgent(input: {
     );
     return 1;
   }
+  if (pruned.keptAsDefault) {
+    p.log.error(
+      `Agent ${folder} is the default agent and cannot be removed. Point the default elsewhere first (gantry agent name ...).`,
+    );
+    return 1;
+  }
   if (pruned.keptForDelegates?.length) {
     p.log.warn(
       `Agent ${folder} is retained: still referenced as a delegate by ${pruned.keptForDelegates.join(', ')}.`,

--- a/apps/core/src/cli/group-remove-routeless.ts
+++ b/apps/core/src/cli/group-remove-routeless.ts
@@ -1,0 +1,86 @@
+import * as p from '@clack/prompts';
+
+import type { ConversationRoute } from '../domain/types.js';
+import {
+  isInteractiveTerminal,
+  pruneDesiredStateAgent,
+  resolveRoutelessAgentFolder,
+} from './group-helpers.js';
+
+/**
+ * Remove an agent that has no conversation routes left.
+ *
+ * `resolveGroupSelector` matches only against existing route keys, so once an
+ * agent's last route is gone it cannot be named by any agent subcommand -- yet
+ * its definition survives in the settings-revision authority and is re-imported
+ * on every boot. This is the entry point that makes such an agent removable.
+ *
+ * Returns an exit code when the selector named a route-less agent, or null when
+ * it did not, so the caller can fall through to its normal not-found handling.
+ */
+export async function removeRoutelessAgent(input: {
+  runtimeHome: string;
+  settings: Parameters<typeof resolveRoutelessAgentFolder>[0]['settings'];
+  groups: Record<string, ConversationRoute>;
+  selector: string;
+  assumeYes: boolean;
+}): Promise<number | null> {
+  const folder = resolveRoutelessAgentFolder({
+    settings: input.settings,
+    groups: input.groups,
+    selector: input.selector,
+  });
+  if (!folder) return null;
+
+  if (!input.assumeYes) {
+    if (!isInteractiveTerminal()) {
+      p.log.error(
+        'Refusing destructive removal in non-interactive mode without --yes.',
+      );
+      return 1;
+    }
+    const decision = await p.select({
+      message: `Remove agent ${folder} (no conversation routes) from desired state?`,
+      options: [
+        { label: 'Yes, remove it', value: 'yes' },
+        { label: 'No, cancel', value: 'no' },
+      ],
+    });
+    if (p.isCancel(decision) || decision !== 'yes') {
+      p.log.warn('Agent removal cancelled. No changes were made.');
+      return 0;
+    }
+  }
+
+  const pruned = await pruneDesiredStateAgent({
+    runtimeHome: input.runtimeHome,
+    folder,
+    remainingRoutes: 0,
+  });
+  if (pruned.error) {
+    p.log.error(
+      `Removal did not persist for ${folder}: ${pruned.error}. It will be recreated on the next reload.`,
+    );
+    return 1;
+  }
+  if (pruned.keptForDelegates?.length) {
+    p.log.warn(
+      `Agent ${folder} is retained: still referenced as a delegate by ${pruned.keptForDelegates.join(', ')}.`,
+    );
+    p.log.info(
+      'Next action: remove those delegate references first if you want the agent fully deleted.',
+    );
+    return 0;
+  }
+  if (!pruned.pruned) {
+    p.log.error(`Agent ${folder} was not removed from desired state.`);
+    return 1;
+  }
+  const accounts = pruned.providerAccountsPruned;
+  p.log.success(
+    `Removed agent ${folder} from desired state${
+      accounts > 0 ? ` (and ${accounts} orphaned provider account(s))` : ''
+    }.`,
+  );
+  return 0;
+}

--- a/apps/core/src/cli/group-remove-routeless.ts
+++ b/apps/core/src/cli/group-remove-routeless.ts
@@ -76,6 +76,11 @@ export async function removeRoutelessAgent(input: {
     p.log.error(`Agent ${folder} was not removed from desired state.`);
     return 1;
   }
+  // Deliberately no filesystem cleanup: Postgres is the source of truth, and
+  // `agent remove` stopped touching agent folders when --delete-folder was
+  // removed. The route-scoped path does not delete folders either, so this
+  // path must not either -- the only fs.rmSync left in this command family is
+  // runAdd's rollback of a folder it had just created.
   const accounts = pruned.providerAccountsPruned;
   p.log.success(
     `Removed agent ${folder} from desired state${

--- a/apps/core/src/cli/group-remove-routeless.ts
+++ b/apps/core/src/cli/group-remove-routeless.ts
@@ -70,7 +70,10 @@ export async function removeRoutelessAgent(input: {
     p.log.info(
       'Next action: remove those delegate references first if you want the agent fully deleted.',
     );
-    return 0;
+    // Nothing was removed here -- unlike the route-scoped path there is no
+    // route deletion to count as partial success -- so automation must not be
+    // told this succeeded.
+    return 1;
   }
   if (!pruned.pruned) {
     p.log.error(`Agent ${folder} was not removed from desired state.`);

--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -22,6 +22,7 @@ import {
   normalizeDefaultAgentName,
 } from './main-agent.js';
 import { RuntimeGroupDb } from './runtime-group-db.js';
+import { removeRoutelessAgent } from './group-remove-routeless.js';
 import { runAccess } from './group-access.js';
 import { runHarness } from './group-harness.js';
 import { runList } from './group-list.js';
@@ -414,6 +415,14 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
       return 1;
     }
     if (!resolved.found) {
+      const routelessExit = await removeRoutelessAgent({
+        runtimeHome,
+        settings: loadRuntimeSettings(runtimeHome),
+        groups,
+        selector,
+        assumeYes: parsed.assumeYes,
+      });
+      if (routelessExit !== null) return routelessExit;
       p.log.error(`No agent found for selector "${selector.trim()}".`);
       return 1;
     }
@@ -479,22 +488,15 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
       remainingRoutes,
     });
     if (desiredPrune.error) {
-      // Stop before any further destructive step: the agent WILL be recreated
-      // on the next reload, so deleting its folder would leave a resurrected
-      // agent pointing at missing files, and reporting success would tell
-      // automation the removal persisted when it did not.
+      // Fail loudly: reporting success would tell automation the removal
+      // persisted when the next reload will bring the agent back.
       p.log.error(
-        `Removal did not persist: the agent definition still exists in desired state for ${found.group.folder} (${desiredPrune.error}). It will be recreated on the next reload.`,
-      );
-      p.log.info(
-        'Next action: fix the settings write, then rerun the removal. The agent folder was left untouched.',
+        `Removal did not persist: ${found.group.folder} still exists in desired state (${desiredPrune.error}). It will be recreated on the next reload.`,
       );
       return 1;
     }
     if (desiredPrune.keptForDelegates?.length) {
-      // The agent stays in desired state because other agents delegate to it,
-      // so its files must stay too: deleting them would leave delegation and
-      // reconciliation pointing at a missing folder.
+      // Retained because other agents delegate to it.
       p.log.warn(
         `Route removed, but agent ${found.group.folder} is retained in desired state: still referenced as a delegate by ${desiredPrune.keptForDelegates.join(', ')}.`,
       );

--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -19,6 +19,7 @@ import {
   defaultTriggerForAgentName,
   displayAgentName,
   defaultAgentNameFromSettings,
+  isDefaultAgentLastRoute,
   normalizeDefaultAgentName,
 } from './main-agent.js';
 import { RuntimeGroupDb } from './runtime-group-db.js';
@@ -427,6 +428,13 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
       return 1;
     }
     const found = resolved.found;
+    // Refuse the default agent's last route: the runtime re-seeds it otherwise.
+    if (isDefaultAgentLastRoute(groups, found.group.folder)) {
+      p.log.error(
+        `${found.group.folder} is the default agent and must keep at least one route; it cannot be removed.`,
+      );
+      return 1;
+    }
     const routeKey = found.jid;
     const { chatJid } = parseAgentThreadQueueKey(routeKey);
 
@@ -492,12 +500,6 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
         `Removal did not persist: ${found.group.folder} still exists in desired state (${desiredPrune.error}). It will be recreated on the next reload.`,
       );
       return 1;
-    }
-    if (desiredPrune.keptAsDefault) {
-      p.log.info(
-        `Route removed. ${found.group.folder} is the default agent (main_agent), so its definition is retained -- the default agent underpins runtime startup and cannot be removed.`,
-      );
-      return 0;
     }
     if (desiredPrune.keptForDelegates?.length) {
       // Retained because other agents delegate to it.

--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -495,7 +495,7 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
     }
     if (desiredPrune.keptAsDefault) {
       p.log.info(
-        `Route removed. Agent ${found.group.folder} is the default agent, so its definition is retained; point the default elsewhere first (gantry agent name ...) to remove the agent itself.`,
+        `Route removed. ${found.group.folder} is the default agent (main_agent), so its definition is retained -- the default agent underpins runtime startup and cannot be removed.`,
       );
       return 0;
     }

--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -494,8 +494,8 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
       return 1;
     }
     if (desiredPrune.keptAsDefault) {
-      p.log.warn(
-        `Route removed, but ${found.group.folder} is the default agent and is retained. Point the default elsewhere first (gantry agent name ...) to remove it.`,
+      p.log.info(
+        `Route removed. Agent ${found.group.folder} is the default agent, so its definition is retained; point the default elsewhere first (gantry agent name ...) to remove the agent itself.`,
       );
       return 0;
     }

--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -475,10 +475,8 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
       );
     }
 
-    // Deleting the route is not durable on its own: desired-state
-    // reconciliation re-imports every settings.agents entry on reload/restart,
-    // so an agent whose definition survives comes back with its routes and
-    // system jobs. Drop the definition once its last route is gone.
+    // Route deletion alone is not durable -- reconciliation re-imports the
+    // agent from desired state. Drop the definition once its last route is gone.
     const remainingRoutes = Object.entries(
       await db.getAllConversationRoutes(),
     ).filter(([, group]) => group.folder === found.group.folder).length;
@@ -494,6 +492,12 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
         `Removal did not persist: ${found.group.folder} still exists in desired state (${desiredPrune.error}). It will be recreated on the next reload.`,
       );
       return 1;
+    }
+    if (desiredPrune.keptAsDefault) {
+      p.log.warn(
+        `Route removed, but ${found.group.folder} is the default agent and is retained. Point the default elsewhere first (gantry agent name ...) to remove it.`,
+      );
+      return 0;
     }
     if (desiredPrune.keptForDelegates?.length) {
       // Retained because other agents delegate to it.

--- a/apps/core/src/cli/main-agent.ts
+++ b/apps/core/src/cli/main-agent.ts
@@ -8,6 +8,24 @@ export { defaultTriggerForAgentName } from '../shared/trigger-pattern.js';
 export const DEFAULT_AGENT_CLI_NAME = DEFAULT_AGENT_NAME;
 export const DEFAULT_AGENT_FOLDER = 'main_agent';
 
+/**
+ * True when `folder` is the default agent and the given routes contain only one
+ * route for it. The runtime re-seeds a default agent route whenever no routes
+ * remain (ensureFreshRuntimeHasDefaultAgent), so removing the default agent's
+ * last route can silently return on the next boot -- callers should refuse it.
+ */
+export function isDefaultAgentLastRoute(
+  groups: Record<string, { folder: string }>,
+  folder: string,
+): boolean {
+  if (folder !== DEFAULT_AGENT_FOLDER) return false;
+  return (
+    Object.values(groups).filter(
+      (group) => group.folder === DEFAULT_AGENT_FOLDER,
+    ).length <= 1
+  );
+}
+
 export function normalizeDefaultAgentName(raw: string | undefined): string {
   return raw?.trim() || DEFAULT_AGENT_CLI_NAME;
 }

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@core/config/settings/runtime-settings.js';
 import { listSlackRecentChats } from '@core/cli/slack-chat-discovery.js';
 import { makeAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
+import { isDefaultAgentLastRoute } from '@core/cli/main-agent.js';
 import {
   pruneAgentSenderPolicyOverride,
   pruneDesiredStateAgent,
@@ -1419,6 +1420,32 @@ describe('cli slack helpers', () => {
     const updated = loadRuntimeSettings(runtimeHome);
     expect(updated.agents.orphan).toBeUndefined();
     expect(updated.providerAccounts.orphan_account).toBeUndefined();
+  });
+
+  it('flags the default agent last route but allows removing one of several', () => {
+    const one = {
+      [makeAgentThreadQueueKey('sl:C1', 'agent:main_agent')]: {
+        name: 'M',
+        folder: 'main_agent',
+        trigger: '',
+        added_at: '2026-04-24T00:00:00.000Z',
+      },
+    };
+    expect(isDefaultAgentLastRoute(one, 'main_agent')).toBe(true);
+
+    const two = {
+      ...one,
+      [makeAgentThreadQueueKey('sl:C2', 'agent:main_agent')]: {
+        name: 'M',
+        folder: 'main_agent',
+        trigger: '',
+        added_at: '2026-04-24T00:00:00.000Z',
+      },
+    };
+    expect(isDefaultAgentLastRoute(two, 'main_agent')).toBe(false);
+
+    // Non-default agents are never flagged.
+    expect(isDefaultAgentLastRoute(one, 'other')).toBe(false);
   });
 
   it('refuses to remove the default agent (main_agent) from desired state', async () => {

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -1421,6 +1421,31 @@ describe('cli slack helpers', () => {
     expect(updated.providerAccounts.orphan_account).toBeUndefined();
   });
 
+  it('refuses to remove the default agent (main_agent) from desired state', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.main_agent = {
+      name: 'Main',
+      folder: 'main_agent',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['main_agent'];
+    saveRuntimeSettings(runtimeHome, settings);
+
+    const result = await pruneDesiredStateAgent({
+      runtimeHome,
+      folder: 'main_agent',
+      remainingRoutes: 0,
+    });
+
+    expect(result.pruned).toBe(false);
+    expect(result.keptAsDefault).toBe(true);
+    expect(loadRuntimeSettings(runtimeHome).agents.main_agent).toBeDefined();
+  });
+
   it('retains a route-less agent that others still delegate to', async () => {
     const runtimeHome = makeRuntimeHome();
     const settings = loadRuntimeSettings(runtimeHome);

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -22,6 +22,7 @@ import { makeAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
 import {
   pruneAgentSenderPolicyOverride,
   pruneDesiredStateAgent,
+  resolveRoutelessAgentFolder,
   resolveGroupSelector,
 } from '@core/cli/group-helpers.js';
 
@@ -1306,6 +1307,137 @@ describe('cli slack helpers', () => {
     expect(updated.bindings.multi_first).toBeUndefined();
     expect(updated.agents.multi.bindings.multi_first).toBeUndefined();
     expect(updated.conversations.slack_default_c0000000001).toBeUndefined();
+  });
+
+  it('resolves a route-less agent so it can be addressed for removal', () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.orphan = {
+      name: 'Orphan',
+      folder: 'orphan',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['orphan'];
+    settings.agents.routed = {
+      ...settings.agents.orphan,
+      name: 'Routed',
+      folder: 'routed',
+    };
+    saveRuntimeSettings(runtimeHome, settings);
+    const reloaded = loadRuntimeSettings(runtimeHome);
+    const routedKey = makeAgentThreadQueueKey('sl:C1', 'agent:routed');
+    const groups = {
+      [routedKey]: {
+        name: 'Routed',
+        folder: 'routed',
+        trigger: '',
+        added_at: '2026-04-24T00:00:00.000Z',
+      },
+    };
+
+    // Route-less agent resolves by both surfaced forms.
+    expect(
+      resolveRoutelessAgentFolder({
+        settings: reloaded,
+        groups,
+        selector: 'agent:orphan',
+      }),
+    ).toBe('orphan');
+    expect(
+      resolveRoutelessAgentFolder({
+        settings: reloaded,
+        groups,
+        selector: 'orphan',
+      }),
+    ).toBe('orphan');
+
+    // An agent that still owns routes belongs to the route-scoped path.
+    expect(
+      resolveRoutelessAgentFolder({
+        settings: reloaded,
+        groups,
+        selector: 'agent:routed',
+      }),
+    ).toBeNull();
+
+    // Unknown selectors stay unknown.
+    expect(
+      resolveRoutelessAgentFolder({
+        settings: reloaded,
+        groups,
+        selector: 'agent:nope',
+      }),
+    ).toBeNull();
+  });
+
+  it('removes a route-less agent from desired state so a reload cannot restore it', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.orphan = {
+      name: 'Orphan',
+      folder: 'orphan',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['orphan'];
+    settings.providerAccounts.orphan_account = {
+      provider: 'slack',
+      agentId: 'orphan',
+      label: 'orphan',
+      runtimeSecretRefs: {},
+    } as (typeof settings.providerAccounts)['orphan_account'];
+    saveRuntimeSettings(runtimeHome, settings);
+
+    const result = await pruneDesiredStateAgent({
+      runtimeHome,
+      folder: 'orphan',
+      remainingRoutes: 0,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.pruned).toBe(true);
+    expect(result.providerAccountsPruned).toBe(1);
+
+    // Re-reading is what a reload/reconcile does: the agent must be gone.
+    const updated = loadRuntimeSettings(runtimeHome);
+    expect(updated.agents.orphan).toBeUndefined();
+    expect(updated.providerAccounts.orphan_account).toBeUndefined();
+  });
+
+  it('retains a route-less agent that others still delegate to', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.helper = {
+      name: 'Helper',
+      folder: 'helper',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['helper'];
+    settings.agents.boss = {
+      ...settings.agents.helper,
+      name: 'Boss',
+      folder: 'boss',
+      delegates: ['helper'],
+    };
+    saveRuntimeSettings(runtimeHome, settings);
+
+    const result = await pruneDesiredStateAgent({
+      runtimeHome,
+      folder: 'helper',
+      remainingRoutes: 0,
+    });
+
+    expect(result.pruned).toBe(false);
+    expect(result.keptForDelegates).toEqual(['boss']);
+    expect(loadRuntimeSettings(runtimeHome).agents.helper).toBeDefined();
   });
 
   it('never leaves a provider account pointing at the removed agent', () => {

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -1371,6 +1371,18 @@ describe('cli slack helpers', () => {
         selector: 'agent:nope',
       }),
     ).toBeNull();
+
+    // Inherited Object properties are not configured agents.
+    for (const reserved of ['constructor', 'toString', '__proto__']) {
+      expect(
+        resolveRoutelessAgentFolder({
+          settings: reloaded,
+          groups,
+          selector: reserved,
+        }),
+        `${reserved} must not resolve as an agent`,
+      ).toBeNull();
+    }
   });
 
   it('removes a route-less agent from desired state so a reload cannot restore it', async () => {

--- a/scripts/agent_chat_test.mjs
+++ b/scripts/agent_chat_test.mjs
@@ -82,7 +82,9 @@ function parseTimeout(raw) {
 
 function assertControlId(value, label) {
   if (!/^[A-Za-z0-9._-]+$/.test(value)) {
-    throw new Error(`${label} must contain only letters, numbers, dot, underscore, or dash`);
+    throw new Error(
+      `${label} must contain only letters, numbers, dot, underscore, or dash`,
+    );
   }
 }
 
@@ -90,7 +92,9 @@ function readRuntimeEnv(runtimeHome) {
   return {
     ...readEnvFile(path.join(runtimeHome, '.env')),
     ...Object.fromEntries(
-      Object.entries(process.env).filter((entry) => typeof entry[1] === 'string'),
+      Object.entries(process.env).filter(
+        (entry) => typeof entry[1] === 'string',
+      ),
     ),
   };
 }
@@ -138,7 +142,8 @@ function controlApiKey(env) {
 }
 
 function controlBaseUrl(env) {
-  if (env.GANTRY_CONTROL_BASE_URL?.trim()) return env.GANTRY_CONTROL_BASE_URL.trim();
+  if (env.GANTRY_CONTROL_BASE_URL?.trim())
+    return env.GANTRY_CONTROL_BASE_URL.trim();
   const port = Number(env.GANTRY_CONTROL_PORT || 0);
   return port > 0 ? `http://127.0.0.1:${port}` : 'http://127.0.0.1';
 }
@@ -146,11 +151,15 @@ function controlBaseUrl(env) {
 function controlSocketPath(runtimeHome, env) {
   if (env.GANTRY_CONTROL_BASE_URL?.trim()) return undefined;
   if (Number(env.GANTRY_CONTROL_PORT || 0) > 0) return undefined;
-  return env.GANTRY_CONTROL_SOCKET_PATH?.trim() || path.join(runtimeHome, 'run', 'control.sock');
+  return (
+    env.GANTRY_CONTROL_SOCKET_PATH?.trim() ||
+    path.join(runtimeHome, 'run', 'control.sock')
+  );
 }
 
 async function requestJson(client, method, requestPath, body) {
-  const payload = body === undefined ? undefined : Buffer.from(JSON.stringify(body));
+  const payload =
+    body === undefined ? undefined : Buffer.from(JSON.stringify(body));
   const url = new URL(requestPath, client.baseUrl);
   const mod = url.protocol === 'https:' ? https : http;
   return await new Promise((resolve, reject) => {
@@ -256,7 +265,8 @@ async function main() {
         )}&timeoutMs=${encodeURIComponent(String(Math.min(remaining, DEFAULT_TIMEOUT_MS)))}`,
       );
     } catch (error) {
-      if (error instanceof Error && error.message.includes('Timed out waiting')) break;
+      if (error instanceof Error && error.message.includes('Timed out waiting'))
+        break;
       throw error;
     }
     if (event?.eventId) afterEventId = event.eventId;

--- a/scripts/architecture-exceptions.json
+++ b/scripts/architecture-exceptions.json
@@ -1,1360 +1,1360 @@
 [
- {
-  "file": "apps/core/src/adapters/credentials/agent-credential-broker-factory.ts",
-  "rule": "provider_specific_path",
-  "reason": "The credential factory composes the Gantry Model Gateway implementation from the approved Anthropic-compatible LLM adapter boundary; capped to this one import path.",
-  "removeByPhase": "model-gateway-composition-boundary-cleanup",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/adapters/storage/postgres/factory.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts",
-  "rule": "provider_specific_path",
-  "reason": "Default LlmProfile insertion persists canonical response_family API shape, not an SDK provider selector; capped so repository projection does not grow provider branches.",
-  "removeByPhase": "schema-generated-llm-profile-defaults",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/adapters/storage/postgres/repositories/control-plane-graph.postgres.ts",
-  "rule": "provider_specific_path",
-  "reason": "Default LlmProfile insertion persists canonical response_family API shape, not an SDK provider selector; capped so repository projection does not grow provider branches.",
-  "removeByPhase": "schema-generated-llm-profile-defaults",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/adapters/storage/postgres/schema/agents.ts",
-  "rule": "provider_specific_path",
-  "reason": "Baseline provider/channel terminology debt from provider-neutral refactor; capped so new provider-specific code outside approved adapters fails.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/adapters/storage/postgres/seeds.ts",
-  "rule": "provider_specific_path",
-  "reason": "Seeded LlmProfile rows persist the current canonical response family, not a provider selector; capped so storage projection does not grow provider-specific branches.",
-  "removeByPhase": "schema-generated-llm-profile-defaults",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/adapters/storage/postgres/storage-readiness.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/adapters/storage/postgres/storage-readiness.ts",
-  "rule": "provider_specific_path",
-  "reason": "Baseline provider/channel terminology debt from provider-neutral refactor; capped so new provider-specific code outside approved adapters fails.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/app/bootstrap/channel-capability-ports.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/app/bootstrap/channel-wiring-types.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/app/bootstrap/channel-wiring.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 7
- },
- {
-  "file": "apps/core/src/app/bootstrap/runtime-app.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 5
- },
- {
-  "file": "apps/core/src/app/bootstrap/runtime-services.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/app/bootstrap/startup.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception. +1 (2026-07-14): observability tracing bootstrap (initTracing/shutdownTracing from infrastructure/observability) \u2014 settings-adjacent init; move behind a domain port when the boundary slice lands.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/app/index.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Runtime composition wires infrastructure adapters, including the bounded MCP DNS lookup adapter, into application/runtime ports.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/channels/channel-provider.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/channels/slack/channel-delivery.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/channels/slack/channel-state.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/channels/telegram/channel-connect.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/channels/telegram/channel-delivery.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/channels/telegram/channel-prompts.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/channels/telegram/channel-shared.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/channels/telegram/channel-state.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/cli/provider.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/config.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/doctor.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 5
- },
- {
-  "file": "apps/core/src/cli/group-args.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/cli/group-harness.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Local CLI agent-harness administration follows existing CLI settings-persistence adapters; capped so additional config imports fail until CLI settings writes are ported.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/cli/group-helpers.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/group-policy-format.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/cli/group.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/index.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/local.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/memory-health.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor, plus embedding default/model imports for the semantic-memory health check; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/model.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Local CLI model-default administration follows existing CLI settings-persistence adapters; capped so additional config imports fail until CLI settings writes are ported.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/cli/memory-status.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/memory.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/memory-embeddings-backfill.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "CLI embedding backfill command drives the runtime backfill engine and reads embedding settings, following the existing CLI memory-administration adapters; capped until the canonical boundary cleanup ports CLI memory writes.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/cli/onboarding-config.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/cli/onboarding-state.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/cli/runtime-group-db.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/setup-credentials.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/cli/setup-flow-core-steps.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/cli/setup-flow-final-steps.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/setup-flow-state.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/cli/setup-flow.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/cli/slack.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/status.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor, plus WP3 deployment-role display: `gantry status` resolves the process role and role-capability summary from the runtime roles module (resolveProcessRole/roleCapabilities). Capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/cli/telegram-connect.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/telegram.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/teams.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Teams setup follows the existing CLI setup adapter pattern for env/settings persistence while the Graph discovery seam lives under channels; capped so additional config imports fail until the boundary slice extracts setup persistence.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/discord.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Discord setup follows the existing CLI setup adapter pattern for env/settings persistence while the REST discovery seam lives under channels; capped so additional config imports fail until the boundary slice extracts setup persistence.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/config/env/index.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact config provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
-  "removeByPhase": "provider-boundary-config-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/config/index.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact config provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
-  "removeByPhase": "provider-boundary-config-cleanup-phase",
-  "maxViolations": 10
- },
- {
-  "file": "apps/core/src/config/preflight.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/config/settings/desired-state-provider-conversations.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact settings provider-conversation debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
-  "removeByPhase": "provider-boundary-config-cleanup-phase",
-  "maxViolations": 14
- },
- {
-  "file": "apps/core/src/config/settings/memory-snapshot.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact settings memory model debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
-  "removeByPhase": "provider-boundary-config-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/config/settings/runtime-settings-memory-parser.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact settings memory model debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
-  "removeByPhase": "provider-boundary-config-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/settings/control-allowlist.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/settings/runtime-home.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/settings/runtime-settings-defaults.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/config/settings/runtime-settings-parser.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/settings/runtime-settings.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Settings desired-state helpers still bridge provider JID and agent-folder legacy primitives until the conversation repository becomes the only registration path; capped so additional imports fail.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/config/settings/runtime-settings.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact settings provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
-  "removeByPhase": "provider-boundary-config-cleanup-phase",
-  "maxViolations": 11
- },
- {
-  "file": "apps/core/src/config/settings/runtime-settings-validation.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 5
- },
- {
-  "file": "apps/core/src/config/settings/sender-allowlist.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/settings/storage.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/source-classification.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact config source-classification provider debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
-  "removeByPhase": "provider-boundary-config-cleanup-phase",
-  "maxViolations": 17
- },
- {
-  "file": "apps/core/src/control/server/handler-context.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/control/server/index.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/control/server/routes/jobs.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/control/server/routes/memory.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/domain/repositories/domain-types.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/infrastructure/pgboss/scheduler-engine.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Scheduler engine composes config plus the full runtime jobs surface (concurrency, capability dispatch/starvation/readiness, session/worker identity, schedule, types) added by the process-role split; capped at exact current count until the scheduler is split behind an application job port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 10
- },
- {
-  "file": "apps/core/src/infrastructure/service/launchd.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/infrastructure/service/manager.ts",
-  "rule": "direct_risky_execution",
-  "reason": "Baseline host-execution debt pending sandbox adapter cutover; capped so new direct execution calls fail.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/infrastructure/service/manager.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/jobs/execution.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/jobs/ipc-admin-handlers.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 5
- },
- {
-  "file": "apps/core/src/jobs/ipc-handler.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/jobs/ipc-scheduler-create-handlers.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/jobs/ipc-scheduler-mutate-handlers.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/jobs/ipc-shared.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 5
- },
- {
-  "file": "apps/core/src/jobs/schedule-math.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/jobs/schedule.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/jobs/scheduler.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/jobs/scheduler.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Non-executing-role manual trigger spins an ephemeral send-only pg-boss client directly; capped at exact count until the queue transport is behind an adapter port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/jobs/system-jobs.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/jobs/types.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-boundaries.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-boundaries.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-dreaming.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-dreaming.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-service.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-service.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Semantic-memory embedding backfill engine carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Semantic-memory embedding backfill engine carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill-candidates.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Semantic-memory backfill candidate scan carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill-candidates.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Semantic-memory backfill candidate scan carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill-runs.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Semantic-memory backfill run records carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill-runs.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Semantic-memory backfill run records carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill-provider-batch.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Semantic-memory provider batch poll/import carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-backfill-provider-batch.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Semantic-memory provider batch poll/import carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-embedding-writes.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Shared semantic-memory embedding write helper carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-embedding-writes.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Shared semantic-memory embedding write helper carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/memory-embedding-cache-store.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Query-embedding cache store carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/memory-embedding-cache-store.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Query-embedding cache store carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-dream-embeddings.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Dream embedding writes now persist pgvector columns via the shared embedding write helper, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-dream-embeddings.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Dream embedding writes now persist pgvector columns via the shared embedding write helper, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-recall-embedding.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Recall query-embedding capability reads embedding config/schema and the shared logger, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/memory/app-memory-embedding-status.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Semantic-memory status counts read embedding schema directly, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-embedding-status.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Semantic-memory status counts read embedding schema/config directly, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-trigger-dreaming.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory dreaming debt; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-trigger-dreaming.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory dreaming debt; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-item-queries.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory debt; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-item-queries.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory debt; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-review.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Memory review storage remains in the current Postgres-backed memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-review.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Memory review storage remains in the current Postgres-backed memory service slice; replace with repository ports in the canonical boundary cleanup.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/maintenance-queue.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/memory-embedding-cache.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/memory-embeddings.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Brokered memory embeddings still resolve credential-broker adapters from the runtime memory module in this slice; extract provider wiring into an adapter-owned composition point.",
-  "removeByPhase": "memory-embedding-provider-adapter-extraction",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/memory/memory-ipc.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/memory-types.ts",
-  "rule": "provider_specific_path",
-  "reason": "Baseline provider/channel terminology debt from provider-neutral refactor; capped so new provider-specific code outside approved adapters fails.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 7
- },
- {
-  "file": "apps/core/src/messaging/router.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/platform/workspace-folder.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/platform/sender-allowlist.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 8
- },
- {
-  "file": "apps/core/src/runtime/agent-spawn-host.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/runtime/agent-spawn-process.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/runtime/agent-spawn-types.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/agent-spawn.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/agent-spawn.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 5
- },
- {
-  "file": "apps/core/src/runtime/browser-capability.ts",
-  "rule": "direct_risky_execution",
-  "reason": "Baseline host-execution debt pending sandbox adapter cutover; capped so new direct execution calls fail.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/browser-capability.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/browser-process.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Browser runtime inspects persisted Chrome command lines to reject non-visible or non-profile-owned session adoption; capped to this host process helper until runtime process ports are extracted.",
-  "removeByPhase": "browser-process-port-extraction",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/browser-profiles.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/continuation-input.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/group-processing-types.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/group-processing.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/runtime/group-queue-stop.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/group-queue.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/group-registry.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/runtime/ipc-auth-validation.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/runtime/ipc-auth.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/runtime/ipc-browser-handler.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/runtime/ipc-interaction-handler.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/runtime/ipc.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/runtime/message-loop.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/shared/message-cursor.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/shared/browser-site.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Browser usage settings and runtime auditing need one shared public-suffix-aware eTLD+1 normalizer; capped to this helper until shared parser dependencies are formally modeled.",
-  "removeByPhase": "browser-usage-config-contract",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/application/mcp/mcp-output-schema-validator.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "MCP outputSchema validation uses the installed JSON Schema validator until MCP proxy execution is split behind an adapter-owned validation port; capped to the single validator import.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/application/mcp/mcp-tool-proxy.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Current MCP proxy owns direct MCP SDK transport calls until the MCP proxy is split behind an adapter port; capped so additional SDK imports fail.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/messaging/text-styles.ts",
-  "rule": "provider_specific_path",
-  "reason": "Baseline channel formatting dialect name remains in the messaging formatter until provider-specific rendering is moved fully behind channel adapters.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/shared/model-catalog.ts",
-  "rule": "provider_specific_path",
-  "reason": "Exact shared model-catalog provider debt after removing the broad shared provider allowlist; capped so new provider-specific shared leakage fails.",
-  "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
-  "maxViolations": 44
- },
- {
-  "file": "apps/core/src/shared/model-catalog-openai-compatible.ts",
-  "rule": "provider_specific_path",
-  "reason": "Sibling of model-catalog.ts holding the eight OpenAI-compatible DeepAgents-lane catalog entries (groq/deepseek/xai/together/fireworks/cerebras/perplexity/gemini); extracted to keep model-catalog.ts under its line budget. Same intentional provider-catalog debt, capped to its exact entry set.",
-  "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
-  "maxViolations": 46
- },
- {
-  "file": "apps/core/src/shared/model-cache-support.ts",
-  "rule": "provider_specific_path",
-  "reason": "Provider-side cache accounting maps catalog cache modes to registry-declared provider behavior in one exact helper; capped so cache logic cannot spread into other shared files.",
-  "removeByPhase": "provider-cache-registry-cleanup-phase",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/shared/model-provider-registry.ts",
-  "rule": "provider_specific_path",
-  "reason": "The model provider registry is the intentional source of truth for provider definitions, credential modes, gateway behavior, and cache metadata until the architecture checker has first-class provider-registry ownership.",
-  "removeByPhase": "provider-registry-boundary-rule",
-  "maxViolations": 41
- },
- {
-  "file": "apps/core/src/shared/model-provider-registry-openai-compatible.ts",
-  "rule": "provider_specific_path",
-  "reason": "Sibling of model-provider-registry.ts holding the eight OpenAI-compatible DeepAgents-lane provider definitions (groq/deepseek/xai/together/fireworks/cerebras/perplexity/gemini); extracted to keep model-provider-registry.ts under its line budget. Same intentional provider-registry source-of-truth debt, capped to its exact provider set.",
-  "removeByPhase": "provider-registry-boundary-rule",
-  "maxViolations": 22
- },
- {
-  "file": "apps/core/src/cli/settings.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Local settings CLI is an adapter over settings.yaml parsing and runtime storage export; extract a command port before tightening this boundary.",
-  "removeByPhase": "settings-desired-state-port-extraction",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/cli/credentials.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "The credentials CLI is an owner/admin adapter over settings-backed credential readiness and still imports runtime settings directly until the credential command service is extracted.",
-  "removeByPhase": "credential-cli-service-boundary",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/jobs/ipc-runtime-admin-handlers.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Runtime admin IPC composes reviewed settings.yaml writes, preflight, and storage-backed validation until the admin settings tool is moved behind an application port.",
-  "removeByPhase": "settings-desired-state-port-extraction",
-  "maxViolations": 9
- },
- {
-  "file": "apps/core/src/runtime/settings-reload-watcher.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Runtime settings watcher composes filesystem reload, validation, and desired-state reconciliation until reload is represented as an application port.",
-  "removeByPhase": "settings-desired-state-port-extraction",
-  "maxViolations": 6
- },
- {
-  "file": "apps/core/src/runtime/egress-gateway.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "The runtime-owned egress gateway owns temporary Node HTTP/socket plumbing until the outbound transport adapter port is extracted.",
-  "removeByPhase": "egress-gateway-adapter-extraction",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/adapters/llm/anthropic-claude-agent/execution-adapter.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Anthropic execution adapter currently consumes the host runtime spawn contract while this phase extracts provider-specific preparation behind a runtime-selected adapter; collapse to an application-owned port in the next boundary cleanup.",
-  "removeByPhase": "provider-neutral execution adapter follow-up",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/adapters/llm/anthropic-claude-agent/memory-query.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Anthropic memory LLM adapter reuses existing config and credential-broker access while direct SDK imports are moved out of memory; move credential runtime config behind an application port next.",
-  "removeByPhase": "memory credential port cleanup",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/adapters/llm/openai-memory/memory-gateway-injection.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "OpenAI-family memory LLM adapter reuses the same credential-broker runtime config as the Anthropic memory adapter to reach the Gantry model gateway; move credential runtime config behind an application port next.",
-  "removeByPhase": "memory credential port cleanup",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/extractor-llm.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Pre-existing memory runtime dependencies on config and logging remain unchanged by the Anthropic SDK extraction.",
-  "removeByPhase": "memory service layering cleanup",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/memory-llm-proposals.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Split from extractor-llm to keep file-size ratchet while preserving existing memory LLM config and logging dependencies.",
-  "removeByPhase": "memory service layering cleanup",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/control/server/routes/agents.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Agent profile-file endpoints materialize visible profile mirrors and resolve the workspace folder; capped so additional adapter->runtime/config imports fail until the canonical boundary slice extracts a profile composition seam.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/app/bootstrap/fleet-boot.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Fleet bootstrap composes Postgres runtime-store, S3/local artifact stores, and settings/config services at the worker entrypoint; capped at exact current count until the fleet-boot composition is moved behind an application bootstrap port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 8
- },
- {
-  "file": "apps/core/src/app/bootstrap/fleet-boot.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Fleet bootstrap composes Postgres runtime-store, S3/local artifact stores, and settings/config services at the worker entrypoint; capped at exact current count until the fleet-boot composition is moved behind an application bootstrap port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/jobs/toolchain-bake-bootstrap.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Toolchain bake bootstrap wires config, Postgres runtime-store, and S3/local artifact stores for first-boot bake provisioning; capped at exact current count until artifact provisioning moves behind a port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 5
- },
- {
-  "file": "apps/core/src/jobs/toolchain-bake-queue.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Toolchain bake/manifest job uses pg/pg-boss directly for LISTEN/NOTIFY and queue plumbing; capped at exact count until the queue transport is behind an adapter port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/jobs/toolchain-manifest-listener.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Toolchain bake/manifest job uses pg/pg-boss directly for LISTEN/NOTIFY and queue plumbing; capped at exact count until the queue transport is behind an adapter port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/jobs/toolchain-manifest-notify.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Toolchain bake/manifest job uses pg/pg-boss directly for LISTEN/NOTIFY and queue plumbing; capped at exact count until the queue transport is behind an adapter port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/settings/settings-import-service.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Fleet settings revision import/notify uses pg directly for LISTEN/NOTIFY revision propagation; capped at exact count until the settings transport is behind an adapter port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/config/settings/settings-revision-notify.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Fleet settings revision import/notify uses pg directly for LISTEN/NOTIFY revision propagation; capped at exact count until the settings transport is behind an adapter port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/cli/artifacts.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Artifacts/bake CLI composes config plus runtime toolchain queue/reaper/notify services as a local admin adapter; capped at exact count until the toolchain command service is extracted.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/bake.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Artifacts/bake CLI composes config plus runtime toolchain queue/reaper/notify services as a local admin adapter; capped at exact count until the toolchain command service is extracted.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/cli/group-access.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Group-access CLI is a local admin adapter over settings.yaml desired-state writers and runtime settings types; capped at exact count until the group-access command service is extracted.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/group-engine.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Group-engine CLI verb is a local admin adapter over settings.yaml desired-state writers and runtime settings types (mirrors group-access); capped at exact count until the agent-command service is extracted.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/cli/group-list.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Group-list CLI verb reads runtime settings to render each agent's effective engine; capped at exact count until the agent-command service is extracted.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/control/server/routes/system.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "System control routes read draining state, settings-load state, and config directly for /readyz, /metrics, and /v1/status; capped at exact count until readiness/draining are injected through ControlRouteContext.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/control/server/routes/settings.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Settings control routes parse and import fleet settings revisions via config services directly; capped at exact count until settings parse/import is injected through ControlRouteContext.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/runtime/settings-revision-listener.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Runtime settings revision listener composes desired-state service, settings import, and revision notify directly; capped at exact count until revision propagation is an application port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 3
- },
- {
-  "file": "apps/core/src/jobs/execution-readiness.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Job execution-readiness reads config and the Postgres runtime-store directly to compute fleet readiness; capped at exact count until readiness storage access is behind a repository port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/runtime/ipc-interaction-processing.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "IPC interaction processing reads the agent access policy from config/profiles for locked-agent enforcement; capped to this single import until access policy is exposed through a runtime-owned port.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/jobs/toolchain-bake-runner.ts",
-  "rule": "direct_risky_execution",
-  "reason": "Toolchain bake runner spawns the registry-pinned npm install child process directly for bake jobs; capped to this single call until bake execution moves through the sandbox adapter.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/shared/agent-engine.ts",
-  "rule": "provider_specific_path",
-  "reason": "public AgentEngine vocabulary per docs/architecture/deepagents-agent-engine-handoff-plan.md",
-  "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/shared/model-execution-route.ts",
-  "rule": "provider_specific_path",
-  "reason": "public AgentEngine vocabulary per docs/architecture/deepagents-agent-engine-handoff-plan.md",
-  "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
-  "maxViolations": 4
- },
- {
-  "file": "apps/core/src/memory/app-memory-review-create.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Memory review creation queries Postgres via drizzle exactly like its sibling memory query modules; capped so new external imports fail until the canonical storage-port refactor removes direct drizzle use from the memory layer.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 2
- },
- {
-  "file": "apps/core/src/memory/app-memory-review-create.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Memory review creation reads the Postgres schema tables directly like its sibling memory query modules; capped so new adapter imports fail until the canonical storage-port refactor.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-dreaming-review-routing.ts",
-  "rule": "forbidden_external_import_by_layer",
-  "reason": "Dream review routing journals decisions and updates candidate status via drizzle exactly like its sibling memory dreaming modules; capped until the canonical storage-port refactor.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/memory/app-memory-dreaming-review-routing.ts",
-  "rule": "forbidden_import_by_layer",
-  "reason": "Dream review routing reads Postgres schema tables directly like its sibling memory dreaming modules; capped until the canonical storage-port refactor.",
-  "removeByPhase": "canonical-boundary-cleanup-phase",
-  "maxViolations": 1
- },
- {
-  "file": "apps/core/src/shared/sdk-native-skill-names.ts",
-  "rule": "provider_specific_path",
-  "reason": "anthropic_sdk is a deliberate sentinel token of the agent-harness selection contract (decision 0028); relocation would force a forbidden application-to-adapter import. Exact ratchet; review trigger ledgered as deferral D-0004.",
-  "removeByPhase": "agent-harness-vocabulary-supersedes-0028",
-  "maxViolations": 4
- }
+  {
+    "file": "apps/core/src/adapters/credentials/agent-credential-broker-factory.ts",
+    "rule": "provider_specific_path",
+    "reason": "The credential factory composes the Gantry Model Gateway implementation from the approved Anthropic-compatible LLM adapter boundary; capped to this one import path.",
+    "removeByPhase": "model-gateway-composition-boundary-cleanup",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/adapters/storage/postgres/factory.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts",
+    "rule": "provider_specific_path",
+    "reason": "Default LlmProfile insertion persists canonical response_family API shape, not an SDK provider selector; capped so repository projection does not grow provider branches.",
+    "removeByPhase": "schema-generated-llm-profile-defaults",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/adapters/storage/postgres/repositories/control-plane-graph.postgres.ts",
+    "rule": "provider_specific_path",
+    "reason": "Default LlmProfile insertion persists canonical response_family API shape, not an SDK provider selector; capped so repository projection does not grow provider branches.",
+    "removeByPhase": "schema-generated-llm-profile-defaults",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/adapters/storage/postgres/schema/agents.ts",
+    "rule": "provider_specific_path",
+    "reason": "Baseline provider/channel terminology debt from provider-neutral refactor; capped so new provider-specific code outside approved adapters fails.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/adapters/storage/postgres/seeds.ts",
+    "rule": "provider_specific_path",
+    "reason": "Seeded LlmProfile rows persist the current canonical response family, not a provider selector; capped so storage projection does not grow provider-specific branches.",
+    "removeByPhase": "schema-generated-llm-profile-defaults",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/adapters/storage/postgres/storage-readiness.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/adapters/storage/postgres/storage-readiness.ts",
+    "rule": "provider_specific_path",
+    "reason": "Baseline provider/channel terminology debt from provider-neutral refactor; capped so new provider-specific code outside approved adapters fails.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/channel-capability-ports.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/channel-wiring-types.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/channel-wiring.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 7
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/runtime-app.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 5
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/runtime-services.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/startup.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception. +1 (2026-07-14): observability tracing bootstrap (initTracing/shutdownTracing from infrastructure/observability) \u2014 settings-adjacent init; move behind a domain port when the boundary slice lands.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/app/index.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Runtime composition wires infrastructure adapters, including the bounded MCP DNS lookup adapter, into application/runtime ports.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/channels/channel-provider.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/channels/slack/channel-delivery.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/channels/slack/channel-state.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/channels/telegram/channel-connect.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/channels/telegram/channel-delivery.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/channels/telegram/channel-prompts.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/channels/telegram/channel-shared.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/channels/telegram/channel-state.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/cli/provider.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/config.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/doctor.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 5
+  },
+  {
+    "file": "apps/core/src/cli/group-args.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/cli/group-harness.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Local CLI agent-harness administration follows existing CLI settings-persistence adapters; capped so additional config imports fail until CLI settings writes are ported.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/cli/group-helpers.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/group-policy-format.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/cli/group.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/index.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/local.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/memory-health.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor, plus embedding default/model imports for the semantic-memory health check; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/model.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Local CLI model-default administration follows existing CLI settings-persistence adapters; capped so additional config imports fail until CLI settings writes are ported.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/cli/memory-status.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/memory.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/memory-embeddings-backfill.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "CLI embedding backfill command drives the runtime backfill engine and reads embedding settings, following the existing CLI memory-administration adapters; capped until the canonical boundary cleanup ports CLI memory writes.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/cli/onboarding-config.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/cli/onboarding-state.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/cli/runtime-group-db.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/setup-credentials.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/cli/setup-flow-core-steps.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/cli/setup-flow-final-steps.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/setup-flow-state.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/cli/setup-flow.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/cli/slack.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/status.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor, plus WP3 deployment-role display: `gantry status` resolves the process role and role-capability summary from the runtime roles module (resolveProcessRole/roleCapabilities). Capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/cli/telegram-connect.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/telegram.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/teams.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Teams setup follows the existing CLI setup adapter pattern for env/settings persistence while the Graph discovery seam lives under channels; capped so additional config imports fail until the boundary slice extracts setup persistence.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/discord.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Discord setup follows the existing CLI setup adapter pattern for env/settings persistence while the REST discovery seam lives under channels; capped so additional config imports fail until the boundary slice extracts setup persistence.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/config/env/index.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact config provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/config/index.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact config provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 10
+  },
+  {
+    "file": "apps/core/src/config/preflight.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/config/settings/desired-state-provider-conversations.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings provider-conversation debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 14
+  },
+  {
+    "file": "apps/core/src/config/settings/memory-snapshot.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings memory model debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-settings-memory-parser.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings memory model debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/settings/control-allowlist.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-home.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-settings-defaults.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-settings-parser.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-settings.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Settings desired-state helpers still bridge provider JID and agent-folder legacy primitives until the conversation repository becomes the only registration path; capped so additional imports fail.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-settings.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact settings provider-name debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 11
+  },
+  {
+    "file": "apps/core/src/config/settings/runtime-settings-validation.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 5
+  },
+  {
+    "file": "apps/core/src/config/settings/sender-allowlist.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/settings/storage.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/source-classification.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact config source-classification provider debt after removing the broad config provider allowlist; capped so new provider-specific config leakage fails.",
+    "removeByPhase": "provider-boundary-config-cleanup-phase",
+    "maxViolations": 17
+  },
+  {
+    "file": "apps/core/src/control/server/handler-context.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/control/server/index.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/control/server/routes/jobs.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/control/server/routes/memory.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/domain/repositories/domain-types.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/infrastructure/pgboss/scheduler-engine.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Scheduler engine composes config plus the full runtime jobs surface (concurrency, capability dispatch/starvation/readiness, session/worker identity, schedule, types) added by the process-role split; capped at exact current count until the scheduler is split behind an application job port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 10
+  },
+  {
+    "file": "apps/core/src/infrastructure/service/launchd.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/infrastructure/service/manager.ts",
+    "rule": "direct_risky_execution",
+    "reason": "Baseline host-execution debt pending sandbox adapter cutover; capped so new direct execution calls fail.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/infrastructure/service/manager.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/jobs/execution.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/jobs/ipc-admin-handlers.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 5
+  },
+  {
+    "file": "apps/core/src/jobs/ipc-handler.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/jobs/ipc-scheduler-create-handlers.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/jobs/ipc-scheduler-mutate-handlers.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/jobs/ipc-shared.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 5
+  },
+  {
+    "file": "apps/core/src/jobs/schedule-math.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/jobs/schedule.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/jobs/scheduler.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/jobs/scheduler.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Non-executing-role manual trigger spins an ephemeral send-only pg-boss client directly; capped at exact count until the queue transport is behind an adapter port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/jobs/system-jobs.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/jobs/types.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-boundaries.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-boundaries.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-dreaming.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-dreaming.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-service.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-service.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Semantic-memory embedding backfill engine carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Semantic-memory embedding backfill engine carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill-candidates.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Semantic-memory backfill candidate scan carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill-candidates.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Semantic-memory backfill candidate scan carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill-runs.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Semantic-memory backfill run records carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill-runs.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Semantic-memory backfill run records carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill-provider-batch.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Semantic-memory provider batch poll/import carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-backfill-provider-batch.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Semantic-memory provider batch poll/import carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-embedding-writes.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Shared semantic-memory embedding write helper carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-embedding-writes.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Shared semantic-memory embedding write helper carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/memory-embedding-cache-store.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Query-embedding cache store carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/memory-embedding-cache-store.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Query-embedding cache store carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-dream-embeddings.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Dream embedding writes now persist pgvector columns via the shared embedding write helper, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-dream-embeddings.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Dream embedding writes now persist pgvector columns via the shared embedding write helper, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-recall-embedding.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Recall query-embedding capability reads embedding config/schema and the shared logger, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-embedding-status.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Semantic-memory status counts read embedding schema directly, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-embedding-status.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Semantic-memory status counts read embedding schema/config directly, carrying the same Postgres-backed runtime debt as the memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-trigger-dreaming.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory dreaming debt; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-trigger-dreaming.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory dreaming debt; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-item-queries.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory debt; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-item-queries.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Split from app-memory-service to keep file-size ratchet while preserving existing Postgres-backed memory debt; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-review.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Memory review storage remains in the current Postgres-backed memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-review.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Memory review storage remains in the current Postgres-backed memory service slice; replace with repository ports in the canonical boundary cleanup.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/maintenance-queue.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/memory-embedding-cache.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/memory-embeddings.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Brokered memory embeddings still resolve credential-broker adapters from the runtime memory module in this slice; extract provider wiring into an adapter-owned composition point.",
+    "removeByPhase": "memory-embedding-provider-adapter-extraction",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/memory/memory-ipc.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/memory-types.ts",
+    "rule": "provider_specific_path",
+    "reason": "Baseline provider/channel terminology debt from provider-neutral refactor; capped so new provider-specific code outside approved adapters fails.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 7
+  },
+  {
+    "file": "apps/core/src/messaging/router.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/platform/workspace-folder.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/platform/sender-allowlist.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 8
+  },
+  {
+    "file": "apps/core/src/runtime/agent-spawn-host.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/runtime/agent-spawn-process.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/runtime/agent-spawn-types.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/agent-spawn.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/agent-spawn.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 5
+  },
+  {
+    "file": "apps/core/src/runtime/browser-capability.ts",
+    "rule": "direct_risky_execution",
+    "reason": "Baseline host-execution debt pending sandbox adapter cutover; capped so new direct execution calls fail.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/browser-capability.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/browser-process.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Browser runtime inspects persisted Chrome command lines to reject non-visible or non-profile-owned session adoption; capped to this host process helper until runtime process ports are extracted.",
+    "removeByPhase": "browser-process-port-extraction",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/browser-profiles.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/continuation-input.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/group-processing-types.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/group-processing.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/runtime/group-queue-stop.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/group-queue.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Baseline external-import debt from runtime-to-adapter extraction; capped so new runtime package imports fail until adapter ports replace this path.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/group-registry.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/runtime/ipc-auth-validation.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/runtime/ipc-auth.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/runtime/ipc-browser-handler.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/runtime/ipc-interaction-handler.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/runtime/ipc.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/runtime/message-loop.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/shared/message-cursor.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Baseline layer-boundary debt from the in-progress canonical runtime refactor; capped so new imports fail until the boundary slice removes this exception.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/shared/browser-site.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Browser usage settings and runtime auditing need one shared public-suffix-aware eTLD+1 normalizer; capped to this helper until shared parser dependencies are formally modeled.",
+    "removeByPhase": "browser-usage-config-contract",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/application/mcp/mcp-output-schema-validator.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "MCP outputSchema validation uses the installed JSON Schema validator until MCP proxy execution is split behind an adapter-owned validation port; capped to the single validator import.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/application/mcp/mcp-tool-proxy.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Current MCP proxy owns direct MCP SDK transport calls until the MCP proxy is split behind an adapter port; capped so additional SDK imports fail.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/messaging/text-styles.ts",
+    "rule": "provider_specific_path",
+    "reason": "Baseline channel formatting dialect name remains in the messaging formatter until provider-specific rendering is moved fully behind channel adapters.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/shared/model-catalog.ts",
+    "rule": "provider_specific_path",
+    "reason": "Exact shared model-catalog provider debt after removing the broad shared provider allowlist; capped so new provider-specific shared leakage fails.",
+    "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
+    "maxViolations": 44
+  },
+  {
+    "file": "apps/core/src/shared/model-catalog-openai-compatible.ts",
+    "rule": "provider_specific_path",
+    "reason": "Sibling of model-catalog.ts holding the eight OpenAI-compatible DeepAgents-lane catalog entries (groq/deepseek/xai/together/fireworks/cerebras/perplexity/gemini); extracted to keep model-catalog.ts under its line budget. Same intentional provider-catalog debt, capped to its exact entry set.",
+    "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
+    "maxViolations": 46
+  },
+  {
+    "file": "apps/core/src/shared/model-cache-support.ts",
+    "rule": "provider_specific_path",
+    "reason": "Provider-side cache accounting maps catalog cache modes to registry-declared provider behavior in one exact helper; capped so cache logic cannot spread into other shared files.",
+    "removeByPhase": "provider-cache-registry-cleanup-phase",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/shared/model-provider-registry.ts",
+    "rule": "provider_specific_path",
+    "reason": "The model provider registry is the intentional source of truth for provider definitions, credential modes, gateway behavior, and cache metadata until the architecture checker has first-class provider-registry ownership.",
+    "removeByPhase": "provider-registry-boundary-rule",
+    "maxViolations": 41
+  },
+  {
+    "file": "apps/core/src/shared/model-provider-registry-openai-compatible.ts",
+    "rule": "provider_specific_path",
+    "reason": "Sibling of model-provider-registry.ts holding the eight OpenAI-compatible DeepAgents-lane provider definitions (groq/deepseek/xai/together/fireworks/cerebras/perplexity/gemini); extracted to keep model-provider-registry.ts under its line budget. Same intentional provider-registry source-of-truth debt, capped to its exact provider set.",
+    "removeByPhase": "provider-registry-boundary-rule",
+    "maxViolations": 22
+  },
+  {
+    "file": "apps/core/src/cli/settings.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Local settings CLI is an adapter over settings.yaml parsing and runtime storage export; extract a command port before tightening this boundary.",
+    "removeByPhase": "settings-desired-state-port-extraction",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/cli/credentials.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "The credentials CLI is an owner/admin adapter over settings-backed credential readiness and still imports runtime settings directly until the credential command service is extracted.",
+    "removeByPhase": "credential-cli-service-boundary",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/jobs/ipc-runtime-admin-handlers.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Runtime admin IPC composes reviewed settings.yaml writes, preflight, and storage-backed validation until the admin settings tool is moved behind an application port.",
+    "removeByPhase": "settings-desired-state-port-extraction",
+    "maxViolations": 9
+  },
+  {
+    "file": "apps/core/src/runtime/settings-reload-watcher.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Runtime settings watcher composes filesystem reload, validation, and desired-state reconciliation until reload is represented as an application port.",
+    "removeByPhase": "settings-desired-state-port-extraction",
+    "maxViolations": 6
+  },
+  {
+    "file": "apps/core/src/runtime/egress-gateway.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "The runtime-owned egress gateway owns temporary Node HTTP/socket plumbing until the outbound transport adapter port is extracted.",
+    "removeByPhase": "egress-gateway-adapter-extraction",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/adapters/llm/anthropic-claude-agent/execution-adapter.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Anthropic execution adapter currently consumes the host runtime spawn contract while this phase extracts provider-specific preparation behind a runtime-selected adapter; collapse to an application-owned port in the next boundary cleanup.",
+    "removeByPhase": "provider-neutral execution adapter follow-up",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/adapters/llm/anthropic-claude-agent/memory-query.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Anthropic memory LLM adapter reuses existing config and credential-broker access while direct SDK imports are moved out of memory; move credential runtime config behind an application port next.",
+    "removeByPhase": "memory credential port cleanup",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/adapters/llm/openai-memory/memory-gateway-injection.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "OpenAI-family memory LLM adapter reuses the same credential-broker runtime config as the Anthropic memory adapter to reach the Gantry model gateway; move credential runtime config behind an application port next.",
+    "removeByPhase": "memory credential port cleanup",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/extractor-llm.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Pre-existing memory runtime dependencies on config and logging remain unchanged by the Anthropic SDK extraction.",
+    "removeByPhase": "memory service layering cleanup",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/memory-llm-proposals.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Split from extractor-llm to keep file-size ratchet while preserving existing memory LLM config and logging dependencies.",
+    "removeByPhase": "memory service layering cleanup",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/control/server/routes/agents.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Agent profile-file endpoints materialize visible profile mirrors and resolve the workspace folder; capped so additional adapter->runtime/config imports fail until the canonical boundary slice extracts a profile composition seam.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/fleet-boot.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Fleet bootstrap composes Postgres runtime-store, S3/local artifact stores, and settings/config services at the worker entrypoint; capped at exact current count until the fleet-boot composition is moved behind an application bootstrap port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 8
+  },
+  {
+    "file": "apps/core/src/app/bootstrap/fleet-boot.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Fleet bootstrap composes Postgres runtime-store, S3/local artifact stores, and settings/config services at the worker entrypoint; capped at exact current count until the fleet-boot composition is moved behind an application bootstrap port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/jobs/toolchain-bake-bootstrap.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Toolchain bake bootstrap wires config, Postgres runtime-store, and S3/local artifact stores for first-boot bake provisioning; capped at exact current count until artifact provisioning moves behind a port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 5
+  },
+  {
+    "file": "apps/core/src/jobs/toolchain-bake-queue.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Toolchain bake/manifest job uses pg/pg-boss directly for LISTEN/NOTIFY and queue plumbing; capped at exact count until the queue transport is behind an adapter port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/jobs/toolchain-manifest-listener.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Toolchain bake/manifest job uses pg/pg-boss directly for LISTEN/NOTIFY and queue plumbing; capped at exact count until the queue transport is behind an adapter port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/jobs/toolchain-manifest-notify.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Toolchain bake/manifest job uses pg/pg-boss directly for LISTEN/NOTIFY and queue plumbing; capped at exact count until the queue transport is behind an adapter port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/settings/settings-import-service.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Fleet settings revision import/notify uses pg directly for LISTEN/NOTIFY revision propagation; capped at exact count until the settings transport is behind an adapter port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/config/settings/settings-revision-notify.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Fleet settings revision import/notify uses pg directly for LISTEN/NOTIFY revision propagation; capped at exact count until the settings transport is behind an adapter port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/cli/artifacts.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Artifacts/bake CLI composes config plus runtime toolchain queue/reaper/notify services as a local admin adapter; capped at exact count until the toolchain command service is extracted.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/bake.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Artifacts/bake CLI composes config plus runtime toolchain queue/reaper/notify services as a local admin adapter; capped at exact count until the toolchain command service is extracted.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/cli/group-access.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Group-access CLI is a local admin adapter over settings.yaml desired-state writers and runtime settings types; capped at exact count until the group-access command service is extracted.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/group-engine.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Group-engine CLI verb is a local admin adapter over settings.yaml desired-state writers and runtime settings types (mirrors group-access); capped at exact count until the agent-command service is extracted.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/cli/group-list.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Group-list CLI verb reads runtime settings to render each agent's effective engine; capped at exact count until the agent-command service is extracted.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/control/server/routes/system.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "System control routes read draining state, settings-load state, and config directly for /readyz, /metrics, and /v1/status; capped at exact count until readiness/draining are injected through ControlRouteContext.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/control/server/routes/settings.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Settings control routes parse and import fleet settings revisions via config services directly; capped at exact count until settings parse/import is injected through ControlRouteContext.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/runtime/settings-revision-listener.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Runtime settings revision listener composes desired-state service, settings import, and revision notify directly; capped at exact count until revision propagation is an application port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 3
+  },
+  {
+    "file": "apps/core/src/jobs/execution-readiness.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Job execution-readiness reads config and the Postgres runtime-store directly to compute fleet readiness; capped at exact count until readiness storage access is behind a repository port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/runtime/ipc-interaction-processing.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "IPC interaction processing reads the agent access policy from config/profiles for locked-agent enforcement; capped to this single import until access policy is exposed through a runtime-owned port.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/jobs/toolchain-bake-runner.ts",
+    "rule": "direct_risky_execution",
+    "reason": "Toolchain bake runner spawns the registry-pinned npm install child process directly for bake jobs; capped to this single call until bake execution moves through the sandbox adapter.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/shared/agent-engine.ts",
+    "rule": "provider_specific_path",
+    "reason": "public AgentEngine vocabulary per docs/architecture/deepagents-agent-engine-handoff-plan.md",
+    "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/shared/model-execution-route.ts",
+    "rule": "provider_specific_path",
+    "reason": "public AgentEngine vocabulary per docs/architecture/deepagents-agent-engine-handoff-plan.md",
+    "removeByPhase": "provider-boundary-model-catalog-cleanup-phase",
+    "maxViolations": 4
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-review-create.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Memory review creation queries Postgres via drizzle exactly like its sibling memory query modules; capped so new external imports fail until the canonical storage-port refactor removes direct drizzle use from the memory layer.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 2
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-review-create.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Memory review creation reads the Postgres schema tables directly like its sibling memory query modules; capped so new adapter imports fail until the canonical storage-port refactor.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-dreaming-review-routing.ts",
+    "rule": "forbidden_external_import_by_layer",
+    "reason": "Dream review routing journals decisions and updates candidate status via drizzle exactly like its sibling memory dreaming modules; capped until the canonical storage-port refactor.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/memory/app-memory-dreaming-review-routing.ts",
+    "rule": "forbidden_import_by_layer",
+    "reason": "Dream review routing reads Postgres schema tables directly like its sibling memory dreaming modules; capped until the canonical storage-port refactor.",
+    "removeByPhase": "canonical-boundary-cleanup-phase",
+    "maxViolations": 1
+  },
+  {
+    "file": "apps/core/src/shared/sdk-native-skill-names.ts",
+    "rule": "provider_specific_path",
+    "reason": "anthropic_sdk is a deliberate sentinel token of the agent-harness selection contract (decision 0028); relocation would force a forbidden application-to-adapter import. Exact ratchet; review trigger ledgered as deferral D-0004.",
+    "removeByPhase": "agent-harness-vocabulary-supersedes-0028",
+    "maxViolations": 4
+  }
 ]

--- a/scripts/architecture-map.json
+++ b/scripts/architecture-map.json
@@ -25,7 +25,7 @@
     "apps/core/src/adapters/storage/postgres/services/canonical-job-ops-service.ts": 807,
     "apps/core/src/adapters/storage/postgres/schema/canonical-ops-repo.postgres.ts": 950,
     "apps/core/src/adapters/storage/postgres/schema/schema.ts": 900,
-    
+
     "apps/core/src/app/bootstrap/inline-agent-loop-tools.ts": 745,
     "apps/core/src/app/bootstrap/runtime-app.ts": 725,
     "apps/core/src/app/bootstrap/runtime-services.ts": 1080,
@@ -34,7 +34,7 @@
     "apps/core/src/channels/slack/channel-interactions.ts": 712,
     "apps/core/src/channels/telegram/channel-connect.ts": 708,
     "apps/core/src/channels/telegram/channel-delivery.ts": 766,
-    "apps/core/src/cli/group.ts": 845,
+    "apps/core/src/cli/group.ts": 850,
     "apps/core/src/cli/model.ts": 723,
     "apps/core/src/config/settings/desired-state-service.ts": 830,
     "apps/core/src/config/settings/runtime-settings-parser.ts": 1145,
@@ -64,20 +64,12 @@
   },
   "layers": {
     "domain": {
-      "paths": [
-        "apps/core/src/domain"
-      ],
-      "allowedImportLayers": [
-        "domain",
-        "shared",
-        "packages/contracts"
-      ],
+      "paths": ["apps/core/src/domain"],
+      "allowedImportLayers": ["domain", "shared", "packages/contracts"],
       "allowedExternalImports": []
     },
     "application": {
-      "paths": [
-        "apps/core/src/application"
-      ],
+      "paths": ["apps/core/src/application"],
       "allowedImportLayers": [
         "domain",
         "application",
@@ -131,14 +123,10 @@
         "shared",
         "packages/contracts"
       ],
-      "allowedExternalImports": [
-        "*"
-      ]
+      "allowedExternalImports": ["*"]
     },
     "config": {
-      "paths": [
-        "apps/core/src/config"
-      ],
+      "paths": ["apps/core/src/config"],
       "allowedImportLayers": [
         "config",
         "domain",
@@ -156,49 +144,19 @@
       ]
     },
     "shared": {
-      "paths": [
-        "apps/core/src/shared",
-        "apps/core/src/infrastructure/logging"
-      ],
-      "allowedImportLayers": [
-        "shared",
-        "packages/contracts"
-      ],
-      "allowedExternalImports": [
-        "node:",
-        "crypto",
-        "fs",
-        "path",
-        "url",
-        "os"
-      ]
+      "paths": ["apps/core/src/shared", "apps/core/src/infrastructure/logging"],
+      "allowedImportLayers": ["shared", "packages/contracts"],
+      "allowedExternalImports": ["node:", "crypto", "fs", "path", "url", "os"]
     },
     "packages/contracts": {
-      "paths": [
-        "packages/contracts/src"
-      ],
-      "allowedImportLayers": [
-        "packages/contracts"
-      ],
-      "allowedExternalImports": [
-        "zod"
-      ]
+      "paths": ["packages/contracts/src"],
+      "allowedImportLayers": ["packages/contracts"],
+      "allowedExternalImports": ["zod"]
     },
     "packages/sdk": {
-      "paths": [
-        "packages/sdk/src"
-      ],
-      "allowedImportLayers": [
-        "packages/contracts",
-        "packages/sdk"
-      ],
-      "allowedExternalImports": [
-        "node:",
-        "http",
-        "https",
-        "url",
-        "crypto"
-      ]
+      "paths": ["packages/sdk/src"],
+      "allowedImportLayers": ["packages/contracts", "packages/sdk"],
+      "allowedExternalImports": ["node:", "http", "https", "url", "crypto"]
     }
   },
   "approvedProviderSpecificPaths": [
@@ -253,8 +211,5 @@
     "registeredGroup": "\\bregisteredGroups?\\b",
     "claude_only": "\\b(?:claude-only|Claude-only|claude only|Claude only|only Claude|only supports Claude)\\b"
   },
-  "emptyFolderScanRoots": [
-    "apps/core/src",
-    "packages"
-  ]
+  "emptyFolderScanRoots": ["apps/core/src", "packages"]
 }

--- a/scripts/require-postgres-integration-env.mjs
+++ b/scripts/require-postgres-integration-env.mjs
@@ -3,7 +3,9 @@
 const value = process.env.GANTRY_TEST_DATABASE_URL?.trim();
 
 if (!value) {
-  console.error('GANTRY_TEST_DATABASE_URL is required for Postgres integration tests.');
+  console.error(
+    'GANTRY_TEST_DATABASE_URL is required for Postgres integration tests.',
+  );
   console.error(
     'Run with: GANTRY_TEST_DATABASE_URL=postgres://user:pass@localhost:5432/gantry_test npm run test:integration:postgres',
   );
@@ -17,6 +19,8 @@ try {
   }
 } catch (error) {
   const reason = error instanceof Error ? error.message : String(error);
-  console.error(`GANTRY_TEST_DATABASE_URL must be a valid postgres:// or postgresql:// URL: ${reason}`);
+  console.error(
+    `GANTRY_TEST_DATABASE_URL must be a valid postgres:// or postgresql:// URL: ${reason}`,
+  );
   process.exit(1);
 }

--- a/scripts/run_postgres_integration_with_url.mjs
+++ b/scripts/run_postgres_integration_with_url.mjs
@@ -14,12 +14,7 @@ if (!databaseUrl) {
 const commandArgs =
   args.length > 0
     ? args
-    : [
-        'run',
-        '-c',
-        'vitest.integration.config.ts',
-        '--no-file-parallelism',
-      ];
+    : ['run', '-c', 'vitest.integration.config.ts', '--no-file-parallelism'];
 
 const result = spawnSync('npx', ['vitest', ...commandArgs], {
   stdio: 'inherit',


### PR DESCRIPTION
Closes #287.

## What & why

An agent with **no conversation routes could not be removed by any interface.**
`resolveGroupSelector` matches only against existing route keys, so once an
agent's last route was gone it was unaddressable by every agent subcommand —
while its definition lived on in the settings-revision authority and was
re-imported into `gantry.agents` on every boot.

**Live:** 14 `codex_test_*` agents, invisible to `gantry agent list`,
un-deletable, recreated at every restart from settings revision 72. This is the
case PR #286 could not reach — #286 makes removal durable for an agent that
*has* routes; this handles the already-route-less one.

## What this PR delivers

- `resolveRoutelessAgentFolder` — when a selector (`agent:<folder>` or a bare
  folder) matches no route but `settings.agents[folder]` exists, it resolves to
  that route-less agent. Uses `Object.hasOwn` so inherited object properties
  (`constructor`, `toString`, `__proto__`) are never treated as agents.
- `removeRoutelessAgent` (its own module, so `group.ts` doesn't grow) — reuses
  the existing `pruneDesiredStateAgent` path, so delegate retention, orphan
  provider-account cleanup, shared-conversation preservation and
  fail-loud-on-error all come from the code #286 already tests rather than a
  second removal implementation.
- A delegate-blocked removal now exits **nonzero** (nothing was removed, so
  reporting success would mislead automation).

No filesystem action: Postgres is the source of truth, and `agent remove`
stopped touching agent folders when `--delete-folder` was removed in #286. That
invariant is now stated in code.

## Persistence detail (a corrected assumption)

An earlier draft treated `writeDesiredRuntimeSettings` returning
`reconciled: false` as a failure. The code disproved it: without a storage
provider the file *is* the store, and with one configured (`cli/index.ts:34`) a
missing store **throws** rather than degrading — so a silent mirror-only write
cannot happen in CLI context. The guard would have broken valid paths while
adding nothing; it was removed and the reasoning recorded.

## Evidence

- **Autoreview: clean** — `no accepted/actionable findings reported`. Three P2s
  were raised along the way: two real (prototype-chain lookup; delegate case
  exiting 0) are **fixed with tests**; one (invoke "the normal path's folder
  cleanup") was **rejected with evidence** — that cleanup was deliberately
  deleted in #286.
- Full suite green: **6,964 tests**; typecheck, prettier and `check:architecture`
  all pass.

## E2E delta

No agent-e2e matrix rows flip: CLI/desired-state behavior covered by the unit
tests above; no agent-visible runtime behavior changes.
