### PR TITLE
fix(ORPHAN-1): agent remove disables its projected gantry.agents row (#289)

### DIFF
--- a/apps/core/src/cli/group-helpers.ts
+++ b/apps/core/src/cli/group-helpers.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import * as p from '@clack/prompts';
+
 import type { ConversationRoute } from '../domain/types.js';
 import type { FileArtifactStore } from '../domain/ports/file-artifact-store.js';
 import { isValidWorkspaceFolder } from '../platform/workspace-folder.js';
@@ -21,6 +23,7 @@ import { RuntimeGroupDb, openRuntimeGroupDb } from './runtime-group-db.js';
 import { normalizeTelegramChatJid } from './telegram.js';
 import { providerForJid } from '../channels/provider-registry.js';
 import { parseAgentThreadQueueKey } from '../shared/thread-queue-key.js';
+import { agentIdForFolder } from '../domain/agent/agent-folder-id.js';
 import { DEFAULT_AGENT_FOLDER } from './main-agent.js';
 
 export { formatAgentHarnessLine } from './group-engine.js';
@@ -160,6 +163,7 @@ export async function pruneDesiredStateAgent(input: {
 }): Promise<{
   pruned: boolean;
   providerAccountsPruned: number;
+  reconciled?: boolean;
   keptForDelegates?: string[];
   keptAsDefault?: boolean;
   error?: string;
@@ -264,18 +268,71 @@ export async function pruneDesiredStateAgent(input: {
     // store, and a file write is correct. `reconciled: false` is therefore not
     // an error condition; a genuine failure surfaces as a throw and is caught
     // below.
-    await writeDesiredRuntimeSettings({
+    const writeResult = await writeDesiredRuntimeSettings({
       runtimeHome: input.runtimeHome,
       settings,
       previousSettings,
     });
-    return { pruned: true, providerAccountsPruned };
+    return {
+      pruned: true,
+      providerAccountsPruned,
+      reconciled: writeResult.reconciled,
+    };
   } catch (err) {
     return {
       pruned: false,
       providerAccountsPruned: 0,
       error: err instanceof Error ? err.message : String(err),
     };
+  }
+}
+
+/**
+ * Best-effort cleanup of a removed agent's projected `gantry.agents` row.
+ *
+ * Desired-state removal (`pruneDesiredStateAgent`) is the durable source of
+ * truth, but the projected row is a mirror that authoritative reconcile only
+ * disables when `desired_state.authoritative` is true -- which live config
+ * leaves false. So an explicit CLI removal must disable the mirror itself, the
+ * same primitive reconcile uses (`desired-state-service.ts` `disableAgent`).
+ *
+ * Never throws: the row is a mirror, not the authority, so a storage failure
+ * here must not fail a removal that already persisted. On failure it warns and
+ * reports the error to the caller (which still exits 0). `disableAgent` returns
+ * null when no row exists (already gone).
+ *
+ * ponytail: not revision-coupled. A concurrent re-add of the same folder
+ * (remover persists a drop; adder persists a newer revision restoring it) can
+ * race this disable and leave a declared agent's row disabled. That state is
+ * transient and self-healing -- the next desired-state reconcile re-imports
+ * every declared agent and upserts status:'active' (desired-state-service.ts
+ * :181). Closing the window fully needs a revision-coupled compare-and-set on
+ * the row (follow-up #290), out of scope for this projection-cleanup fix.
+ */
+export async function disableRemovedAgentProjection(
+  folder: string,
+): Promise<{ disabled: boolean; error?: string }> {
+  try {
+    const { closeRuntimeStorage, getRuntimeStorage, initializeRuntimeStorage } =
+      await import('../adapters/storage/postgres/runtime-store.js');
+    await initializeRuntimeStorage();
+    try {
+      const disabled =
+        await getRuntimeStorage().repositories.agents.disableAgent({
+          appId: 'default' as never,
+          agentId: agentIdForFolder(folder),
+          updatedAt: new Date().toISOString(),
+        });
+      return { disabled: disabled !== null };
+    } finally {
+      await closeRuntimeStorage();
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    p.log.warn(
+      `Agent ${folder} removed from desired state, but its projected agents row could not be disabled (${error}); it stays removed and will not resurrect.`,
+    );
+    return { disabled: false, error };
   }
 }
 

--- a/apps/core/src/cli/group-remove-routeless.ts
+++ b/apps/core/src/cli/group-remove-routeless.ts
@@ -2,6 +2,7 @@ import * as p from '@clack/prompts';
 
 import type { ConversationRoute } from '../domain/types.js';
 import {
+  disableRemovedAgentProjection,
   isInteractiveTerminal,
   pruneDesiredStateAgent,
   resolveRoutelessAgentFolder,
@@ -90,6 +91,11 @@ export async function removeRoutelessAgent(input: {
   // removed. The route-scoped path does not delete folders either, so this
   // path must not either -- the only fs.rmSync left in this command family is
   // runAdd's rollback of a folder it had just created.
+  // Best-effort: only when the revision durably persisted (reconciled) do we
+  // disable the projected agents row so it stops reading active. The desired-
+  // state prune above is the durable removal; the helper warns (and this path
+  // still succeeds) if the mirror write fails.
+  if (pruned.reconciled) await disableRemovedAgentProjection(folder);
   const accounts = pruned.providerAccountsPruned;
   p.log.success(
     `Removed agent ${folder} from desired state${

--- a/apps/core/src/cli/group.ts
+++ b/apps/core/src/cli/group.ts
@@ -42,6 +42,7 @@ import {
 import {
   allocateGroupFolder,
   conversationIdsForProvider,
+  disableRemovedAgentProjection,
   ensureGroupFiles,
   findConversationIdForAgent,
   formatAgentHarnessLine,
@@ -435,9 +436,6 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
       );
       return 1;
     }
-    const routeKey = found.jid;
-    const { chatJid } = parseAgentThreadQueueKey(routeKey);
-
     if (!parsed.assumeYes) {
       if (!isInteractiveTerminal()) {
         p.log.error(
@@ -461,7 +459,7 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
     }
 
     try {
-      await db.deleteConversationRoute(routeKey);
+      await db.deleteConversationRoute(found.jid);
       await db.deleteSession(found.group.folder);
     } catch (err) {
       p.log.error(`Could not remove agent from database: ${errorMessage(err)}`);
@@ -470,7 +468,7 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
 
     const policyPrune = await pruneAgentSenderPolicyOverride(
       runtimeHome,
-      chatJid,
+      parseAgentThreadQueueKey(found.jid).chatJid,
       found.group.folder,
     );
     if (policyPrune.error) {
@@ -512,6 +510,8 @@ async function runRemove(runtimeHome: string, args: string[]): Promise<number> {
       return 0;
     }
     if (desiredPrune.pruned) {
+      if (desiredPrune.reconciled)
+        await disableRemovedAgentProjection(found.group.folder);
       const accounts = desiredPrune.providerAccountsPruned;
       p.log.info(
         `Removed agent ${found.group.folder} from desired state${

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -26,6 +26,7 @@ import {
   resolveRoutelessAgentFolder,
   resolveGroupSelector,
 } from '@core/cli/group-helpers.js';
+import { agentIdForFolder } from '@core/domain/agent/agent-folder-id.js';
 
 const groupsStore = vi.hoisted(() => new Map<string, any>());
 const fileArtifacts = vi.hoisted(() => new Map<string, string>());
@@ -146,6 +147,56 @@ function mockRuntimeSecretStorage(runtimeHome: string) {
     storeRuntimeSecretInput,
   }));
   return storeRuntimeSecretInput;
+}
+
+// Mock the dynamic runtime-store import used by disableRemovedAgentProjection so
+// the projection-cleanup step is observable without a live Postgres.
+function mockRuntimeStoreDisableAgent(
+  impl: (input: any) => any = async () => ({ id: 'row' }),
+) {
+  const disableAgent = vi.fn(impl);
+  vi.doMock('@core/adapters/storage/postgres/runtime-store.js', () => ({
+    initializeRuntimeStorage: vi.fn(async () => undefined),
+    closeRuntimeStorage: vi.fn(async () => undefined),
+    getRuntimeStorage: () => ({ repositories: { agents: { disableAgent } } }),
+  }));
+  return disableAgent;
+}
+
+// Force the desired-state write to report a durable settings-revision append
+// (`reconciled: true`) while still persisting to the on-disk settings file, so
+// the projection-cleanup step runs. Without a storage provider the real writer
+// returns `reconciled: false`; tests that omit this helper exercise that path.
+function mockReconciledDesiredWrite() {
+  vi.doMock(
+    '@core/config/settings/runtime-settings.js',
+    async (importOriginal) => {
+      const actual =
+        await importOriginal<
+          typeof import('@core/config/settings/runtime-settings.js')
+        >();
+      return {
+        ...actual,
+        writeDesiredRuntimeSettings: vi.fn(async (input: any) => {
+          actual.saveRuntimeSettings(input.runtimeHome, input.settings);
+          return { reconciled: true, restartRequired: [] };
+        }),
+      };
+    },
+  );
+}
+
+function clackLogMock() {
+  const warn = vi.fn();
+  vi.doMock('@clack/prompts', () => ({
+    isCancel: () => false,
+    select: vi.fn(),
+    text: vi.fn(),
+    note: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+    log: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warn },
+  }));
+  return { warn };
 }
 
 describe('cli slack helpers', () => {
@@ -1223,7 +1274,11 @@ describe('cli slack helpers', () => {
         folder: 'doomed',
         remainingRoutes: 0,
       }),
-    ).resolves.toEqual({ pruned: true, providerAccountsPruned: 0 });
+    ).resolves.toEqual({
+      pruned: true,
+      providerAccountsPruned: 0,
+      reconciled: false,
+    });
     expect(loadRuntimeSettings(runtimeHome).agents.doomed).toBeUndefined();
 
     // Other agents are untouched.
@@ -1564,5 +1619,250 @@ describe('cli slack helpers', () => {
       conversation: undefined,
       danglingAccounts: 0,
     });
+  });
+
+  it('disables the projected agents row after a route-bearing last-route removal', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.providerAccounts.slack_doomed = {
+      provider: 'slack',
+      agentId: 'doomed',
+      label: 'slack',
+      runtimeSecretRefs: {},
+    } as (typeof settings.providerAccounts)['slack_doomed'];
+    settings.agents.doomed = {
+      name: 'Doomed',
+      folder: 'doomed',
+      bindings: {
+        doomed_b: {
+          jid: 'sl:C0000000009',
+          provider: 'slack',
+          providerAccountId: 'slack_doomed',
+          name: 'Doomed',
+          trigger: '',
+          addedAt: '2026-01-01T00:00:00.000Z',
+          requiresTrigger: false,
+        },
+      },
+      sources: { skills: [], mcpServers: [], tools: [] },
+      capabilities: [],
+      delegates: [],
+      accessPreset: 'full',
+    } as (typeof settings.agents)['doomed'];
+    settings.bindings.doomed_b = {
+      agent: 'doomed',
+      conversation: 'slack_doomed_c9',
+      installKey: 'doomed',
+      trigger: '',
+      addedAt: '2026-01-01T00:00:00.000Z',
+      requiresTrigger: false,
+      memoryScope: 'conversation',
+    } as (typeof settings.bindings)['doomed_b'];
+    settings.conversations.slack_doomed_c9 = {
+      providerAccount: 'slack_doomed',
+      externalId: 'C0000000009',
+      kind: 'channel',
+      displayName: 'Doomed',
+      senderPolicy: { allow: '*', mode: 'trigger' },
+      controlApprovers: [],
+      installedAgents: {
+        doomed: {
+          agentId: 'doomed',
+          providerAccountId: 'slack_doomed',
+          status: 'active',
+          addedAt: '2026-01-01T00:00:00.000Z',
+          memoryScope: 'conversation',
+        },
+      },
+    } as (typeof settings.conversations)['slack_doomed_c9'];
+    saveRuntimeSettings(runtimeHome, settings);
+    const routeKey = makeAgentThreadQueueKey('sl:C0000000009', 'agent:doomed');
+    groupsStore.set(routeKey, {
+      name: 'Doomed',
+      folder: 'doomed',
+      trigger: '',
+      added_at: '2026-04-24T00:00:00.000Z',
+    });
+
+    mockReconciledDesiredWrite();
+    clackLogMock();
+    const disableAgent = mockRuntimeStoreDisableAgent();
+    const { runAgentCommand } = await import('@core/cli/group.js');
+    const code = await runAgentCommand(runtimeHome, [
+      'remove',
+      routeKey,
+      '--yes',
+    ]);
+
+    expect(code).toBe(0);
+    expect(loadRuntimeSettings(runtimeHome).agents.doomed).toBeUndefined();
+    expect(disableAgent).toHaveBeenCalledTimes(1);
+    expect(disableAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'default',
+        agentId: agentIdForFolder('doomed'),
+      }),
+    );
+  });
+
+  it('disables the projected agents row after a route-less removal', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.orphan = {
+      name: 'Orphan',
+      folder: 'orphan',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['orphan'];
+    saveRuntimeSettings(runtimeHome, settings);
+
+    mockReconciledDesiredWrite();
+    clackLogMock();
+    const disableAgent = mockRuntimeStoreDisableAgent();
+    const { runAgentCommand } = await import('@core/cli/group.js');
+    const code = await runAgentCommand(runtimeHome, [
+      'remove',
+      'orphan',
+      '--yes',
+    ]);
+
+    expect(code).toBe(0);
+    expect(loadRuntimeSettings(runtimeHome).agents.orphan).toBeUndefined();
+    expect(disableAgent).toHaveBeenCalledTimes(1);
+    expect(disableAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'default',
+        agentId: agentIdForFolder('orphan'),
+      }),
+    );
+  });
+
+  it('does not disable a projected row when the desired-state write is file-only', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.orphan = {
+      name: 'Orphan',
+      folder: 'orphan',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['orphan'];
+    saveRuntimeSettings(runtimeHome, settings);
+
+    // Use the real writer (no mockReconciledDesiredWrite): with no storage
+    // provider it returns reconciled:false (file-only), so no DB projection
+    // exists to clean. doUnmock guards against a reconciled mock leaking in from
+    // an earlier test via the shared doMock registry.
+    vi.doUnmock('@core/config/settings/runtime-settings.js');
+    clackLogMock();
+    const disableAgent = mockRuntimeStoreDisableAgent();
+    const { runAgentCommand } = await import('@core/cli/group.js');
+    const code = await runAgentCommand(runtimeHome, [
+      'remove',
+      'orphan',
+      '--yes',
+    ]);
+
+    expect(code).toBe(0);
+    expect(loadRuntimeSettings(runtimeHome).agents.orphan).toBeUndefined();
+    expect(disableAgent).not.toHaveBeenCalled();
+  });
+
+  it('does not disable a projected row when the agent is retained for delegates', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.helper = {
+      name: 'Helper',
+      folder: 'helper',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['helper'];
+    settings.agents.boss = {
+      ...settings.agents.helper,
+      name: 'Boss',
+      folder: 'boss',
+      delegates: ['helper'],
+    };
+    saveRuntimeSettings(runtimeHome, settings);
+
+    clackLogMock();
+    const disableAgent = mockRuntimeStoreDisableAgent();
+    const { runAgentCommand } = await import('@core/cli/group.js');
+    const code = await runAgentCommand(runtimeHome, [
+      'remove',
+      'helper',
+      '--yes',
+    ]);
+
+    expect(code).toBe(1);
+    expect(disableAgent).not.toHaveBeenCalled();
+  });
+
+  it('does not disable a projected row when refusing the default agent', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.main_agent = {
+      name: 'Main',
+      folder: 'main_agent',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['main_agent'];
+    saveRuntimeSettings(runtimeHome, settings);
+
+    clackLogMock();
+    const disableAgent = mockRuntimeStoreDisableAgent();
+    const { runAgentCommand } = await import('@core/cli/group.js');
+    const code = await runAgentCommand(runtimeHome, [
+      'remove',
+      'main_agent',
+      '--yes',
+    ]);
+
+    expect(code).toBe(1);
+    expect(disableAgent).not.toHaveBeenCalled();
+  });
+
+  it('still succeeds and warns when the projection disable fails (best-effort)', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const settings = loadRuntimeSettings(runtimeHome);
+    settings.agents.orphan = {
+      name: 'Orphan',
+      folder: 'orphan',
+      bindings: {},
+      capabilities: [],
+      delegates: [],
+      sources: { skills: [], mcpServers: [], tools: [] },
+      accessPreset: 'full',
+    } as (typeof settings.agents)['orphan'];
+    saveRuntimeSettings(runtimeHome, settings);
+
+    mockReconciledDesiredWrite();
+    const disableAgent = mockRuntimeStoreDisableAgent(async () => {
+      throw new Error('storage offline');
+    });
+    const { warn } = clackLogMock();
+    const { runAgentCommand } = await import('@core/cli/group.js');
+    const code = await runAgentCommand(runtimeHome, [
+      'remove',
+      'orphan',
+      '--yes',
+    ]);
+
+    expect(code).toBe(0);
+    expect(disableAgent).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    // Desired-state removal is durable regardless of the mirror write.
+    expect(loadRuntimeSettings(runtimeHome).agents.orphan).toBeUndefined();
   });
 });

--- a/docs/decisions/0050-agent-removal-projection-cleanup.md
+++ b/docs/decisions/0050-agent-removal-projection-cleanup.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-25
+---
+
+# Agent Removal Projection Cleanup
+
+## Context
+<!-- Why this decision was needed; the forces at play. -->
+
+Removing an agent from desired state (`gantry agent remove`, PR #288) advances
+the settings revision and drops the agent, but its projected `gantry.agents`
+row survives with `status: active` (#289). Desired-state reconciliation only
+disables absent agents when `desired_state.authoritative` is true
+(`apps/core/src/config/settings/desired-state-service.ts:330`), and live config
+leaves that false — so a removed agent's row is neither recreated (good, #288
+holds) nor cleaned. Three options were on the table (see #289). Accepted
+decision **0007** (`docs/decisions/0007-settings-runtime-truth.md:55`) already
+fixes that destructive reconciliation happens **only** when
+`desired_state.authoritative: true`, to protect live rows from a partial or
+transient settings load. There is no hard-delete primitive for an agent row;
+reconcile models removal as `disableAgent` (soft).
+
+## Decision
+<!-- What was decided, in one or two sentences. -->
+
+The CLI agent-removal path cleans its own projection: after a successful
+`pruneDesiredStateAgent` whose settings write actually persisted a revision
+(`reconciled: true`), it disables the projected `gantry.agents` row via the
+existing `repositories.agents.disableAgent` (reached through the CLI's existing
+`withRuntimeStorage()` helper) — the same primitive authoritative reconcile
+uses. We do **not** flip the reconcile gate (that would contradict 0007) and we
+do **not** add a hard delete.
+
+## Consequences
+<!-- What follows: tradeoffs accepted, doors closed, work implied. -->
+
+- Explicit operator removal — the case 0007's gate is *not* guarding — becomes
+  the trigger for projection cleanup; reconcile semantics and decision 0007 are
+  untouched.
+- Removal in file-only degraded mode (`reconciled: false`, no storage provider)
+  skips the projection step and reports the partial outcome rather than
+  disabling a row while the authority still declares the agent.
+- Rows are disabled, not deleted — history/audit preserved, consistent with the
+  only existing primitive; no schema migration.
+- The ~14 pre-existing inert `codex_test_*` orphan rows need a one-off
+  idempotent sweep (they predate this change); keyed off current desired-state
+  settings so it can never disable a still-declared agent.
+- A control-API `DELETE /v1/agents` remains out of scope; the CLI is the only
+  remover today.


### PR DESCRIPTION
## What this fixes (plain language)

When you remove an agent with `gantry agent remove`, it disappears from the runtime's desired-state authority — but its row in the `gantry.agents` projection table was left behind reading `status: active`, forever. It has no routes, no jobs, and can't come back, so it's harmless — just untidy. This closes that gap: removing an agent now also disables its projection row, so "removed" means removed in both places. (Follow-up to #288, which made route-less agents removable in the first place.)

Fixes #289.

## Why disable, not delete

There is **no hard-delete primitive** for an agent row anywhere in the codebase — desired-state reconciliation itself models removal as `disableAgent` (soft). We stay consistent with that: removal now disables the row using the exact same primitive reconcile uses. This keeps audit history, needs no schema migration, and lets a later re-add of the same agent cleanly re-enable the row instead of orphaning a duplicate. Recorded as decision **0050**.

We deliberately do **not** flip the reconcile gate to delete absent agents unconditionally — that would contradict accepted decision **0007** (destructive reconciliation only when `desired_state.authoritative: true`, which protects live rows from a partial settings load). An explicit operator `agent remove` is exactly the case that gate isn't guarding, so removal cleaning its own projection is the right seam.

## The change

- New shared helper `disableRemovedAgentProjection(folder)` in `cli/group-helpers.ts`: opens runtime storage (`initializeRuntimeStorage` → `disableAgent` → `finally closeRuntimeStorage`, the established `provider.ts` pattern) and disables the row. Best-effort — the desired-state prune is the durable source of truth, so a storage failure warns and still exits 0 rather than failing a removal that already persisted.
- Both removal paths (route-bearing last-route in `group.ts`, route-less in `group-remove-routeless.ts`) call it, **gated on `pruned && reconciled`** — so a file-only write (no DB) skips it cleanly, and a row is only disabled once the settings revision durably persisted.

## Tests

`cli/slack.test.ts` gains command-level coverage: route-bearing and route-less removal disable the row (correct `appId`/`agentId`); delegate-retained and default-agent (`main_agent`) removals do **not**; a `reconciled: false` (file-only) write does **not**; a thrown `disableAgent` still exits 0 and warns. Full unit suite green (6864 tests); the 3 pre-existing zod-fixture suites that fail locally on `main` are excluded locally and run in CI.

## Review

Two branch-autoreview rounds. Round 1 caught two real bugs (both fixed): `getRuntimeStorage()` without initialization would have silently no-oped the fix in a normal standalone CLI invocation (P1), and the disable wasn't gated on `reconciled` (P2). Round 2 surfaced a concurrent same-folder add+remove ordering race — verified **transient and self-healing** (the next reconcile re-imports declared agents and upserts `status:'active'`), whose proper fix is a revision-coupled compare-and-set (a repository-contract change). Deferred to **#290** and documented inline, consistent with the scope of a projection-cleanup fix.

## Pre-existing orphans

There are 13 inert `codex_test_*` orphan rows on the live runtime today. They are declared route-less agents, so the shipped `agent remove` handles them directly — no extra code. The one-off sweep runs at the post-merge deploy.

## agent-e2e delta

None. This is a CLI admin-command side effect (projection cleanup), not agent-turn runtime behavior; no agent-e2e matrix row changes. Covered by the CLI unit tests above.
