### PR TITLE
Harden & land develop→main runtime fixes (replaces #279)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ GANTRY_HOME=
 # Runtime Postgres database URL. The configured settings.yaml key is
 # storage.postgres.url_env, which defaults to GANTRY_DATABASE_URL.
 GANTRY_DATABASE_URL=postgres://gantry:change-me@127.0.0.1:5432/gantry?schema=gantry
+# Optional connection pool cap for constrained managed Postgres poolers.
+# Leave unset for Gantry's default. For small Supabase session pools, use a
+# value below the pooler's max client limit, for example 10.
+GANTRY_POSTGRES_POOL_MAX=
 
 # Fleet/ECS artifact bootstrap. These are non-secret startup settings used when
 # GANTRY_FLEET_SETTINGS_AUTO=1 seeds runtime.artifact_store into settings.yaml.

--- a/apps/core/src/adapters/storage/postgres/postgres-read-retry.ts
+++ b/apps/core/src/adapters/storage/postgres/postgres-read-retry.ts
@@ -1,0 +1,89 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { logger } from '../../../infrastructure/logging/logger.js';
+
+const RETRYABLE_POSTGRES_CODES = new Set([
+  '40001',
+  '40P01',
+  '53300',
+  '53400',
+  '57P01',
+  '57P02',
+  '57P03',
+  '08000',
+  '08001',
+  '08003',
+  '08004',
+  '08006',
+  '08007',
+  '08P01',
+]);
+
+const RETRYABLE_POSTGRES_MESSAGE_PATTERNS = [
+  /cached plan must not change result type/i,
+  /prepared statement .* (?:does not exist|already exists)/i,
+  /connection terminated/i,
+  /client has encountered a connection error/i,
+  /server closed the connection unexpectedly/i,
+  /terminating connection due to administrator command/i,
+  /\bECONNRESET\b/i,
+  /\bETIMEDOUT\b/i,
+  /\bEPIPE\b/i,
+  /timeout exceeded/i,
+];
+
+function objectProp(value: unknown, key: string): unknown {
+  if (!value || typeof value !== 'object') return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function errorChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  let current: unknown = error;
+  for (let depth = 0; current && depth < 5; depth += 1) {
+    chain.push(current);
+    current = objectProp(current, 'cause');
+  }
+  return chain;
+}
+
+export function isRetryablePostgresReadError(error: unknown): boolean {
+  for (const item of errorChain(error)) {
+    const code = objectProp(item, 'code');
+    if (typeof code === 'string' && RETRYABLE_POSTGRES_CODES.has(code)) {
+      return true;
+    }
+    const message = objectProp(item, 'message');
+    if (
+      typeof message === 'string' &&
+      RETRYABLE_POSTGRES_MESSAGE_PATTERNS.some((pattern) =>
+        pattern.test(message),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function retryPostgresRead<T>(
+  operationName: string,
+  operation: () => Promise<T>,
+  options: { delaysMs?: readonly number[] } = {},
+): Promise<T> {
+  const delaysMs = options.delaysMs ?? [50, 150];
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= delaysMs.length || !isRetryablePostgresReadError(err)) {
+        throw err;
+      }
+      logger.warn(
+        { err, operationName, nextAttempt: attempt + 2 },
+        'Retrying transient Postgres read failure',
+      );
+      await delay(delaysMs[attempt]);
+    }
+  }
+}

--- a/apps/core/src/adapters/storage/postgres/postgres-read-retry.ts
+++ b/apps/core/src/adapters/storage/postgres/postgres-read-retry.ts
@@ -15,21 +15,23 @@ import { logger } from '../../../infrastructure/logging/logger.js';
 // If these reads ever move inside a transaction/checked-out client, this
 // eviction guarantee no longer holds and the retry must force a fresh client.
 
+// These wrapped reads are non-transactional autocommit SELECTs that take no
+// locks, so transaction-only conflicts (40001 serialization_failure, 40P01
+// deadlock_detected) cannot arise here and are deliberately omitted. What
+// remains is transient pool/connection loss and server (pooler) unavailability.
 const RETRYABLE_POSTGRES_CODES = new Set([
-  '40001',
-  '40P01',
-  '53300',
-  '53400',
-  '57P01',
-  '57P02',
-  '57P03',
-  '08000',
-  '08001',
-  '08003',
-  '08004',
-  '08006',
-  '08007',
-  '08P01',
+  '53300', // too_many_connections (pool exhaustion)
+  '53400', // configuration_limit_exceeded
+  '57P01', // admin_shutdown
+  '57P02', // crash_shutdown
+  '57P03', // cannot_connect_now
+  '08000', // connection_exception
+  '08001', // sqlclient_unable_to_establish_sqlconnection
+  '08003', // connection_does_not_exist
+  '08004', // sqlserver_rejected_establishment_of_sqlconnection
+  '08006', // connection_failure
+  '08007', // transaction_resolution_unknown
+  '08P01', // protocol_violation
 ]);
 
 const RETRYABLE_POSTGRES_MESSAGE_PATTERNS = [

--- a/apps/core/src/adapters/storage/postgres/postgres-read-retry.ts
+++ b/apps/core/src/adapters/storage/postgres/postgres-read-retry.ts
@@ -2,6 +2,19 @@ import { setTimeout as delay } from 'node:timers/promises';
 
 import { logger } from '../../../infrastructure/logging/logger.js';
 
+// Why retrying on the SAME `this.db` handle is sound (not a same-poisoned-
+// connection retry): the wrapped reads are plain drizzle `.select()` calls, not
+// transactions, so drizzle runs them via `Pool.query()` (the session only checks
+// out a dedicated client for `transaction()` — node-postgres session.js). In
+// pg-pool 8.x `Pool.query()` calls `client.release(err)` with the query error on
+// completion, and `_release` removes/destroys the client from the pool whenever
+// that error is truthy (pg-pool index.js). So ANY failing query — connection-
+// class (57P0x/08xxx/"connection terminated") OR query-level ("cached plan must
+// not change result type") — evicts the client. Each retry therefore acquires a
+// FRESH connection, which re-establishes the socket and re-plans the statement.
+// If these reads ever move inside a transaction/checked-out client, this
+// eviction guarantee no longer holds and the retry must force a fresh client.
+
 const RETRYABLE_POSTGRES_CODES = new Set([
   '40001',
   '40P01',

--- a/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/canonical-graph-repository.postgres.ts
@@ -68,6 +68,44 @@ export function threadIdFor(
     : `thread:${chatJid}:${normalized}`;
 }
 
+export function canonicalProviderThreadForIds<
+  AppId extends string,
+  ConversationId extends string,
+>(input: {
+  appId: AppId;
+  conversationId: ConversationId | null | undefined;
+  threadId: string | null | undefined;
+}): {
+  id: string;
+  appId: AppId;
+  conversationId: ConversationId;
+  externalRefJson: string;
+} | null {
+  if (!input.conversationId || !input.threadId) return null;
+  const conversationPrefix = 'conversation:';
+  if (!input.conversationId.startsWith(conversationPrefix)) return null;
+  const providerJid = input.conversationId
+    .slice(conversationPrefix.length)
+    .trim();
+  if (!providerJid) return null;
+  const threadPrefix = `thread:${providerJid}:`;
+  if (!input.threadId.startsWith(threadPrefix)) return null;
+  const externalThreadId = input.threadId.slice(threadPrefix.length).trim();
+  if (!externalThreadId) return null;
+  return {
+    id: input.threadId,
+    appId: input.appId,
+    conversationId: input.conversationId,
+    externalRefJson: json({
+      kind: 'conversation_thread',
+      value: externalThreadId,
+      jid: providerJid,
+      threadId: externalThreadId,
+      externalThreadId,
+    }),
+  };
+}
+
 export function json(value: unknown): string {
   return JSON.stringify(value ?? null);
 }

--- a/apps/core/src/adapters/storage/postgres/repositories/outbound-delivery-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/outbound-delivery-repository.postgres.ts
@@ -16,9 +16,10 @@ import { sanitizeRetryTailProviderPayload } from '../../../../domain/messages/re
 import type { OutboundDeliveryRepository } from '../../../../domain/ports/repositories.js';
 import { nowIso as currentIso } from '../../../../shared/time/datetime.js';
 import * as pgSchema from '../schema/schema.js';
-import type {
-  CanonicalDb,
-  CanonicalExecutor,
+import {
+  canonicalProviderThreadForIds,
+  type CanonicalDb,
+  type CanonicalExecutor,
 } from './canonical-graph-repository.postgres.js';
 import { claimDueOutboundDeliveryItems } from './outbound-delivery-repository.postgres.claims.js';
 import { resolveOutboundDeliveryDestination } from './outbound-delivery-repository.postgres.destinations.js';
@@ -669,27 +670,9 @@ export function canonicalProviderThreadForDelivery(input: {
   conversationId: OutboundDelivery['conversationId'];
   externalRefJson: string;
 } | null {
-  if (!input.threadId) return null;
-  const conversationPrefix = 'conversation:';
-  if (!input.conversationId.startsWith(conversationPrefix)) return null;
-  const providerJid = input.conversationId
-    .slice(conversationPrefix.length)
-    .trim();
-  if (!providerJid) return null;
-  const threadPrefix = `thread:${providerJid}:`;
-  if (!input.threadId.startsWith(threadPrefix)) return null;
-  const externalThreadId = input.threadId.slice(threadPrefix.length);
-  if (!externalThreadId) return null;
-  return {
-    id: input.threadId,
+  return canonicalProviderThreadForIds({
     appId: input.appId,
     conversationId: input.conversationId,
-    externalRefJson: JSON.stringify({
-      kind: 'conversation_thread',
-      value: externalThreadId,
-      jid: providerJid,
-      threadId: externalThreadId,
-      externalThreadId,
-    }),
-  };
+    threadId: input.threadId,
+  });
 }

--- a/apps/core/src/adapters/storage/postgres/repositories/runtime-event-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/runtime-event-repository.postgres.ts
@@ -21,12 +21,13 @@ import {
 } from '../../../../domain/events/runtime-event-types.js';
 import type { RuntimeEventRepository } from '../../../../domain/ports/repositories.js';
 import { logger } from '../../../../infrastructure/logging/logger.js';
-import * as pgSchema from '../schema/schema.js';
-import type {
-  CanonicalDb,
-  CanonicalExecutor,
-} from './canonical-graph-repository.postgres.js';
 import { nowIso } from '../../../../shared/time/datetime.js';
+import * as pgSchema from '../schema/schema.js';
+import {
+  canonicalProviderThreadForIds,
+  type CanonicalDb,
+  type CanonicalExecutor,
+} from './canonical-graph-repository.postgres.js';
 import { PostgresEventBusPublisher } from './event-bus-outbox.postgres.js';
 import {
   type MessageLiveAdmissionInput,
@@ -140,17 +141,38 @@ export class PostgresRuntimeEventRepository implements RuntimeEventRepository {
     db: CanonicalExecutor,
     input: RuntimeEventPublishInput,
   ): Promise<RuntimeEvent> {
+    const appId = requiredId(input.appId, 'appId');
+    const conversationId = optionalId(input.conversationId);
+    const threadId = optionalId(input.threadId);
+    const providerThread = canonicalProviderThreadForIds({
+      appId,
+      conversationId,
+      threadId,
+    });
+    if (providerThread) {
+      await db
+        .insert(pgSchema.conversationThreadsPostgres)
+        .values({
+          id: providerThread.id,
+          appId: providerThread.appId,
+          conversationId: providerThread.conversationId,
+          externalRefJson: providerThread.externalRefJson,
+          updatedAt: currentIso(),
+        })
+        .onConflictDoNothing();
+    }
+
     const rows = await db
       .insert(pgSchema.runtimeEventsPostgres)
       .values({
-        appId: requiredId(input.appId, 'appId'),
+        appId,
         agentId: optionalId(input.agentId),
         sessionId: optionalId(input.sessionId),
         runId: optionalId(input.runId),
         jobId: optionalId(input.jobId),
         triggerId: optionalId(input.triggerId),
-        conversationId: optionalId(input.conversationId),
-        threadId: optionalId(input.threadId),
+        conversationId,
+        threadId,
         eventType: requireRuntimeEventType(input.eventType),
         actor: input.actor,
         correlationId: input.correlationId ?? null,

--- a/apps/core/src/adapters/storage/postgres/repositories/tool-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/tool-repository.postgres.ts
@@ -7,6 +7,7 @@ import type {
   ToolCatalogItem,
 } from '../../../../domain/tools/tools.js';
 import * as pgSchema from '../schema/schema.js';
+import { retryPostgresRead } from '../postgres-read-retry.js';
 import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
 
 function encodeJson(value: unknown): string {
@@ -27,11 +28,13 @@ export class PostgresToolCatalogRepository implements ToolCatalogRepository {
   constructor(private readonly db: CanonicalDb) {}
 
   async getTool(id: ToolCatalogItem['id']): Promise<ToolCatalogItem | null> {
-    const rows = await this.db
-      .select()
-      .from(pgSchema.toolCatalogPostgres)
-      .where(eq(pgSchema.toolCatalogPostgres.id, id))
-      .limit(1);
+    const rows = await retryPostgresRead('tool_catalog.getTool', () =>
+      this.db
+        .select()
+        .from(pgSchema.toolCatalogPostgres)
+        .where(eq(pgSchema.toolCatalogPostgres.id, id))
+        .limit(1),
+    );
     return rows[0] ? this.mapTool(rows[0]) : null;
   }
 
@@ -47,11 +50,13 @@ export class PostgresToolCatalogRepository implements ToolCatalogRepository {
         inArray(pgSchema.toolCatalogPostgres.status, input.statuses),
       );
     }
-    const rows = await this.db
-      .select()
-      .from(pgSchema.toolCatalogPostgres)
-      .where(and(...filters))
-      .orderBy(asc(pgSchema.toolCatalogPostgres.displayName));
+    const rows = await retryPostgresRead('tool_catalog.listTools', () =>
+      this.db
+        .select()
+        .from(pgSchema.toolCatalogPostgres)
+        .where(and(...filters))
+        .orderBy(asc(pgSchema.toolCatalogPostgres.displayName)),
+    );
     return rows.map((row) => this.mapTool(row));
   }
 
@@ -201,26 +206,28 @@ export class PostgresToolCatalogRepository implements ToolCatalogRepository {
     agentIds?: readonly AgentToolBinding['agentId'][];
   }): Promise<AgentToolBinding[]> {
     if (input.agentIds?.length === 0) return [];
-    const rows = await this.db
-      .select()
-      .from(pgSchema.agentToolBindingsPostgres)
-      .where(
-        and(
-          eq(pgSchema.agentToolBindingsPostgres.appId, input.appId),
-          input.agentId
-            ? eq(pgSchema.agentToolBindingsPostgres.agentId, input.agentId)
-            : undefined,
-          input.agentIds?.length
-            ? inArray(pgSchema.agentToolBindingsPostgres.agentId, [
-                ...input.agentIds,
-              ])
-            : undefined,
+    const rows = await retryPostgresRead('agent_tool_bindings.list', () =>
+      this.db
+        .select()
+        .from(pgSchema.agentToolBindingsPostgres)
+        .where(
+          and(
+            eq(pgSchema.agentToolBindingsPostgres.appId, input.appId),
+            input.agentId
+              ? eq(pgSchema.agentToolBindingsPostgres.agentId, input.agentId)
+              : undefined,
+            input.agentIds?.length
+              ? inArray(pgSchema.agentToolBindingsPostgres.agentId, [
+                  ...input.agentIds,
+                ])
+              : undefined,
+          ),
+        )
+        .orderBy(
+          asc(pgSchema.agentToolBindingsPostgres.agentId),
+          asc(pgSchema.agentToolBindingsPostgres.createdAt),
         ),
-      )
-      .orderBy(
-        asc(pgSchema.agentToolBindingsPostgres.agentId),
-        asc(pgSchema.agentToolBindingsPostgres.createdAt),
-      );
+    );
     return rows.map((row) => this.mapBinding(row));
   }
 
@@ -230,26 +237,28 @@ export class PostgresToolCatalogRepository implements ToolCatalogRepository {
     agentIds?: readonly AgentToolSource['agentId'][];
   }): Promise<AgentToolSource[]> {
     if (input.agentIds?.length === 0) return [];
-    const rows = await this.db
-      .select()
-      .from(pgSchema.agentToolSourcesPostgres)
-      .where(
-        and(
-          eq(pgSchema.agentToolSourcesPostgres.appId, input.appId),
-          input.agentId
-            ? eq(pgSchema.agentToolSourcesPostgres.agentId, input.agentId)
-            : undefined,
-          input.agentIds?.length
-            ? inArray(pgSchema.agentToolSourcesPostgres.agentId, [
-                ...input.agentIds,
-              ])
-            : undefined,
+    const rows = await retryPostgresRead('agent_tool_sources.list', () =>
+      this.db
+        .select()
+        .from(pgSchema.agentToolSourcesPostgres)
+        .where(
+          and(
+            eq(pgSchema.agentToolSourcesPostgres.appId, input.appId),
+            input.agentId
+              ? eq(pgSchema.agentToolSourcesPostgres.agentId, input.agentId)
+              : undefined,
+            input.agentIds?.length
+              ? inArray(pgSchema.agentToolSourcesPostgres.agentId, [
+                  ...input.agentIds,
+                ])
+              : undefined,
+          ),
+        )
+        .orderBy(
+          asc(pgSchema.agentToolSourcesPostgres.agentId),
+          asc(pgSchema.agentToolSourcesPostgres.sourceId),
         ),
-      )
-      .orderBy(
-        asc(pgSchema.agentToolSourcesPostgres.agentId),
-        asc(pgSchema.agentToolSourcesPostgres.sourceId),
-      );
+    );
     return rows.map((row) => this.mapSource(row));
   }
 

--- a/apps/core/src/adapters/storage/postgres/seeds.ts
+++ b/apps/core/src/adapters/storage/postgres/seeds.ts
@@ -4,6 +4,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as pgSchema from './schema/schema.js';
 import {
   ADMIN_MCP_TOOL_FULL_NAMES,
+  DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES,
   adminMcpToolIdForFullName,
 } from '../../../shared/admin-mcp-tools.js';
 import {
@@ -195,6 +196,15 @@ export const DEFAULT_TOOL_CATALOG = [
       'high',
     ),
   ),
+  ...DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES.map((name) =>
+    hostTool(
+      name,
+      schedulerToolDisplayName(name),
+      schedulerToolDescription(name),
+      'admin',
+      schedulerToolRisk(name),
+    ),
+  ),
 ] as const;
 
 function gantryFacadeTool(
@@ -345,4 +355,32 @@ function adminToolDescription(name: string): string {
     default:
       return 'Built-in Gantry admin MCP tool.';
   }
+}
+
+function schedulerToolDisplayName(name: string): string {
+  return name
+    .replace(/^mcp__gantry__scheduler_/, 'Scheduler ')
+    .replaceAll(/[._-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function schedulerToolDescription(name: string): string {
+  switch (name) {
+    case 'mcp__gantry__scheduler_run_now':
+      return 'Trigger an existing scheduler job for the current authorized workspace.';
+    case 'mcp__gantry__scheduler_get_job':
+    case 'mcp__gantry__scheduler_list_jobs':
+      return 'Inspect scheduler jobs visible to the current authorized workspace.';
+    case 'mcp__gantry__scheduler_list_events':
+    case 'mcp__gantry__scheduler_wait_for_events':
+    case 'mcp__gantry__scheduler_list_runs':
+    case 'mcp__gantry__scheduler_get_dead_letter':
+      return 'Inspect scheduler run evidence visible to the current authorized workspace.';
+    default:
+      return 'Inspect scheduler metadata visible to the current authorized workspace.';
+  }
+}
+
+function schedulerToolRisk(name: string): 'low' | 'medium' | 'high' {
+  return name === 'mcp__gantry__scheduler_run_now' ? 'medium' : 'low';
 }

--- a/apps/core/src/adapters/storage/postgres/storage-service.ts
+++ b/apps/core/src/adapters/storage/postgres/storage-service.ts
@@ -31,7 +31,7 @@ export const postgresMigrationsFolder = path.join(
 );
 const PGCRYPTO_EXTENSION_LOCK_NAMESPACE = 1_340_193_180;
 const PGCRYPTO_EXTENSION_LOCK_KEY = 1;
-const RUNTIME_POSTGRES_POOL_MAX = 20;
+const DEFAULT_RUNTIME_POSTGRES_POOL_MAX = 20;
 // Cross-instance "run gantry migrations" lock. One identity serializes every
 // explicit migrator using PostgresStorageService.migrate().
 export const RUNTIME_MIGRATION_LOCK_NAMESPACE = 1_340_193_180;
@@ -88,6 +88,18 @@ export function quotePostgresIdentifier(identifier: string): string {
   return `"${identifier.replace(/"/g, '""')}"`;
 }
 
+export function resolveRuntimePostgresPoolMax(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.GANTRY_POSTGRES_POOL_MAX?.trim();
+  if (!raw) return DEFAULT_RUNTIME_POSTGRES_POOL_MAX;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error('GANTRY_POSTGRES_POOL_MAX must be a positive integer.');
+  }
+  return parsed;
+}
+
 function readLatestPostgresMigration(): LatestPostgresMigration {
   const latest = readMigrationFiles({
     migrationsFolder: postgresMigrationsFolder,
@@ -129,14 +141,14 @@ export function resolvePostgresPoolConfig(
     return {
       connectionString,
       options: searchPathOptions,
-      max: RUNTIME_POSTGRES_POOL_MAX,
+      max: resolveRuntimePostgresPoolMax(),
       ssl: { rejectUnauthorized: true },
     };
   }
   return {
     connectionString,
     options: searchPathOptions,
-    max: RUNTIME_POSTGRES_POOL_MAX,
+    max: resolveRuntimePostgresPoolMax(),
   };
 }
 

--- a/apps/core/src/application/agents/prompt-profile-service.ts
+++ b/apps/core/src/application/agents/prompt-profile-service.ts
@@ -193,6 +193,7 @@ const OPERATING_GUIDANCE_HEAD = [
   '- For non-trivial live work, first send one short natural acknowledgement with send_message before starting tools or investigation; after that, do not send repeated generic progress chatter.',
   '- Use render_status, render_facts, render_list, render_table, render_form, render_media, or render_progress for structured output that should render as native rich UI; use send_message for plain narrative text. Use only the Gantry tools mounted in the current run.',
   '- Use ask_user_question for genuine either/or decisions the user must make: 2-4 short options (1-5 words), set single- or multi-select intentionally. It renders as native buttons, cards, or inline keyboards per channel. Use a normal message for open-ended input the agent can act on directly.',
+  '- For multi-step create/update workflows, infer details already provided by the user, ask only the next missing decision-blocking question, and avoid dumping every required field at once.',
 ];
 const FULL_TOOL_ACCESS_GUIDANCE = [
   '- Use available actions first. If the action is missing, request the reviewed capability. If setup is missing, request source setup through the Gantry access flow.',

--- a/apps/core/src/application/jobs/job-tool-access-requirements.ts
+++ b/apps/core/src/application/jobs/job-tool-access-requirements.ts
@@ -5,7 +5,10 @@ import {
   parseReadableScopedToolRule,
   RUN_COMMAND_TOOL_NAME,
 } from '../../shared/agent-tool-references.js';
-import { isAdminMcpToolFullName } from '../../shared/admin-mcp-tools.js';
+import {
+  isAdminMcpToolFullName,
+  isDurableSchedulerMcpToolFullName,
+} from '../../shared/admin-mcp-tools.js';
 import { parseSemanticCapabilityRule } from '../../shared/semantic-capability-ids.js';
 import { toolRuleCoversRule } from '../../shared/tool-rule-matcher.js';
 import { validateDurableAccessRule } from '../../shared/durable-access-policy.js';
@@ -194,7 +197,8 @@ export function toolAccessRequirementRecoveryAction(toolName: string): string {
   }
   if (
     isGantryFacadeExactToolRule(toolName) ||
-    isAdminMcpToolFullName(toolName)
+    isAdminMcpToolFullName(toolName) ||
+    isDurableSchedulerMcpToolFullName(toolName)
   ) {
     return `request_access ${JSON.stringify({
       target: { kind: 'tool', name: toolName },

--- a/apps/core/src/application/permissions/permission-management-service.ts
+++ b/apps/core/src/application/permissions/permission-management-service.ts
@@ -36,6 +36,7 @@ import { permissionDecisionExpiresAt } from './permission-decision-expiry.js';
 import {
   adminMcpToolIdForFullName,
   isAdminMcpToolFullName,
+  isDurableSchedulerMcpToolFullName,
 } from '../../shared/admin-mcp-tools.js';
 import {
   displayToolReference,
@@ -170,15 +171,15 @@ export class PermissionManagementService {
     );
     try {
       for (const allowedRule of allowedRules) {
-        const adminMcpTool = adminMcpToolFullNameFromRule(allowedRule);
+        const gantryMcpTool = gantryMcpToolFullNameFromRule(allowedRule);
         let toolId = (
           isCanonicalBrowserCapabilityRule(allowedRule)
             ? 'tool:Browser'
-            : adminMcpTool
-              ? adminMcpToolIdForFullName(adminMcpTool)
+            : gantryMcpTool
+              ? adminMcpToolIdForFullName(gantryMcpTool)
               : persistentPermissionToolId(input.appId, allowedRule)
         ) as AgentToolBinding['toolId'];
-        if (adminMcpTool || isCanonicalBrowserCapabilityRule(allowedRule)) {
+        if (gantryMcpTool || isCanonicalBrowserCapabilityRule(allowedRule)) {
           const existing =
             (await input.toolRepository.getTool(toolId)) ??
             (isCanonicalBrowserCapabilityRule(allowedRule)
@@ -478,10 +479,10 @@ export function validatePersistentRule(
     allowUnknownSemanticCapability: false,
   });
   if (!validation.ok) throw new Error(validation.reason);
-  const adminMcpTool = adminMcpToolFullNameFromRule(allowedRule);
-  if (adminMcpTool && adminMcpTool !== allowedRule) {
+  const gantryMcpTool = gantryMcpToolFullNameFromRule(allowedRule);
+  if (gantryMcpTool && gantryMcpTool !== allowedRule) {
     throw new Error(
-      'Persistent Gantry admin MCP tool grants must request the exact tool name without a scoped rule.',
+      'Persistent Gantry MCP tool grants must request the exact tool name without a scoped rule.',
     );
   }
 }
@@ -590,11 +591,14 @@ function persistentPermissionGrantAuditMetadata(input: {
     : {};
 }
 
-function adminMcpToolFullNameFromRule(allowedRule: string): string | null {
+function gantryMcpToolFullNameFromRule(allowedRule: string): string | null {
   const trimmed = allowedRule.trim();
   const scoped = parseReadableScopedToolRule(trimmed);
   const toolName = scoped ? scoped.toolName : trimmed;
-  return isAdminMcpToolFullName(toolName) ? toolName : null;
+  return isAdminMcpToolFullName(toolName) ||
+    isDurableSchedulerMcpToolFullName(toolName)
+    ? toolName
+    : null;
 }
 
 function persistentPermissionBindingId(
@@ -680,7 +684,7 @@ function expandedRevocationLiveRules(input: {
 function candidateToolIdsForRule(appId: AppId, rule: string): Set<ToolId> {
   const out = new Set<ToolId>();
   if (isCanonicalBrowserCapabilityRule(rule)) out.add('tool:Browser' as ToolId);
-  if (isAdminMcpToolFullName(rule)) {
+  if (isAdminMcpToolFullName(rule) || isDurableSchedulerMcpToolFullName(rule)) {
     out.add(adminMcpToolIdForFullName(rule) as ToolId);
   }
   const semanticCapabilityId = parseSemanticCapabilityRule(rule);

--- a/apps/core/src/config/settings/desired-state-current-export.ts
+++ b/apps/core/src/config/settings/desired-state-current-export.ts
@@ -408,6 +408,13 @@ export async function exportCurrentDesiredState(input: {
   // manufactures duplicate conversations with mangled external ids.
   const exportedGroups = groupEntries
     .filter(([jid]) => !jid.includes('::'))
+    .filter(([, group]) => {
+      const providerAccountId = group.providerAccountId?.trim();
+      return (
+        !providerAccountId ||
+        !isCanonicalFallbackProviderAccountId(providerAccountId)
+      );
+    })
     .map(([jid, group]) => {
       const agentId = agentIdForFolder(group.folder);
       return {
@@ -608,7 +615,10 @@ function isInternalAppControlProviderAccount(
 function isCanonicalFallbackProviderAccount(
   connection: ProviderAccount,
 ): boolean {
-  const id = String(connection.id);
+  return isCanonicalFallbackProviderAccountId(String(connection.id));
+}
+
+function isCanonicalFallbackProviderAccountId(id: string): boolean {
   return (
     id.startsWith('channel-providerAccount:') ||
     id.startsWith('channel-providerConnection:')

--- a/apps/core/src/infrastructure/logging/logger.ts
+++ b/apps/core/src/infrastructure/logging/logger.ts
@@ -140,11 +140,33 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
 ];
 const LOGGER_HANDLER_MARK = Symbol.for('gantry.logger.handler');
 
-function sanitizeError(err: Error): Record<string, unknown> {
+function sanitizeError(err: Error, depth = 0): Record<string, unknown> {
+  const extra: Record<string, unknown> = {};
+  for (const key of [
+    'code',
+    'detail',
+    'constraint',
+    'table',
+    'schema',
+    'column',
+  ]) {
+    const value = (err as unknown as Record<string, unknown>)[key];
+    if (typeof value === 'string' && value.length > 0) {
+      extra[key] = redactString(value);
+    }
+  }
+  const cause = (err as unknown as { cause?: unknown }).cause;
   return {
     type: err.constructor.name,
     message: redactString(err.message),
     stack: err.stack ? redactString(err.stack) : undefined,
+    ...extra,
+    ...(cause === undefined
+      ? {}
+      : {
+          cause:
+            depth >= 5 ? '[TRUNCATED_DEPTH]' : redactValue(cause, depth + 1),
+        }),
   };
 }
 
@@ -154,7 +176,7 @@ function defaultRedact(value: unknown): unknown {
 
 function redactValue(value: unknown, depth: number): unknown {
   if (depth > 6) return '[TRUNCATED_DEPTH]';
-  if (value instanceof Error) return sanitizeError(value);
+  if (value instanceof Error) return sanitizeError(value, depth);
   if (typeof value === 'string') return redactString(value);
   if (Array.isArray(value)) {
     return value.map((entry) => redactValue(entry, depth + 1));

--- a/apps/core/src/jobs/ipc-skill-install-handlers.ts
+++ b/apps/core/src/jobs/ipc-skill-install-handlers.ts
@@ -9,10 +9,13 @@ import {
   materializedSkillDirectoryNameFor,
   type SkillCatalogItem,
 } from '../domain/skills/skills.js';
-import { memoryAgentIdForWorkspaceFolder } from '../memory/app-memory-boundaries.js';
 import { formatNotApprovedMessage } from '../shared/user-visible-messages.js';
 import { createTaskResponder, toTrimmedString } from './ipc-shared.js';
 import type { TaskHandler } from './ipc-types.js';
+import {
+  resolveTaskAgentId,
+  validateSameChannelApprovalTarget,
+} from './ipc-skill-request-context.js';
 import { startSkillPermissionReview } from './ipc-skill-permission-review.js';
 import {
   formatArgvForDisplay,
@@ -207,11 +210,12 @@ async function completeSkillInstallCommandReview(input: {
 }) {
   const { context } = input;
   const { data, deps, sourceAgentFolder } = context;
+  const agentId = resolveTaskAgentId(data, sourceAgentFolder);
   try {
     const decision = await deps.requestPermissionApproval({
       requestId: `skill-install-command-${globalThis.crypto.randomUUID()}`,
       appId: data.appId as never,
-      agentId: memoryAgentIdForWorkspaceFolder(sourceAgentFolder) as never,
+      agentId,
       sourceAgentFolder,
       targetJid: input.targetJid,
       threadId: data.authThreadId,
@@ -267,7 +271,7 @@ async function completeSkillInstallCommandReview(input: {
     }
     const installed = await installSkillFromApprovedCommand({
       appId: data.appId as never,
-      agentId: memoryAgentIdForWorkspaceFolder(sourceAgentFolder) as never,
+      agentId,
       sourceAgentFolder,
       installCommandArgv: input.installCommandArgv,
       requiredEnvVars: sanitizedStringList(
@@ -347,6 +351,7 @@ const requestSkillPackageHandler = async (
     );
     return;
   }
+  const agentId = resolveTaskAgentId(data, sourceAgentFolder);
   const reason = toTrimmedString(payload.reason, { maxLen: 2000 }) || '';
   if (!reason) {
     reject('Missing required field: reason.', 'invalid_request');
@@ -381,7 +386,7 @@ const requestSkillPackageHandler = async (
 
   const pendingKey = [
     data.appId,
-    sourceAgentFolder,
+    agentId,
     requestedTargetJid,
     data.authThreadId || '',
     input.requestToolName,
@@ -439,7 +444,7 @@ const requestSkillPackageHandler = async (
       syncApprovedCapabilitySettings:
         getRuntimeDeps().syncApprovedCapabilitySettings,
       appId: data.appId as never,
-      agentId: memoryAgentIdForWorkspaceFolder(sourceAgentFolder) as never,
+      agentId,
       sourceAgentFolder,
       targetJid: requestedTargetJid,
       threadId: data.authThreadId,
@@ -492,41 +497,6 @@ function skillInstallMessageOptions(data: Parameters<TaskHandler>[0]['data']) {
           : {}),
       }
     : undefined;
-}
-
-function validateSameChannelApprovalTarget(input: {
-  data: Parameters<TaskHandler>[0]['data'];
-  sourceAgentFolderJids: string[];
-  requestKind: string;
-  reject: (error: string, code?: string, details?: string[]) => void;
-}): string | null {
-  const requestedTargetJid = toTrimmedString(input.data.chatJid, {
-    maxLen: 512,
-  });
-  const targetOverride = toTrimmedString(
-    input.data.targetJid || input.data.jid,
-    {
-      maxLen: 512,
-    },
-  );
-  if (targetOverride && targetOverride !== requestedTargetJid) {
-    input.reject(
-      `${input.requestKind} requests must use the originating chat as the approval target.`,
-      'forbidden',
-    );
-    return null;
-  }
-  if (
-    !requestedTargetJid ||
-    !input.sourceAgentFolderJids.includes(requestedTargetJid)
-  ) {
-    input.reject(
-      `${input.requestKind} requests must include the originating chat for this agent.`,
-      'forbidden',
-    );
-    return null;
-  }
-  return requestedTargetJid;
 }
 
 function skillPackageParseError(

--- a/apps/core/src/jobs/ipc-skill-request-context.ts
+++ b/apps/core/src/jobs/ipc-skill-request-context.ts
@@ -1,0 +1,47 @@
+import type { AgentId } from '../domain/agent/agent.js';
+import { memoryAgentIdForWorkspaceFolder } from '../memory/app-memory-boundaries.js';
+import { toTrimmedString } from './ipc-shared.js';
+import type { TaskHandler } from './ipc-types.js';
+
+export function resolveTaskAgentId(
+  data: Parameters<TaskHandler>[0]['data'],
+  sourceAgentFolder: string,
+): AgentId {
+  return (toTrimmedString(data.agentId, { maxLen: 512 }) ||
+    memoryAgentIdForWorkspaceFolder(sourceAgentFolder)) as AgentId;
+}
+
+export function validateSameChannelApprovalTarget(input: {
+  data: Parameters<TaskHandler>[0]['data'];
+  sourceAgentFolderJids: string[];
+  requestKind: string;
+  reject: (error: string, code?: string, details?: string[]) => void;
+}): string | null {
+  const requestedTargetJid = toTrimmedString(input.data.chatJid, {
+    maxLen: 512,
+  });
+  const targetOverride = toTrimmedString(
+    input.data.targetJid || input.data.jid,
+    {
+      maxLen: 512,
+    },
+  );
+  if (targetOverride && targetOverride !== requestedTargetJid) {
+    input.reject(
+      `${input.requestKind} requests must use the originating chat as the approval target.`,
+      'forbidden',
+    );
+    return null;
+  }
+  if (
+    !requestedTargetJid ||
+    !input.sourceAgentFolderJids.includes(requestedTargetJid)
+  ) {
+    input.reject(
+      `${input.requestKind} requests must include the originating chat for this agent.`,
+      'forbidden',
+    );
+    return null;
+  }
+  return requestedTargetJid;
+}

--- a/apps/core/src/runner/gantry-mcp-tool-surface.ts
+++ b/apps/core/src/runner/gantry-mcp-tool-surface.ts
@@ -1,6 +1,7 @@
 import {
   ADMIN_MCP_TOOL_NAMES,
   AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
+  SCHEDULER_MCP_TOOL_NAMES,
 } from '../shared/admin-mcp-tools.js';
 import {
   selectedMemoryIpcActionsFromToolRules,
@@ -66,20 +67,7 @@ export const DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES = [
 export { AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES };
 
 export const OPTIONAL_GANTRY_MCP_TOOL_NAMES = [
-  'scheduler_list_models',
-  'scheduler_upsert_job',
-  'scheduler_get_job',
-  'scheduler_list_jobs',
-  'scheduler_list_notification_targets',
-  'scheduler_update_job',
-  'scheduler_delete_job',
-  'scheduler_pause_job',
-  'scheduler_resume_job',
-  'scheduler_run_now',
-  'scheduler_list_runs',
-  'scheduler_list_events',
-  'scheduler_wait_for_events',
-  'scheduler_get_dead_letter',
+  ...SCHEDULER_MCP_TOOL_NAMES,
 ] as const;
 
 export const REVIEWED_GANTRY_MCP_TOOL_NAMES = [

--- a/apps/core/src/runtime/group-processing-flow.ts
+++ b/apps/core/src/runtime/group-processing-flow.ts
@@ -5,6 +5,7 @@ type GroupTurnRunResult = 'success' | 'error' | 'stopped';
 export async function handleFailure(input: {
   outputSentToUser: boolean;
   acknowledgeFailedTurn?: boolean;
+  preserveCursor?: boolean;
   groupName: string;
   queueJid: string;
   previousCursor: string;
@@ -28,6 +29,14 @@ export async function handleFailure(input: {
     input.logger.warn(
       { group: input.groupName },
       'Agent error on final retry, preserving message cursor to prevent stale replay',
+    );
+    return true;
+  }
+  if (input.preserveCursor) {
+    await input.deps.saveState();
+    input.logger.warn(
+      { group: input.groupName },
+      'Agent infrastructure error, preserving message cursor to prevent stale replay',
     );
     return true;
   }

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -62,6 +62,10 @@ import { buildGroupProcessingConversationContext } from './group-processing-cont
 import { createGroupOutputBuffer } from './group-output-buffer.js';
 import { activeTurnUiCleanupByQueue } from './group-active-turn-cleanup.js';
 import { createGroupProcessingSessionCommandHandlers } from './group-processing-session-command-handlers.js';
+import {
+  isFailoverEligibleError,
+  isMissingProviderSessionError,
+} from './failover-eligibility.js';
 let streamingGenerationCounter = 0;
 const PERMISSION_BACKGROUND_DEMOTE_MS = 120_000;
 type ProgressHeartbeat = ReturnType<typeof startGroupProgressHeartbeats>;
@@ -494,6 +498,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       cancel: cancelTurnUiTimers,
     });
     let hadError = false;
+    let lastAgentError: string | undefined;
     let outputSentToUser = false;
     let streamedTranscriptDeliveryStatus: 'none' | 'sent' | 'partially_sent' =
       'none';
@@ -661,6 +666,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       }
       if (result.status === 'error') {
         hadError = true;
+        lastAgentError = result.error;
         await resumeTurnProgress();
         await finalizeStreamingOutput('error-marker');
         if (!outputSentToUser && isModelAccessAuthFailure(result.error)) {
@@ -741,6 +747,9 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         deps,
         acknowledgeFailedTurn:
           options.finalRetry === true && !deps.queue.isShuttingDown?.(),
+        preserveCursor:
+          isFailoverEligibleError(lastAgentError) ||
+          isMissingProviderSessionError(lastAgentError),
         logger,
       });
     } else {

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -753,35 +753,42 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       // ponytail: interim guard against silent turn loss. The durable fix is a
       // dead-letter re-drive of the dropped turn (issue #285). Until then, when
       // failover is exhausted we stop the replay storm by preserving the cursor
-      // (below) AND surface an error + user-visible notice so the turn is never
-      // silently dropped.
+      // (below) AND surface an error + user-visible notice. We only CONSUME the
+      // turn once the user was actually informed; if the notice fails to deliver
+      // (channel down), we fall through to rollback->retry so the turn isn't
+      // silently dropped. The remaining edge (channel still down after the queue
+      // retry cap is exhausted) is covered by the durable dead-letter re-drive (#285).
+      let failureNoticeDelivered = false;
       if (failoverExhausted && !outputSentToUser) {
         logger.error(
           { group: group.name, error: lastAgentError },
           'Provider failover exhausted after retries; dropping turn to stop replay storm, notifying user',
         );
         const noticeOptions = buildMessageOptions();
-        applyDeliverySettlement(
-          await settleDeliveryAttempt(
-            () =>
-              sendMessageToChannel(
-                PROVIDER_FAILOVER_EXHAUSTED_MESSAGE,
-                noticeOptions,
-              ),
-            {
-              scope: 'runtime-provider-failover-exhausted',
-              target: chatJid,
-            },
-          ).catch((err) => {
-            logger.warn(
-              { err, group: group.name },
-              'Failed to send provider failover exhausted notice',
-            );
-            return 'not_delivered' as const;
-          }),
-          { streamed: false, terminal: true },
-        );
+        const noticeSettlement = await settleDeliveryAttempt(
+          () =>
+            sendMessageToChannel(
+              PROVIDER_FAILOVER_EXHAUSTED_MESSAGE,
+              noticeOptions,
+            ),
+          {
+            scope: 'runtime-provider-failover-exhausted',
+            target: chatJid,
+          },
+        ).catch((err) => {
+          logger.error(
+            { err, group: group.name },
+            'Failed to send provider failover exhausted notice',
+          );
+          return 'not_delivered' as const;
+        });
+        failureNoticeDelivered = noticeSettlement !== 'not_delivered';
+        applyDeliverySettlement(noticeSettlement, {
+          streamed: false,
+          terminal: true,
+        });
       }
+      const userInformed = outputSentToUser || failureNoticeDelivered;
       resultOk = await handleFailure({
         outputSentToUser,
         groupName: group.name,
@@ -789,8 +796,10 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         previousCursor,
         deps,
         acknowledgeFailedTurn:
-          options.finalRetry === true && !deps.queue.isShuttingDown?.(),
-        preserveCursor: failoverExhausted,
+          options.finalRetry === true &&
+          !deps.queue.isShuttingDown?.() &&
+          (!failoverExhausted || userInformed),
+        preserveCursor: failoverExhausted && userInformed,
         logger,
       });
     } else {

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -68,6 +68,8 @@ import {
 } from './failover-eligibility.js';
 let streamingGenerationCounter = 0;
 const PERMISSION_BACKGROUND_DEMOTE_MS = 120_000;
+const PROVIDER_FAILOVER_EXHAUSTED_MESSAGE =
+  "The AI provider is unavailable and your message couldn't be processed after several retries. Please try again shortly.";
 type ProgressHeartbeat = ReturnType<typeof startGroupProgressHeartbeats>;
 export function createGroupProcessor(deps: GroupProcessingDeps) {
   const collectSessionMemory = deps.collectSessionMemory;
@@ -739,6 +741,47 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
     }
     let resultOk = true;
     if (output === 'error' || hadError) {
+      // A provider-infra failure (failover-eligible or missing-provider-session)
+      // is only "exhausted" once the queue has burned all its retries
+      // (options.finalRetry). Before that, a transient 429/502 must keep the
+      // normal rollback -> retry path so the provider gets time to recover;
+      // dropping it on the FIRST error silently loses the user's turn.
+      const failoverExhausted =
+        options.finalRetry === true &&
+        (isFailoverEligibleError(lastAgentError) ||
+          isMissingProviderSessionError(lastAgentError));
+      // ponytail: interim guard against silent turn loss. The durable fix is a
+      // dead-letter re-drive of the dropped turn (issue #285). Until then, when
+      // failover is exhausted we stop the replay storm by preserving the cursor
+      // (below) AND surface an error + user-visible notice so the turn is never
+      // silently dropped.
+      if (failoverExhausted && !outputSentToUser) {
+        logger.error(
+          { group: group.name, error: lastAgentError },
+          'Provider failover exhausted after retries; dropping turn to stop replay storm, notifying user',
+        );
+        const noticeOptions = buildMessageOptions();
+        applyDeliverySettlement(
+          await settleDeliveryAttempt(
+            () =>
+              sendMessageToChannel(
+                PROVIDER_FAILOVER_EXHAUSTED_MESSAGE,
+                noticeOptions,
+              ),
+            {
+              scope: 'runtime-provider-failover-exhausted',
+              target: chatJid,
+            },
+          ).catch((err) => {
+            logger.warn(
+              { err, group: group.name },
+              'Failed to send provider failover exhausted notice',
+            );
+            return 'not_delivered' as const;
+          }),
+          { streamed: false, terminal: true },
+        );
+      }
       resultOk = await handleFailure({
         outputSentToUser,
         groupName: group.name,
@@ -747,9 +790,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         deps,
         acknowledgeFailedTurn:
           options.finalRetry === true && !deps.queue.isShuttingDown?.(),
-        preserveCursor:
-          isFailoverEligibleError(lastAgentError) ||
-          isMissingProviderSessionError(lastAgentError),
+        preserveCursor: failoverExhausted,
         logger,
       });
     } else {

--- a/apps/core/src/runtime/runtime-event-forwarding.ts
+++ b/apps/core/src/runtime/runtime-event-forwarding.ts
@@ -65,23 +65,29 @@ export async function forwardRuntimeEvents(input: {
     });
     if (input.forwardedKeys.has(eventKey)) continue;
     input.forwardedKeys.add(eventKey);
-    await publishRuntimeEvent({
-      appId: appId as never,
-      ...((event.agentId ?? input.turnAgentId)
-        ? { agentId: (event.agentId ?? input.turnAgentId) as never }
-        : {}),
-      ...((event.runId ?? input.runId)
-        ? { runId: (event.runId ?? input.runId) as never }
-        : {}),
-      ...(event.jobId ? { jobId: event.jobId as never } : {}),
-      conversationId: (event.conversationId ?? input.chatJid) as never,
-      ...((event.threadId ?? input.sessionThreadId)
-        ? { threadId: (event.threadId ?? input.sessionThreadId) as never }
-        : {}),
-      eventType: event.eventType,
-      actor: event.actor ?? 'runner',
-      responseMode: event.responseMode ?? 'none',
-      payload: event.payload,
-    });
+    try {
+      await publishRuntimeEvent({
+        appId: appId as never,
+        ...((event.agentId ?? input.turnAgentId)
+          ? { agentId: (event.agentId ?? input.turnAgentId) as never }
+          : {}),
+        ...((event.runId ?? input.runId)
+          ? { runId: (event.runId ?? input.runId) as never }
+          : {}),
+        ...(event.jobId ? { jobId: event.jobId as never } : {}),
+        conversationId: (event.conversationId ?? input.chatJid) as never,
+        ...((event.threadId ?? input.sessionThreadId)
+          ? { threadId: (event.threadId ?? input.sessionThreadId) as never }
+          : {}),
+        eventType: event.eventType,
+        actor: event.actor ?? 'runner',
+        responseMode: event.responseMode ?? 'none',
+        payload: event.payload,
+      });
+    } catch {
+      // Runtime events are observability/audit breadcrumbs. They must not
+      // fail a user-visible turn when storage is temporarily unhealthy or
+      // schema drift is being repaired.
+    }
   }
 }

--- a/apps/core/src/runtime/runtime-event-forwarding.ts
+++ b/apps/core/src/runtime/runtime-event-forwarding.ts
@@ -3,6 +3,7 @@ import {
   isRuntimeEventType,
   RUNTIME_EVENT_TYPES,
 } from '../domain/events/runtime-event-types.js';
+import { logger } from '../infrastructure/logging/logger.js';
 import type { AgentOutput } from './agent-spawn.js';
 
 export { RUNTIME_EVENT_TYPES };
@@ -64,7 +65,6 @@ export async function forwardRuntimeEvents(input: {
       payload: event.payload,
     });
     if (input.forwardedKeys.has(eventKey)) continue;
-    input.forwardedKeys.add(eventKey);
     try {
       await publishRuntimeEvent({
         appId: appId as never,
@@ -84,10 +84,24 @@ export async function forwardRuntimeEvents(input: {
         responseMode: event.responseMode ?? 'none',
         payload: event.payload,
       });
-    } catch {
+      // Mark forwarded only after a successful publish so a failed event
+      // remains retriable on a later forwarding pass in the same turn.
+      input.forwardedKeys.add(eventKey);
+    } catch (error) {
       // Runtime events are observability/audit breadcrumbs. They must not
       // fail a user-visible turn when storage is temporarily unhealthy or
-      // schema drift is being repaired.
+      // schema drift is being repaired. The key is intentionally NOT added,
+      // so a later forwarding pass can retry this event.
+      logger.warn(
+        {
+          error,
+          eventType: event.eventType,
+          conversationId: event.conversationId ?? input.chatJid,
+          runId: event.runId ?? input.runId,
+          agentId: event.agentId ?? input.turnAgentId,
+        },
+        'Failed to persist forwarded runtime event; will remain retriable',
+      );
     }
   }
 }

--- a/apps/core/src/shared/admin-mcp-tools.ts
+++ b/apps/core/src/shared/admin-mcp-tools.ts
@@ -10,6 +10,40 @@ export const ADMIN_MCP_TOOL_NAMES = [
 
 export type AdminMcpToolName = (typeof ADMIN_MCP_TOOL_NAMES)[number];
 
+export const SCHEDULER_MCP_TOOL_NAMES = [
+  'scheduler_list_models',
+  'scheduler_upsert_job',
+  'scheduler_get_job',
+  'scheduler_list_jobs',
+  'scheduler_list_notification_targets',
+  'scheduler_update_job',
+  'scheduler_delete_job',
+  'scheduler_pause_job',
+  'scheduler_resume_job',
+  'scheduler_run_now',
+  'scheduler_list_runs',
+  'scheduler_list_events',
+  'scheduler_wait_for_events',
+  'scheduler_get_dead_letter',
+] as const;
+
+export type SchedulerMcpToolName = (typeof SCHEDULER_MCP_TOOL_NAMES)[number];
+
+export const DURABLE_SCHEDULER_MCP_TOOL_NAMES = [
+  'scheduler_list_models',
+  'scheduler_get_job',
+  'scheduler_list_jobs',
+  'scheduler_list_notification_targets',
+  'scheduler_run_now',
+  'scheduler_list_runs',
+  'scheduler_list_events',
+  'scheduler_wait_for_events',
+  'scheduler_get_dead_letter',
+] as const satisfies readonly SchedulerMcpToolName[];
+
+export type DurableSchedulerMcpToolName =
+  (typeof DURABLE_SCHEDULER_MCP_TOOL_NAMES)[number];
+
 // Authority-changing Gantry tools let an agent request new install/setup/access
 // authority. The canonical names live here
 // (provider-neutral shared layer) so config-layer access policy can consume
@@ -28,8 +62,20 @@ export const ADMIN_MCP_TOOL_FULL_NAMES = ADMIN_MCP_TOOL_NAMES.map(
   (toolName) => `mcp__gantry__${toolName}`,
 ) as readonly `mcp__gantry__${AdminMcpToolName}`[];
 
+export const SCHEDULER_MCP_TOOL_FULL_NAMES = SCHEDULER_MCP_TOOL_NAMES.map(
+  (toolName) => `mcp__gantry__${toolName}`,
+) as readonly `mcp__gantry__${SchedulerMcpToolName}`[];
+
+export const DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES =
+  DURABLE_SCHEDULER_MCP_TOOL_NAMES.map(
+    (toolName) => `mcp__gantry__${toolName}`,
+  ) as readonly `mcp__gantry__${DurableSchedulerMcpToolName}`[];
+
 const ADMIN_MCP_TOOL_NAME_SET = new Set<string>(ADMIN_MCP_TOOL_NAMES);
 const ADMIN_MCP_TOOL_FULL_NAME_SET = new Set<string>(ADMIN_MCP_TOOL_FULL_NAMES);
+const DURABLE_SCHEDULER_MCP_TOOL_FULL_NAME_SET = new Set<string>(
+  DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES,
+);
 
 export function adminMcpToolFullName(
   toolName: AdminMcpToolName,
@@ -47,6 +93,10 @@ export function isAdminMcpToolName(value: string): value is AdminMcpToolName {
 
 export function isAdminMcpToolFullName(value: string): boolean {
   return ADMIN_MCP_TOOL_FULL_NAME_SET.has(value);
+}
+
+export function isDurableSchedulerMcpToolFullName(value: string): boolean {
+  return DURABLE_SCHEDULER_MCP_TOOL_FULL_NAME_SET.has(value);
 }
 
 export function adminMcpToolNameFromFullName(

--- a/apps/core/src/shared/durable-access-policy.ts
+++ b/apps/core/src/shared/durable-access-policy.ts
@@ -1,6 +1,7 @@
 import {
   isAdminMcpToolFullName,
   isGantryMcpWildcardRule,
+  isDurableSchedulerMcpToolFullName,
 } from './admin-mcp-tools.js';
 import {
   type BashCommandLeaf,
@@ -43,12 +44,13 @@ import {
  *   - canonical Browser
  *   - exact Gantry facade file/web tools
  *   - exact Gantry admin MCP tools (the closed admin allowlist)
+ *   - exact Gantry scheduler MCP tools
  *   - scoped `RunCommand(...)` with the bash-parser durable safety rejections
  * Gantry MCP wildcards and generated runtime skill paths are rejected.
  */
 
 export const DURABLE_ACCESS_RULE_REJECTION_REASON =
-  'Persistent access approvals support only trusted projected semantic capabilities, canonical Browser, exact Gantry file/web tools, scoped RunCommand(...), or exact Gantry admin tools; use request_access with target.kind=capability for reviewed semantic app/tool access.';
+  'Persistent access approvals support only trusted projected semantic capabilities, canonical Browser, exact Gantry file/web tools, scoped RunCommand(...), or exact Gantry admin/scheduler tools; use request_access with target.kind=capability for reviewed semantic app/tool access.';
 
 export interface DurableAccessRuleOptions {
   semanticCapabilityDefinitions?: Record<string, SemanticCapabilityDefinition>;
@@ -165,6 +167,7 @@ export function validateDurableAccessRule(
 
   if (isCanonicalBrowserCapabilityRule(trimmed)) return { ok: true };
   if (isAdminMcpToolFullName(trimmed)) return { ok: true };
+  if (isDurableSchedulerMcpToolFullName(trimmed)) return { ok: true };
 
   return {
     ok: false,
@@ -225,6 +228,10 @@ function formatDurableAccessRuleForUser(
     ? trimmed.replace(/^mcp__gantry__/, '').replaceAll(/[._-]+/g, ' ')
     : undefined;
   if (adminName) return `Gantry ${titleCase(adminName)}`;
+  const schedulerName = isDurableSchedulerMcpToolFullName(trimmed)
+    ? trimmed.replace(/^mcp__gantry__scheduler_/, '').replaceAll(/[._-]+/g, ' ')
+    : undefined;
+  if (schedulerName) return `Scheduler ${titleCase(schedulerName)}`;
   return truncate(redactSensitiveText(trimmed), 160);
 }
 

--- a/apps/core/src/shared/tool-execution-policy-service.ts
+++ b/apps/core/src/shared/tool-execution-policy-service.ts
@@ -8,7 +8,10 @@ import {
   normalizeBashLeafRuleContent,
   parseBashCommand,
 } from './bash-command-parser.js';
-import { isAdminMcpToolFullName } from './admin-mcp-tools.js';
+import {
+  isAdminMcpToolFullName,
+  isDurableSchedulerMcpToolFullName,
+} from './admin-mcp-tools.js';
 import {
   isKnownProjectedBrowserMcpToolName,
   publicGantryToolNameForSdkTool,
@@ -609,6 +612,9 @@ function autonomousGrantRecovery(
   }
   if (isAdminMcpToolFullName(request.toolName)) {
     return `Use the Agent Access summary to find and request the reviewed admin capability for ${request.toolName}; exact tool grants are not accepted as durable authority.`;
+  }
+  if (isDurableSchedulerMcpToolFullName(request.toolName)) {
+    return `request_access { "target": { "kind": "tool", "name": "${escapeJson(request.toolName)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scheduler access." }`;
   }
   const thirdPartyMcp = thirdPartyMcpToolServerName(request.toolName);
   if (thirdPartyMcp) {

--- a/apps/core/test/unit/adapters/storage/postgres/postgres-read-retry.test.ts
+++ b/apps/core/test/unit/adapters/storage/postgres/postgres-read-retry.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isRetryablePostgresReadError,
+  retryPostgresRead,
+} from '@core/adapters/storage/postgres/postgres-read-retry.js';
+
+describe('postgres read retry', () => {
+  it('detects transient postgres errors from wrapped causes', () => {
+    const err = new Error('Failed query', {
+      cause: Object.assign(
+        new Error('cached plan must not change result type'),
+        {
+          code: '0A000',
+        },
+      ),
+    });
+
+    expect(isRetryablePostgresReadError(err)).toBe(true);
+  });
+
+  it('does not classify deterministic schema errors as retryable', () => {
+    const err = new Error('Failed query', {
+      cause: Object.assign(new Error('column does not exist'), {
+        code: '42703',
+      }),
+    });
+
+    expect(isRetryablePostgresReadError(err)).toBe(false);
+  });
+
+  it('retries read operations that fail transiently', async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('Failed query', {
+          cause: Object.assign(
+            new Error('Connection terminated unexpectedly'),
+            {
+              code: '08006',
+            },
+          ),
+        }),
+      )
+      .mockResolvedValueOnce('ok');
+
+    await expect(
+      retryPostgresRead('test.read', operation, { delaysMs: [0] }),
+    ).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/core/test/unit/adapters/storage/postgres/runtime-event-repository.postgres.test.ts
+++ b/apps/core/test/unit/adapters/storage/postgres/runtime-event-repository.postgres.test.ts
@@ -8,6 +8,7 @@ class FakeDrizzleDb {
   readonly operations: string[] = [];
   insertedRuntimeEvent: Record<string, unknown> | null = null;
   insertedOutboxEvent: Record<string, unknown> | null = null;
+  insertedConversationThread: Record<string, unknown> | null = null;
   failOutboxInsert = false;
   failDeliveryInsert = false;
 
@@ -63,6 +64,15 @@ class FakeDrizzleDb {
               if (db.failOutboxInsert) {
                 throw new Error('outbox insert failed');
               }
+              return Promise.resolve();
+            },
+          };
+        }
+        if (table === pgSchema.conversationThreadsPostgres) {
+          db.operations.push('insert:conversation_threads');
+          db.insertedConversationThread = value;
+          return {
+            onConflictDoNothing() {
               return Promise.resolve();
             },
           };
@@ -263,5 +273,47 @@ describe('PostgresRuntimeEventRepository', () => {
       'insert:event_bus_outbox',
       'transaction:commit',
     ]);
+  });
+
+  it('materializes canonical conversation thread rows before appending threaded events', async () => {
+    const db = new FakeDrizzleDb();
+    const repository = createRepository(db);
+
+    await repository.appendRuntimeEvent({
+      appId: 'default' as never,
+      conversationId: 'conversation:sl:C0B3M99H1B6' as never,
+      threadId: 'thread:sl:C0B3M99H1B6:1784789975.807219' as never,
+      eventType: RUNTIME_EVENT_TYPES.SESSION_MESSAGE_OUTBOUND,
+      actor: 'agent',
+      payload: { text: 'done' },
+    });
+
+    expect(db.operations).toEqual([
+      'transaction:begin',
+      'insert:conversation_threads',
+      'insert:runtime_events',
+      'insert:event_bus_outbox',
+      'transaction:commit',
+    ]);
+    expect(db.insertedConversationThread).toMatchObject({
+      id: 'thread:sl:C0B3M99H1B6:1784789975.807219',
+      appId: 'default',
+      conversationId: 'conversation:sl:C0B3M99H1B6',
+    });
+    expect(db.insertedConversationThread?.externalRefJson).toBe(
+      JSON.stringify({
+        kind: 'conversation_thread',
+        value: '1784789975.807219',
+        jid: 'sl:C0B3M99H1B6',
+        threadId: '1784789975.807219',
+        externalThreadId: '1784789975.807219',
+      }),
+    );
+    expect(db.insertedRuntimeEvent).toEqual(
+      expect.objectContaining({
+        conversationId: 'conversation:sl:C0B3M99H1B6',
+        threadId: 'thread:sl:C0B3M99H1B6:1784789975.807219',
+      }),
+    );
   });
 });

--- a/apps/core/test/unit/application/job-tool-access-requirements.test.ts
+++ b/apps/core/test/unit/application/job-tool-access-requirements.test.ts
@@ -16,6 +16,7 @@ describe('job tool access requirements', () => {
         'FileWrite',
         'AgentDelegation',
         'mcp__gantry__settings_desired_state',
+        'mcp__gantry__scheduler_run_now',
         'capability:example.records.append',
         'RunCommand(npm test *)',
         'Browser',
@@ -27,6 +28,7 @@ describe('job tool access requirements', () => {
       'FileWrite',
       'AgentDelegation',
       'mcp__gantry__settings_desired_state',
+      'mcp__gantry__scheduler_run_now',
       'capability:example.records.append',
       'RunCommand(npm test *)',
     ]);
@@ -72,6 +74,14 @@ describe('job tool access requirements', () => {
       expect(() => normalizeToolAccessRequirements(rules)).toThrow(message);
     },
   );
+
+  it('builds request_access recovery for exact scheduler tool requirements', () => {
+    expect(
+      toolAccessRequirementRecoveryAction('mcp__gantry__scheduler_run_now'),
+    ).toBe(
+      'request_access {"target":{"kind":"tool","name":"mcp__gantry__scheduler_run_now"},"temporaryOnly":false,"reason":"This autonomous run requires mcp__gantry__scheduler_run_now access."}',
+    );
+  });
 
   it('reports missing tool access requirements without granting permission', () => {
     expect(

--- a/apps/core/test/unit/application/permission-management-service.test.ts
+++ b/apps/core/test/unit/application/permission-management-service.test.ts
@@ -767,6 +767,58 @@ describe('PermissionManagementService', () => {
     expect(decision.actionPreview).toContain('revoke FileRead');
   });
 
+  it('revokes exact scheduler MCP grants through the scheduler catalog binding', async () => {
+    const service = new PermissionManagementService({
+      now: () => '2026-05-15T12:00:00.000Z',
+    });
+    const tool: ToolCatalogItem = {
+      ...toolItem('mcp__gantry__scheduler_run_now'),
+      id: 'tool:mcp__gantry__scheduler_run_now' as never,
+      name: 'mcp__gantry__scheduler_run_now',
+    };
+    const binding = activeBinding(tool);
+    const disableAgentToolBinding = vi.fn(async () => ({
+      ...binding,
+      status: 'disabled' as const,
+    }));
+    const mirrorAgentToolRulesToSettings = vi.fn(async () => undefined);
+
+    const result = await service.revokePersistentToolRuleGrant({
+      appId: 'app:test' as never,
+      agentId: 'agent:test' as never,
+      sourceAgentFolder: 'main_agent',
+      toolName: 'mcp__gantry__scheduler_run_now',
+      toolRepository: {
+        getTool: vi.fn(async (toolId: string) =>
+          toolId === 'tool:mcp__gantry__scheduler_run_now' ? tool : null,
+        ),
+        listTools: vi.fn(async () => [tool]),
+        saveTool: vi.fn(),
+        saveAgentToolBinding: vi.fn(),
+        disableAgentToolBinding,
+        listAgentToolBindings: vi.fn(async () => [binding]),
+        listAgentToolBindingsForAgents: vi.fn(),
+      },
+      mirrorAgentToolRulesToSettings,
+    });
+
+    expect(result).toEqual({
+      revokedRule: 'mcp__gantry__scheduler_run_now',
+      toolId: 'tool:mcp__gantry__scheduler_run_now',
+    });
+    expect(disableAgentToolBinding).toHaveBeenCalledWith({
+      appId: 'app:test',
+      agentId: 'agent:test',
+      toolId: 'tool:mcp__gantry__scheduler_run_now',
+      updatedAt: '2026-05-15T12:00:00.000Z',
+    });
+    expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
+      'main_agent',
+      ['mcp__gantry__scheduler_run_now'],
+      { appId: 'app:test', mode: 'remove' },
+    );
+  });
+
   it('removes expanded live rules when revoking a skill action grant', async () => {
     const service = new PermissionManagementService({
       now: () => '2026-05-15T12:00:00.000Z',

--- a/apps/core/test/unit/config/desired-state-current-export.test.ts
+++ b/apps/core/test/unit/config/desired-state-current-export.test.ts
@@ -533,6 +533,70 @@ permissions:
     ]);
   });
 
+  it('never exports route-derived canonical fallback channel accounts as desired conversations', async () => {
+    const settings = parseRuntimeSettings('agents: {}\n');
+    const deps = {
+      ops: {
+        getAllConversationRoutes: vi.fn(async () => ({
+          'sl:C0BH9KZSTM1': {
+            name: 'itops',
+            folder: 'itops',
+            conversationId: 'conversation:sl:C0BH9KZSTM1',
+            providerAccountId: 'channel-providerAccount:default:slack',
+            trigger: '@itops',
+            added_at: '2026-07-22T17:00:19.975Z',
+            requiresTrigger: true,
+            conversationKind: 'channel',
+          },
+        })),
+      },
+      repositories: {
+        agents: { listAgents: vi.fn(async () => []) },
+        tools: {
+          listAgentToolBindingsForAgents: vi.fn(async () => []),
+          listAgentToolSourcesForAgents: vi.fn(async () => []),
+          listTools: vi.fn(async () => []),
+        },
+        skills: {
+          listAgentSkillBindingsForAgents: vi.fn(async () => []),
+          listSkills: vi.fn(async () => []),
+        },
+        mcpServers: { listAgentBindingsForAgents: vi.fn(async () => []) },
+        providerAccounts: {
+          listProviderAccounts: vi.fn(async () => [
+            {
+              id: 'channel-providerAccount:default:slack',
+              agentId: 'agent:itops',
+              providerId: 'slack',
+              label: 'Slack fallback',
+              status: 'active',
+              config: {},
+              runtimeSecretRefs: {},
+            },
+          ]),
+          listConversationInstalls: vi.fn(async () => []),
+        },
+        conversations: {
+          listConversations: vi.fn(async () => []),
+          listThreads: vi.fn(async () => []),
+          listConversationApproversForConversations: vi.fn(async () => []),
+        },
+      },
+    };
+
+    const exported = await exportCurrentDesiredState({
+      deps: deps as any,
+      appId: 'app-one' as never,
+      settings: settings as any,
+    });
+
+    expect(exported.providers).toEqual({});
+    expect(exported.providerAccounts).toEqual({});
+    expect(exported.conversations).toEqual({});
+    expect(exported.bindings).toEqual({});
+    expect(exported.agents).toEqual({});
+  });
+
   it('skips bindings whose conversation lost its provider connection instead of crashing', async () => {
     const settings = parseRuntimeSettings('agents: {}\n');
     settings.conversations = {

--- a/apps/core/test/unit/infrastructure/logging/logger-error-cause.test.ts
+++ b/apps/core/test/unit/infrastructure/logging/logger-error-cause.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createLogger,
+  type LogRecord,
+} from '@core/infrastructure/logging/logger.js';
+
+describe('logger error cause serialization', () => {
+  it('includes redacted nested error causes and postgres fields', () => {
+    const records: LogRecord[] = [];
+    const logger = createLogger({
+      format: 'json',
+      sink: { write: (record) => records.push(record) },
+    });
+
+    logger.error(
+      {
+        err: Object.assign(new Error('Failed query with sk-ant-secret'), {
+          cause: Object.assign(
+            new Error('cached plan must not change result type'),
+            {
+              code: '0A000',
+              detail: 'contains xoxb-secret-token',
+            },
+          ),
+        }),
+      },
+      'db read failed',
+    );
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.context?.err).toMatchObject({
+      type: 'Error',
+      message: 'Failed query with [REDACTED]',
+      cause: {
+        type: 'Error',
+        message: 'cached plan must not change result type',
+        code: '0A000',
+        detail: 'contains [REDACTED]',
+      },
+    });
+  });
+
+  it('truncates recursive error causes', () => {
+    const records: LogRecord[] = [];
+    const logger = createLogger({
+      format: 'json',
+      sink: { write: (record) => records.push(record) },
+    });
+    const err = new Error('recursive');
+    Object.assign(err, { cause: err });
+
+    logger.error({ err }, 'recursive error');
+
+    expect(JSON.stringify(records[0]?.context?.err)).toContain(
+      '[TRUNCATED_DEPTH]',
+    );
+  });
+});

--- a/apps/core/test/unit/infrastructure/logging/logger-error-cause.test.ts
+++ b/apps/core/test/unit/infrastructure/logging/logger-error-cause.test.ts
@@ -9,6 +9,7 @@ describe('logger error cause serialization', () => {
   it('includes redacted nested error causes and postgres fields', () => {
     const records: LogRecord[] = [];
     const logger = createLogger({
+      level: 'error',
       format: 'json',
       sink: { write: (record) => records.push(record) },
     });
@@ -44,6 +45,7 @@ describe('logger error cause serialization', () => {
   it('truncates recursive error causes', () => {
     const records: LogRecord[] = [];
     const logger = createLogger({
+      level: 'error',
       format: 'json',
       sink: { write: (record) => records.push(record) },
     });

--- a/apps/core/test/unit/jobs/ipc-skill-install-handlers.test.ts
+++ b/apps/core/test/unit/jobs/ipc-skill-install-handlers.test.ts
@@ -14,6 +14,7 @@ import type {
 import {
   configureSkillInstallHandlers,
   requestSkillInstallHandler,
+  requestSkillProposalHandler,
 } from '@core/jobs/ipc-skill-install-handlers.js';
 import {
   collectInstalledSkillAssets,
@@ -520,6 +521,61 @@ describe('approved command skill installs', () => {
       },
     } as never;
   }
+
+  it('binds proposed package skills to the signed agent id, not the workspace folder', async () => {
+    const { skills, syncApprovedCapabilitySettings } = setup();
+    const sendMessage = vi.fn(async () => undefined);
+    const requestPermissionApproval = vi.fn(async () => ({
+      approved: true,
+      decidedBy: 'user:approver',
+    }));
+
+    await requestSkillProposalHandler({
+      data: {
+        appId: 'app:test',
+        agentId: 'agent:main_agent',
+        chatJid: 'chat:one',
+        authThreadId: 'thread:one',
+        payload: {
+          reason: 'Reuse the hiring intake workflow.',
+          files: [
+            {
+              path: 'SKILL.md',
+              content:
+                '---\nname: hiring-intake\ndescription: Ask hiring intake questions one at a time\n---\n# Hiring Intake\n',
+            },
+          ],
+        },
+      },
+      sourceAgentFolder: 'main_agent_2',
+      sourceAgentFolderJids: ['chat:one'],
+      conversationBindings: {},
+      deps: {
+        requestPermissionApproval,
+        sendMessage,
+      },
+    } as never);
+
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1));
+    expect(requestPermissionApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'app:test',
+        agentId: 'agent:main_agent',
+        sourceAgentFolder: 'main_agent_2',
+        targetJid: 'chat:one',
+        toolName: 'request_skill_proposal',
+      }),
+    );
+    expect(
+      [...skills.bindings.values()].map((binding) => binding.agentId),
+    ).toEqual(['agent:main_agent']);
+    expect(
+      [...skills.bindings.values()].some(
+        (binding) => binding.agentId === 'agent:main_agent_2',
+      ),
+    ).toBe(false);
+    expect(syncApprovedCapabilitySettings).toHaveBeenCalledWith('app:test');
+  });
 
   it('installs and binds every discovered skill and lists their names', async () => {
     const { skills, syncApprovedCapabilitySettings } = setup();

--- a/apps/core/test/unit/jobs/request-permission-review.test.ts
+++ b/apps/core/test/unit/jobs/request-permission-review.test.ts
@@ -195,6 +195,45 @@ describe('request permission review helpers', () => {
     }
   });
 
+  it('suggests persistent grants for exact scheduler tool requests', () => {
+    for (const toolName of [
+      'mcp__gantry__scheduler_list_jobs',
+      'mcp__gantry__scheduler_run_now',
+    ]) {
+      expect(
+        requestPermissionReviewSuggestions({
+          permissionKind: 'tool',
+          toolName,
+          temporaryOnly: false,
+        }),
+      ).toEqual([
+        {
+          type: 'addRules',
+          behavior: 'allow',
+          destination: 'session',
+          rules: [{ toolName }],
+        },
+      ]);
+      expect(
+        requestPermissionSetupDecisionOptions({
+          permissionKind: 'tool',
+          toolName,
+          temporaryOnly: false,
+        }),
+      ).toContain('allow_persistent_rule');
+    }
+  });
+
+  it('does not suggest persistent grants for scheduler mutation tool requests', () => {
+    expect(
+      requestPermissionSetupDecisionOptions({
+        permissionKind: 'tool',
+        toolName: 'mcp__gantry__scheduler_upsert_job',
+        temporaryOnly: false,
+      }),
+    ).not.toContain('allow_persistent_rule');
+  });
+
   it('prefers explicit scoped RunCommand permission over capability metadata on setup requests', () => {
     expect(
       requestPermissionReviewSuggestions({
@@ -1295,6 +1334,57 @@ describe('request permission review helpers', () => {
     expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
       'main_agent',
       ['Browser'],
+      { appId: 'app:test' },
+    );
+  });
+
+  it('binds exact scheduler MCP persistent approvals to scheduler catalog tools', async () => {
+    const mirrorAgentToolRulesToSettings = vi.fn(async () => undefined);
+    const repository = {
+      getTool: vi.fn(async (toolId: string) =>
+        toolId === 'tool:mcp__gantry__scheduler_run_now'
+          ? {
+              id: 'tool:mcp__gantry__scheduler_run_now',
+              appId: 'app:test',
+              name: 'mcp__gantry__scheduler_run_now',
+              status: 'active',
+              selectable: true,
+            }
+          : null,
+      ),
+      listTools: vi.fn(async () => []),
+      saveTool: vi.fn(async () => undefined),
+      saveAgentToolBinding: vi.fn(async () => undefined),
+      disableAgentToolBinding: vi.fn(async () => null),
+    };
+
+    const persisted = await persistRequestPermissionRules({
+      appId: 'app:test' as never,
+      agentId: 'agent:test' as never,
+      deps: {
+        getToolRepository: () => repository as never,
+        mirrorAgentToolRulesToSettings,
+      },
+      sourceAgentFolder: 'main_agent',
+      updates: [
+        {
+          type: 'addRules',
+          behavior: 'allow',
+          rules: [{ toolName: 'mcp__gantry__scheduler_run_now' }],
+        },
+      ],
+    });
+
+    expect(persisted).toEqual(['mcp__gantry__scheduler_run_now']);
+    expect(repository.saveTool).not.toHaveBeenCalled();
+    expect(repository.saveAgentToolBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolId: 'tool:mcp__gantry__scheduler_run_now',
+      }),
+    );
+    expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
+      'main_agent',
+      ['mcp__gantry__scheduler_run_now'],
       { appId: 'app:test' },
     );
   });

--- a/apps/core/test/unit/runtime/group-processing-flow.test.ts
+++ b/apps/core/test/unit/runtime/group-processing-flow.test.ts
@@ -49,6 +49,21 @@ describe('handleFailure', () => {
     );
   });
 
+  it('preserves the cursor for infrastructure failures that should not replay the Slack message', async () => {
+    const input = makeInput({
+      preserveCursor: true,
+    });
+
+    await expect(handleFailure(input)).resolves.toBe(true);
+
+    expect(input.deps.setCursor).not.toHaveBeenCalled();
+    expect(input.deps.saveState).toHaveBeenCalledTimes(1);
+    expect(input.logger.warn).toHaveBeenCalledWith(
+      { group: 'Main Agent' },
+      'Agent infrastructure error, preserving message cursor to prevent stale replay',
+    );
+  });
+
   it('rolls back first thread failures to the empty cursor for retry', async () => {
     const input = makeInput({
       queueJid: 'sl:C1234567890::thread:1711111111.000200',

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1393,6 +1393,42 @@ describe('createGroupProcessor', () => {
       expect(lastSetCursor).toEqual(['group1@g.us', 'prev-cursor']);
     });
 
+    it('preserves the cursor for provider gateway failures so Slack messages are not replayed', async () => {
+      const group = makeGroup();
+      const messages = [makeMessage({ timestamp: '1700000001' })];
+      const { deps } = setupHappyPath({ group, messages });
+
+      const errorOutput: AgentOutput = {
+        status: 'error',
+        result: null,
+        error: 'API Error: 502 Bad Gateway',
+      };
+      mockSpawnAgent.mockImplementation(
+        async (
+          _group: ConversationRoute,
+          _input: unknown,
+          _onProc: unknown,
+          onOutput?: (output: AgentOutput) => Promise<void>,
+        ) => {
+          if (onOutput) await onOutput(errorOutput);
+          return errorOutput;
+        },
+      );
+
+      (deps.getCursor as ReturnType<typeof vi.fn>).mockReturnValue(
+        'prev-cursor',
+      );
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      const result = await processGroupMessages('group1@g.us');
+
+      expect(result).toBe(true);
+      expect(deps.setCursor).not.toHaveBeenCalledWith(
+        'group1@g.us',
+        'prev-cursor',
+      );
+    });
+
     it('delivers the last response_schema candidate from structured failure metadata', async () => {
       const candidate = '{"wrong":"last"}';
       const { deps, channel } = setupHappyPath({
@@ -1499,13 +1535,7 @@ describe('createGroupProcessor', () => {
 
       await expect(processGroupMessages('group1@g.us')).resolves.toBe(true);
       expect(channel.sendMessage).toHaveBeenCalledWith('group1@g.us', 'done');
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          err: expect.any(Error),
-          group: 'TestGroup',
-        }),
-        'Failed to publish normalized model usage runtime event',
-      );
+      expect(publishRuntimeEvent).toHaveBeenCalled();
     });
 
     it('publishes terminal runner runtime events on error', async () => {

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1488,6 +1488,60 @@ describe('createGroupProcessor', () => {
       );
     });
 
+    it('rolls back for retry when the failover-exhausted notice fails to deliver', async () => {
+      const group = makeGroup({ requiresTrigger: false });
+      const messages = [makeMessage({ timestamp: '1700000001' })];
+      const { deps, channel } = setupHappyPath({ group, messages });
+
+      const errorOutput: AgentOutput = {
+        status: 'error',
+        result: null,
+        error: 'API Error: 502 Bad Gateway',
+      };
+      mockSpawnAgent.mockImplementation(
+        async (
+          _group: ConversationRoute,
+          _input: unknown,
+          _onProc: unknown,
+          onOutput?: (output: AgentOutput) => Promise<void>,
+        ) => {
+          if (onOutput) await onOutput(errorOutput);
+          return errorOutput;
+        },
+      );
+
+      // Channel is down: the notice send throws -> settles not_delivered.
+      (channel.sendMessage as ReturnType<typeof vi.fn>).mockImplementation(
+        async (_jid: string, text: string) => {
+          if (typeof text === 'string' && text.includes('provider is unavailable')) {
+            throw new Error('channel down');
+          }
+          return undefined;
+        },
+      );
+
+      (deps.getCursor as ReturnType<typeof vi.fn>).mockReturnValue(
+        'prev-cursor',
+      );
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      const result = await processGroupMessages('group1@g.us', {
+        finalRetry: true,
+      });
+
+      // User was NOT informed -> turn is not consumed: roll back and retry.
+      expect(result).toBe(false);
+      const setCursorCalls = (deps.setCursor as ReturnType<typeof vi.fn>).mock
+        .calls;
+      const lastSetCursor = setCursorCalls[setCursorCalls.length - 1];
+      expect(lastSetCursor).toEqual(['group1@g.us', 'prev-cursor']);
+      // The undeliverable notice is logged at error level for observability.
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ group: group.name }),
+        'Failed to send provider failover exhausted notice',
+      );
+    });
+
     it('delivers the last response_schema candidate from structured failure metadata', async () => {
       const candidate = '{"wrong":"last"}';
       const { deps, channel } = setupHappyPath({

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1471,9 +1471,8 @@ describe('createGroupProcessor', () => {
         'prev-cursor',
       );
       // User is notified: the turn is never silently dropped.
-      const sendMessageCalls = (
-        channel.sendMessage as ReturnType<typeof vi.fn>
-      ).mock.calls;
+      const sendMessageCalls = (channel.sendMessage as ReturnType<typeof vi.fn>)
+        .mock.calls;
       const noticeCall = sendMessageCalls.find(
         (call) =>
           call[0] === 'group1@g.us' &&
@@ -1513,7 +1512,10 @@ describe('createGroupProcessor', () => {
       // Channel is down: the notice send throws -> settles not_delivered.
       (channel.sendMessage as ReturnType<typeof vi.fn>).mockImplementation(
         async (_jid: string, text: string) => {
-          if (typeof text === 'string' && text.includes('provider is unavailable')) {
+          if (
+            typeof text === 'string' &&
+            text.includes('provider is unavailable')
+          ) {
             throw new Error('channel down');
           }
           return undefined;

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1393,8 +1393,8 @@ describe('createGroupProcessor', () => {
       expect(lastSetCursor).toEqual(['group1@g.us', 'prev-cursor']);
     });
 
-    it('preserves the cursor for provider gateway failures so Slack messages are not replayed', async () => {
-      const group = makeGroup();
+    it('rolls back a transient provider gateway failure for retry before failover is exhausted', async () => {
+      const group = makeGroup({ requiresTrigger: false });
       const messages = [makeMessage({ timestamp: '1700000001' })];
       const { deps } = setupHappyPath({ group, messages });
 
@@ -1420,12 +1420,71 @@ describe('createGroupProcessor', () => {
       );
 
       const { processGroupMessages } = createGroupProcessor(deps);
+      // No finalRetry: queue retries are NOT yet exhausted, so a transient
+      // 502 must roll the cursor back and retry, not be silently dropped.
       const result = await processGroupMessages('group1@g.us');
 
+      expect(result).toBe(false);
+      const setCursorCalls = (deps.setCursor as ReturnType<typeof vi.fn>).mock
+        .calls;
+      const lastSetCursor = setCursorCalls[setCursorCalls.length - 1];
+      expect(lastSetCursor).toEqual(['group1@g.us', 'prev-cursor']);
+    });
+
+    it('preserves the cursor and notifies the user when provider failover is exhausted', async () => {
+      const group = makeGroup({ requiresTrigger: false });
+      const messages = [makeMessage({ timestamp: '1700000001' })];
+      const { deps, channel } = setupHappyPath({ group, messages });
+
+      const errorOutput: AgentOutput = {
+        status: 'error',
+        result: null,
+        error: 'API Error: 502 Bad Gateway',
+      };
+      mockSpawnAgent.mockImplementation(
+        async (
+          _group: ConversationRoute,
+          _input: unknown,
+          _onProc: unknown,
+          onOutput?: (output: AgentOutput) => Promise<void>,
+        ) => {
+          if (onOutput) await onOutput(errorOutput);
+          return errorOutput;
+        },
+      );
+
+      (deps.getCursor as ReturnType<typeof vi.fn>).mockReturnValue(
+        'prev-cursor',
+      );
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      // finalRetry: queue retries exhausted -> stop the replay storm by
+      // preserving the cursor, but surface an error + a user-visible notice.
+      const result = await processGroupMessages('group1@g.us', {
+        finalRetry: true,
+      });
+
       expect(result).toBe(true);
+      // Cursor is NOT rolled back to the previous value (storm stopped).
       expect(deps.setCursor).not.toHaveBeenCalledWith(
         'group1@g.us',
         'prev-cursor',
+      );
+      // User is notified: the turn is never silently dropped.
+      const sendMessageCalls = (
+        channel.sendMessage as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      const noticeCall = sendMessageCalls.find(
+        (call) =>
+          call[0] === 'group1@g.us' &&
+          typeof call[1] === 'string' &&
+          call[1].includes('provider is unavailable'),
+      );
+      expect(noticeCall).toBeDefined();
+      // And an error is logged for observability.
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ group: group.name }),
+        expect.stringContaining('Provider failover exhausted'),
       );
     });
 

--- a/apps/core/test/unit/runtime/prompt-profile.test.ts
+++ b/apps/core/test/unit/runtime/prompt-profile.test.ts
@@ -527,6 +527,9 @@ describe('PromptProfileService', () => {
       'The single short acknowledgement before non-trivial live work is the only exception.',
     );
     expect(prompt).toContain(
+      'ask only the next missing decision-blocking question',
+    );
+    expect(prompt).toContain(
       'no closers ("Let me know if..."), no pleasantry filler',
     );
     expect(prompt).toContain('Never use dashes as punctuation');

--- a/apps/core/test/unit/runtime/runtime-event-forwarding.test.ts
+++ b/apps/core/test/unit/runtime/runtime-event-forwarding.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RUNTIME_EVENT_TYPES } from '@core/domain/events/runtime-event-types.js';
+import { forwardRuntimeEvents } from '@core/runtime/runtime-event-forwarding.js';
+
+describe('forwardRuntimeEvents', () => {
+  it('treats runtime event persistence as best effort', async () => {
+    const publishRuntimeEvent = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('runtime event storage unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const forwardedKeys = new Set<string>();
+
+    await expect(
+      forwardRuntimeEvents({
+        output: {
+          status: 'success',
+          result: 'ok',
+          runtimeEvents: [
+            {
+              eventType: RUNTIME_EVENT_TYPES.MODEL_USAGE,
+              payload: { usageEventId: 'first' },
+            },
+            {
+              eventType: RUNTIME_EVENT_TYPES.MODEL_USAGE,
+              payload: { usageEventId: 'second' },
+            },
+          ],
+        },
+        publishRuntimeEvent,
+        runtimeAppId: 'default',
+        turnAgentId: 'agent:main',
+        runId: 'agent-run:test',
+        chatJid: 'sl:C123',
+        sessionThreadId: 'thread:sl:C123:1',
+        forwardedKeys,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(publishRuntimeEvent).toHaveBeenCalledTimes(2);
+    expect(forwardedKeys.size).toBe(2);
+  });
+});

--- a/apps/core/test/unit/runtime/runtime-event-forwarding.test.ts
+++ b/apps/core/test/unit/runtime/runtime-event-forwarding.test.ts
@@ -1,16 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { RUNTIME_EVENT_TYPES } from '@core/domain/events/runtime-event-types.js';
+import { logger } from '@core/infrastructure/logging/logger.js';
 import { forwardRuntimeEvents } from '@core/runtime/runtime-event-forwarding.js';
 
 describe('forwardRuntimeEvents', () => {
-  it('treats runtime event persistence as best effort', async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not fail the turn, logs, and keeps a failed event retriable', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
     const publishRuntimeEvent = vi
       .fn()
       .mockRejectedValueOnce(new Error('runtime event storage unavailable'))
       .mockResolvedValueOnce(undefined);
     const forwardedKeys = new Set<string>();
 
+    // (a) still completes without throwing
     await expect(
       forwardRuntimeEvents({
         output: {
@@ -38,6 +45,38 @@ describe('forwardRuntimeEvents', () => {
     ).resolves.toBeUndefined();
 
     expect(publishRuntimeEvent).toHaveBeenCalledTimes(2);
-    expect(forwardedKeys.size).toBe(2);
+    // (b) the persistence failure is logged as a warning
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // (c) only the successful event's key is recorded; the failed one is NOT
+    //     present so a later forwarding pass can retry it.
+    expect(forwardedKeys.size).toBe(1);
+  });
+
+  it('records the forwarded key when publish succeeds', async () => {
+    const publishRuntimeEvent = vi.fn().mockResolvedValue(undefined);
+    const forwardedKeys = new Set<string>();
+
+    await forwardRuntimeEvents({
+      output: {
+        status: 'success',
+        result: 'ok',
+        runtimeEvents: [
+          {
+            eventType: RUNTIME_EVENT_TYPES.MODEL_USAGE,
+            payload: { usageEventId: 'only' },
+          },
+        ],
+      },
+      publishRuntimeEvent,
+      runtimeAppId: 'default',
+      turnAgentId: 'agent:main',
+      runId: 'agent-run:test',
+      chatJid: 'sl:C123',
+      sessionThreadId: 'thread:sl:C123:1',
+      forwardedKeys,
+    });
+
+    expect(publishRuntimeEvent).toHaveBeenCalledTimes(1);
+    expect(forwardedKeys.size).toBe(1);
   });
 });

--- a/apps/core/test/unit/shared/durable-access-policy.test.ts
+++ b/apps/core/test/unit/shared/durable-access-policy.test.ts
@@ -69,6 +69,22 @@ describe('durable access policy', () => {
     ).toEqual({ ok: true });
   });
 
+  it('allows exact Gantry scheduler tools as durable access rules', () => {
+    expect(
+      validateDurableAccessRule('mcp__gantry__scheduler_list_jobs'),
+    ).toEqual({
+      ok: true,
+    });
+    expect(validateDurableAccessRule('mcp__gantry__scheduler_run_now')).toEqual(
+      {
+        ok: true,
+      },
+    );
+    expect(
+      formatDurableAccessRulesForUser(['mcp__gantry__scheduler_run_now']),
+    ).toBe('Scheduler Run Now');
+  });
+
   it('rejects exact third-party MCP tools', () => {
     expect(validateDurableAccessRule('mcp__github__get_issue')).toEqual({
       ok: false,
@@ -169,6 +185,32 @@ describe('durable access policy', () => {
       ok: false,
       reason:
         'Persistent RunCommand rules cannot reference generated runtime paths; use a reviewed stable capability or let Gantry-owned runtime scratch reads stay internal.',
+    });
+  });
+
+  it('rejects scheduler mutation tools as durable exact tool rules', () => {
+    expect(
+      validateDurableAccessRule('mcp__gantry__scheduler_upsert_job'),
+    ).toEqual({
+      ok: false,
+      reason: expect.stringContaining(
+        'Persistent access approvals support only',
+      ),
+    });
+    expect(
+      validateDurableAccessRule('mcp__gantry__scheduler_delete_job'),
+    ).toEqual({
+      ok: false,
+      reason: expect.stringContaining(
+        'Persistent access approvals support only',
+      ),
+    });
+  });
+
+  it('rejects non-exact scheduler wildcard rules as durable access rules', () => {
+    expect(validateDurableAccessRule('mcp__gantry__scheduler_*')).toEqual({
+      ok: false,
+      reason: 'Wildcard persistent tool grants are not supported.',
     });
   });
 

--- a/apps/core/test/unit/shared/tool-execution-policy-service.test.ts
+++ b/apps/core/test/unit/shared/tool-execution-policy-service.test.ts
@@ -418,6 +418,29 @@ describe('ToolExecutionPolicyService', () => {
     expect(result.recoveryAction).not.toContain('scheduler_grant_tool');
   });
 
+  it('points autonomous scheduler tool denials to exact persistent tool approval', () => {
+    const request = classifier.classify({
+      origin: 'mcp',
+      toolName: 'mcp__gantry__scheduler_run_now',
+      toolInput: { jobId: 'job-1' },
+      executionMode: 'autonomous',
+      runContext: { jobId: 'job-manager' },
+    });
+
+    const result = policy.evaluate({ request, autonomousAllowedToolRules: [] });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'deny',
+        reason: expect.stringContaining(
+          'Tool not on autonomous run allowlist: mcp__gantry__scheduler_run_now.',
+        ),
+        recoveryAction:
+          'request_access { "target": { "kind": "tool", "name": "mcp__gantry__scheduler_run_now" }, "temporaryOnly": false, "reason": "This autonomous run needs scheduler access." }',
+      }),
+    );
+  });
+
   it('allows autonomous read-only inspection of generated runtime tool results without durable grants', () => {
     const resultPath =
       '/Users/example/gantry/agents/main_agent/.llm-runtime/claude/projects/-Users-example-gantry-agents-main-agent/run-1/tool-results/result.txt';

--- a/apps/core/test/unit/storage/storage-service.test.ts
+++ b/apps/core/test/unit/storage/storage-service.test.ts
@@ -7,6 +7,7 @@ import {
   createStorageService,
   postgresMigrationsFolder,
   resolvePostgresPoolConfig,
+  resolveRuntimePostgresPoolMax,
 } from '@core/adapters/storage/postgres/storage-service.js';
 import {
   DEFAULT_SKILL_CATALOG,
@@ -45,6 +46,25 @@ describe('storage-service', () => {
     );
 
     expect(config.max).toBeGreaterThanOrEqual(20);
+  });
+
+  it('uses the default runtime postgres pool size when unset', () => {
+    expect(resolveRuntimePostgresPoolMax({})).toBe(20);
+  });
+
+  it('honors GANTRY_POSTGRES_POOL_MAX for constrained managed pools', () => {
+    expect(
+      resolveRuntimePostgresPoolMax({ GANTRY_POSTGRES_POOL_MAX: '10' }),
+    ).toBe(10);
+  });
+
+  it('rejects invalid GANTRY_POSTGRES_POOL_MAX values', () => {
+    expect(() =>
+      resolveRuntimePostgresPoolMax({ GANTRY_POSTGRES_POOL_MAX: '0' }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      resolveRuntimePostgresPoolMax({ GANTRY_POSTGRES_POOL_MAX: 'ten' }),
+    ).toThrow(/positive integer/);
   });
 
   it('constructs postgres storage with custom runtime schema', async () => {

--- a/apps/core/test/unit/storage/storage-service.test.ts
+++ b/apps/core/test/unit/storage/storage-service.test.ts
@@ -129,6 +129,18 @@ describe('storage-service', () => {
     await service.close();
   });
 
+  it('seeds durable scheduler tools as selectable built-in catalog entries', () => {
+    const seededToolNames = new Set(
+      DEFAULT_TOOL_CATALOG.map((tool) => tool.name),
+    );
+
+    expect(seededToolNames.has('mcp__gantry__scheduler_run_now')).toBe(true);
+    expect(seededToolNames.has('mcp__gantry__scheduler_list_jobs')).toBe(true);
+    expect(seededToolNames.has('mcp__gantry__scheduler_upsert_job')).toBe(
+      false,
+    );
+  });
+
   it('rejects skipped runtime migrations before the current migration head', async () => {
     const service = new PostgresStorageService(
       'postgres://user:pass@127.0.0.1:5432/gantry',


### PR DESCRIPTION
## What this is

Production hot-fixes made on `develop` (running on ECS) needed to reach `main`. PR #279 proposed merging all six wholesale. A read-only architectural pass (Codex) found that three of the six were fixed at the right boundary, but three were narrow symptom patches that traded a production symptom for a durability/correctness regression.

This branch lands **all six fixes properly**: the three sound ones as-is, and the three narrow ones reworked at the correct ownership boundary — so #279 can be closed without merging.

## The six fixes

**Kept as-is (correct at the right boundary):**
- **Scheduler grants + skill-proposal ownership** — exact-name, closed subset of scheduler MCP tools made durably grantable; skill requests bound to the signed runtime agent id. No wildcard, no third-party MCP authority granted; scheduler execution still rechecks conversation/workspace ownership.
- **Runtime-event thread persistence + pool cap** — canonical thread row materialized before threaded event / outbound-delivery inserts, inside the same Postgres transaction. Adds optional `GANTRY_POSTGRES_POOL_MAX` (default 20).
- **Desired-state export fallback-route leak** — synthetic fallback provider-account route groups no longer leak into exported settings; preserves the settings-authority boundary.

**Reworked (were narrow symptom patches):**
- **Runtime-event forwarding** — the original made forwarding "best-effort" by swallowing *every* persistence failure silently and marking events forwarded *before* the write, so a failed event could never retry and vanished with no log. Reworked: key is recorded only after a successful publish (failed events stay retriable), and failures now log a warning with full context. Turns still never fail on an event-store hiccup.
- **Postgres catalog-read retry** — reviewer flagged that a leaf-repository retry might reuse a poisoned pooled connection. Verified against the drivers: these reads run through `Pool.query()` (never a transaction/checked-out client), and pg-pool evicts a client on *any* query error, so every retry gets a fresh connection and re-planned statement. The helper is sound as-is; added a comment documenting the mechanism and the condition that would invalidate it.
- **Provider-failure Slack replay** — the original stopped an infinite replay storm by advancing the message cursor on *any* failover-eligible error, dropping the user's turn on the **first** transient failure with only a `warn` (silent data loss). Reworked: the turn is dropped only when provider failover is **genuinely exhausted** (`finalRetry`); transient errors keep normal retry. On a genuine drop it now emits an error log **and** a user-visible "provider unavailable after several retries" channel message, so nothing is lost silently. Anti-storm guarantee preserved. (Durable dead-letter re-drive tracked as the full fix, issue #285.)

## Verification

- Typecheck clean; 423 affected-suite unit tests green.
- Three reworks each verified their real control flow before changing anything (one caught a masked test that was passing via a trigger-gated early-return, not the path it claimed to cover).
- Inherited commits keep their original authorship + `(cherry picked from …)` provenance.

Replaces #279.
