### PR TITLE
fix(DREAM-P0): system jobs dead-letter on route-not-found — store bare chatJid + providerAccountId

### DIFF
--- a/apps/core/src/jobs/job-notification-routes.ts
+++ b/apps/core/src/jobs/job-notification-routes.ts
@@ -80,6 +80,7 @@ export function buildCanonicalJobLifecycleTarget(input: {
   threadId?: string | null;
   workspaceKey: string;
   sessionId?: string | null;
+  providerAccountId?: string | null;
   label?: string;
 }): {
   executionContext: JobExecutionContext;
@@ -93,6 +94,7 @@ export function buildCanonicalJobLifecycleTarget(input: {
     );
   }
   const threadId = normalizeOptional(input.threadId) ?? null;
+  const providerAccountId = normalizeOptional(input.providerAccountId);
   const executionContext: JobExecutionContext = {
     conversationJid,
     threadId,
@@ -105,6 +107,7 @@ export function buildCanonicalJobLifecycleTarget(input: {
       {
         conversationJid,
         threadId,
+        ...(providerAccountId ? { providerAccountId } : {}),
         label: normalizeOptional(input.label) ?? 'Primary',
       },
     ],

--- a/apps/core/src/jobs/system-jobs.ts
+++ b/apps/core/src/jobs/system-jobs.ts
@@ -117,7 +117,8 @@ function buildSystemJobTargetFromRouteKey(input: {
 }): ReturnType<typeof buildCanonicalJobLifecycleTarget> | null {
   const parsed = parseAgentThreadQueueKey(input.routeKey);
   const expectedAgentId = agentIdForJobWorkspaceKey(input.group.folder);
-  const routeProviderAccountId = input.group.providerAccountId?.trim() || undefined;
+  const routeProviderAccountId =
+    input.group.providerAccountId?.trim() || undefined;
   const providerAccountId = parsed.providerAccountId ?? routeProviderAccountId;
   // Guard against a stale key whose agent/provider no longer match the current
   // registry route; the resolver would never find such a route.

--- a/apps/core/src/jobs/system-jobs.ts
+++ b/apps/core/src/jobs/system-jobs.ts
@@ -63,6 +63,10 @@ import {
 } from '../shared/system-job-identity.js';
 import { computeNextJobRun } from './schedule-math.js';
 import { buildCanonicalJobLifecycleTarget } from './job-notification-routes.js';
+import { parseAgentThreadQueueKey } from '../shared/thread-queue-key.js';
+import { agentIdForJobWorkspaceKey } from '../application/jobs/job-tool-policy.js';
+import { logger } from '../infrastructure/logging/logger.js';
+import type { ConversationRoute } from '../domain/types.js';
 import type { SchedulerDependencies } from './types.js';
 
 export {
@@ -98,6 +102,40 @@ function routeDigest(value: string): string {
 
 function systemDreamingJobId(input: { folder: string; jid: string }): string {
   return `${MEMORY_DREAMING_JOB_ID_PREFIX}${input.folder}:${routeDigest(input.jid)}`;
+}
+
+// A conversationRoutes() key is a fully-qualified route-registry key
+// (chatJid + agent + provider_account), not a bare conversation JID. The
+// execution resolver expects the BARE chatJid in execution_context and takes
+// the agent from workspace_key + the providerAccountId from the notification
+// route, re-appending the qualifiers itself. Parse the key once here so the
+// stored target honors that contract instead of double-qualifying it.
+function buildSystemJobTargetFromRouteKey(input: {
+  routeKey: string;
+  group: ConversationRoute;
+  label: string;
+}): ReturnType<typeof buildCanonicalJobLifecycleTarget> | null {
+  const parsed = parseAgentThreadQueueKey(input.routeKey);
+  const expectedAgentId = agentIdForJobWorkspaceKey(input.group.folder);
+  const routeProviderAccountId = input.group.providerAccountId?.trim() || undefined;
+  const providerAccountId = parsed.providerAccountId ?? routeProviderAccountId;
+  // Guard against a stale key whose agent/provider no longer match the current
+  // registry route; the resolver would never find such a route.
+  if (parsed.agentId && parsed.agentId !== expectedAgentId) return null;
+  if (
+    parsed.providerAccountId &&
+    routeProviderAccountId &&
+    parsed.providerAccountId !== routeProviderAccountId
+  ) {
+    return null;
+  }
+  return buildCanonicalJobLifecycleTarget({
+    conversationJid: parsed.chatJid,
+    workspaceKey: input.group.folder,
+    threadId: parsed.threadId ?? null,
+    providerAccountId,
+    label: input.label,
+  });
 }
 
 export function memoryDreamingTimeoutForJob(
@@ -221,18 +259,25 @@ export async function registerSystemJobs(
   }
 
   const nowIso = currentIso();
+  let unresolvedTrustedJobs = 0;
   if (RUNTIME_MEMORY_DREAMING_ENABLED) {
     for (const { jid, group } of registrations) {
       const jobId = systemDreamingJobId({ folder: group.folder, jid });
+      // Re-stamp the corrected target even on dead-lettered jobs: the repo
+      // upsert preserves the dead_lettered status (no auto-resume), but a later
+      // operator resume needs the fixed bare-jid target already persisted.
       const existing = await deps.opsRepository.getJobById(jobId);
-      if (existing?.status === 'dead_lettered') {
-        // Dead-lettered jobs are not revived here, but silent must still track
-        // the current alerts setting so a later resume reactivates the job
-        // with the correct value (the resume path itself never re-stamps it).
-        const desiredSilent = !RUNTIME_MEMORY_DREAMING_ALERTS_ENABLED;
-        if (existing.silent !== desiredSilent) {
-          await deps.opsRepository.updateJob(jobId, { silent: desiredSilent });
-        }
+      const target = buildSystemJobTargetFromRouteKey({
+        routeKey: jid,
+        group,
+        label: 'primary',
+      });
+      if (!target) {
+        unresolvedTrustedJobs += 1;
+        logger.warn(
+          { jobId, routeKey: jid, folder: group.folder },
+          'system dreaming job route no longer matches a current registry route; skipping registration',
+        );
         continue;
       }
       const computedNextRun = computeNextJobRun(
@@ -244,12 +289,6 @@ export async function registerSystemJobs(
       );
       const nextRun = existing?.next_run || computedNextRun;
       const desiredStatus = existing?.status === 'paused' ? 'paused' : 'active';
-      const target = buildCanonicalJobLifecycleTarget({
-        conversationJid: jid,
-        workspaceKey: group.folder,
-        threadId: null,
-        label: 'primary',
-      });
 
       const systemJob = {
         id: jobId,
@@ -283,17 +322,26 @@ export async function registerSystemJobs(
   const primary = registrations[0];
   if (RUNTIME_MEMORY_DREAMING_ENABLED && primary) {
     const existing = await deps.opsRepository.getJobById(BRAIN_DREAMING_JOB_ID);
-    if (existing?.status !== 'dead_lettered') {
+    const target = buildSystemJobTargetFromRouteKey({
+      routeKey: primary.jid,
+      group: primary.group,
+      label: 'primary',
+    });
+    if (!target) {
+      unresolvedTrustedJobs += 1;
+      logger.warn(
+        {
+          jobId: BRAIN_DREAMING_JOB_ID,
+          routeKey: primary.jid,
+          folder: primary.group.folder,
+        },
+        'brain dreaming job route no longer matches a current registry route; skipping registration',
+      );
+    } else {
       const computedNextRun = computeNextJobRun(
         { schedule_type: 'cron', schedule_value: MEMORY_DREAMING_CRON },
         nowIso,
       );
-      const target = buildCanonicalJobLifecycleTarget({
-        conversationJid: primary.jid,
-        workspaceKey: primary.group.folder,
-        threadId: null,
-        label: 'primary',
-      });
       await deps.opsRepository.upsertJob({
         id: BRAIN_DREAMING_JOB_ID,
         name: 'Brain Dreaming',
@@ -322,17 +370,26 @@ export async function registerSystemJobs(
     const existing = await deps.opsRepository.getJobById(
       MEMORY_EMBEDDING_BACKFILL_JOB_ID,
     );
-    if (existing?.status !== 'dead_lettered') {
+    const target = buildSystemJobTargetFromRouteKey({
+      routeKey: primary.jid,
+      group: primary.group,
+      label: 'primary',
+    });
+    if (!target) {
+      unresolvedTrustedJobs += 1;
+      logger.warn(
+        {
+          jobId: MEMORY_EMBEDDING_BACKFILL_JOB_ID,
+          routeKey: primary.jid,
+          folder: primary.group.folder,
+        },
+        'memory embedding backfill job route no longer matches a current registry route; skipping registration',
+      );
+    } else {
       const computedNextRun = computeNextJobRun(
         { schedule_type: 'cron', schedule_value: MEMORY_BACKFILL_CRON },
         nowIso,
       );
-      const target = buildCanonicalJobLifecycleTarget({
-        conversationJid: primary.jid,
-        workspaceKey: primary.group.folder,
-        threadId: null,
-        label: 'primary',
-      });
       const backfillJob = {
         id: MEMORY_EMBEDDING_BACKFILL_JOB_ID,
         name: 'Memory Embedding Backfill',
@@ -362,17 +419,27 @@ export async function registerSystemJobs(
     const existingBrain = await deps.opsRepository.getJobById(
       BRAIN_EMBEDDING_BACKFILL_JOB_ID,
     );
-    if (existingBrain?.status !== 'dead_lettered') {
+    const brainTarget = buildSystemJobTargetFromRouteKey({
+      routeKey: primary.jid,
+      group: primary.group,
+      label: 'primary',
+    });
+    if (!brainTarget) {
+      unresolvedTrustedJobs += 1;
+      logger.warn(
+        {
+          jobId: BRAIN_EMBEDDING_BACKFILL_JOB_ID,
+          routeKey: primary.jid,
+          folder: primary.group.folder,
+        },
+        'brain embedding backfill job route no longer matches a current registry route; skipping registration',
+      );
+    } else {
       const computedNextRun = computeNextJobRun(
         { schedule_type: 'cron', schedule_value: MEMORY_BACKFILL_CRON },
         nowIso,
       );
-      const target = buildCanonicalJobLifecycleTarget({
-        conversationJid: primary.jid,
-        workspaceKey: primary.group.folder,
-        threadId: null,
-        label: 'primary',
-      });
+      const target = brainTarget;
       const brainBackfillJob = {
         id: BRAIN_EMBEDDING_BACKFILL_JOB_ID,
         name: 'Brain Embedding Backfill',
@@ -398,6 +465,13 @@ export async function registerSystemJobs(
         >[0],
       );
     }
+  }
+
+  if (unresolvedTrustedJobs > 0) {
+    logger.warn(
+      { unresolvedTrustedJobs },
+      'one or more trusted system jobs could not be registered against a current registry route',
+    );
   }
 
   setSystemJobRegistrationSignature(deps.opsRepository, registrationSignature);

--- a/apps/core/test/unit/jobs/system-jobs.test.ts
+++ b/apps/core/test/unit/jobs/system-jobs.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Job, ConversationRoute } from '@core/domain/types.js';
+import { resolveExecutionContext } from '@core/jobs/execution-context.js';
+import { makeAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
 
 function makeJob(overrides: Partial<Job> = {}): Job {
   return {
@@ -180,9 +182,9 @@ describe('system memory dreaming jobs', () => {
     expect(deleteJob).not.toHaveBeenCalled();
   });
 
-  it('re-stamps silent on dead-lettered dreaming jobs without reviving them', async () => {
+  it('re-stamps the corrected target on dead-lettered dreaming jobs (repo preserves the dead-letter status)', async () => {
     const { registerSystemJobs } = await loadSystemJobs();
-    const upsertJob = vi.fn().mockResolvedValue({ created: true });
+    const upsertJob = vi.fn().mockResolvedValue({ created: false });
     const updateJob = vi.fn(async () => undefined);
     const getJobById = vi.fn(async (id: string) =>
       id.startsWith('system:dreaming:')
@@ -205,16 +207,81 @@ describe('system memory dreaming jobs', () => {
       },
     } as never);
 
-    expect(updateJob).toHaveBeenCalledTimes(1);
-    expect(updateJob).toHaveBeenCalledWith(
-      expect.stringMatching(/^system:dreaming:/),
-      { silent: true },
+    // A dead-lettered job is no longer skipped: registration re-stamps the
+    // corrected bare-jid target (and silent) so a later operator resume works.
+    // The repo upsert preserves the dead_lettered status, so this is not a
+    // revival — no auto-resume happens here.
+    const dreamUpserts = upsertJob.mock.calls.filter(
+      (call) => call[0].prompt === '__system:memory_dream',
     );
-    expect(
-      upsertJob.mock.calls.filter(
-        (call) => call[0].prompt === '__system:memory_dream',
-      ),
-    ).toHaveLength(0);
+    expect(dreamUpserts).toHaveLength(1);
+    expect(dreamUpserts[0]?.[0].execution_context).toEqual({
+      conversationJid: 'sl:C123',
+      threadId: null,
+      workspaceKey: 'agent',
+      sessionId: null,
+    });
+    expect(dreamUpserts[0]?.[0].silent).toBe(true);
+    expect(updateJob).not.toHaveBeenCalled();
+  });
+
+  it('stores a bare execution jid + provider account for a fully-qualified route key and resolves without dead-lettering', async () => {
+    const { registerSystemJobs } = await loadSystemJobs();
+    // The binding loader collapses the bare, agent-qualified, and
+    // provider-qualified aliases down to this single fully-qualified route key
+    // (see canonical-binding-repository.test.ts). conversationRoutes() hands
+    // that key to the registrar verbatim.
+    const routeKey = makeAgentThreadQueueKey(
+      'tg:5759865942',
+      'agent:main_agent',
+      null,
+      'telegram_default',
+    );
+    const route = makeRoute({
+      folder: 'main_agent',
+      conversationKind: 'channel',
+      providerAccountId: 'telegram_default',
+    });
+    const routes = { [routeKey]: route };
+    const upsertJob = vi.fn().mockResolvedValue({ created: true });
+    const getJobById = vi.fn().mockResolvedValue(undefined);
+
+    await registerSystemJobs({
+      conversationRoutes: () => routes,
+      opsRepository: {
+        getJobById,
+        getAllJobs: vi.fn(async () => []),
+        deleteJob: vi.fn(async () => undefined),
+        upsertJob,
+      },
+    } as never);
+
+    const dreamUpsert = upsertJob.mock.calls.find(
+      (call) => call[0].prompt === '__system:memory_dream',
+    )?.[0];
+    expect(dreamUpsert).toBeDefined();
+    // Bare chatJid in execution_context, provider account carried on the route.
+    expect(dreamUpsert.execution_context).toEqual({
+      conversationJid: 'tg:5759865942',
+      threadId: null,
+      workspaceKey: 'main_agent',
+      sessionId: null,
+    });
+    expect(dreamUpsert.notification_routes).toEqual([
+      {
+        conversationJid: 'tg:5759865942',
+        threadId: null,
+        providerAccountId: 'telegram_default',
+        label: 'primary',
+      },
+    ]);
+
+    // The stored target resolves back to the kept fully-qualified route; a
+    // non-null result means the scheduler would run it, not dead-letter it.
+    const resolved = resolveExecutionContext(dreamUpsert as Job, routes);
+    expect(resolved).not.toBeNull();
+    expect(resolved?.executionJid).toBe('tg:5759865942');
+    expect(resolved?.group).toBe(route);
   });
 
   it('registers per-conversation dreaming jobs non-silent when dreaming alerts are enabled', async () => {


### PR DESCRIPTION
## Goal

Scheduled **system jobs** — per-agent memory dreaming, company-brain dreaming, and both embedding backfills — silently **dead-letter** with `Execution context route not found` and can never self-heal (resume doesn't repair the stored target; re-registration skips dead-lettered jobs). The live `system:dreaming:main_agent` job has failed every run this way. This fixes the root cause so dreaming actually runs.

## Why it was breaking

`registerSystemJobs()` stored the fully-qualified conversation-route **registry key** (e.g. `tg:5759865942::agent:agent%3Amain_agent::provider_account:telegram_default`) verbatim into `execution_context.conversationJid`. But `resolveExecutionContext()` expects a **bare** `chatJid`: it derives the agent from `workspace_key`, takes `providerAccountId` from the notification route, and re-appends both qualifiers via `makeAgentThreadQueueKey()`. Feeding it an already-qualified key double-qualifies it; the parser reads the **last** provider marker, corrupting the provider suffix → no route matches → dead-letter. The same malformed construction was shared by all four system jobs, so one skew could silence company-wide dreaming.

## The fix

- Parse each route-registry key **once** (`parseAgentThreadQueueKey`); store the **bare `chatJid`** in `execution_context` and carry `providerAccountId` (+ threadId) on the **notification route**. Validate parsed agent/provider against the route record; on mismatch, don't schedule and log an operator warning.
- Applied to all four constructions (memory dream, brain dream, memory + brain embedding backfills).
- **Re-stamp dead-lettered jobs** instead of skipping them: registration now always upserts the corrected target. Audit is preserved because the upsert keeps `dead_lettered`/`running` status — the job is repaired but **not** auto-resumed (operator resume stays the only revival path, and now it actually works).
- Operator-visible warning if any trusted system job remains unresolved after registration.

Aligns with the canonical no-fallback cutover (decision 0009): it makes the registrar honor the resolver's existing bare-jid + separate-`providerAccountId` contract; it does **not** reintroduce the dropped bare route alias. No schema/contract change — `JobNotificationRoute.providerAccountId` already existed and round-trips.

## Verification

- New regression: fully-qualified alias-collapsed key → registration persists bare exec jid + `providerAccountId` on the route → real `resolveExecutionContext` returns a non-null match (would run, not dead-letter). Dead-letter test rewritten to assert re-stamp instead of skip.
- Full unit suite green (only the 3 known esbuild zod-fixture suites fail locally; green in CI); typecheck clean; autoreview clean.

## After deploy

The live `system:dreaming:main_agent` target is re-stamped to bare `tg:5759865942` + `telegram_default`; an operator resume then resolves and runs. First of the DREAM initiative (fix → finish Observer delivery → scale); see `~/.claude/plans/dream-fix-finish-scale.md`.
