### PR TITLE
ARCH-1: bring system-jobs.ts under its line budget so main goes green

### DIFF
--- a/apps/core/src/jobs/memory-dreaming-job-outcome.ts
+++ b/apps/core/src/jobs/memory-dreaming-job-outcome.ts
@@ -1,0 +1,105 @@
+import type { MemoryMaintenanceQueueEnqueueResult } from '../memory/maintenance-queue.js';
+import type {
+  DreamingRunStatus,
+  NormalizedMemorySubject,
+} from '../memory/memory-types.js';
+import { AppMemoryService } from '../memory/app-memory-service.js';
+
+const MEMORY_REVIEW_NOTIFICATION_LOOKUP_TIMEOUT_MS = 2_000;
+
+function pendingMemoryReviewLabel(count: number): string {
+  return `${count} pending memory review${count === 1 ? '' : 's'}`;
+}
+
+function pendingMemoryReviewNotice(count: number): string {
+  return `${pendingMemoryReviewLabel(count)} need${count === 1 ? 's' : ''} review`;
+}
+
+export async function countPendingReviewsForNotification(input: {
+  memory: AppMemoryService;
+  subject: NormalizedMemorySubject;
+}): Promise<number> {
+  try {
+    const reviews = await input.memory.listPendingReviews(input.subject, {
+      statementTimeoutMs: MEMORY_REVIEW_NOTIFICATION_LOOKUP_TIMEOUT_MS,
+    });
+    return reviews.length;
+  } catch {
+    return 0;
+  }
+}
+
+export function appendPendingReviewContextToError(
+  error: unknown,
+  pendingReviews: number,
+): Error {
+  if (pendingReviews <= 0) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  const baseMessage =
+    error instanceof Error ? error.message : String(error || 'unknown error');
+  const separator = /[.!?]\s*$/.test(baseMessage) ? ' ' : '. ';
+  return new Error(
+    `${baseMessage}${separator}${pendingMemoryReviewNotice(pendingReviews)}.`,
+  );
+}
+
+function numericSummaryValue(
+  summary: unknown,
+  key: string,
+): number | undefined {
+  if (!summary || typeof summary !== 'object' || Array.isArray(summary)) {
+    return undefined;
+  }
+  const value = (summary as Record<string, unknown>)[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : undefined;
+}
+
+export function formatMemoryDreamingOutcome(
+  run: DreamingRunStatus | undefined,
+  queueResult: MemoryMaintenanceQueueEnqueueResult,
+): string {
+  if (queueResult.deduped) {
+    return 'Memory dreaming was already running for this conversation.';
+  }
+  if (!run) {
+    return 'Memory dreaming completed.';
+  }
+  if (run.status === 'failed') {
+    const summary =
+      run.summary && typeof run.summary === 'object'
+        ? (run.summary as Record<string, unknown>)
+        : {};
+    const error = typeof summary.error === 'string' ? summary.error : '';
+    const pendingReviews = numericSummaryValue(summary, 'pendingReviews') ?? 0;
+    const base = error
+      ? `Memory dreaming failed: ${error}${/[.!?]\s*$/.test(error) ? '' : '.'}`
+      : 'Memory dreaming failed.';
+    return appendPendingReviewNotice(base, pendingReviews);
+  }
+  const needsReview = numericSummaryValue(run.summary, 'needsReview') ?? 0;
+  const pendingReviews =
+    numericSummaryValue(run.summary, 'pendingReviews') ?? needsReview;
+  const blocked = numericSummaryValue(run.summary, 'blocked') ?? 0;
+  const issues: string[] = [];
+  if (needsReview > 0) issues.push(`${needsReview} sent to review`);
+  if (pendingReviews > needsReview) {
+    issues.push(pendingMemoryReviewNotice(pendingReviews));
+  }
+  if (blocked > 0) issues.push(`${blocked} blocked`);
+  if (issues.length > 0) {
+    return `Memory dreaming needs attention: ${issues.join(', ')}.`;
+  }
+  return 'Memory dreaming completed.';
+}
+
+function appendPendingReviewNotice(
+  summary: string,
+  pendingReviews: number,
+  alreadyReported = 0,
+) {
+  if (pendingReviews <= alreadyReported) return summary;
+  return `${summary} ${pendingMemoryReviewNotice(pendingReviews)}.`;
+}

--- a/apps/core/src/jobs/system-jobs.ts
+++ b/apps/core/src/jobs/system-jobs.ts
@@ -30,10 +30,7 @@ import {
 import { runEmbeddingBackfill } from '../memory/app-memory-backfill.js';
 import { pollAndImportProviderBatches } from '../memory/app-memory-backfill-provider-batch.js';
 import { createEmbeddingProvider } from '../memory/memory-embeddings.js';
-import type {
-  DreamingRunStatus,
-  NormalizedMemorySubject,
-} from '../memory/memory-types.js';
+import type { DreamingRunStatus } from '../memory/memory-types.js';
 import {
   DEFAULT_MEMORY_APP_ID,
   memoryAgentIdForWorkspaceFolder,
@@ -51,6 +48,11 @@ import {
   getSystemJobRegistrationSignature,
   setSystemJobRegistrationSignature,
 } from './system-registration-cache.js';
+import {
+  appendPendingReviewContextToError,
+  countPendingReviewsForNotification,
+  formatMemoryDreamingOutcome,
+} from './memory-dreaming-job-outcome.js';
 import {
   MEMORY_DREAM_SYSTEM_PROMPT,
   MEMORY_DREAMING_JOB_ID_PREFIX,
@@ -77,7 +79,6 @@ export {
 } from '../shared/system-job-identity.js';
 const MEMORY_EMBEDDING_BACKFILL_TIMEOUT_MS = 10 * 60 * 1000;
 const BRAIN_DREAMING_TIMEOUT_MS = 10 * 60 * 1000;
-const MEMORY_REVIEW_NOTIFICATION_LOOKUP_TIMEOUT_MS = 2_000;
 
 function embeddingBackfillEnabled(): boolean {
   return MEMORY_BACKFILL_ENABLED && MEMORY_EMBED_PROVIDER !== 'disabled';
@@ -149,43 +150,6 @@ export function memoryDreamingTimeoutForJob(
   return Math.max(
     30_000,
     normalizedJobTimeoutMs - MEMORY_DREAM_SYSTEM_JOB_FINALIZATION_GRACE_MS,
-  );
-}
-
-function pendingMemoryReviewLabel(count: number): string {
-  return `${count} pending memory review${count === 1 ? '' : 's'}`;
-}
-
-function pendingMemoryReviewNotice(count: number): string {
-  return `${pendingMemoryReviewLabel(count)} need${count === 1 ? 's' : ''} review`;
-}
-
-async function countPendingReviewsForNotification(input: {
-  memory: AppMemoryService;
-  subject: NormalizedMemorySubject;
-}): Promise<number> {
-  try {
-    const reviews = await input.memory.listPendingReviews(input.subject, {
-      statementTimeoutMs: MEMORY_REVIEW_NOTIFICATION_LOOKUP_TIMEOUT_MS,
-    });
-    return reviews.length;
-  } catch {
-    return 0;
-  }
-}
-
-function appendPendingReviewContextToError(
-  error: unknown,
-  pendingReviews: number,
-): Error {
-  if (pendingReviews <= 0) {
-    return error instanceof Error ? error : new Error(String(error));
-  }
-  const baseMessage =
-    error instanceof Error ? error.message : String(error || 'unknown error');
-  const separator = /[.!?]\s*$/.test(baseMessage) ? ' ' : '. ';
-  return new Error(
-    `${baseMessage}${separator}${pendingMemoryReviewNotice(pendingReviews)}.`,
   );
 }
 
@@ -673,66 +637,6 @@ async function runScheduledEmbeddingBackfill(
     return `Memory embedding batch submitted: ${result.submitted} items queued.${pollNote}`;
   }
   return `Memory embedding backfill ${result.status}: ${result.indexed} indexed, ${result.pending} pending.${pollNote}`;
-}
-
-function numericSummaryValue(
-  summary: unknown,
-  key: string,
-): number | undefined {
-  if (!summary || typeof summary !== 'object' || Array.isArray(summary)) {
-    return undefined;
-  }
-  const value = (summary as Record<string, unknown>)[key];
-  return typeof value === 'number' && Number.isFinite(value)
-    ? Math.max(0, Math.trunc(value))
-    : undefined;
-}
-
-function formatMemoryDreamingOutcome(
-  run: DreamingRunStatus | undefined,
-  queueResult: MemoryMaintenanceQueueEnqueueResult,
-): string {
-  if (queueResult.deduped) {
-    return 'Memory dreaming was already running for this conversation.';
-  }
-  if (!run) {
-    return 'Memory dreaming completed.';
-  }
-  if (run.status === 'failed') {
-    const summary =
-      run.summary && typeof run.summary === 'object'
-        ? (run.summary as Record<string, unknown>)
-        : {};
-    const error = typeof summary.error === 'string' ? summary.error : '';
-    const pendingReviews = numericSummaryValue(summary, 'pendingReviews') ?? 0;
-    const base = error
-      ? `Memory dreaming failed: ${error}${/[.!?]\s*$/.test(error) ? '' : '.'}`
-      : 'Memory dreaming failed.';
-    return appendPendingReviewNotice(base, pendingReviews);
-  }
-  const needsReview = numericSummaryValue(run.summary, 'needsReview') ?? 0;
-  const pendingReviews =
-    numericSummaryValue(run.summary, 'pendingReviews') ?? needsReview;
-  const blocked = numericSummaryValue(run.summary, 'blocked') ?? 0;
-  const issues: string[] = [];
-  if (needsReview > 0) issues.push(`${needsReview} sent to review`);
-  if (pendingReviews > needsReview) {
-    issues.push(pendingMemoryReviewNotice(pendingReviews));
-  }
-  if (blocked > 0) issues.push(`${blocked} blocked`);
-  if (issues.length > 0) {
-    return `Memory dreaming needs attention: ${issues.join(', ')}.`;
-  }
-  return 'Memory dreaming completed.';
-}
-
-function appendPendingReviewNotice(
-  summary: string,
-  pendingReviews: number,
-  alreadyReported = 0,
-) {
-  if (pendingReviews <= alreadyReported) return summary;
-  return `${summary} ${pendingMemoryReviewNotice(pendingReviews)}.`;
 }
 
 export function resetSystemJobStateForTests(): void {

--- a/docs/decisions/0055-arch1-client-signoff.md
+++ b/docs/decisions/0055-arch1-client-signoff.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-25
+---
+
+# Arch1 Client Signoff
+
+## Context
+`npm run check:architecture` is failing on `main`. Two files exceed their line
+budgets at `c986aff4e`:
+
+- `apps/core/src/jobs/system-jobs.ts` — 745 lines against 700, introduced by
+  PR #295 (DREAM-P0)
+- `apps/core/src/runtime/group-processing.ts` — 860 lines against 840, already
+  fixed in open PR #296
+
+This matters more than a style nit because `.agents/scripts/verify.py` aborts at
+its FIRST failing phase, and `structural` runs first. A single over-budget file
+therefore masks typecheck and tests for every branch in the repo — nobody gets a
+deterministic verify signal until it is fixed.
+
+The breach went unnoticed because `check:architecture` is not part of the GitHub
+CI workflow; it runs only locally inside `verify.py`. PR #296's `ci` check passed
+with the `system-jobs.ts` breach already present on its base, which is the direct
+evidence. That is how two breaches accumulated on `main` in a single day.
+
+## Decision
+Ravi asked for `main` to be green on 2026-07-25, after being shown that the
+`system-jobs.ts` breach came from PR #295 and was deliberately left out of
+PR #296 to avoid entangling an unrelated cancellation-hardening review with
+another effort's file.
+
+Split `system-jobs.ts` below its budget on a dedicated branch off `main`, as a
+behaviour-neutral extraction following the existing `apps/core/src/jobs/*`
+module convention. Do not ratchet the budget: the owner chose splitting over
+ratcheting earlier the same day for the analogous `group-processing.ts` breach,
+the 840 there was itself a ratchet from the 700 default, and D-0003 in
+`plans/deferrals.md` shows ratchets accumulate.
+
+## Consequences
+- Phases at `planning` or later are unblocked for ARCH-1.
+- `main` is green on this gate only once BOTH this change and PR #296 land.
+  Neither alone is sufficient, and this task must not claim otherwise.
+- Scope is a pure move: exports unchanged, no existing test modified, `scripts/`
+  untouched. If a seam cannot satisfy that, the seam is wrong, not the constraint.
+- A seam that drags `../config/**` or `../adapters/**` imports into a fresh
+  sibling can expose a layer violation the original file was grandfathered for.
+  That exact failure occurred on the `group-processing.ts` split earlier today and
+  was re-cut rather than papered over with a new exception.
+- The underlying process gap — the architecture gate being absent from CI — is
+  NOT addressed here and remains open for the repo owner. See
+  [[architecture-gate-not-in-ci]].


### PR DESCRIPTION
## What this is for

`main` is red on `npm run check:architecture`, and that blocks more than a style rule: `verify.py` stops at its **first** failing phase and `structural` runs first, so a single over-budget file hides typecheck and test results from every branch in the repo. Nobody gets a deterministic verify signal until it's fixed.

This brings `apps/core/src/jobs/system-jobs.ts` back under its budget: **745 → 652 lines** (limit 700).

## Why main went red without anyone noticing

`check:architecture` is **not part of GitHub CI** — it only runs locally, inside `verify.py`. So a PR can merge fully green while leaving the gate broken on `main`. Direct evidence: PR #296's `ci` check passed with this very breach already present on its base.

That's how two breaches accumulated on `main` in one day. Worth fixing separately by adding the check to the CI workflow; not done here.

## main needs both PRs

At `c986aff4e` there were **two** breaches:

| File | Lines / budget | Fixed by |
|---|---|---|
| `apps/core/src/jobs/system-jobs.ts` | 745 / 700 | **this PR** → 652 |
| `apps/core/src/runtime/group-processing.ts` | 860 / 840 | #296 → 759 |

Neither alone clears the gate. I verified the combination locally by merging both branches into a scratch ref: `Architecture checks passed`, and full `verify.py` — structural, typecheck, tests — **passed**. The merge was clean, so they can land in either order.

## What changed

The memory-dreaming outcome unit (pending-review notification and error-path helpers) moves into a sibling, `memory-dreaming-job-outcome.ts`, following the existing `apps/core/src/jobs/*` convention — that directory already holds ~100 small focused modules. `system-jobs.ts` lands at 652 with real headroom rather than sitting at the cap, so the next few lines added there don't immediately re-break the gate.

Note for the DREAM lane: this touches the area PR #295 grew. It is a pure relocation with no semantic change, but if you have follow-up work in flight on those helpers, they now live in the sibling module.

## Why a split rather than raising the budget

`scripts/architecture-map.json` is untouched and no budget was raised. The owner chose splitting over ratcheting for the analogous `group-processing.ts` breach earlier today; the 840 there was itself a ratchet from the 700 default, and D-0003 in `plans/deferrals.md` shows ratchets accumulate.

## Proof it's behaviour-neutral

- all **6 exports** of `system-jobs.ts` keep their signatures; no import site outside the file changed
- **no existing test was modified** — the jobs suites pass **562 tests across 53 files** unmodified, which is the actual proof
- `scripts/` untouched, no budget raised
- no new layer violation: the moved code carries no `../config/**` or `../adapters/**` import, so it does not depend on any grandfathered exception
- `check:architecture` on this branch now reports only `group-processing.ts`, which #296 fixes
- typecheck clean, autoreview clean

## Risk

None to runtime behaviour by design — pure relocation, no contract, schema, CLI, or UI surface touched.
