### PR TITLE
ci: run the static checks before the expensive steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,25 @@ jobs:
           cache: npm
       - run: npm ci
 
+      # Static checks run first because they need nothing but `npm ci`, and they
+      # are the cheapest signal in the job. Everything below — Postgres bootstrap,
+      # SBOM, the ~4 minute image build — is wasted work when formatting, an
+      # architecture budget, or a type error is already broken.
+      #
+      # Format check and Architecture check stay adjacent because together they
+      # mirror verify.py's `structural` phase (format:check && check:architecture).
+      # Without the architecture step a PR can merge green while leaving main
+      # failing that gate, and because verify.py aborts at its first failing phase,
+      # one over-budget file then masks typecheck and tests for every branch.
+      - name: Format check
+        run: npm run format:check
+
+      - name: Architecture check
+        run: npm run check:architecture
+
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Bootstrap Postgres test DB
         run: |
           docker exec ${{ job.services.postgres.id }} psql -U postgres -d gantry_test -v ON_ERROR_STOP=1 \
@@ -72,20 +91,6 @@ jobs:
 
       - name: Check runtime images
         run: npm run security:images -- --inspect-compose-images --require-content-inspection
-
-      - name: Format check
-        run: npm run format:check
-
-      # Pairs with the format check above to mirror verify.py's `structural`
-      # phase (format:check && check:architecture). Without this step a PR can
-      # merge green while leaving main failing the architecture gate — and
-      # because verify.py aborts at its first failing phase, one over-budget
-      # file then masks typecheck and tests for every branch in the repo.
-      - name: Architecture check
-        run: npm run check:architecture
-
-      - name: Typecheck
-        run: npm run typecheck
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## What this changes

`Format check`, `Architecture check` and `Typecheck` ran **after** the ~4 minute runtime image build. So a formatting slip, an over-budget file, or a type error burned the image build, the SBOM generation and the Postgres bootstrap before failing on something that needs nothing but `npm ci`.

They now run immediately after `npm ci`.

## Step order

| Before | After |
|---|---|
| npm ci | npm ci |
| Bootstrap Postgres | **Format check** |
| Supply-chain audit | **Architecture check** |
| SBOM generate + upload | **Typecheck** |
| **Build runtime image** (~4 min) | Bootstrap Postgres |
| Check runtime images | Supply-chain audit |
| Format check | SBOM generate + upload |
| Architecture check | Build runtime image |
| Typecheck | Check runtime images |
| Build … | Build … |

`Format check` and `Architecture check` stay adjacent, because together they mirror `verify.py`'s `structural` phase.

## Why it's safe

It is a pure move — each step keeps its `name` and `run` unchanged, verified by diffing: every one is removed exactly once and added exactly once, with identical commands. Nothing between them and `npm ci` was reordered.

None of the three depends on anything that used to precede them: they need only the installed dependencies, not the image build, the SBOM, or the database. `npm run typecheck` builds `@gantry/contracts` itself and is self-contained.

YAML validated by parsing the workflow and printing the resulting step order.

## Context

Follow-up to #299, which added the architecture check to CI after `main` went red twice in one day without failing anyone's checks. This is the placement improvement flagged there but deliberately kept out of that PR, since reorganising the workflow is a separate concern from turning the gate on.
