### PR TITLE
Design: async completion contract — bounded sync wait, then durable push

### DIFF
--- a/docs/decisions/0060-async-completion-contract.md
+++ b/docs/decisions/0060-async-completion-contract.md
@@ -115,9 +115,11 @@ facade, the polling obligation, and the `task_wait` tool proposed in the first d
 
 ### Delivery rules (decided 2026-07-26)
 
-1. **Batch, do not spam.** After a task reaches terminal state, hold briefly to collect any
-   other tasks finishing in the same window, then re-engage the parent ONCE with all of them.
-   With no inline path every task would otherwise cost a wake-up; batching is the cost control.
+1. **Batch, do not spam.** After a task reaches terminal state, hold for a **few seconds** to
+   collect any other tasks finishing in that window, then re-engage the parent ONCE with all of
+   them. With no inline path every task would otherwise cost a wake-up; batching is the cost
+   control. A few seconds catches a genuine burst while keeping the news fresh; a minute-long
+   window would group harder but leave the parent unaware of work that already finished.
 2. **Never interrupt a turn in progress.** If a task completes while the parent is mid-turn,
    queue the delivery and hand it over when that turn ends. No half-finished replies, and no
    dropped results.
@@ -166,10 +168,12 @@ facade, the polling obligation, and the `task_wait` tool proposed in the first d
   implementing — "no remembered reason" is not the same as "no reason".
 - The test asserting `sendMessage` is never called for generic delegation must be updated
   knowingly, with loop protection in place — not deleted to make a new assertion pass.
-- Artifact-store spill inherits that subsystem's retention model rather than inventing one.
-  Bound the POPULATION, not the rate: CANCEL-1's archive quarantine took six review cycles
-  precisely because each attempt bounded work-per-call, entries-scanned, then removal-rate
-  before landing on population. See [[audit-paydown-2026-07]].
+- **Retention bounds the POPULATION, not the rate or the age.** Keep the most recent N spilled
+  outputs and delete the oldest beyond that, so storage cannot run away no matter how many
+  tasks run. A time-based policy ("keep 30 days") leaves the total unbounded, which is the
+  same trap CANCEL-1's archive quarantine fell into: six review cycles, each bounding
+  work-per-call, then entries-scanned, then removal-rate, before population turned out to be
+  the only quantity that actually bounds disk. See [[audit-paydown-2026-07]].
 - Scalability comes from convergence: every async kind and both runtimes end at the same
   completion contract and the same artifact-backed output. A new runtime inherits it.
 - `async_mcp_call` nests its id under `task.id` while other starts return a top-level `id`.
@@ -180,14 +184,13 @@ facade, the polling obligation, and the `task_wait` tool proposed in the first d
 Resolved during the 2026-07-26 grill: the wait budget (removed — no sync wait at all), whether
 the inline fast path earns its complexity (no — cut), why generic delegation was push-free
 (unfinished, not deliberate), where output lives (artifact store, fleet-safe), how completions
-are delivered (batched, never interrupting, never waking an absent parent), and whether
-delegation may default to the caller's own agent (no — an explicit target is required).
+are delivered (batched, never interrupting, never waking an absent parent), whether delegation
+may default to the caller's own agent (no — an explicit target is required), the batching
+window (a few seconds), and the retention shape (population cap, oldest deleted first).
 
 Remaining:
 
-1. **How long is the batching window?** The only remaining tuning knob on wake cost. Long
-   enough to group a burst, short enough that news is not stale.
-2. Within a batch, does delivery order matter, or is a set of results sufficient?
+1. Within a batch, does delivery order matter, or is a set of results sufficient?
 3. Is there admission control if an agent starts many tasks at once, or can the queue grow
    unbounded?
 4. What is the artifact retention policy for spilled output — bound the POPULATION, not the

--- a/docs/decisions/0060-async-completion-contract.md
+++ b/docs/decisions/0060-async-completion-contract.md
@@ -1,0 +1,141 @@
+---
+status: proposed
+confirmed_by: ""
+date: 2026-07-26
+---
+
+# Async Completion Contract
+
+**Status is `proposed` on purpose.** Design only, to be grilled before any code. Numbered 0060
+because 0058 is held by PERM-5 on an unmerged branch and 0059 landed with #302 — see
+[[decision-number-collision-parallel-branches]].
+
+## Context
+
+An operator reported that an agent cannot use the async subagent / agent-as-a-tool properly:
+it cannot check status and get the result back after completion. Two read-only audits traced
+this end to end. The report is directionally right but misstates the first failure, and three
+of the premises this investigation started from were wrong. Both matter, so both are recorded.
+
+### What is NOT broken
+
+- **Handles work.** All three starts return a model-visible public `task_<uuid>`.
+- **Status polling works.** `task_get` / `task_list` accept that same id and expose a richer
+  status enum than assumed: `queued | running | needs_attention | completed | failed |
+  cancelled | timed_out`.
+- **Cross-turn retrieval works** for gantry task ids, scoped by app/agent/conversation/thread.
+- **Cancellation mostly works** — queued tasks dequeue, live tasks abort their controller,
+  process groups get SIGTERM then SIGKILL, linked children cascade.
+- **Parity between runtimes already exists.** Both the Anthropic SDK runner and the DeepAgents
+  runner converge on the same gantry IPC tools. The audit's finding: the shared path is
+  *"materially stronger than either provider-native path"*.
+
+### Corrections to premises this work started from
+
+1. **The SDK's native `Agent` tool is disallowed** — excluded from `availableTools` and
+   explicitly denied, so the model can never select it
+   (`anthropic-claude-agent/native-sdk-tools.ts:19`, `agent-capabilities.ts:211`).
+   `forceBackgroundNativeAgentInput()` is therefore inert defensive code, and registering
+   `SubagentStop` would achieve nothing because no SDK subagent ever runs. An earlier
+   conclusion that this hook was the primary gap was wrong.
+2. **DeepAgents' five async tools are a version-drift probe, not a surface.**
+   `async-subagent-sentinel.ts` declares expected schemas to detect package drift; the tools
+   are neither registered nor used, and are explicitly filtered
+   (`builtin-tool-exclusion.ts:55`). "DeepAgents is ahead on async" was wrong.
+3. **`output_file` is omitted from runtime events correctly.** `taskRuntimeEvent()` builds
+   OPERATOR observability frames published to the runtime event bus and webhooks. A host
+   filesystem path does not belong in a payload delivered to external subscribers. An earlier
+   suggestion to "stop stripping it" would have leaked host paths.
+
+### What is actually broken
+
+1. **Output is destroyed, not truncated.** `async_run_command` and `async_mcp_call` keep only a
+   4,000-byte rolling in-memory tail, then persist a ~1,000-character summary; running tails
+   become null at terminal state. There is no spill file. No amount of correct polling can
+   recover the result. Delegated-agent output is the exception — stored in full.
+2. **Completion is passive for most paths.** Commands, MCP calls and generic `delegate_task`
+   update Postgres and never re-engage the parent. A focused test explicitly asserts
+   `sendMessage` is never called for generic delegation, so this is a design choice rather
+   than an accident.
+3. **Two delegation products masquerade as one.** Curated `delegate_to_<agent>` pins a target,
+   waits up to 60 seconds, returns inline when it can, and otherwise arms a durable follow-up
+   that starts another parent turn. Generic `delegate_task` does none of that, and with no
+   target supplied the host defaults the child to the CALLER'S OWN AGENT.
+4. **The DeepAgents `AgentDelegation` facade is a duplicate entry point** onto the weak path
+   (`gantry-facade-tools.ts:191`), supplying neither target, sync wait, nor callable identity.
+5. **No wait primitive.** The only options are poll immediately, poll repeatedly (which the
+   tool descriptions discourage without offering an alternative), or end the turn and hope a
+   later turn remembers.
+
+## Decision (proposed)
+
+Converge on one async completion contract. Reuse what already works — the durable follow-up,
+the task table, the curated pipeline — rather than adding a parallel system.
+
+**1. Gantry owns a spill file.** Write the full stdout/stderr and MCP result to a
+gantry-controlled file, record the path on the task row, return it through `task_get` and in
+the start handle. This is a different channel from the observability event, so no host path is
+ever published to a webhook subscriber.
+
+**2. Converge the two delegation products into one pipeline with different defaults.** Target
+resolution and follow-up arming should be decided in one place. Do NOT simply arm completion
+follow-up on the generic path: because it defaults the child to the caller's own agent,
+universal waking invites self-delegation loops, and the existing test asserting no push is
+evidence someone already considered this.
+
+**3. Add `task_wait(taskId, timeoutMs)` that does not hold a runner slot.** Bounded, parking
+without a lease, falling back to the durable follow-up when the bound expires. This replaces
+the curated path's 60-second magic number rather than relocating it.
+
+**4. Delete the duplicate `AgentDelegation` facade** so there is one start entry point.
+
+### Sequencing, by damage
+
+| Order | Change | Why |
+|---|---|---|
+| 1 | Output spill | data is destroyed; nothing can recover it afterwards |
+| 2 | Delegation convergence | results exist but never arrive |
+| 3 | `task_wait` | ergonomics; removes a hack |
+| 4 | Facade removal | tidy-up |
+
+### Explicitly NOT doing
+
+- **No `SubagentStop`.** The native `Agent` path is disallowed; the hook would never fire.
+- **No event streaming into the model.** Every pushed event costs a full inference turn, so a
+  chatty task would cost dozens. `task_get` already exposes a ~1s-refreshed stdout/stderr tail
+  plus `lastProgress` and heartbeat for diagnosis, which is a poll-shaped need. Waiting is
+  worth building; streaming is not.
+- **No Managed Agents migration.** It is Anthropic's purpose-built durable-async product and
+  does solve this shape, but it is beta and ineligible for ZDR and HIPAA BAA because session
+  state persists server-side. That is a product-level decision, not a bug fix.
+- **No new task table, queue or notification bus.** All three exist and work.
+
+## Consequences
+
+- Scalability comes from convergence rather than addition: every async kind — command, MCP
+  call, delegated agent, both runtimes — ends at the same completion contract and the same
+  file-backed output. A future runtime implements one small adapter instead of a parallel stack.
+- Changing generic delegation's completion behaviour changes deliberate current behaviour
+  pinned by a test. That test must be updated knowingly, with the self-delegation loop risk
+  addressed, not deleted to make a new assertion pass.
+- A spill file introduces retention and cleanup obligations that the current in-memory buffer
+  does not have — size caps, TTL, and cleanup on task deletion all need answering.
+- `async_mcp_call` nests its id under `task.id` while the other starts return a top-level `id`.
+  Worth normalising while touching this surface; the model should not have to handle two shapes.
+
+## Open questions for the grill
+
+1. **Can `task_wait` park without holding a runner slot or live-admission capacity?** If not,
+   change 3 needs a different shape — a blocking wait that consumes interactive capacity does
+   not scale, which defeats the point.
+2. Why was generic delegation deliberately left push-free? The test is evidence of intent; the
+   reasoning should be recovered before overriding it.
+3. Where should spill files live, and under what retention? They contain arbitrary command
+   output, so they inherit the same protection questions as any host-side artifact.
+4. Should the child-target default (caller's own agent) change, or is self-delegation a
+   legitimate supported case?
+5. Does the DeepAgents sentinel still earn its keep once the facade is deleted, given the tools
+   it probes are never mounted?
+
+See [[semantic-capabilities-are-the-feature]] and [[tool-surface-tiering]] — this contract must
+not duplicate either.

--- a/docs/decisions/0060-async-completion-contract.md
+++ b/docs/decisions/0060-async-completion-contract.md
@@ -113,6 +113,22 @@ The 60-second magic number, the synchronous wait on every path, the inline fast 
 tuning, the generic-versus-curated delegation split, the duplicate DeepAgents `AgentDelegation`
 facade, the polling obligation, and the `task_wait` tool proposed in the first draft.
 
+### Delivery rules (decided 2026-07-26)
+
+1. **Batch, do not spam.** After a task reaches terminal state, hold briefly to collect any
+   other tasks finishing in the same window, then re-engage the parent ONCE with all of them.
+   With no inline path every task would otherwise cost a wake-up; batching is the cost control.
+2. **Never interrupt a turn in progress.** If a task completes while the parent is mid-turn,
+   queue the delivery and hand it over when that turn ends. No half-finished replies, and no
+   dropped results.
+3. **No parent, no turn.** If the conversation has ended or the agent was deleted by the time a
+   task completes, persist the result so `task_get` still serves it, but do NOT start a turn.
+   Nothing is lost and nobody is messaged out of the blue. This is the mirror of the CANCEL-1
+   failure — a delivery outliving the thing that asked for it.
+4. **Delegation must name its target.** Generic `delegate_task` currently defaults the child to
+   the caller's own agent when no target is given. Require an explicit target instead. Handing
+   work to yourself is usually a mistake, and once completions are pushed it can loop.
+
 ### Sequencing, by damage
 
 | Order | Change | Why this order |
@@ -135,6 +151,9 @@ facade, the polling obligation, and the `task_wait` tool proposed in the first d
 
 ## Consequences
 
+- **Delivery semantics are decided, not deferred**: batch-then-deliver, never interrupt a live
+  turn, never start a turn when the parent is gone, and require an explicit delegation target.
+  The remaining tuning question is the batching window, not the shape.
 - **Coalescing is now the only cost control, which makes it load-bearing rather than a nicety.**
   With no inline path, EVERY async task costs a wake-up — including trivial ones. Completions
   landing while the parent is idle must batch into a single re-engagement, and the batching
@@ -158,24 +177,22 @@ facade, the polling obligation, and the `task_wait` tool proposed in the first d
 
 ## Open questions for the grill
 
-Resolved during the 2026-07-26 grill: the wait budget (removed — no sync wait), whether the
-inline fast path earns its complexity (no — cut), why generic delegation was push-free
-(unfinished, not deliberate), and where output lives (artifact store, fleet-safe).
+Resolved during the 2026-07-26 grill: the wait budget (removed — no sync wait at all), whether
+the inline fast path earns its complexity (no — cut), why generic delegation was push-free
+(unfinished, not deliberate), where output lives (artifact store, fleet-safe), how completions
+are delivered (batched, never interrupting, never waking an absent parent), and whether
+delegation may default to the caller's own agent (no — an explicit target is required).
 
 Remaining:
 
-1. **What is the coalescing window?** If two tasks finish ten minutes apart, is that one
-   re-engagement or two? This is now the only control on wake cost.
-2. What happens when completions land mid-turn — queue until the turn ends, or interrupt?
-3. Does the parent receive batched results in completion order, and does order matter?
-4. What wakes when the parent is gone — conversation ended, agent deleted? A follow-up must not
-   create a spurious turn that talks to nobody. CANCEL-1 spent its existence on the mirror
-   image of this.
-5. Is there admission control if an agent fires many async tasks at once, or does the follow-up
-   queue grow unbounded?
-6. Should the child-target default (caller's own agent) change, or is self-delegation a
-   supported case that simply needs loop protection?
-7. Does the DeepAgents sentinel still earn its keep once the facade is deleted, given the tools
+1. **How long is the batching window?** The only remaining tuning knob on wake cost. Long
+   enough to group a burst, short enough that news is not stale.
+2. Within a batch, does delivery order matter, or is a set of results sufficient?
+3. Is there admission control if an agent starts many tasks at once, or can the queue grow
+   unbounded?
+4. What is the artifact retention policy for spilled output — bound the POPULATION, not the
+   rate (see [[audit-paydown-2026-07]]).
+5. Does the DeepAgents sentinel still earn its keep once the facade is deleted, given the tools
    it probes are never mounted?
 
 See [[semantic-capabilities-are-the-feature]] and [[tool-surface-tiering]] — this contract must

--- a/docs/decisions/0060-async-completion-contract.md
+++ b/docs/decisions/0060-async-completion-contract.md
@@ -69,97 +69,113 @@ of the premises this investigation started from were wrong. Both matter, so both
 
 ## Decision (proposed)
 
-**One completion contract for every async kind: bounded sync wait, then durable push.**
+**One completion contract for every async kind: always return a handle, always push the
+result.** Grilled and revised 2026-07-26; the owner's answers cut this further than the first
+draft proposed.
 
-The curated `delegate_to_<agent>` path already implements the correct shape — wait briefly,
-return the result inline if it finishes, otherwise hand back a handle and durably wake the
-parent when it completes. It is built, tested and works. Its only flaw is being wired for
-callable agents alone. Promote it to THE contract for commands, MCP calls and all delegation,
-on both runtimes.
-
-1. Every async start accepts a **sync wait budget** (small default, configurable).
-2. Work finishing inside that budget **returns inline** — no extra turn, no polling, no wake-up.
-3. Work exceeding it returns a handle, and on terminal state emits **one durable follow-up**
-   that re-engages the parent.
-4. Output **always spills to a gantry-owned file** — bounded summary inline, path in the
-   handle, full content via `task_get`. This is a separate channel from the observability
-   event, so no host path is ever published to a webhook subscriber.
-5. `task_get` / `task_list` / `task_cancel` / `task_message` remain for explicit inspection and
+1. Every async start **returns a handle immediately**. No synchronous wait, for any kind.
+2. On terminal state the task emits **one durable follow-up** that re-engages the parent.
+3. Output **always spills to the artifact store** — bounded summary inline, artifact reference
+   on the task row, full content via `task_get`.
+4. `task_get` / `task_list` / `task_cancel` / `task_message` remain for explicit inspection and
    live steering.
 
-### Why this shape rather than the alternatives
+### Why no synchronous wait
 
-- **Generalisation, not invention.** Universal push, better-polling, and a standalone wait tool
-  are each a NEW mechanism. This is the existing one applied consistently.
-- **The common case costs nothing.** Most async work is fast: it returns inline and never
-  touches the push path. Slow work cannot lose its result. Neither case asks the agent to
-  remember anything.
-- **It removes a tool rather than adding one.** The bounded wait belongs in the start call, not
-  in a separate `task_wait`. That also dissolves this design's most load-bearing open question
-  — whether a wait primitive could park without holding a runner slot — because there is no
-  wait primitive to park.
-- **Scalability comes from the interface.** A new async kind implements one contract; a new
-  runtime inherits it. That is what holds as the surface grows.
+The first draft generalised the curated path's bounded sync wait. That was wrong twice over:
+
+- **It did not dissolve the slot-holding problem, it spread it.** `delegate_to_<agent>` blocks
+  its turn for up to 60 seconds; generalising that would let any `async_run_command` block a
+  turn for a minute. Moving the wait into the start call renamed the problem rather than
+  removing it.
+- **The inline fast path rested on an unevidenced assumption** — that most async work is fast.
+  A caller that wanted a fast synchronous answer would not have reached for an async tool.
+  Async means slow; optimising the short case is complexity for a case that barely exists.
+
+Removing the wait entirely deletes the 60-second magic number rather than shrinking it, removes
+budget tuning from the design, and leaves exactly one code path.
+
+### Why the artifact store rather than a local file
+
+Output must survive multi-host. The task row lives in shared Postgres, so a local file on the
+host that ran the task would be unreadable from any other host serving `task_get` — a latent
+bug the day the fleet runs multi-host, and this repo already builds a fleet image.
+
+Reuse the artifact stores that already exist (`adapters/artifacts/` has S3-backed stores for
+skills, toolchains and browser profiles). The task row carries an artifact reference, not a
+filesystem path, so any host can serve the result and retention hooks into a solved shape.
+This is also a different channel from the observability event, so no host path is ever
+published to a webhook subscriber.
 
 ### What this removes
 
-The 60-second magic number (becomes a configured budget), the generic-versus-curated
-delegation split, the duplicate DeepAgents `AgentDelegation` facade, the polling obligation,
-and the previously proposed `task_wait` tool.
+The 60-second magic number, the synchronous wait on every path, the inline fast path, budget
+tuning, the generic-versus-curated delegation split, the duplicate DeepAgents `AgentDelegation`
+facade, the polling obligation, and the `task_wait` tool proposed in the first draft.
 
 ### Sequencing, by damage
 
 | Order | Change | Why this order |
 |---|---|---|
-| 1 | Gantry-owned spill file | data is destroyed today; nothing recovers it afterwards |
-| 2 | One delegation pipeline with explicit target resolution | results exist but never arrive |
-| 3 | Sync-wait budget on every async start | replaces the 60s hack; makes the fast path free |
+| 1 | Artifact-store spill | data is destroyed today; nothing recovers it afterwards |
+| 2 | Durable push on every terminal task, with coalescing | results exist but never arrive |
+| 3 | One delegation pipeline with explicit target resolution | removes the weak path and the loop risk |
 | 4 | Delete the duplicate facade | one start entry point per runtime |
 
 ### Explicitly NOT doing
 
 - **No `SubagentStop`.** The native `Agent` path is disallowed; the hook would never fire.
-- **No `task_wait` tool.** Superseded by the sync-wait budget on the start call.
-- **No event streaming into the model.** Every pushed event costs a full inference turn, so a
-  chatty task would cost dozens. `task_get` already exposes a ~1s-refreshed stdout/stderr tail
-  plus `lastProgress` and heartbeat for diagnosis, which is a poll-shaped need.
+- **No `task_wait` tool and no sync wait.** Cut during the grill.
+- **No event streaming into the model.** Every pushed event costs a full inference turn.
+  `task_get` already exposes a ~1s-refreshed stdout/stderr tail plus `lastProgress` and
+  heartbeat for diagnosis, which is a poll-shaped need.
 - **No Managed Agents migration.** Purpose-built for this shape, but beta and ineligible for
-  ZDR and HIPAA BAA because session state persists server-side. A product decision, not a bug fix.
+  ZDR and HIPAA BAA because session state persists server-side.
 - **No new task table, queue or notification bus.** All three exist and work.
 
 ## Consequences
 
-- Scalability comes from convergence rather than addition: every async kind — command, MCP
-  call, delegated agent, both runtimes — ends at the same completion contract and the same
-  file-backed output.
-- **Wake amplification is a real cost and must be designed for, not discovered.** Ten
-  background commands completing means ten follow-ups unless completions landing while the
-  parent is idle are COALESCED into a single re-engagement. Treat coalescing as part of the
-  contract.
-- **Self-delegation loops become reachable.** Generic delegation currently defaults the child
-  target to the caller's own agent. With push enabled that can loop, so target resolution must
-  be explicit in one place and same-agent delegation handled deliberately rather than by default.
-- Changing generic delegation's completion behaviour changes deliberate current behaviour
-  pinned by a test asserting `sendMessage` is never called. That test must be updated knowingly,
-  with the loop risk addressed — not deleted to make a new assertion pass.
-- A spill file introduces retention obligations the in-memory buffer does not have: size caps,
-  TTL, and cleanup on task deletion.
+- **Coalescing is now the only cost control, which makes it load-bearing rather than a nicety.**
+  With no inline path, EVERY async task costs a wake-up — including trivial ones. Completions
+  landing while the parent is idle must batch into a single re-engagement, and the batching
+  window is a first-class design parameter, not an implementation detail.
+- **Self-delegation loop protection is required regardless of the test's provenance.** The
+  owner reports the push-free behaviour was unfinished rather than deliberate, but generic
+  delegation still defaults the child target to the caller's own agent, so enabling push makes
+  looping reachable on its own merits. Target resolution must become explicit and same-agent
+  delegation handled deliberately. The originating commit should still be spot-checked when
+  implementing — "no remembered reason" is not the same as "no reason".
+- The test asserting `sendMessage` is never called for generic delegation must be updated
+  knowingly, with loop protection in place — not deleted to make a new assertion pass.
+- Artifact-store spill inherits that subsystem's retention model rather than inventing one.
+  Bound the POPULATION, not the rate: CANCEL-1's archive quarantine took six review cycles
+  precisely because each attempt bounded work-per-call, entries-scanned, then removal-rate
+  before landing on population. See [[audit-paydown-2026-07]].
+- Scalability comes from convergence: every async kind and both runtimes end at the same
+  completion contract and the same artifact-backed output. A new runtime inherits it.
 - `async_mcp_call` nests its id under `task.id` while other starts return a top-level `id`.
-  Worth normalising while this surface is open; the model should not handle two shapes.
+  Worth normalising while this surface is open.
 
 ## Open questions for the grill
 
-1. What is the right default sync-wait budget? Too short and everything takes the push path;
-   too long and turns stall. It should be configurable per async kind.
-2. How are concurrent completions coalesced into one re-engagement, and what is the batching
-   window?
-3. Why was generic delegation deliberately left push-free? The test is evidence of intent; the
-   reasoning should be recovered before overriding it.
-4. Where do spill files live, and under what retention? They contain arbitrary command output
-   and inherit the same protection questions as any host-side artifact.
-5. Should the child-target default (caller's own agent) change, or is self-delegation a
-   legitimate supported case that simply needs loop protection?
-6. Does the DeepAgents sentinel still earn its keep once the facade is deleted, given the tools
+Resolved during the 2026-07-26 grill: the wait budget (removed — no sync wait), whether the
+inline fast path earns its complexity (no — cut), why generic delegation was push-free
+(unfinished, not deliberate), and where output lives (artifact store, fleet-safe).
+
+Remaining:
+
+1. **What is the coalescing window?** If two tasks finish ten minutes apart, is that one
+   re-engagement or two? This is now the only control on wake cost.
+2. What happens when completions land mid-turn — queue until the turn ends, or interrupt?
+3. Does the parent receive batched results in completion order, and does order matter?
+4. What wakes when the parent is gone — conversation ended, agent deleted? A follow-up must not
+   create a spurious turn that talks to nobody. CANCEL-1 spent its existence on the mirror
+   image of this.
+5. Is there admission control if an agent fires many async tasks at once, or does the follow-up
+   queue grow unbounded?
+6. Should the child-target default (caller's own agent) change, or is self-delegation a
+   supported case that simply needs loop protection?
+7. Does the DeepAgents sentinel still earn its keep once the facade is deleted, given the tools
    it probes are never mounted?
 
 See [[semantic-capabilities-are-the-feature]] and [[tool-surface-tiering]] — this contract must

--- a/docs/decisions/0060-async-completion-contract.md
+++ b/docs/decisions/0060-async-completion-contract.md
@@ -69,72 +69,97 @@ of the premises this investigation started from were wrong. Both matter, so both
 
 ## Decision (proposed)
 
-Converge on one async completion contract. Reuse what already works — the durable follow-up,
-the task table, the curated pipeline — rather than adding a parallel system.
+**One completion contract for every async kind: bounded sync wait, then durable push.**
 
-**1. Gantry owns a spill file.** Write the full stdout/stderr and MCP result to a
-gantry-controlled file, record the path on the task row, return it through `task_get` and in
-the start handle. This is a different channel from the observability event, so no host path is
-ever published to a webhook subscriber.
+The curated `delegate_to_<agent>` path already implements the correct shape — wait briefly,
+return the result inline if it finishes, otherwise hand back a handle and durably wake the
+parent when it completes. It is built, tested and works. Its only flaw is being wired for
+callable agents alone. Promote it to THE contract for commands, MCP calls and all delegation,
+on both runtimes.
 
-**2. Converge the two delegation products into one pipeline with different defaults.** Target
-resolution and follow-up arming should be decided in one place. Do NOT simply arm completion
-follow-up on the generic path: because it defaults the child to the caller's own agent,
-universal waking invites self-delegation loops, and the existing test asserting no push is
-evidence someone already considered this.
+1. Every async start accepts a **sync wait budget** (small default, configurable).
+2. Work finishing inside that budget **returns inline** — no extra turn, no polling, no wake-up.
+3. Work exceeding it returns a handle, and on terminal state emits **one durable follow-up**
+   that re-engages the parent.
+4. Output **always spills to a gantry-owned file** — bounded summary inline, path in the
+   handle, full content via `task_get`. This is a separate channel from the observability
+   event, so no host path is ever published to a webhook subscriber.
+5. `task_get` / `task_list` / `task_cancel` / `task_message` remain for explicit inspection and
+   live steering.
 
-**3. Add `task_wait(taskId, timeoutMs)` that does not hold a runner slot.** Bounded, parking
-without a lease, falling back to the durable follow-up when the bound expires. This replaces
-the curated path's 60-second magic number rather than relocating it.
+### Why this shape rather than the alternatives
 
-**4. Delete the duplicate `AgentDelegation` facade** so there is one start entry point.
+- **Generalisation, not invention.** Universal push, better-polling, and a standalone wait tool
+  are each a NEW mechanism. This is the existing one applied consistently.
+- **The common case costs nothing.** Most async work is fast: it returns inline and never
+  touches the push path. Slow work cannot lose its result. Neither case asks the agent to
+  remember anything.
+- **It removes a tool rather than adding one.** The bounded wait belongs in the start call, not
+  in a separate `task_wait`. That also dissolves this design's most load-bearing open question
+  — whether a wait primitive could park without holding a runner slot — because there is no
+  wait primitive to park.
+- **Scalability comes from the interface.** A new async kind implements one contract; a new
+  runtime inherits it. That is what holds as the surface grows.
+
+### What this removes
+
+The 60-second magic number (becomes a configured budget), the generic-versus-curated
+delegation split, the duplicate DeepAgents `AgentDelegation` facade, the polling obligation,
+and the previously proposed `task_wait` tool.
 
 ### Sequencing, by damage
 
-| Order | Change | Why |
+| Order | Change | Why this order |
 |---|---|---|
-| 1 | Output spill | data is destroyed; nothing can recover it afterwards |
-| 2 | Delegation convergence | results exist but never arrive |
-| 3 | `task_wait` | ergonomics; removes a hack |
-| 4 | Facade removal | tidy-up |
+| 1 | Gantry-owned spill file | data is destroyed today; nothing recovers it afterwards |
+| 2 | One delegation pipeline with explicit target resolution | results exist but never arrive |
+| 3 | Sync-wait budget on every async start | replaces the 60s hack; makes the fast path free |
+| 4 | Delete the duplicate facade | one start entry point per runtime |
 
 ### Explicitly NOT doing
 
 - **No `SubagentStop`.** The native `Agent` path is disallowed; the hook would never fire.
+- **No `task_wait` tool.** Superseded by the sync-wait budget on the start call.
 - **No event streaming into the model.** Every pushed event costs a full inference turn, so a
   chatty task would cost dozens. `task_get` already exposes a ~1s-refreshed stdout/stderr tail
-  plus `lastProgress` and heartbeat for diagnosis, which is a poll-shaped need. Waiting is
-  worth building; streaming is not.
-- **No Managed Agents migration.** It is Anthropic's purpose-built durable-async product and
-  does solve this shape, but it is beta and ineligible for ZDR and HIPAA BAA because session
-  state persists server-side. That is a product-level decision, not a bug fix.
+  plus `lastProgress` and heartbeat for diagnosis, which is a poll-shaped need.
+- **No Managed Agents migration.** Purpose-built for this shape, but beta and ineligible for
+  ZDR and HIPAA BAA because session state persists server-side. A product decision, not a bug fix.
 - **No new task table, queue or notification bus.** All three exist and work.
 
 ## Consequences
 
 - Scalability comes from convergence rather than addition: every async kind — command, MCP
   call, delegated agent, both runtimes — ends at the same completion contract and the same
-  file-backed output. A future runtime implements one small adapter instead of a parallel stack.
+  file-backed output.
+- **Wake amplification is a real cost and must be designed for, not discovered.** Ten
+  background commands completing means ten follow-ups unless completions landing while the
+  parent is idle are COALESCED into a single re-engagement. Treat coalescing as part of the
+  contract.
+- **Self-delegation loops become reachable.** Generic delegation currently defaults the child
+  target to the caller's own agent. With push enabled that can loop, so target resolution must
+  be explicit in one place and same-agent delegation handled deliberately rather than by default.
 - Changing generic delegation's completion behaviour changes deliberate current behaviour
-  pinned by a test. That test must be updated knowingly, with the self-delegation loop risk
-  addressed, not deleted to make a new assertion pass.
-- A spill file introduces retention and cleanup obligations that the current in-memory buffer
-  does not have — size caps, TTL, and cleanup on task deletion all need answering.
-- `async_mcp_call` nests its id under `task.id` while the other starts return a top-level `id`.
-  Worth normalising while touching this surface; the model should not have to handle two shapes.
+  pinned by a test asserting `sendMessage` is never called. That test must be updated knowingly,
+  with the loop risk addressed — not deleted to make a new assertion pass.
+- A spill file introduces retention obligations the in-memory buffer does not have: size caps,
+  TTL, and cleanup on task deletion.
+- `async_mcp_call` nests its id under `task.id` while other starts return a top-level `id`.
+  Worth normalising while this surface is open; the model should not handle two shapes.
 
 ## Open questions for the grill
 
-1. **Can `task_wait` park without holding a runner slot or live-admission capacity?** If not,
-   change 3 needs a different shape — a blocking wait that consumes interactive capacity does
-   not scale, which defeats the point.
-2. Why was generic delegation deliberately left push-free? The test is evidence of intent; the
+1. What is the right default sync-wait budget? Too short and everything takes the push path;
+   too long and turns stall. It should be configurable per async kind.
+2. How are concurrent completions coalesced into one re-engagement, and what is the batching
+   window?
+3. Why was generic delegation deliberately left push-free? The test is evidence of intent; the
    reasoning should be recovered before overriding it.
-3. Where should spill files live, and under what retention? They contain arbitrary command
-   output, so they inherit the same protection questions as any host-side artifact.
-4. Should the child-target default (caller's own agent) change, or is self-delegation a
-   legitimate supported case?
-5. Does the DeepAgents sentinel still earn its keep once the facade is deleted, given the tools
+4. Where do spill files live, and under what retention? They contain arbitrary command output
+   and inherit the same protection questions as any host-side artifact.
+5. Should the child-target default (caller's own agent) change, or is self-delegation a
+   legitimate supported case that simply needs loop protection?
+6. Does the DeepAgents sentinel still earn its keep once the facade is deleted, given the tools
    it probes are never mounted?
 
 See [[semantic-capabilities-are-the-feature]] and [[tool-surface-tiering]] — this contract must


### PR DESCRIPTION
> **Design only — no code.** `status: proposed`, to be grilled before implementation.

## The decision

**One completion contract for every async kind: bounded sync wait, then durable push.**

The curated `delegate_to_<agent>` path already implements the correct shape — wait briefly, return the result inline if it finishes, otherwise hand back a handle and durably wake the parent on completion. It is built, tested and correct. Its only flaw is being wired for callable agents alone.

Promote it to *the* contract for commands, MCP calls and all delegation, on both runtimes:

1. Every async start accepts a **sync wait budget**
2. Finishes inside it → **returns inline** — no extra turn, no polling, no wake-up
3. Exceeds it → returns a handle; on terminal, **one durable follow-up** re-engages the parent
4. Output **always spills to a gantry-owned file** — summary inline, path in the handle, full content via `task_get`
5. `task_get`/`list`/`cancel`/`message` remain for inspection and live steering

## Why this shape

- **Generalisation, not invention.** Universal push, better-polling, and a standalone wait tool are each a *new* mechanism. This is the existing one applied consistently.
- **The common case costs nothing.** Most async work is fast — it returns inline and never touches the push path. Slow work can't lose its result. Neither asks the agent to remember anything.
- **It removes a tool rather than adding one.** The bounded wait belongs in the start call, not a separate `task_wait`. That dissolves this design's most load-bearing open question — whether a wait primitive could park without holding a runner slot — because there's no longer a wait primitive to park.
- **Scalability comes from the interface.** A new async kind implements one contract; a new runtime inherits it.

## What it removes

The 60-second magic number (becomes a configured budget), the generic-vs-curated delegation split, the duplicate DeepAgents facade, the polling obligation, and the previously proposed `task_wait`.

## What's actually broken today

1. **Output is destroyed, not truncated** — 4,000-byte rolling buffer → ~1,000-char summary, tails nulled at terminal state, no spill file. **No amount of correct polling recovers it.**
2. **Completion is passive** for commands, MCP calls and generic `delegate_task`
3. **Two delegation products masquerade as one**; generic defaults the child to the **caller's own agent**
4. **A duplicate DeepAgents facade** routes onto the weak path

## What is NOT broken

Handles, status polling, cross-turn retrieval and cancellation all work — and **parity between runtimes already exists**. Both converge on the same gantry IPC tools, which the audit found *"materially stronger than either provider-native path."*

## Premises corrected during the audit

1. **The SDK's native `Agent` tool is disallowed** — so `forceBackgroundNativeAgentInput()` is inert and `SubagentStop` would never fire. Dropped from the plan.
2. **DeepAgents' five async tools are a version-drift probe, not a surface** — never registered, explicitly filtered.
3. **`output_file` is correctly omitted from runtime events** — those are operator frames published to webhooks, where a host path would leak.

## Two costs stated up front

- **Wake amplification.** Ten completing commands would mean ten re-engagements. **Coalescing is part of the contract**, not an afterthought.
- **Self-delegation loops.** Generic delegation defaults the child to the caller's own agent; with push enabled that can loop. Target resolution must be explicit and same-agent delegation deliberate.

## Sequencing, by damage

| Order | Change |
|---|---|
| 1 | Gantry-owned spill file — data is destroyed today |
| 2 | One delegation pipeline with explicit target resolution |
| 3 | Sync-wait budget on every async start |
| 4 | Delete the duplicate facade |

## Still open

Default budget per async kind; the coalescing window; why generic delegation was deliberately left push-free; spill-file location and retention; whether the caller's-own-agent default should change.
