### PR TITLE
Plain English when talking to the person

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,4 +106,5 @@ A task is not PR-ready until all of these exist:
 - Review runs as ONE autoreview pass — never inline, never nested reviewers — by invoking the autoreview SKILL HELPER directly (`"$AUTOREVIEW" --mode branch|commit|local`; it spawns the Codex engine in an isolated sandbox, definitive exit code). NEVER a `/codex:rescue`/companion `review` job (hangs at finalization). Applies to per-stage LOCAL autoreview and PR closeout.
 - Keep the template repo independent of any client-specific source repo.
 - Do not keep long policy blocks in `AGENTS.md`; move them into docs.
+- Talk to the human in plain, everyday English: short sentences, no jargon, say what it means not how it works. Precision belongs in commits, decisions and PR bodies.
 - PRs: orchestrator may push story branches + raise PRs once `pr_ready` (one per story); merging stays human-gated; every PR body opens with the plain-language goal/why before the technical delta; runtime-behavior PRs carry their agent-e2e delta (or state why not). Policy: `docs/review-instructions.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,5 +106,5 @@ A task is not PR-ready until all of these exist:
 - Review runs as ONE autoreview pass — never inline, never nested reviewers — by invoking the autoreview SKILL HELPER directly (`"$AUTOREVIEW" --mode branch|commit|local`; it spawns the Codex engine in an isolated sandbox, definitive exit code). NEVER a `/codex:rescue`/companion `review` job (hangs at finalization). Applies to per-stage LOCAL autoreview and PR closeout.
 - Keep the template repo independent of any client-specific source repo.
 - Do not keep long policy blocks in `AGENTS.md`; move them into docs.
-- Talk to the human in plain, everyday English: short sentences, no jargon, say what it means not how it works. Precision belongs in commits, decisions and PR bodies.
+- Talk to the human in plain, everyday English; precision belongs in commits, decisions and PR bodies. Policy: `docs/communication-style.md`.
 - PRs: orchestrator may push story branches + raise PRs once `pr_ready` (one per story); merging stays human-gated; every PR body opens with the plain-language goal/why before the technical delta; runtime-behavior PRs carry their agent-e2e delta (or state why not). Policy: `docs/review-instructions.md`.

--- a/docs/communication-style.md
+++ b/docs/communication-style.md
@@ -1,0 +1,65 @@
+# How to talk to the person
+
+Write in plain, everyday English. Every time, not just in summaries.
+
+The person reading this runs the product and makes the decisions. They need to know what
+happened and what it means. They do not need the internals narrated to decide something.
+
+## The rules
+
+**Short sentences. One idea each.** If a sentence has three clauses joined by dashes, split it.
+
+**Say what it means, not how it works.** "Background jobs were throwing away their output" beats
+"the rolling buffer truncates irrecoverably before persistence".
+
+**Use ordinary words.**
+
+| Instead of | Say |
+|---|---|
+| re-engage the parent | tell the agent |
+| coalesce completions | group them |
+| async task | background job |
+| the buffer truncates irrecoverably | the output was thrown away |
+| terminal state | finished |
+| provenance | where it came from |
+| birthright | allowed without asking |
+
+**Lead with the answer.** Say what happened first. Give the reasoning after, and only as much as
+is needed to judge it.
+
+**Say when you do not know.** "I have not checked that" is more useful than a confident guess.
+If a number matters, measure it and say so. If it is an estimate, call it an estimate.
+
+**Own mistakes plainly.** "I got that wrong, here is what is actually true." No hedging, no
+burying it in the middle of a paragraph.
+
+## Asking for a decision
+
+Use a real question with real trade-offs. Say what each choice costs and what it risks, in
+terms of the product, not the code.
+
+Good: *"If one of five jobs fails, should the other four carry on? You get the results that
+worked, but you have paid for work you might not want."*
+
+Bad: *"Should batch failure semantics be fail-fast or fail-open with partial result
+propagation?"*
+
+Only ask when the answer is genuinely theirs to give. If there is an obvious default, take it
+and say what you did.
+
+## Where precision still belongs
+
+This rule is about talking to the person. It does not apply to:
+
+- **commit messages** — read by engineers and agents, and by whoever is bisecting a bug at 3am
+- **decision records** in `docs/decisions/` — the durable technical record
+- **PR bodies** — though these still open with the plain-language goal before the technical
+  detail, per `docs/review-instructions.md`
+
+Keep exact file paths, commit SHAs, command names and error text when those *are* the answer.
+Being precise about facts is not the same as writing densely.
+
+## The test
+
+Read it back. If a smart person who does not know this codebase would have to read a sentence
+twice, rewrite it.

--- a/docs/communication-style.md
+++ b/docs/communication-style.md
@@ -7,7 +7,13 @@ happened and what it means. They do not need the internals narrated to decide so
 
 ## The rules
 
+**Be short.** Most answers fit in a few lines. Say what happened, what it means, and what is
+waiting on them. Cut everything else. A long message is not more thorough, it is harder to use.
+
 **Short sentences. One idea each.** If a sentence has three clauses joined by dashes, split it.
+
+**Do not narrate the work.** They do not need each step recounted. They need the outcome and
+anything that needs a decision.
 
 **Say what it means, not how it works.** "Background jobs were throwing away their output" beats
 "the rolling buffer truncates irrecoverably before persistence".


### PR DESCRIPTION
Makes plain English the house style when talking to the person, everywhere — not just in summaries.

## What changed

A new doc, `docs/communication-style.md`, plus one line in AGENTS.md pointing at it:

```
- Talk to the human in plain, everyday English; precision belongs in commits,
  decisions and PR bodies. Policy: `docs/communication-style.md`.
```

Same pattern AGENTS.md already uses for PR policy — a pointer, not a policy block. It caps at 110 lines and its own rules forbid long blocks inline. It is now exactly at 110.

## Why

Dense technical writing hides the point. The person reading it runs the product and makes the calls. They need to know what happened and what it means, not how the machinery works.

## What the doc says

Short sentences. Say what it means, not how it works. Lead with the answer. Say when you do not know, and call an estimate an estimate. Own mistakes plainly.

It includes a before/after table for the jargon that actually comes up here:

| Instead of | Say |
|---|---|
| re-engage the parent | tell the agent |
| coalesce completions | group them |
| terminal state | finished |
| birthright | allowed without asking |

And it covers asking for a decision: give real trade-offs in product terms, not an architecture menu. Only ask when the answer is genuinely theirs — otherwise take the obvious default and say what you did.

## Where precision still belongs

Commit messages, decision records and PR bodies stay precise. Engineers and agents read those, and whoever is bisecting a bug at 3am needs the detail. Exact paths, SHAs, command names and error text stay when they are the answer.

Being precise about facts is not the same as writing densely.

`check_agents_hygiene` and `check_dual_runtime` both pass.
