### PR TITLE
Job and subagent shell commands are judged on the clean command, not the proxy wrapper

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/runner/bash-trust-env.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/runner/bash-trust-env.ts
@@ -58,13 +58,15 @@ export function applyBashTrustEnvWithProvenance(
   }
 
   const prefix = bashTrustEnvPrefix(toolNetworkEnv);
-  if (command.startsWith(`${prefix} `)) return { toolInput: input };
+  const toolInput = command.startsWith(`${prefix} `)
+    ? input
+    : {
+        ...input,
+        [commandKey]: `${prefix} ${command}`,
+      };
 
   return {
-    toolInput: {
-      ...input,
-      [commandKey]: `${prefix} ${command}`,
-    },
+    toolInput,
     hostInjectedCommandPrefix: prefix,
   };
 }

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/runner/tool-permission-gate.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/runner/tool-permission-gate.ts
@@ -234,6 +234,18 @@ export function createCanUseToolCallback(
       input.agentInput.toolNetworkEnv ?? {},
     );
     const trustInput = () => trustedInput.toolInput;
+    const requestPermissionApprovalWithTrustProvenance = (
+      approvalInput: ApprovalInput,
+    ) =>
+      requestPermissionApproval({
+        ...approvalInput,
+        toolInput: trustedInput.toolInput,
+        ...(trustedInput.hostInjectedCommandPrefix
+          ? {
+              hostInjectedCommandPrefix: trustedInput.hostInjectedCommandPrefix,
+            }
+          : {}),
+      });
     const sdkApprovalPrincipal =
       permissionOpts.agentID?.trim() ||
       input.agentInput.agentId ||
@@ -433,7 +445,7 @@ export function createCanUseToolCallback(
       const suggestions = yoloDenylistReason
         ? undefined
         : permissionPlan.suggestions;
-      const decision = await requestPermissionApproval({
+      const decision = await requestPermissionApprovalWithTrustProvenance({
         appId: input.agentInput.appId,
         agentId: input.agentInput.agentId,
         targetJid: input.agentInput.chatJid,
@@ -560,7 +572,7 @@ export function createCanUseToolCallback(
     const suggestions = yoloDenylistReason
       ? undefined
       : permissionPlan.suggestions;
-    const decision = await requestPermissionApproval({
+    const decision = await requestPermissionApprovalWithTrustProvenance({
       appId: input.agentInput.appId,
       agentId: input.agentInput.agentId,
       targetJid: input.agentInput.chatJid,

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -10,6 +10,7 @@ import {
   GANTRY_CLAUDE_SDK_SKILLS_ENV,
   SDK_NATIVE_SKILL_OVERRIDES,
 } from '@core/adapters/llm/anthropic-claude-agent/native-sdk-skills.js';
+import { stripShellCommandEnvPrefix } from '@core/runtime/ipc-shell-command-prefix.js';
 
 const RUNNER_IPC_CHILD_TIMEOUT_MS = 50_000;
 const RUNNER_IPC_TEST_TIMEOUT_MS = 60_000;
@@ -2292,15 +2293,29 @@ describe('agent-runner IPC lifecycle', () => {
         '"interactionBoundary":"user_interaction"',
       );
       const call = readRecord(fixture.recordPath).calls[0];
+      const hostInjectedCommandPrefix = 'GODEBUG=netdns=go';
       expect(call?.permissionRequest).toEqual(
         expect.objectContaining({
           sourceAgentFolder: 'team',
           runHandle: 'runner-test-run',
           toolName: 'RunCommand',
+          hostInjectedCommandPrefix,
           signature: expect.any(String),
         }),
       );
       expect(call?.permissionRequest?.toolInput).toEqual(
+        expect.objectContaining({
+          cmd: `${hostInjectedCommandPrefix} npm test`,
+          apiToken: 'secret-token',
+        }),
+      );
+      expect(
+        stripShellCommandEnvPrefix(
+          'RunCommand',
+          call?.permissionRequest?.toolInput,
+          hostInjectedCommandPrefix,
+        ),
+      ).toEqual(
         expect.objectContaining({ cmd: 'npm test', apiToken: 'secret-token' }),
       );
       expect(call?.permissionRequest?.suggestions).toEqual([
@@ -2346,13 +2361,27 @@ describe('agent-runner IPC lifecycle', () => {
 
       expect(result.exitCode, result.stderr).toBe(0);
       const call = readRecord(fixture.recordPath).calls[0];
+      const hostInjectedCommandPrefix = 'GODEBUG=netdns=go';
       expect(call?.permissionRequest).toEqual(
         expect.objectContaining({
           toolName: 'RunCommand',
+          hostInjectedCommandPrefix,
           toolInput: expect.objectContaining({
-            cmd: command,
+            cmd: `${hostInjectedCommandPrefix} ${command}`,
             dangerouslyDisableSandbox: true,
           }),
+        }),
+      );
+      expect(
+        stripShellCommandEnvPrefix(
+          'RunCommand',
+          call?.permissionRequest?.toolInput,
+          hostInjectedCommandPrefix,
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          cmd: command,
+          dangerouslyDisableSandbox: true,
         }),
       );
       expect(call?.permissionDecision).toEqual({

--- a/apps/core/test/unit/runner/bash-trust-env.test.ts
+++ b/apps/core/test/unit/runner/bash-trust-env.test.ts
@@ -114,7 +114,22 @@ describe('applyBashTrustEnv', () => {
     });
   });
 
-  it('does not claim provenance for a prefix it did not inject', () => {
+  it('wraps fresh commands and declares the exact injected prefix', () => {
+    expect(
+      applyBashTrustEnvWithProvenance(
+        'RunCommand',
+        { command: 'pwd' },
+        { HTTP_PROXY: TOOL_PROXY_URL },
+      ),
+    ).toEqual({
+      toolInput: {
+        command: `GODEBUG=netdns=go HTTP_PROXY='${TOOL_PROXY_URL}' pwd`,
+      },
+      hostInjectedCommandPrefix: `GODEBUG=netdns=go HTTP_PROXY='${TOOL_PROXY_URL}'`,
+    });
+  });
+
+  it('declares the exact current prefix when the command is already wrapped', () => {
     const input = {
       command: `${TRUST_PREFIX} curl https://example.test`,
     };
@@ -137,6 +152,28 @@ describe('applyBashTrustEnv', () => {
         CARGO_HTTP_CAINFO: CA_PATH,
         DENO_CERT: CA_PATH,
       }),
-    ).toEqual({ toolInput: input });
+    ).toEqual({
+      toolInput: input,
+      hostInjectedCommandPrefix: TRUST_PREFIX,
+    });
+  });
+
+  it('does not recognize a stale proxy prefix as the current host wrap', () => {
+    const stalePrefix =
+      "GODEBUG=netdns=go HTTP_PROXY='http://127.0.0.1:18079/'";
+    const currentPrefix = `GODEBUG=netdns=go HTTP_PROXY='${TOOL_PROXY_URL}'`;
+
+    expect(
+      applyBashTrustEnvWithProvenance(
+        'Bash',
+        { command: `${stalePrefix} pwd` },
+        { HTTP_PROXY: TOOL_PROXY_URL },
+      ),
+    ).toEqual({
+      toolInput: {
+        command: `${currentPrefix} ${stalePrefix} pwd`,
+      },
+      hostInjectedCommandPrefix: currentPrefix,
+    });
   });
 });

--- a/apps/core/test/unit/runner/tool-permission-gate.test.ts
+++ b/apps/core/test/unit/runner/tool-permission-gate.test.ts
@@ -17,6 +17,10 @@ const { createCanUseToolCallback } =
   await import('@core/adapters/llm/anthropic-claude-agent/runner/tool-permission-gate.js');
 const { WORKSPACE_FOLDER_OPTION_KEY } =
   await import('@core/adapters/llm/anthropic-claude-agent/runner/types.js');
+const { evaluatePermissionDeterministicRails } =
+  await import('@core/domain/permission-deterministic-rails.js');
+const { stripShellCommandEnvPrefix } =
+  await import('@core/runtime/ipc-shell-command-prefix.js');
 
 function makePermissionOptions(overrides: Record<string, unknown> = {}) {
   return {
@@ -74,6 +78,34 @@ function combinedConsoleOutput(): string {
   ]
     .map((call) => String(call[0]))
     .join('');
+}
+
+function decideWrappedReadOnlyRequest(request: {
+  toolInput?: unknown;
+  hostInjectedCommandPrefix?: string;
+}) {
+  const toolInput = stripShellCommandEnvPrefix(
+    'RunCommand',
+    request.toolInput,
+    request.hostInjectedCommandPrefix,
+  );
+  const decision = evaluatePermissionDeterministicRails({
+    request: {
+      requestId: 'permission-test',
+      sourceAgentFolder: 'main_agent',
+      toolName: 'RunCommand',
+      toolInput,
+    },
+    approvedCapabilityIds: ['filesystem.read'],
+  });
+  return decision?.railOutcome === 'allow'
+    ? decision
+    : {
+        approved: false,
+        mode: 'cancel' as const,
+        reason: 'wrapped command was not deterministically read-only',
+        decidedBy: 'deterministic_rails',
+      };
 }
 
 describe('createCanUseToolCallback', () => {
@@ -489,7 +521,7 @@ describe('createCanUseToolCallback', () => {
     );
   });
 
-  it('keeps the runner prefix out of the permission request and adds it for execution', async () => {
+  it('wraps and declares a fresh command for permission and execution', async () => {
     const canUseTool = makeCallback({
       agentInput: {
         runMode: 'normal',
@@ -521,9 +553,11 @@ describe('createCanUseToolCallback', () => {
     const approvalRequest =
       permissionMock.requestPermissionApproval.mock.calls[0]?.[0];
     expect(approvalRequest).toMatchObject({
-      toolInput: { command: 'curl https://example.test' },
+      toolInput: {
+        command: `${hostInjectedCommandPrefix} curl https://example.test`,
+      },
+      hostInjectedCommandPrefix,
     });
-    expect(approvalRequest).not.toHaveProperty('hostInjectedCommandPrefix');
     expect(result).toEqual(
       expect.objectContaining({
         behavior: 'allow',
@@ -533,6 +567,75 @@ describe('createCanUseToolCallback', () => {
       }),
     );
   });
+
+  it.each([
+    {
+      lane: 'job subagent lane',
+      isScheduledJob: true,
+      jobId: 'job-1',
+      agentID: 'subagent-1',
+    },
+    {
+      lane: 'interactive retry',
+      isScheduledJob: false,
+      jobId: undefined,
+      agentID: undefined,
+    },
+  ])(
+    'declares an already-wrapped read-only command on the $lane without double-wrapping',
+    async ({ isScheduledJob, jobId, agentID }) => {
+      const hostInjectedCommandPrefix =
+        "GODEBUG=netdns=go HTTP_PROXY='http://127.0.0.1:18790/'";
+      permissionMock.requestPermissionApproval.mockImplementationOnce(
+        decideWrappedReadOnlyRequest,
+      );
+      const canUseTool = makeCallback({
+        agentInput: {
+          runMode: 'normal',
+          isScheduledJob,
+          appId: 'default',
+          agentId: 'agent:test',
+          runId: 'run-1',
+          jobId,
+          chatJid: 'tg:test',
+          threadId: undefined,
+          allowedTools: [],
+          toolNetworkEnv: {
+            HTTP_PROXY: 'http://127.0.0.1:18790/',
+          },
+          yoloMode: {
+            enabled: true,
+            denylist: [],
+            denylistPaths: [],
+          },
+        } as never,
+      });
+
+      await expect(
+        canUseTool(
+          'Bash',
+          { command: `${hostInjectedCommandPrefix} uname -s` },
+          makePermissionOptions({ ...(agentID ? { agentID } : {}) }) as never,
+        ),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          behavior: 'allow',
+          updatedInput: {
+            command: `${hostInjectedCommandPrefix} uname -s`,
+          },
+        }),
+      );
+      expect(permissionMock.requestPermissionApproval).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolInput: {
+            command: `${hostInjectedCommandPrefix} uname -s`,
+          },
+          hostInjectedCommandPrefix,
+          ...(agentID ? { agentID } : {}),
+        }),
+      );
+    },
+  );
 
   it('does not silently allow a tool listed in allowedTools — the coordinator still decides', async () => {
     // PERM-2 Task F: a rule on the agent's configured allowedTools must not

--- a/apps/core/test/unit/runtime/ipc-shell-command-prefix.test.ts
+++ b/apps/core/test/unit/runtime/ipc-shell-command-prefix.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyBashTrustEnvWithProvenance } from '@core/adapters/llm/anthropic-claude-agent/runner/bash-trust-env.js';
+import { stripShellCommandEnvPrefix } from '@core/runtime/ipc-shell-command-prefix.js';
+import { evaluateAutonomousToolUse } from '@core/shared/tool-rule-matcher.js';
+
+function wrapAtPort(port: number) {
+  return applyBashTrustEnvWithProvenance(
+    'RunCommand',
+    { command: 'pwd' },
+    { HTTP_PROXY: `http://127.0.0.1:${port}/` },
+  );
+}
+
+describe('host-injected shell command prefix', () => {
+  it('keeps a saved rule matching across proxy-port rotation', () => {
+    for (const port of [18080, 18790]) {
+      const wrapped = wrapAtPort(port);
+      const decisionInput = stripShellCommandEnvPrefix(
+        'RunCommand',
+        wrapped.toolInput,
+        wrapped.hostInjectedCommandPrefix,
+      );
+
+      expect(
+        evaluateAutonomousToolUse({
+          rules: ['RunCommand(pwd)'],
+          toolName: 'RunCommand',
+          toolInput: decisionInput,
+        }),
+      ).toMatchObject({
+        allowed: true,
+        matchedRule: 'RunCommand(pwd)',
+      });
+    }
+  });
+
+  it('strips only a byte-exact declared prefix', () => {
+    const wrapped = wrapAtPort(18080);
+
+    expect(
+      stripShellCommandEnvPrefix(
+        'RunCommand',
+        wrapped.toolInput,
+        "GODEBUG=netdns=go HTTP_PROXY='http://127.0.0.1:18790/'",
+      ),
+    ).toBe(wrapped.toolInput);
+    expect(
+      stripShellCommandEnvPrefix(
+        'RunCommand',
+        wrapped.toolInput,
+        wrapped.hostInjectedCommandPrefix,
+      ),
+    ).toEqual({ command: 'pwd' });
+  });
+});

--- a/apps/core/test/unit/shared/permission-deterministic-rails.test.ts
+++ b/apps/core/test/unit/shared/permission-deterministic-rails.test.ts
@@ -309,6 +309,7 @@ describe('permission deterministic rails', () => {
   it.each([
     ['parse failure', 'echo "unterminated'],
     ['environment assignment', 'NAME=value git status'],
+    ['timezone environment assignment', 'TZ=Asia/Kolkata date'],
     ['shell expansion', 'echo $HOME'],
     ['oversize command', `echo ${'x'.repeat(4097)}`],
     ['bash string', 'bash -c echo'],

--- a/docs/decisions/0062-perm6-client-signoff.md
+++ b/docs/decisions/0062-perm6-client-signoff.md
@@ -1,0 +1,48 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-26
+---
+
+# Perm6 Client Signoff
+
+## Context
+The lead-maintenance job kept stalling on "Needs permission". Ravi reported it live on
+2026-07-26 and asked for the issue to be fixed; his agent independently diagnosed it.
+
+What actually happens: the host wraps every job shell command with network-proxy environment
+assignments (`GODEBUG=netdns=go HTTP_PROXY='http://127.0.0.1:<port>/' ...`) so the command's
+traffic goes through the egress proxy. The permission check then judges the WRAPPED text.
+Confirmed in the runtime log — the refused `commandPreview` begins with the proxy wrap, and the
+refusal is "Shell input is unsupported: Bash environment assignments are not supported",
+cancelled by `deterministic_rails`.
+
+Two knock-on effects make it unfixable from the outside:
+- the proxy port rotates every run, so the wrapped text differs each time and no saved command
+  rule can ever match;
+- even a human grant cannot help, because the rails hard-refuse env assignments before any rule
+  or classifier runs.
+
+PERM-3 built the exact remedy: `applyBashTrustEnvWithProvenance` wraps the command AND returns
+`hostInjectedCommandPrefix`, and `stripShellCommandEnvPrefix` removes that declared prefix
+before the check judges the command. It is wired in the interactive lane
+(`tool-permission-gate.ts:231`). The job lane injects the same wrap but never declares it.
+
+The immediate incident is resolved at the job level — the job now uses its injected IST time
+and the reviewed Sheets capabilities instead of shelling out. This task fixes the lane, so any
+other job that runs any shell command does not hit the same wall.
+
+## Decision
+Ravi asked on 2026-07-26 to fix the issue ("Try fixing the issues — is it with running,
+permissions or just the job itself"). Scope: thread the host-injected prefix declaration
+through the job-run shell path, exactly as the interactive lane already does, so the permission
+check and rule matching judge the clean command.
+
+## Consequences
+- Job shell commands become classifiable and grantable again: a read-only `date +%A` can
+  auto-allow, and a saved rule for a command can match regardless of the rotating proxy port.
+- The hard floor on environment assignments is NOT relaxed. A command that genuinely contains
+  user-authored env assignments (for example `TZ=Asia/Kolkata date`) is still refused — only
+  the HOST's own declared wrap is stripped, provenance-exact, as PERM-3 designed.
+- The fix must not weaken the trust boundary: the prefix is stripped only when it matches the
+  declared host-injected prefix byte-for-byte. Anything else is judged as-is.


### PR DESCRIPTION
Fixes the bug that made your scheduled job stall on "Needs permission" — and would have hit any job or subagent running any shell command.

## What was happening

The system wraps every job shell command with its own network-proxy settings before running it. The permission check then judged that **wrapped** text instead of the real command. Wrapped text looks like environment tampering, so it was refused outright — and because the proxy port changes every run, no saved approval could ever match either. Nothing the owner granted could fix it.

Seen live: the refused command preview begins `GODEBUG=netdns=go HTTP_PROXY='http://127.0.0.1:18166/'...` — the system's own wrapper, not the agent's command.

## The root cause — one line

The shared wrap function was supposed to *declare* the wrapper so the check could peel it off (built in PERM-3, working for interactive chats). But when a command arrived **already wrapped**, it exited early and declared nothing. Judged wrapped, refused. That one line explains job runs, subagent runs, and the interactive flapping where a retried command got refused again.

A second, smaller half: there were **two** places raising permission requests, and only one carried the declaration.

## The fix — one point of execution

Per the owner's direction: no per-area patching.

- the wrap function now **always declares the prefix**, wrapping only when absent — branches collapsed into one path
- both permission call sites route through **one wrapper** that attaches the wrapped input and its declaration together

Every lane — interactive, jobs, subagents — is now judged on the clean command **by construction**, not by which code path it happens to hit.

## What did not change

- Genuinely suspicious commands (`TZ=Asia/Kolkata date` — user-authored env settings) are **still refused**. Only the system's own declared wrapper is peeled, matched byte-for-byte.
- No fuzzy matching of "things that look like our wrapper" — that would be exactly the smuggling hole the strict design prevents. One narrow case (a command echoed across a proxy-port change) stays refused by design and is recorded as a known limitation.

## Proof

- Four tests reproduced the loss **before** the fix, then passed after
- Saved rules match across proxy-port rotation
- Two older tests pinned the buggy contract (bare command, no declaration); updated knowingly to pin the new pair — wrapped command **plus** declaration — so they fail if either half regresses
- 156 focused tests, then full `verify.py` green

The job that surfaced this was separately fixed at its own level (it no longer shells out at all). This repairs the lane for everything else.

Refs `docs/decisions/0062-perm6-client-signoff.md`.
