### PR TITLE
Expired approvals now actually expire

### DIFF
--- a/apps/core/src/adapters/storage/postgres/repositories/permission-decision-memory-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/permission-decision-memory-repository.postgres.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, gt, isNull, or, sql } from 'drizzle-orm';
 
 import {
   AllowOnceNeverPersistedError,
@@ -162,6 +162,7 @@ export class PostgresPermissionDecisionMemoryRepository implements PermissionDec
           eq(table.kind, input.kind),
           eq(table.lookupIdentity, input.lookupIdentity),
           isNull(table.revokedAt),
+          or(isNull(table.expiresAt), gt(table.expiresAt, sql`now()`)),
         ),
       )
       .limit(1);
@@ -181,6 +182,7 @@ export class PostgresPermissionDecisionMemoryRepository implements PermissionDec
           eq(table.appId, input.appId),
           eq(table.agentFolder, input.agentFolder),
           isNull(table.revokedAt),
+          or(isNull(table.expiresAt), gt(table.expiresAt, sql`now()`)),
           input.kind ? eq(table.kind, input.kind) : undefined,
         ),
       );

--- a/apps/core/test/integration/permission-decision-memory.postgres.integration.test.ts
+++ b/apps/core/test/integration/permission-decision-memory.postgres.integration.test.ts
@@ -100,6 +100,57 @@ maybeDescribe('Postgres permission decision memory', () => {
     expect(row?.canonicalRoot).not.toBeNull();
   });
 
+  it.each([
+    {
+      label: 'past',
+      effectHash: 'effect-expired',
+      expiresAt: '2000-01-01T00:00:00.000Z',
+      returned: false,
+    },
+    {
+      label: 'future',
+      effectHash: 'effect-future',
+      expiresAt: '2999-01-01T00:00:00.000Z',
+      returned: true,
+    },
+    {
+      label: 'NULL',
+      effectHash: 'effect-no-expiry',
+      expiresAt: undefined,
+      returned: true,
+    },
+  ])(
+    'returns only active rows when expires_at is $label',
+    async ({ effectHash, expiresAt, returned }) => {
+      const repository = runtime.repositories.permissionDecisionMemory;
+      await repository.putClassifierVerdict({
+        appId: APP,
+        agentFolder: FOLDER,
+        effectHash,
+        decision: 'allow',
+        reason: 'expiry test',
+        risk_level: 'low',
+        effectSchemaVersion: 1,
+        railVersion: 3,
+        provenance: 'classifier',
+        nowIso: '2026-07-12T00:00:00.000Z',
+        expiresAt,
+      });
+
+      const result = await repository.get({
+        appId: APP,
+        agentFolder: FOLDER,
+        kind: 'classifier_verdict',
+        lookupIdentity: effectHash,
+      });
+      if (returned) {
+        expect(result).toMatchObject({ lookupIdentity: effectHash });
+      } else {
+        expect(result).toBeNull();
+      }
+    },
+  );
+
   it('enforces the (app, folder, kind, lookup_identity) unique constraint', async () => {
     const base = {
       appId: APP,

--- a/apps/core/test/unit/runtime/permission-decision-coordinator.test.ts
+++ b/apps/core/test/unit/runtime/permission-decision-coordinator.test.ts
@@ -331,6 +331,28 @@ describe('coordinatePermissionDecision', () => {
     expect(tail).not.toHaveBeenCalled();
   });
 
+  it('falls through to the live classifier when an expired cached verdict is excluded', async () => {
+    const liveClassifierDecision = {
+      approved: false,
+      mode: 'cancel' as const,
+      decidedBy: 'live_classifier',
+    };
+    const tail = vi.fn(async () => liveClassifierDecision);
+    const getClassifierVerdict = vi.fn(async () => null);
+
+    await expect(
+      coordinatePermissionDecision({
+        request: { ...request },
+        effectHash: 'expired-effect-hash',
+        decisionMemory: { getClassifierVerdict } as never,
+        deterministicRails: () => undefined,
+        tail,
+      }),
+    ).resolves.toEqual(liveClassifierDecision);
+    expect(getClassifierVerdict).toHaveBeenCalledOnce();
+    expect(tail).toHaveBeenCalledOnce();
+  });
+
   it('reuses a cached verdict only within the same parent conversation, including its threads', async () => {
     const base = {
       ...request,

--- a/apps/core/test/unit/storage/permission-decision-memory-guard.test.ts
+++ b/apps/core/test/unit/storage/permission-decision-memory-guard.test.ts
@@ -3,6 +3,81 @@ import { describe, expect, it, vi } from 'vitest';
 import { PostgresPermissionDecisionMemoryRepository } from '@core/adapters/storage/postgres/repositories/permission-decision-memory-repository.postgres.js';
 import { AllowOnceNeverPersistedError } from '@core/domain/ports/permission-decision-memory.js';
 
+function flattenSqlShape(value: unknown, seen = new Set<object>()): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value);
+  }
+  if (typeof value !== 'object' || seen.has(value)) return '';
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((entry) => flattenSqlShape(entry, seen)).join(' ');
+  }
+  const record = value as Record<string | symbol, unknown>;
+  return [
+    flattenSqlShape(record.value, seen),
+    typeof record.name === 'string' ? record.name : '',
+    flattenSqlShape(record.queryChunks, seen),
+    flattenSqlShape(record.config, seen),
+  ].join(' ');
+}
+
+function decisionMemoryRow(input: {
+  lookupIdentity: string;
+  expiresAt: string | null;
+}) {
+  return {
+    id: `row:${input.lookupIdentity}`,
+    appId: 'app',
+    agentFolder: 'main_agent',
+    kind: 'classifier_verdict',
+    lookupIdentity: input.lookupIdentity,
+    effectHash: input.lookupIdentity,
+    decision: 'allow',
+    reason: 'cached allow',
+    riskLevel: 'low',
+    riskCategory: null,
+    canonicalRoot: null,
+    principal: null,
+    effectSchemaVersion: 1,
+    railVersion: 1,
+    provenance: 'classifier',
+    createdAt: '2026-07-12T00:00:00.000Z',
+    expiresAt: input.expiresAt,
+    revokedAt: null,
+  };
+}
+
+function readDb(
+  rows: ReturnType<typeof decisionMemoryRow>[],
+  expiredLookupIdentities: string[] = [],
+) {
+  const expired = new Set(expiredLookupIdentities);
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn((predicate: unknown) => {
+          const sqlShape = flattenSqlShape(predicate);
+          const hasActiveExpiryPredicate =
+            sqlShape.includes('expires_at') &&
+            sqlShape.includes(' is null') &&
+            sqlShape.includes(' or ') &&
+            sqlShape.includes(' > ') &&
+            sqlShape.includes('now()');
+          const filtered = hasActiveExpiryPredicate
+            ? rows.filter((row) => !expired.has(row.lookupIdentity))
+            : rows;
+          return Object.assign(filtered, {
+            limit: vi.fn(async (limit: number) => filtered.slice(0, limit)),
+          });
+        }),
+      })),
+    })),
+  } as unknown as ConstructorParameters<
+    typeof PostgresPermissionDecisionMemoryRepository
+  >[0];
+}
+
 // Stub db whose insert throws a sentinel — proves whether the write path reached
 // the database or was short-circuited by the allow_once guard first.
 const DB_REACHED = new Error('db-reached');
@@ -86,5 +161,72 @@ describe('permission decision memory allow_once guard', () => {
       risk_level: 'low',
       risk_category: 'filesystem',
     });
+  });
+});
+
+describe('permission decision memory active reads', () => {
+  const get = async (expiresAt: string | null, expired = false) => {
+    const row = decisionMemoryRow({
+      lookupIdentity: 'effect-read',
+      expiresAt,
+    });
+    const repository = new PostgresPermissionDecisionMemoryRepository(
+      readDb([row], expired ? [row.lookupIdentity] : []),
+    );
+    return repository.get({
+      appId: row.appId,
+      agentFolder: row.agentFolder,
+      kind: 'classifier_verdict',
+      lookupIdentity: row.lookupIdentity,
+    });
+  };
+
+  it('does not return an expired allow from get', async () => {
+    await expect(get('2000-01-01T00:00:00.000Z', true)).resolves.toBeNull();
+  });
+
+  it('returns a future-dated allow from get', async () => {
+    await expect(get('2999-01-01T00:00:00.000Z')).resolves.toMatchObject({
+      decision: 'allow',
+      expiresAt: '2999-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('returns a NULL-expiry allow from get', async () => {
+    await expect(get(null)).resolves.toMatchObject({
+      decision: 'allow',
+      expiresAt: undefined,
+    });
+  });
+
+  it('excludes expired rows from list while retaining future and NULL expiry rows', async () => {
+    const rows = [
+      decisionMemoryRow({
+        lookupIdentity: 'effect-expired',
+        expiresAt: '2000-01-01T00:00:00.000Z',
+      }),
+      decisionMemoryRow({
+        lookupIdentity: 'effect-future',
+        expiresAt: '2999-01-01T00:00:00.000Z',
+      }),
+      decisionMemoryRow({
+        lookupIdentity: 'effect-no-expiry',
+        expiresAt: null,
+      }),
+    ];
+    const repository = new PostgresPermissionDecisionMemoryRepository(
+      readDb(rows, ['effect-expired']),
+    );
+
+    await expect(
+      repository.list({
+        appId: 'app',
+        agentFolder: 'main_agent',
+        kind: 'classifier_verdict',
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ lookupIdentity: 'effect-future' }),
+      expect.objectContaining({ lookupIdentity: 'effect-no-expiry' }),
+    ]);
   });
 });

--- a/docs/decisions/0063-perm7-client-signoff.md
+++ b/docs/decisions/0063-perm7-client-signoff.md
@@ -1,0 +1,39 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-26
+---
+
+# Perm7 Client Signoff
+
+## Context
+A test-coverage audit of the permission system found, and the orchestrator confirmed in
+source, that classifier decision-memory rows are saved with an `expires_at` but the read path
+never checks it. `get`/`list` in
+`permission-decision-memory-repository.postgres.ts` filter only `revokedAt IS NULL`, and the
+coordinator's cache stage (`permission-decision-coordinator.ts:124-146`) trusts
+`cached.decision === 'allow'` as-is. So an approval meant to lapse keeps auto-allowing forever,
+silently, until revoked by hand or invalidated by a rail-version change.
+
+Trusted-root grants do not share the defect: they pass through `isActiveGrant`
+(`permission-decision-coordinator.ts:251`), which checks both `revokedAt` and `expiresAt`. The
+classifier-verdict path simply never received the same check.
+
+This is stale authority rather than an injection vector, but it undermines the design intent
+that a cached verdict must not outlive the conditions under which it was issued.
+
+## Decision
+Ravi confirmed the fix on 2026-07-26 ("Yes"). Enforce expiry on the decision-memory read path
+so an expired row can never produce an auto-allow, matching the semantics `isActiveGrant`
+already applies to trusted-root grants. He also asked for the audit's identified missing tests
+to be written; that is tracked separately (TEST-1) so this security fix ships without waiting
+on a large test backlog.
+
+## Consequences
+- An expired classifier verdict falls through to the live classifier (or the human), which is
+  the intended ladder.
+- Enforce at the repository read, so every consumer — present and future — inherits the check
+  rather than each caller remembering to apply it. This mirrors the single-choke-point rule
+  applied in PERM-6.
+- Expired rows become dead data; whether to prune them is a retention question, not a
+  correctness one, and stays out of scope here.


### PR DESCRIPTION
Fixes a security gap found by today's coverage audit and confirmed in the code: **approvals with an expiry date never actually expired.**

## What was wrong

When the safety checker approves something, that approval is saved with an expiry. But the code reading saved approvals only checked whether they'd been revoked — never whether they'd expired. So anything approved once kept auto-approving **forever**, silently, until someone revoked it by hand.

The odd part: trusted-folder grants, one function away, *do* check expiry. The checker's approvals just never got the same line.

## The fix

One condition added where approvals are read: not revoked **and** not expired. Compared in the database against the database's own clock, so there's no clock-skew or string-comparison trap. Enforced at the single reading point, so every caller —现有 and future — inherits it automatically. Same principle as yesterday's fix: one choke point, not per-caller patches.

An expired approval now falls through to a fresh safety check or to you — which is how the ladder was always meant to work.

## Proof

- Two tests reproduced the bug first: expired approvals were still being returned
- After the fix: expired excluded, future-dated still honoured, no-expiry still honoured
- The agent falls through to a fresh check when a cached approval has expired
- **Run against a real database** — the 8 integration tests that silently skip on local machines were actually executed. That skip is how bugs like this one survived; not repeating it here.
- Full verify green

## Not included

Expired rows stay in the table as dead data. Cleaning them up is housekeeping, not correctness, and is deliberately out of scope.

Refs `docs/decisions/0063-perm7-client-signoff.md`.
