### PR TITLE
Let the human durably grant tools — by category, not by list

### DIFF
--- a/apps/core/src/adapters/storage/postgres/seeds.ts
+++ b/apps/core/src/adapters/storage/postgres/seeds.ts
@@ -4,7 +4,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as pgSchema from './schema/schema.js';
 import {
   ADMIN_MCP_TOOL_FULL_NAMES,
-  DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES,
+  SEEDED_SCHEDULER_MCP_TOOL_FULL_NAMES,
   adminMcpToolIdForFullName,
 } from '../../../shared/admin-mcp-tools.js';
 import {
@@ -196,7 +196,7 @@ export const DEFAULT_TOOL_CATALOG = [
       'high',
     ),
   ),
-  ...DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES.map((name) =>
+  ...SEEDED_SCHEDULER_MCP_TOOL_FULL_NAMES.map((name) =>
     hostTool(
       name,
       schedulerToolDisplayName(name),

--- a/apps/core/src/application/jobs/job-tool-access-requirements.ts
+++ b/apps/core/src/application/jobs/job-tool-access-requirements.ts
@@ -5,10 +5,7 @@ import {
   parseReadableScopedToolRule,
   RUN_COMMAND_TOOL_NAME,
 } from '../../shared/agent-tool-references.js';
-import {
-  isAdminMcpToolFullName,
-  isDurableSchedulerMcpToolFullName,
-} from '../../shared/admin-mcp-tools.js';
+import { isDurableGantryMcpToolFullName } from '../../shared/admin-mcp-tools.js';
 import { parseSemanticCapabilityRule } from '../../shared/semantic-capability-ids.js';
 import { toolRuleCoversRule } from '../../shared/tool-rule-matcher.js';
 import { validateDurableAccessRule } from '../../shared/durable-access-policy.js';
@@ -197,8 +194,7 @@ export function toolAccessRequirementRecoveryAction(toolName: string): string {
   }
   if (
     isGantryFacadeExactToolRule(toolName) ||
-    isAdminMcpToolFullName(toolName) ||
-    isDurableSchedulerMcpToolFullName(toolName)
+    isDurableGantryMcpToolFullName(toolName)
   ) {
     return `request_access ${JSON.stringify({
       target: { kind: 'tool', name: toolName },

--- a/apps/core/src/application/permissions/permission-management-service.ts
+++ b/apps/core/src/application/permissions/permission-management-service.ts
@@ -35,8 +35,8 @@ import {
 import { permissionDecisionExpiresAt } from './permission-decision-expiry.js';
 import {
   adminMcpToolIdForFullName,
-  isAdminMcpToolFullName,
-  isDurableSchedulerMcpToolFullName,
+  isDurableGantryMcpToolFullName,
+  isKnownGantryMcpToolFullName,
 } from '../../shared/admin-mcp-tools.js';
 import {
   displayToolReference,
@@ -172,24 +172,29 @@ export class PermissionManagementService {
     try {
       for (const allowedRule of allowedRules) {
         const gantryMcpTool = gantryMcpToolFullNameFromRule(allowedRule);
-        let toolId = (
-          isCanonicalBrowserCapabilityRule(allowedRule)
-            ? 'tool:Browser'
-            : gantryMcpTool
-              ? adminMcpToolIdForFullName(gantryMcpTool)
-              : persistentPermissionToolId(input.appId, allowedRule)
-        ) as AgentToolBinding['toolId'];
-        if (gantryMcpTool || isCanonicalBrowserCapabilityRule(allowedRule)) {
+        let toolId: AgentToolBinding['toolId'];
+        if (gantryMcpTool) {
+          const tool = await ensureAgentToolCatalogItem({
+            repository: input.toolRepository,
+            appId: input.appId,
+            reference: gantryMcpTool,
+            now: timestamp,
+            description:
+              'Persistent Gantry tool approved from permission management.',
+            adapterRef: 'permission/request_permission',
+            semanticCapabilityDefinitions: trustedSemanticCapabilityDefinitions,
+          });
+          toolId = tool.id;
+        } else if (isCanonicalBrowserCapabilityRule(allowedRule)) {
+          toolId = 'tool:Browser' as AgentToolBinding['toolId'];
           const existing =
             (await input.toolRepository.getTool(toolId)) ??
-            (isCanonicalBrowserCapabilityRule(allowedRule)
-              ? (
-                  await input.toolRepository.listTools({
-                    appId: input.appId,
-                    statuses: ['active'],
-                  })
-                ).find((tool) => tool.id === toolId)
-              : null);
+            (
+              await input.toolRepository.listTools({
+                appId: input.appId,
+                statuses: ['active'],
+              })
+            ).find((tool) => tool.id === toolId);
           if (
             !existing ||
             existing.appId !== input.appId ||
@@ -595,10 +600,7 @@ function gantryMcpToolFullNameFromRule(allowedRule: string): string | null {
   const trimmed = allowedRule.trim();
   const scoped = parseReadableScopedToolRule(trimmed);
   const toolName = scoped ? scoped.toolName : trimmed;
-  return isAdminMcpToolFullName(toolName) ||
-    isDurableSchedulerMcpToolFullName(toolName)
-    ? toolName
-    : null;
+  return isDurableGantryMcpToolFullName(toolName) ? toolName : null;
 }
 
 function persistentPermissionBindingId(
@@ -684,7 +686,7 @@ function expandedRevocationLiveRules(input: {
 function candidateToolIdsForRule(appId: AppId, rule: string): Set<ToolId> {
   const out = new Set<ToolId>();
   if (isCanonicalBrowserCapabilityRule(rule)) out.add('tool:Browser' as ToolId);
-  if (isAdminMcpToolFullName(rule) || isDurableSchedulerMcpToolFullName(rule)) {
+  if (isKnownGantryMcpToolFullName(rule)) {
     out.add(adminMcpToolIdForFullName(rule) as ToolId);
   }
   const semanticCapabilityId = parseSemanticCapabilityRule(rule);

--- a/apps/core/src/channels/permission-interaction.ts
+++ b/apps/core/src/channels/permission-interaction.ts
@@ -83,6 +83,7 @@ const USER_FACING_TOOL_LABELS: Record<string, string> = {
   AgentDelegation: 'agent delegation',
   Agent: 'agent delegation',
   Task: 'agent delegation',
+  mcp__gantry__mcp_call_tool: 'MCP Call Tool (any connected server)',
 };
 
 export function normalizePermissionAction(

--- a/apps/core/src/domain/tools/agent-tool-catalog-references.ts
+++ b/apps/core/src/domain/tools/agent-tool-catalog-references.ts
@@ -3,7 +3,8 @@ import type { ToolCatalogRepository } from '../ports/repositories.js';
 import type { ToolCatalogItem, ToolId } from './tools.js';
 import {
   adminMcpToolIdForFullName,
-  isAdminMcpToolFullName,
+  isDurableGantryMcpToolFullName,
+  isSeededGantryMcpToolFullName,
 } from '../../shared/admin-mcp-tools.js';
 import {
   persistentPermissionToolId,
@@ -15,7 +16,10 @@ import {
   containsGeneratedRuntimeSkillPath,
   GENERATED_RUNTIME_SKILL_PATH_DURABLE_REJECTION_REASON,
 } from '../../shared/generated-runtime-paths.js';
-import { validateDurableAccessRule } from '../../shared/durable-access-policy.js';
+import {
+  formatDurableAccessRulesForUser,
+  validateDurableAccessRule,
+} from '../../shared/durable-access-policy.js';
 import {
   semanticCapabilityInputSchema,
   semanticCapabilityFromToolCatalogItem,
@@ -42,6 +46,35 @@ export async function ensureAgentToolCatalogItem(input: {
     semanticCapabilityDefinitions: input.semanticCapabilityDefinitions,
   });
   if (!durableValidation.ok) throw new Error(durableValidation.reason);
+  if (isDurableGantryMcpToolFullName(reference)) {
+    const toolId = durableGantryCatalogToolId(input.appId, reference);
+    const existing = await input.repository.getTool(toolId);
+    if (existing) {
+      const validated = validateCatalogTool(input.appId, toolId, existing);
+      if (validated.tool) return validated.tool;
+      throw new Error(validated.error);
+    }
+    const item: ToolCatalogItem = {
+      id: toolId,
+      appId: input.appId,
+      name: reference,
+      kind: 'host',
+      provider: 'gantry',
+      displayName: formatDurableAccessRulesForUser([reference]),
+      description:
+        input.description ??
+        'Persistent Gantry tool approved from settings.yaml.',
+      category: 'admin',
+      risk: 'high',
+      selectable: true,
+      status: 'active',
+      adapterRef: input.adapterRef ?? 'permission/settings.yaml',
+      createdAt: input.now as never,
+      updatedAt: input.now as never,
+    };
+    await input.repository.saveTool(item);
+    return item;
+  }
   const requestedSemanticCapabilityId = parseSemanticCapabilityRule(reference);
   const requestedCapability = requestedSemanticCapabilityId
     ? input.semanticCapabilityDefinitions?.[requestedSemanticCapabilityId]
@@ -185,13 +218,13 @@ export async function resolveAgentToolReference(input: {
   );
   if (byName) return validateCatalogTool(input.appId, byName.id, byName);
 
-  if (isAdminMcpToolFullName(reference)) {
-    const adminId = adminMcpToolIdForFullName(reference);
-    const adminTool = await input.repository.getTool(adminId as ToolId);
-    if (adminTool) {
-      return validateCatalogTool(input.appId, adminId, adminTool);
+  if (isDurableGantryMcpToolFullName(reference)) {
+    const toolId = durableGantryCatalogToolId(input.appId, reference);
+    const tool = await input.repository.getTool(toolId);
+    if (tool) {
+      return validateCatalogTool(input.appId, toolId, tool);
     }
-    return { error: `Tool catalog row ${adminId} is unavailable.` };
+    return {};
   }
 
   const validation = validateReadableAgentToolRule(reference);
@@ -227,6 +260,14 @@ function validateCatalogTool(
     return { error: `Tool catalog row ${reference} is unavailable.` };
   }
   return { tool };
+}
+
+function durableGantryCatalogToolId(appId: AppId, reference: string): ToolId {
+  return (
+    isSeededGantryMcpToolFullName(reference)
+      ? adminMcpToolIdForFullName(reference)
+      : persistentPermissionToolId(appId, reference)
+  ) as ToolId;
 }
 
 function catalogToolMatchesSemanticCapability(

--- a/apps/core/src/runner/gantry-mcp-tool-surface.ts
+++ b/apps/core/src/runner/gantry-mcp-tool-surface.ts
@@ -1,7 +1,14 @@
 import {
   ADMIN_MCP_TOOL_NAMES,
+  ALL_GANTRY_MCP_TOOL_NAMES,
+  ASYNC_TASK_GANTRY_MCP_TOOL_NAMES,
   AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
-  SCHEDULER_MCP_TOOL_NAMES,
+  BASELINE_GANTRY_MCP_TOOL_NAMES,
+  DEFAULT_GANTRY_MCP_TOOL_NAMES,
+  DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
+  GATED_GANTRY_MCP_TOOL_NAMES,
+  OPTIONAL_GANTRY_MCP_TOOL_NAMES,
+  REVIEWED_GANTRY_MCP_TOOL_NAMES,
 } from '../shared/admin-mcp-tools.js';
 import {
   selectedMemoryIpcActionsFromToolRules,
@@ -10,75 +17,23 @@ import {
 } from '../shared/memory-ipc-actions.js';
 import { isCanonicalBrowserCapabilityRule } from '../shared/agent-tool-references.js';
 
-export const BASELINE_GANTRY_MCP_TOOL_NAMES = [
-  'send_message',
-  'ask_user_question',
-  'render_status',
-  'render_facts',
-  'render_list',
-  'render_table',
-  'render_form',
-  'render_media',
-  'render_progress',
-  'todo_update',
-  'memory_search',
-  'memory_save',
-  'brain_search',
-  'brain_query',
-  'brain_write',
-  'continuity_summary',
-  'procedure_save',
-  'request_skill_install',
-  'request_skill_proposal',
-  'pattern_candidate_decision',
-  'proactive_surfacing_consent',
-  'request_skill_dependency_install',
-  'request_mcp_server',
-  'request_access',
-  'file',
-  'agent_profile_read',
-  'request_agent_profile_update',
-  'mcp_list_tools',
-  'mcp_search_tools',
-  'mcp_describe_tool',
-  'mcp_call_tool',
-] as const;
-
-export const ASYNC_TASK_GANTRY_MCP_TOOL_NAMES = [
-  'async_run_command',
-  'async_mcp_call',
-  'task_cancel',
-  'task_get',
-  'task_list',
-] as const;
-
-export const DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES = [
-  'delegate_task',
-  'task_message',
-] as const;
-
 // Authority-changing Gantry tools let an agent request new install/setup/access
 // authority for itself. In the fixed-image worker product mode they are hidden
 // from user-facing live agents and scheduled jobs: workers never install tools,
 // skills, MCP servers, or dependencies during a run. Admin tools are tracked
-// separately in ADMIN_MCP_TOOL_NAMES. The canonical names live in the shared
-// admin-mcp-tools module; this re-export keeps the runner the agent-facing
-// source of truth for the tool surface.
-export { AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES };
-
-export const OPTIONAL_GANTRY_MCP_TOOL_NAMES = [
-  ...SCHEDULER_MCP_TOOL_NAMES,
-] as const;
-
-export const REVIEWED_GANTRY_MCP_TOOL_NAMES = [
-  'memory_patch',
-  'memory_demote',
-  'procedure_patch',
-  'memory_dream',
-  'memory_consolidate',
-  'memory_review_pending',
-  'memory_review_decision',
-] as const;
+// separately in ADMIN_MCP_TOOL_NAMES. The canonical constants live in shared;
+// these re-exports preserve the runner's public tool-surface API.
+export {
+  ALL_GANTRY_MCP_TOOL_NAMES,
+  ASYNC_TASK_GANTRY_MCP_TOOL_NAMES,
+  AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
+  BASELINE_GANTRY_MCP_TOOL_NAMES,
+  DEFAULT_GANTRY_MCP_TOOL_NAMES,
+  DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
+  GATED_GANTRY_MCP_TOOL_NAMES,
+  OPTIONAL_GANTRY_MCP_TOOL_NAMES,
+  REVIEWED_GANTRY_MCP_TOOL_NAMES,
+};
 
 const REVIEWER_MEMORY_REVIEW_GANTRY_MCP_TOOL_NAMES = [
   'memory_review_pending',
@@ -109,28 +64,6 @@ export function isAuthorityChangingGantryMcpToolName(value: string): boolean {
 export function isNoPermissionHiddenGantryMcpToolName(value: string): boolean {
   return NO_PERMISSION_HIDDEN_GANTRY_MCP_TOOL_NAME_SET.has(value);
 }
-
-export const GATED_GANTRY_MCP_TOOL_NAMES = [
-  'browser_status',
-  'browser_open',
-  'browser_inspect',
-  'browser_act',
-  'browser_close',
-] as const;
-
-export const DEFAULT_GANTRY_MCP_TOOL_NAMES = [
-  ...BASELINE_GANTRY_MCP_TOOL_NAMES,
-  ...OPTIONAL_GANTRY_MCP_TOOL_NAMES,
-] as const;
-
-export const ALL_GANTRY_MCP_TOOL_NAMES = [
-  ...DEFAULT_GANTRY_MCP_TOOL_NAMES,
-  ...ASYNC_TASK_GANTRY_MCP_TOOL_NAMES,
-  ...DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
-  ...GATED_GANTRY_MCP_TOOL_NAMES,
-  ...REVIEWED_GANTRY_MCP_TOOL_NAMES,
-  ...ADMIN_MCP_TOOL_NAMES,
-] as const;
 
 const ALL_GANTRY_MCP_TOOL_NAME_SET = new Set<string>(ALL_GANTRY_MCP_TOOL_NAMES);
 

--- a/apps/core/src/shared/admin-mcp-tools.ts
+++ b/apps/core/src/shared/admin-mcp-tools.ts
@@ -29,7 +29,10 @@ export const SCHEDULER_MCP_TOOL_NAMES = [
 
 export type SchedulerMcpToolName = (typeof SCHEDULER_MCP_TOOL_NAMES)[number];
 
-export const DURABLE_SCHEDULER_MCP_TOOL_NAMES = [
+// These scheduler rows predate the general durable-grant rule and remain
+// startup catalog seeds. This list defines seed inventory only, not which
+// Gantry tools may receive durable grants.
+export const SEEDED_SCHEDULER_MCP_TOOL_NAMES = [
   'scheduler_list_models',
   'scheduler_get_job',
   'scheduler_list_jobs',
@@ -41,14 +44,60 @@ export const DURABLE_SCHEDULER_MCP_TOOL_NAMES = [
   'scheduler_get_dead_letter',
 ] as const satisfies readonly SchedulerMcpToolName[];
 
-export type DurableSchedulerMcpToolName =
-  (typeof DURABLE_SCHEDULER_MCP_TOOL_NAMES)[number];
+export type SeededSchedulerMcpToolName =
+  (typeof SEEDED_SCHEDULER_MCP_TOOL_NAMES)[number];
 
-// Authority-changing Gantry tools let an agent request new install/setup/access
-// authority. The canonical names live here
-// (provider-neutral shared layer) so config-layer access policy can consume
-// them without importing the runner adapter; the runner re-exports them as the
-// agent-facing source of truth.
+export const BASELINE_GANTRY_MCP_TOOL_NAMES = [
+  'send_message',
+  'ask_user_question',
+  'render_status',
+  'render_facts',
+  'render_list',
+  'render_table',
+  'render_form',
+  'render_media',
+  'render_progress',
+  'todo_update',
+  'memory_search',
+  'memory_save',
+  'brain_search',
+  'brain_query',
+  'brain_write',
+  'continuity_summary',
+  'procedure_save',
+  'request_skill_install',
+  'request_skill_proposal',
+  'pattern_candidate_decision',
+  'proactive_surfacing_consent',
+  'request_skill_dependency_install',
+  'request_mcp_server',
+  'request_access',
+  'file',
+  'agent_profile_read',
+  'request_agent_profile_update',
+  'mcp_list_tools',
+  'mcp_search_tools',
+  'mcp_describe_tool',
+  'mcp_call_tool',
+] as const;
+
+export const ASYNC_TASK_GANTRY_MCP_TOOL_NAMES = [
+  'async_run_command',
+  'async_mcp_call',
+  'task_cancel',
+  'task_get',
+  'task_list',
+] as const;
+
+export const DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES = [
+  'delegate_task',
+  'task_message',
+] as const;
+
+// A tool is excluded from durable grants if granting it durably would let the
+// agent change what it or another agent is permitted to do, alter runtime
+// configuration or topology, or restart the service. The canonical tool-name
+// registry lives here so every layer validates against the same closed set.
 export const AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES = [
   'request_skill_install',
   'request_skill_proposal',
@@ -56,7 +105,82 @@ export const AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES = [
   'request_mcp_server',
   'request_access',
   'request_agent_profile_update',
+  'admin_permission_revoke',
+  'register_agent',
+  'request_settings_update',
+  'service_restart',
 ] as const;
+
+// Decision actors persist a human consent or review decision. They must remain
+// per-request reviewed so a durable tool grant cannot let the agent assert the
+// human's decision on a later call.
+export const DECISION_ACTOR_GANTRY_MCP_TOOL_NAMES = [
+  'memory_review_decision',
+  'pattern_candidate_decision',
+  'proactive_surfacing_consent',
+] as const;
+
+// Unscoped dispatchers that reach arbitrary tools or commands cannot be
+// durably granted because an exact grant on the dispatcher cannot constrain
+// the actual effect it dispatches to.
+export const DURABLE_GRANT_EXCLUDED_DISPATCHERS = [
+  'mcp_call_tool',
+  'async_mcp_call',
+  'async_run_command',
+] as const;
+
+// Delegation dispatchers start or steer another agent's work. An exact grant
+// cannot bound the tools or commands that delegated agent may use.
+export const DELEGATION_DISPATCHERS = [
+  'delegate_task',
+  'task_message',
+] as const;
+
+export const OPTIONAL_GANTRY_MCP_TOOL_NAMES = [
+  ...SCHEDULER_MCP_TOOL_NAMES,
+] as const;
+
+export const REVIEWED_GANTRY_MCP_TOOL_NAMES = [
+  'memory_patch',
+  'memory_demote',
+  'procedure_patch',
+  'memory_dream',
+  'memory_consolidate',
+  'memory_review_pending',
+  'memory_review_decision',
+] as const;
+
+export const GATED_GANTRY_MCP_TOOL_NAMES = [
+  'browser_status',
+  'browser_open',
+  'browser_inspect',
+  'browser_act',
+  'browser_close',
+] as const;
+
+export const DEFAULT_GANTRY_MCP_TOOL_NAMES = [
+  ...BASELINE_GANTRY_MCP_TOOL_NAMES,
+  ...OPTIONAL_GANTRY_MCP_TOOL_NAMES,
+] as const;
+
+export const ALL_GANTRY_MCP_TOOL_NAMES = [
+  ...DEFAULT_GANTRY_MCP_TOOL_NAMES,
+  ...ASYNC_TASK_GANTRY_MCP_TOOL_NAMES,
+  ...DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
+  ...GATED_GANTRY_MCP_TOOL_NAMES,
+  ...REVIEWED_GANTRY_MCP_TOOL_NAMES,
+  ...ADMIN_MCP_TOOL_NAMES,
+] as const;
+
+export type GantryMcpToolName = (typeof ALL_GANTRY_MCP_TOOL_NAMES)[number];
+
+export type DurableGantryMcpToolBucket =
+  | 'grantable-exact'
+  | 'runtime-projection'
+  | 'unscoped-dispatcher'
+  | 'delegation'
+  | 'authority-changing'
+  | 'decision-actor';
 
 export const ADMIN_MCP_TOOL_FULL_NAMES = ADMIN_MCP_TOOL_NAMES.map(
   (toolName) => `mcp__gantry__${toolName}`,
@@ -66,16 +190,38 @@ export const SCHEDULER_MCP_TOOL_FULL_NAMES = SCHEDULER_MCP_TOOL_NAMES.map(
   (toolName) => `mcp__gantry__${toolName}`,
 ) as readonly `mcp__gantry__${SchedulerMcpToolName}`[];
 
-export const DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES =
-  DURABLE_SCHEDULER_MCP_TOOL_NAMES.map(
+export const SEEDED_SCHEDULER_MCP_TOOL_FULL_NAMES =
+  SEEDED_SCHEDULER_MCP_TOOL_NAMES.map(
     (toolName) => `mcp__gantry__${toolName}`,
-  ) as readonly `mcp__gantry__${DurableSchedulerMcpToolName}`[];
+  ) as readonly `mcp__gantry__${SeededSchedulerMcpToolName}`[];
 
 const ADMIN_MCP_TOOL_NAME_SET = new Set<string>(ADMIN_MCP_TOOL_NAMES);
 const ADMIN_MCP_TOOL_FULL_NAME_SET = new Set<string>(ADMIN_MCP_TOOL_FULL_NAMES);
-const DURABLE_SCHEDULER_MCP_TOOL_FULL_NAME_SET = new Set<string>(
-  DURABLE_SCHEDULER_MCP_TOOL_FULL_NAMES,
+const SEEDED_SCHEDULER_MCP_TOOL_NAME_SET = new Set<string>(
+  SEEDED_SCHEDULER_MCP_TOOL_NAMES,
 );
+const AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAME_SET = new Set<string>(
+  AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
+);
+const DECISION_ACTOR_GANTRY_MCP_TOOL_NAME_SET = new Set<string>(
+  DECISION_ACTOR_GANTRY_MCP_TOOL_NAMES,
+);
+const DURABLE_GRANT_EXCLUDED_DISPATCHER_SET = new Set<string>(
+  DURABLE_GRANT_EXCLUDED_DISPATCHERS,
+);
+const DELEGATION_DISPATCHER_SET = new Set<string>(DELEGATION_DISPATCHERS);
+const ALL_GANTRY_MCP_TOOL_NAME_SET = new Set<string>(ALL_GANTRY_MCP_TOOL_NAMES);
+const GANTRY_MCP_TOOL_FULL_NAME_PATTERN = /^mcp__gantry__([a-z][a-z0-9_]*)$/;
+
+export const GRANTABLE_EXACT_GANTRY_MCP_TOOL_NAMES =
+  ALL_GANTRY_MCP_TOOL_NAMES.filter(
+    (toolName) =>
+      !(GATED_GANTRY_MCP_TOOL_NAMES as readonly string[]).includes(toolName) &&
+      !AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAME_SET.has(toolName) &&
+      !DECISION_ACTOR_GANTRY_MCP_TOOL_NAME_SET.has(toolName) &&
+      !DURABLE_GRANT_EXCLUDED_DISPATCHER_SET.has(toolName) &&
+      !DELEGATION_DISPATCHER_SET.has(toolName),
+  );
 
 export function adminMcpToolFullName(
   toolName: AdminMcpToolName,
@@ -95,8 +241,80 @@ export function isAdminMcpToolFullName(value: string): boolean {
   return ADMIN_MCP_TOOL_FULL_NAME_SET.has(value);
 }
 
-export function isDurableSchedulerMcpToolFullName(value: string): boolean {
-  return DURABLE_SCHEDULER_MCP_TOOL_FULL_NAME_SET.has(value);
+export function isSeededGantryMcpToolFullName(value: string): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return (
+    isAdminMcpToolFullName(value) ||
+    (toolName !== null && SEEDED_SCHEDULER_MCP_TOOL_NAME_SET.has(toolName))
+  );
+}
+
+export function parseExactGantryMcpToolName(value: string): string | null {
+  return GANTRY_MCP_TOOL_FULL_NAME_PATTERN.exec(value)?.[1] ?? null;
+}
+
+export function isKnownGantryMcpToolFullName(value: string): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return toolName !== null && ALL_GANTRY_MCP_TOOL_NAME_SET.has(toolName);
+}
+
+export function isAuthorityChangingGantryMcpToolFullName(
+  value: string,
+): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return (
+    toolName !== null &&
+    AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAME_SET.has(toolName)
+  );
+}
+
+export function isDurableGrantExcludedDispatcherFullName(
+  value: string,
+): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return (
+    toolName !== null && DURABLE_GRANT_EXCLUDED_DISPATCHER_SET.has(toolName)
+  );
+}
+
+export function isDelegationDispatcherFullName(value: string): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return toolName !== null && DELEGATION_DISPATCHER_SET.has(toolName);
+}
+
+export function isDecisionActorGantryMcpToolFullName(value: string): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return (
+    toolName !== null && DECISION_ACTOR_GANTRY_MCP_TOOL_NAME_SET.has(toolName)
+  );
+}
+
+export function classifyDurableGantryMcpToolName(
+  value: string,
+): DurableGantryMcpToolBucket | null {
+  if (!ALL_GANTRY_MCP_TOOL_NAME_SET.has(value)) return null;
+  if ((GATED_GANTRY_MCP_TOOL_NAMES as readonly string[]).includes(value)) {
+    return 'runtime-projection';
+  }
+  if (DURABLE_GRANT_EXCLUDED_DISPATCHER_SET.has(value)) {
+    return 'unscoped-dispatcher';
+  }
+  if (DELEGATION_DISPATCHER_SET.has(value)) return 'delegation';
+  if (AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAME_SET.has(value)) {
+    return 'authority-changing';
+  }
+  if (DECISION_ACTOR_GANTRY_MCP_TOOL_NAME_SET.has(value)) {
+    return 'decision-actor';
+  }
+  return 'grantable-exact';
+}
+
+export function isDurableGantryMcpToolFullName(value: string): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return (
+    toolName !== null &&
+    classifyDurableGantryMcpToolName(toolName) === 'grantable-exact'
+  );
 }
 
 export function adminMcpToolNameFromFullName(

--- a/apps/core/src/shared/durable-access-policy.ts
+++ b/apps/core/src/shared/durable-access-policy.ts
@@ -1,7 +1,12 @@
 import {
   isAdminMcpToolFullName,
+  isAuthorityChangingGantryMcpToolFullName,
+  isDecisionActorGantryMcpToolFullName,
+  isDelegationDispatcherFullName,
+  isDurableGrantExcludedDispatcherFullName,
+  isDurableGantryMcpToolFullName,
   isGantryMcpWildcardRule,
-  isDurableSchedulerMcpToolFullName,
+  parseExactGantryMcpToolName,
 } from './admin-mcp-tools.js';
 import {
   type BashCommandLeaf,
@@ -10,8 +15,10 @@ import {
   wildcardSensitiveBashLeafReason,
 } from './bash-command-parser.js';
 import {
+  BROWSER_PROJECTED_MCP_RULE_REJECTION_REASON,
   isCanonicalBrowserCapabilityRule,
   isGantryFacadeExactToolRule,
+  isProjectedBrowserMcpToolRule,
   parseReadableScopedToolRule,
   RUN_COMMAND_TOOL_NAME,
   validateReadableAgentToolRule,
@@ -44,13 +51,26 @@ import {
  *   - canonical Browser
  *   - exact Gantry facade file/web tools
  *   - exact Gantry admin MCP tools (the closed admin allowlist)
- *   - exact Gantry scheduler MCP tools
+ *   - exact Gantry MCP tools except unscoped dispatchers, delegation
+ *     dispatchers, authority/config-changing tools, and decision actors
  *   - scoped `RunCommand(...)` with the bash-parser durable safety rejections
  * Gantry MCP wildcards and generated runtime skill paths are rejected.
  */
 
 export const DURABLE_ACCESS_RULE_REJECTION_REASON =
-  'Persistent access approvals support only trusted projected semantic capabilities, canonical Browser, exact Gantry file/web tools, scoped RunCommand(...), or exact Gantry admin/scheduler tools; use request_access with target.kind=capability for reviewed semantic app/tool access.';
+  'Persistent access approvals support only trusted projected semantic capabilities, canonical Browser, exact Gantry file/web tools, scoped RunCommand(...), or exact Gantry tools except unscoped dispatchers, delegation dispatchers, authority/config-changing tools, and decision actors.';
+
+export const AUTHORITY_CHANGING_GANTRY_MCP_TOOL_REJECTION_REASON =
+  'Authority/config-changing Gantry tools cannot be granted persistent access because they can change what an agent is permitted to do, alter runtime configuration or topology, or restart the service; review each request explicitly.';
+
+export const DECISION_ACTOR_GANTRY_MCP_TOOL_REJECTION_REASON =
+  'Gantry tools that record a durable user consent or review decision cannot be granted persistent access because the agent must not assert the human decision without per-request review.';
+
+export const DURABLE_GRANT_EXCLUDED_DISPATCHER_REJECTION_REASON =
+  'Unscoped Gantry dispatchers cannot be granted persistent access because an exact grant on the dispatcher cannot constrain the arbitrary tool or command it dispatches to; use a scoped command or reviewed target-specific capability instead.';
+
+export const DELEGATION_DISPATCHER_REJECTION_REASON =
+  "Gantry delegation dispatchers cannot be granted persistent access because an exact grant cannot bound the tools or commands used by another agent's delegated work; review each delegation or steering request explicitly.";
 
 export interface DurableAccessRuleOptions {
   semanticCapabilityDefinitions?: Record<string, SemanticCapabilityDefinition>;
@@ -69,6 +89,9 @@ export function validateDurableAccessRule(
   options: DurableAccessRuleOptions = {},
 ): { ok: true } | { ok: false; reason: string } {
   const trimmed = rule.trim();
+  const scoped = parseReadableScopedToolRule(trimmed);
+  const underlyingExactToolName = scoped?.toolName ?? trimmed;
+
   if (isGantryMcpWildcardRule(trimmed)) {
     return {
       ok: false,
@@ -77,7 +100,38 @@ export function validateDurableAccessRule(
     };
   }
 
-  const scoped = parseReadableScopedToolRule(trimmed);
+  if (isProjectedBrowserMcpToolRule(trimmed)) {
+    return {
+      ok: false,
+      reason: BROWSER_PROJECTED_MCP_RULE_REJECTION_REASON,
+    };
+  }
+  if (isAuthorityChangingGantryMcpToolFullName(underlyingExactToolName)) {
+    return {
+      ok: false,
+      reason: AUTHORITY_CHANGING_GANTRY_MCP_TOOL_REJECTION_REASON,
+    };
+  }
+  if (isDurableGrantExcludedDispatcherFullName(underlyingExactToolName)) {
+    return {
+      ok: false,
+      reason: DURABLE_GRANT_EXCLUDED_DISPATCHER_REJECTION_REASON,
+    };
+  }
+  if (isDelegationDispatcherFullName(underlyingExactToolName)) {
+    return {
+      ok: false,
+      reason: DELEGATION_DISPATCHER_REJECTION_REASON,
+    };
+  }
+  if (isDecisionActorGantryMcpToolFullName(underlyingExactToolName)) {
+    return {
+      ok: false,
+      reason: DECISION_ACTOR_GANTRY_MCP_TOOL_REJECTION_REASON,
+    };
+  }
+  if (isDurableGantryMcpToolFullName(trimmed)) return { ok: true };
+
   if (scoped?.toolName === RUN_COMMAND_TOOL_NAME) {
     if (containsGeneratedRuntimeSkillPath(scoped.scope)) {
       return {
@@ -167,7 +221,6 @@ export function validateDurableAccessRule(
 
   if (isCanonicalBrowserCapabilityRule(trimmed)) return { ok: true };
   if (isAdminMcpToolFullName(trimmed)) return { ok: true };
-  if (isDurableSchedulerMcpToolFullName(trimmed)) return { ok: true };
 
   return {
     ok: false,
@@ -228,10 +281,11 @@ function formatDurableAccessRuleForUser(
     ? trimmed.replace(/^mcp__gantry__/, '').replaceAll(/[._-]+/g, ' ')
     : undefined;
   if (adminName) return `Gantry ${titleCase(adminName)}`;
-  const schedulerName = isDurableSchedulerMcpToolFullName(trimmed)
-    ? trimmed.replace(/^mcp__gantry__scheduler_/, '').replaceAll(/[._-]+/g, ' ')
-    : undefined;
-  if (schedulerName) return `Scheduler ${titleCase(schedulerName)}`;
+  const gantryName = parseExactGantryMcpToolName(trimmed);
+  if (gantryName === 'mcp_call_tool') {
+    return 'MCP Call Tool (any connected server)';
+  }
+  if (gantryName) return titleCase(gantryName.replaceAll(/[._-]+/g, ' '));
   return truncate(redactSensitiveText(trimmed), 160);
 }
 

--- a/apps/core/src/shared/tool-execution-policy-service.ts
+++ b/apps/core/src/shared/tool-execution-policy-service.ts
@@ -8,10 +8,7 @@ import {
   normalizeBashLeafRuleContent,
   parseBashCommand,
 } from './bash-command-parser.js';
-import {
-  isAdminMcpToolFullName,
-  isDurableSchedulerMcpToolFullName,
-} from './admin-mcp-tools.js';
+import { isDurableGantryMcpToolFullName } from './admin-mcp-tools.js';
 import {
   isKnownProjectedBrowserMcpToolName,
   publicGantryToolNameForSdkTool,
@@ -610,11 +607,8 @@ function autonomousGrantRecovery(
     }
     return `request_access { "target": { "kind": "run_command", "argvPattern": "${escapeJson(rule)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scoped command access." }`;
   }
-  if (isAdminMcpToolFullName(request.toolName)) {
-    return `Use the Agent Access summary to find and request the reviewed admin capability for ${request.toolName}; exact tool grants are not accepted as durable authority.`;
-  }
-  if (isDurableSchedulerMcpToolFullName(request.toolName)) {
-    return `request_access { "target": { "kind": "tool", "name": "${escapeJson(request.toolName)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scheduler access." }`;
+  if (isDurableGantryMcpToolFullName(request.toolName)) {
+    return `request_access { "target": { "kind": "tool", "name": "${escapeJson(request.toolName)}" }, "temporaryOnly": false, "reason": "This autonomous run needs exact Gantry tool access." }`;
   }
   const thirdPartyMcp = thirdPartyMcpToolServerName(request.toolName);
   if (thirdPartyMcp) {

--- a/apps/core/test/unit/application/job-tool-access-requirements.test.ts
+++ b/apps/core/test/unit/application/job-tool-access-requirements.test.ts
@@ -34,7 +34,7 @@ describe('job tool access requirements', () => {
     ]);
   });
 
-  it('rejects raw browser and broad wildcard tool access requirement rules', () => {
+  it('rejects projected and host-private browser tools plus broad wildcards', () => {
     expect(() =>
       normalizeToolAccessRequirements([
         'mcp__browser' + '_' + 'backend' + '__navigate',
@@ -174,12 +174,28 @@ describe('job tool access requirements', () => {
     expect(delegationAction).toContain('"kind":"tool"');
     expect(delegationAction).toContain('"name":"AgentDelegation"');
 
-    const adminAction = toolAccessRequirementRecoveryAction(
+    for (const toolName of [
+      'mcp__gantry__scheduler_upsert_job',
+      'mcp__gantry__scheduler_update_job',
+      'mcp__gantry__scheduler_delete_job',
+      'mcp__gantry__scheduler_pause_job',
+      'mcp__gantry__scheduler_resume_job',
+    ]) {
+      const action = toolAccessRequirementRecoveryAction(toolName);
+      expect(action, toolName).toContain('"kind":"tool"');
+      expect(action, toolName).toContain(`"name":"${toolName}"`);
+    }
+
+    for (const toolName of [
+      'mcp__gantry__mcp_call_tool',
+      'mcp__gantry__delegate_task',
       'mcp__gantry__request_settings_update',
-    );
-    expect(adminAction).toContain('"kind":"tool"');
-    expect(adminAction).toContain(
-      '"name":"mcp__gantry__request_settings_update"',
-    );
+      'mcp__gantry__memory_review_decision',
+    ]) {
+      expect(
+        toolAccessRequirementRecoveryAction(toolName),
+        toolName,
+      ).not.toContain('"kind":"tool"');
+    }
   });
 });

--- a/apps/core/test/unit/application/permission-management-service.test.ts
+++ b/apps/core/test/unit/application/permission-management-service.test.ts
@@ -16,6 +16,10 @@ import type {
 } from '@core/domain/tools/tools.js';
 import { persistentPermissionToolId } from '@core/shared/agent-tool-references.js';
 import {
+  adminMcpToolIdForFullName,
+  isDurableGantryMcpToolFullName,
+} from '@core/shared/admin-mcp-tools.js';
+import {
   appendLiveToolRules,
   readLiveToolRules,
 } from '@core/shared/live-tool-rules.js';
@@ -718,6 +722,62 @@ describe('PermissionManagementService', () => {
     expect(mirrorAgentToolRulesToSettings).not.toHaveBeenCalled();
   });
 
+  it('creates a catalog row when a human grants a newly durable Gantry tool', async () => {
+    const service = new PermissionManagementService({
+      now: () => '2026-05-15T12:00:00.000Z',
+    });
+    const saveTool = vi.fn(async () => undefined);
+    const saveAgentToolBinding = vi.fn(async () => undefined);
+    const mirrorAgentToolRulesToSettings = vi.fn(async () => undefined);
+
+    const persisted = await service.applyPersistentToolRuleGrant({
+      appId: 'app:test' as never,
+      agentId: 'agent:test' as never,
+      sourceAgentFolder: 'main_agent',
+      updates: [
+        {
+          type: 'addRules',
+          behavior: 'allow',
+          rules: [{ toolName: 'mcp__gantry__task_cancel' }],
+        },
+      ],
+      toolRepository: {
+        getTool: vi.fn(async () => null),
+        listTools: vi.fn(async () => []),
+        saveTool,
+        saveAgentToolBinding,
+        disableAgentToolBinding: vi.fn(async () => null),
+        listAgentToolBindings: vi.fn(async () => []),
+        listAgentToolBindingsForAgents: vi.fn(),
+      },
+      mirrorAgentToolRulesToSettings,
+    });
+
+    expect(persisted).toEqual(['mcp__gantry__task_cancel']);
+    expect(saveTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: persistentPermissionToolId('app:test', 'mcp__gantry__task_cancel'),
+        name: 'mcp__gantry__task_cancel',
+        displayName: 'Task Cancel',
+        risk: 'high',
+      }),
+    );
+    expect(saveAgentToolBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolId: persistentPermissionToolId(
+          'app:test',
+          'mcp__gantry__task_cancel',
+        ),
+        status: 'active',
+      }),
+    );
+    expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
+      'main_agent',
+      ['mcp__gantry__task_cancel'],
+      { appId: 'app:test' },
+    );
+  });
+
   it('revokes a current-agent persistent tool grant and mirrors settings removal', async () => {
     const { repository, saveDecision } = permissionRepository();
     const service = new PermissionManagementService({
@@ -767,14 +827,70 @@ describe('PermissionManagementService', () => {
     expect(decision.actionPreview).toContain('revoke FileRead');
   });
 
-  it('revokes exact scheduler MCP grants through the scheduler catalog binding', async () => {
+  it('revokes legacy fixed-ID grants for Gantry tools that are no longer grantable', async () => {
     const service = new PermissionManagementService({
       now: () => '2026-05-15T12:00:00.000Z',
     });
+
+    for (const toolName of ['service_restart', 'admin_permission_revoke']) {
+      const fullName = `mcp__gantry__${toolName}`;
+      expect(isDurableGantryMcpToolFullName(fullName)).toBe(false);
+      const tool: ToolCatalogItem = {
+        ...toolItem(fullName),
+        id: `tool:${fullName}` as never,
+        name: fullName,
+      };
+      const binding = activeBinding(tool);
+      const disableAgentToolBinding = vi.fn(async () => ({
+        ...binding,
+        status: 'disabled' as const,
+      }));
+      const mirrorAgentToolRulesToSettings = vi.fn(async () => undefined);
+
+      const result = await service.revokePersistentToolRuleGrant({
+        appId: 'app:test' as never,
+        agentId: 'agent:test' as never,
+        sourceAgentFolder: 'main_agent',
+        toolName: fullName,
+        toolRepository: {
+          getTool: vi.fn(async () => null),
+          listTools: vi.fn(async () => []),
+          saveTool: vi.fn(),
+          saveAgentToolBinding: vi.fn(),
+          disableAgentToolBinding,
+          listAgentToolBindings: vi.fn(async () => [binding]),
+          listAgentToolBindingsForAgents: vi.fn(),
+        },
+        mirrorAgentToolRulesToSettings,
+      });
+
+      expect(result).toEqual({
+        revokedRule: fullName,
+        toolId: `tool:${fullName}`,
+      });
+      expect(disableAgentToolBinding).toHaveBeenCalledWith({
+        appId: 'app:test',
+        agentId: 'agent:test',
+        toolId: `tool:${fullName}`,
+        updatedAt: '2026-05-15T12:00:00.000Z',
+      });
+      expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
+        'main_agent',
+        [fullName],
+        { appId: 'app:test', mode: 'remove' },
+      );
+    }
+  });
+
+  it('revokes a seeded scheduler grant through its fixed catalog ID', async () => {
+    const service = new PermissionManagementService({
+      now: () => '2026-05-15T12:00:00.000Z',
+    });
+    const rule = 'mcp__gantry__scheduler_run_now';
     const tool: ToolCatalogItem = {
-      ...toolItem('mcp__gantry__scheduler_run_now'),
-      id: 'tool:mcp__gantry__scheduler_run_now' as never,
-      name: 'mcp__gantry__scheduler_run_now',
+      ...toolItem(rule),
+      id: adminMcpToolIdForFullName(rule) as never,
+      name: rule,
     };
     const binding = activeBinding(tool);
     const disableAgentToolBinding = vi.fn(async () => ({
@@ -787,10 +903,10 @@ describe('PermissionManagementService', () => {
       appId: 'app:test' as never,
       agentId: 'agent:test' as never,
       sourceAgentFolder: 'main_agent',
-      toolName: 'mcp__gantry__scheduler_run_now',
+      toolName: rule,
       toolRepository: {
         getTool: vi.fn(async (toolId: string) =>
-          toolId === 'tool:mcp__gantry__scheduler_run_now' ? tool : null,
+          toolId === tool.id ? tool : null,
         ),
         listTools: vi.fn(async () => [tool]),
         saveTool: vi.fn(),
@@ -803,18 +919,81 @@ describe('PermissionManagementService', () => {
     });
 
     expect(result).toEqual({
-      revokedRule: 'mcp__gantry__scheduler_run_now',
-      toolId: 'tool:mcp__gantry__scheduler_run_now',
+      revokedRule: rule,
+      toolId: adminMcpToolIdForFullName(rule),
     });
     expect(disableAgentToolBinding).toHaveBeenCalledWith({
       appId: 'app:test',
       agentId: 'agent:test',
-      toolId: 'tool:mcp__gantry__scheduler_run_now',
+      toolId: adminMcpToolIdForFullName(rule),
       updatedAt: '2026-05-15T12:00:00.000Z',
     });
     expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
       'main_agent',
-      ['mcp__gantry__scheduler_run_now'],
+      [rule],
+      { appId: 'app:test', mode: 'remove' },
+    );
+  });
+
+  it('revokes an app-scoped grant for a newly durable Gantry tool', async () => {
+    const service = new PermissionManagementService({
+      now: () => '2026-05-15T12:00:00.000Z',
+    });
+    const tool: ToolCatalogItem = {
+      ...toolItem('mcp__gantry__scheduler_resume_job'),
+      name: 'mcp__gantry__scheduler_resume_job',
+    };
+    const binding = activeBinding(tool);
+    const disableAgentToolBinding = vi.fn(async () => ({
+      ...binding,
+      status: 'disabled' as const,
+    }));
+    const mirrorAgentToolRulesToSettings = vi.fn(async () => undefined);
+
+    const result = await service.revokePersistentToolRuleGrant({
+      appId: 'app:test' as never,
+      agentId: 'agent:test' as never,
+      sourceAgentFolder: 'main_agent',
+      toolName: 'mcp__gantry__scheduler_resume_job',
+      toolRepository: {
+        getTool: vi.fn(async (toolId: string) =>
+          toolId ===
+          persistentPermissionToolId(
+            'app:test',
+            'mcp__gantry__scheduler_resume_job',
+          )
+            ? tool
+            : null,
+        ),
+        listTools: vi.fn(async () => [tool]),
+        saveTool: vi.fn(),
+        saveAgentToolBinding: vi.fn(),
+        disableAgentToolBinding,
+        listAgentToolBindings: vi.fn(async () => [binding]),
+        listAgentToolBindingsForAgents: vi.fn(),
+      },
+      mirrorAgentToolRulesToSettings,
+    });
+
+    expect(result).toEqual({
+      revokedRule: 'mcp__gantry__scheduler_resume_job',
+      toolId: persistentPermissionToolId(
+        'app:test',
+        'mcp__gantry__scheduler_resume_job',
+      ),
+    });
+    expect(disableAgentToolBinding).toHaveBeenCalledWith({
+      appId: 'app:test',
+      agentId: 'agent:test',
+      toolId: persistentPermissionToolId(
+        'app:test',
+        'mcp__gantry__scheduler_resume_job',
+      ),
+      updatedAt: '2026-05-15T12:00:00.000Z',
+    });
+    expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
+      'main_agent',
+      ['mcp__gantry__scheduler_resume_job'],
       { appId: 'app:test', mode: 'remove' },
     );
   });

--- a/apps/core/test/unit/channels/permission-interaction.test.ts
+++ b/apps/core/test/unit/channels/permission-interaction.test.ts
@@ -27,6 +27,27 @@ function requestWithSuggestions(
 }
 
 describe('permission interaction', () => {
+  it('labels the generic MCP passthrough as access to any connected server', () => {
+    const text = formatPermissionPromptText(
+      {
+        requestId: 'permission_123',
+        sourceAgentFolder: 'main_agent',
+        toolName: 'mcp__gantry__mcp_call_tool',
+        suggestions: [
+          {
+            type: 'addRules',
+            behavior: 'allow',
+            destination: 'session',
+            rules: [{ toolName: 'mcp__gantry__mcp_call_tool' }],
+          },
+        ],
+      },
+      60_000,
+    );
+
+    expect(text).toContain('MCP Call Tool (any connected server)');
+  });
+
   it('renders request risk exactly once in plain-text and structured prompt paths', () => {
     const request: PermissionApprovalRequest = {
       ...requestWithSuggestions([]),

--- a/apps/core/test/unit/domain/agent-tool-catalog-references.test.ts
+++ b/apps/core/test/unit/domain/agent-tool-catalog-references.test.ts
@@ -2,9 +2,134 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ensureAgentToolCatalogItem } from '@core/domain/tools/agent-tool-catalog-references.js';
 import type { ToolCatalogRepository } from '@core/domain/ports/repositories.js';
+import type { ToolCatalogItem } from '@core/domain/tools/tools.js';
+import { persistentPermissionToolId } from '@core/shared/agent-tool-references.js';
+import { adminMcpToolIdForFullName } from '@core/shared/admin-mcp-tools.js';
 import type { SemanticCapabilityDefinition } from '@core/shared/semantic-capabilities.js';
 
 describe('agent tool catalog references', () => {
+  it('returns an existing seeded admin row without overwriting its curated fields', async () => {
+    const existing: ToolCatalogItem = {
+      id: 'tool:mcp__gantry__settings_desired_state' as never,
+      appId: 'default' as never,
+      name: 'mcp__gantry__settings_desired_state',
+      kind: 'host',
+      provider: 'gantry',
+      displayName: 'Settings Desired State',
+      description: 'Curated admin seed row.',
+      category: 'admin',
+      risk: 'low',
+      selectable: true,
+      status: 'active',
+      adapterRef: 'builtin:mcp__gantry__settings_desired_state',
+      createdAt: '2026-05-01T00:00:00.000Z' as never,
+      updatedAt: '2026-05-01T00:00:00.000Z' as never,
+    };
+    const saveTool = vi.fn(async () => undefined);
+    const repository = {
+      listTools: vi.fn(async () => []),
+      getTool: vi.fn(async () => existing),
+      saveTool,
+    } as unknown as ToolCatalogRepository;
+
+    const item = await ensureAgentToolCatalogItem({
+      repository,
+      appId: 'default' as never,
+      reference: 'mcp__gantry__settings_desired_state',
+      now: '2026-07-26T00:00:00.000Z',
+    });
+
+    expect(item).toBe(existing);
+    expect(item).toMatchObject({
+      category: 'admin',
+      risk: 'low',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    expect(saveTool).not.toHaveBeenCalled();
+  });
+
+  it('returns an existing seeded scheduler row without creating a duplicate', async () => {
+    const rule = 'mcp__gantry__scheduler_run_now';
+    const existing: ToolCatalogItem = {
+      id: adminMcpToolIdForFullName(rule) as never,
+      appId: 'default' as never,
+      name: rule,
+      kind: 'host',
+      provider: 'gantry',
+      displayName: 'Run Job Now',
+      description: 'Curated scheduler seed row.',
+      category: 'admin',
+      risk: 'high',
+      selectable: true,
+      status: 'active',
+      adapterRef: `builtin:${rule}`,
+      createdAt: '2026-05-01T00:00:00.000Z' as never,
+      updatedAt: '2026-05-01T00:00:00.000Z' as never,
+    };
+    const saveTool = vi.fn(async () => undefined);
+    const repository = {
+      listTools: vi.fn(async () => []),
+      getTool: vi.fn(async (toolId: string) =>
+        toolId === existing.id ? existing : null,
+      ),
+      saveTool,
+    } as unknown as ToolCatalogRepository;
+
+    const item = await ensureAgentToolCatalogItem({
+      repository,
+      appId: 'default' as never,
+      reference: rule,
+      now: '2026-07-26T00:00:00.000Z',
+    });
+
+    expect(item).toBe(existing);
+    expect(repository.getTool).toHaveBeenCalledWith(existing.id);
+    expect(saveTool).not.toHaveBeenCalled();
+  });
+
+  it('creates separate active rows when two apps durably grant the same non-admin Gantry tool', async () => {
+    const tools = new Map<string, ToolCatalogItem>();
+    const saveTool = vi.fn(async (tool: ToolCatalogItem) => {
+      tools.set(tool.id, tool);
+    });
+    const repository = {
+      listTools: vi.fn(async ({ appId }: { appId: string }) =>
+        [...tools.values()].filter((tool) => tool.appId === appId),
+      ),
+      getTool: vi.fn(async (toolId: string) => tools.get(toolId)),
+      saveTool,
+    } as unknown as ToolCatalogRepository;
+
+    const rule = 'mcp__gantry__scheduler_resume_job';
+    const appA = await ensureAgentToolCatalogItem({
+      repository,
+      appId: 'app:a' as never,
+      reference: rule,
+      now: '2026-07-26T00:00:00.000Z',
+    });
+    const appB = await ensureAgentToolCatalogItem({
+      repository,
+      appId: 'app:b' as never,
+      reference: rule,
+      now: '2026-07-26T00:00:00.000Z',
+    });
+
+    expect(appA).toMatchObject({
+      id: persistentPermissionToolId('app:a', rule),
+      appId: 'app:a',
+      name: rule,
+      status: 'active',
+    });
+    expect(appB).toMatchObject({
+      id: persistentPermissionToolId('app:b', rule),
+      appId: 'app:b',
+      name: rule,
+      status: 'active',
+    });
+    expect(appA.id).not.toBe(appB.id);
+    expect(saveTool).toHaveBeenCalledTimes(2);
+  });
+
   it('refreshes semantic capability rows from supplied reviewed definitions instead of stale projections', async () => {
     const reviewedDefinition: SemanticCapabilityDefinition = {
       capabilityId: 'acme.records.append',

--- a/apps/core/test/unit/jobs/request-permission-review.test.ts
+++ b/apps/core/test/unit/jobs/request-permission-review.test.ts
@@ -224,14 +224,55 @@ describe('request permission review helpers', () => {
     }
   });
 
-  it('does not suggest persistent grants for scheduler mutation tool requests', () => {
+  it('suggests persistent grants for scheduler mutation tool requests', () => {
+    for (const toolName of [
+      'mcp__gantry__scheduler_upsert_job',
+      'mcp__gantry__scheduler_update_job',
+      'mcp__gantry__scheduler_delete_job',
+      'mcp__gantry__scheduler_pause_job',
+      'mcp__gantry__scheduler_resume_job',
+    ]) {
+      expect(
+        requestPermissionSetupDecisionOptions({
+          permissionKind: 'tool',
+          toolName,
+          temporaryOnly: false,
+        }),
+        toolName,
+      ).toContain('allow_persistent_rule');
+    }
+  });
+
+  it('suggests grantable admin tools but excludes all four non-durable categories', () => {
     expect(
-      requestPermissionSetupDecisionOptions({
+      requestPermissionReviewSuggestions({
         permissionKind: 'tool',
-        toolName: 'mcp__gantry__scheduler_upsert_job',
+        toolName: 'mcp__gantry__admin_permission_list',
         temporaryOnly: false,
       }),
-    ).not.toContain('allow_persistent_rule');
+    ).toEqual([
+      {
+        type: 'addRules',
+        behavior: 'allow',
+        destination: 'session',
+        rules: [{ toolName: 'mcp__gantry__admin_permission_list' }],
+      },
+    ]);
+    for (const toolName of [
+      'mcp__gantry__mcp_call_tool',
+      'mcp__gantry__delegate_task',
+      'mcp__gantry__admin_permission_revoke',
+      'mcp__gantry__memory_review_decision',
+    ]) {
+      expect(
+        requestPermissionReviewSuggestions({
+          permissionKind: 'tool',
+          toolName,
+          temporaryOnly: false,
+        }),
+        toolName,
+      ).toBeUndefined();
+    }
   });
 
   it('prefers explicit scoped RunCommand permission over capability metadata on setup requests', () => {
@@ -584,13 +625,13 @@ describe('request permission review helpers', () => {
     );
   });
 
-  it('binds exact admin MCP tools without creating synthetic wildcard grants', async () => {
+  it('binds grantable exact admin MCP tools without creating synthetic wildcard grants', async () => {
     const ipcDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gantry-admin-live-tool-rules-'),
     );
     const repository = {
       getTool: vi.fn(async () => ({
-        id: 'tool:mcp__gantry__service_restart',
+        id: 'tool:mcp__gantry__admin_permission_list',
         appId: 'app:test',
         status: 'active',
         selectable: true,
@@ -612,19 +653,19 @@ describe('request permission review helpers', () => {
         {
           type: 'addRules',
           behavior: 'allow',
-          rules: [{ toolName: 'mcp__gantry__service_restart' }],
+          rules: [{ toolName: 'mcp__gantry__admin_permission_list' }],
         },
       ],
     });
 
-    expect(persisted).toEqual(['mcp__gantry__service_restart']);
+    expect(persisted).toEqual(['mcp__gantry__admin_permission_list']);
     expect(repository.getTool).toHaveBeenCalledWith(
-      'tool:mcp__gantry__service_restart',
+      'tool:mcp__gantry__admin_permission_list',
     );
     expect(repository.saveTool).not.toHaveBeenCalled();
     expect(repository.saveAgentToolBinding).toHaveBeenCalledWith(
       expect.objectContaining({
-        toolId: 'tool:mcp__gantry__service_restart',
+        toolId: 'tool:mcp__gantry__admin_permission_list',
         status: 'active',
       }),
     );
@@ -635,7 +676,7 @@ describe('request permission review helpers', () => {
           'utf-8',
         ),
       ),
-    ).toEqual(['mcp__gantry__service_restart']);
+    ).toEqual(['mcp__gantry__admin_permission_list']);
   });
 
   it('binds persistent Browser approvals to the catalog Browser tool and mirrors settings', async () => {
@@ -1797,7 +1838,7 @@ describe('request permission review helpers', () => {
   it('rejects scoped admin MCP tool approvals', async () => {
     const repository = {
       getTool: vi.fn(async () => ({
-        id: 'tool:mcp__gantry__service_restart',
+        id: 'tool:mcp__gantry__admin_permission_list',
         appId: 'app:test',
         status: 'active',
         selectable: true,
@@ -1820,7 +1861,7 @@ describe('request permission review helpers', () => {
             behavior: 'allow',
             rules: [
               {
-                toolName: 'mcp__gantry__service_restart',
+                toolName: 'mcp__gantry__admin_permission_list',
                 ruleContent: 'reason=test',
               },
             ],

--- a/apps/core/test/unit/runner/agent-runner-ipc.test.ts
+++ b/apps/core/test/unit/runner/agent-runner-ipc.test.ts
@@ -2397,36 +2397,53 @@ describe('agent-runner IPC lifecycle', () => {
   );
 
   it(
-    'synthesizes exact persistent permission suggestions for Gantry admin tools',
+    'synthesizes persistent suggestions only for grantable Gantry admin tools',
     async () => {
-      const fixture = createRunnerFixture();
+      const grantableFixture = createRunnerFixture();
 
-      const result = await runRunner(fixture, baseInput(), {
+      const grantableResult = await runRunner(grantableFixture, baseInput(), {
         TEST_PERMISSION_DECISION: 'approve',
-        TEST_PERMISSION_TOOL_NAME: 'mcp__gantry__service_restart',
+        TEST_PERMISSION_TOOL_NAME: 'mcp__gantry__admin_permission_list',
         TEST_PERMISSION_SCOPE: 'environment:staging',
         TEST_EXIT_AFTER_QUERY: '1',
       });
 
-      expect(result.exitCode).toBe(0);
-      const call = readRecord(fixture.recordPath).calls[0];
-      expect(call?.permissionRequest).toEqual(
+      expect(grantableResult.exitCode).toBe(0);
+      const grantableCall = readRecord(grantableFixture.recordPath).calls[0];
+      expect(grantableCall?.permissionRequest).toEqual(
         expect.objectContaining({
-          toolName: 'mcp__gantry__service_restart',
+          toolName: 'mcp__gantry__admin_permission_list',
           suggestions: [
             {
               type: 'addRules',
               behavior: 'allow',
               destination: 'session',
-              rules: [{ toolName: 'mcp__gantry__service_restart' }],
+              rules: [{ toolName: 'mcp__gantry__admin_permission_list' }],
             },
           ],
         }),
       );
-      expect(call?.permissionDecision).toEqual({
+      expect(grantableCall?.permissionDecision).toEqual({
         behavior: 'allow',
         updatedInput: { scope: 'environment:staging' },
       });
+
+      const excludedFixture = createRunnerFixture();
+      const excludedResult = await runRunner(excludedFixture, baseInput(), {
+        TEST_PERMISSION_DECISION: 'approve',
+        TEST_PERMISSION_TOOL_NAME: 'mcp__gantry__admin_permission_revoke',
+        TEST_PERMISSION_SCOPE: 'environment:staging',
+        TEST_EXIT_AFTER_QUERY: '1',
+      });
+
+      expect(excludedResult.exitCode).toBe(0);
+      const excludedCall = readRecord(excludedFixture.recordPath).calls[0];
+      expect(excludedCall?.permissionRequest).toEqual(
+        expect.objectContaining({
+          toolName: 'mcp__gantry__admin_permission_revoke',
+        }),
+      );
+      expect(excludedCall?.permissionRequest).not.toHaveProperty('suggestions');
     },
     RUNNER_IPC_TEST_TIMEOUT_MS,
   );

--- a/apps/core/test/unit/runner/permission-suggestions.test.ts
+++ b/apps/core/test/unit/runner/permission-suggestions.test.ts
@@ -74,6 +74,38 @@ describe('scheduledPermissionSuggestions', () => {
     ]);
   });
 
+  it('offers a persistent suggestion for an exact non-authority Gantry tool', () => {
+    expect(
+      synthesizePermissionSuggestions('mcp__gantry__scheduler_resume_job', {}),
+    ).toEqual([
+      {
+        type: 'addRules',
+        behavior: 'allow',
+        destination: 'session',
+        rules: [{ toolName: 'mcp__gantry__scheduler_resume_job' }],
+      },
+    ]);
+  });
+
+  it('offers grantable admin suggestions but excludes authority-changing admin tools', () => {
+    expect(
+      synthesizePermissionSuggestions('mcp__gantry__admin_permission_list', {}),
+    ).toEqual([
+      {
+        type: 'addRules',
+        behavior: 'allow',
+        destination: 'session',
+        rules: [{ toolName: 'mcp__gantry__admin_permission_list' }],
+      },
+    ]);
+    expect(
+      synthesizePermissionSuggestions(
+        'mcp__gantry__admin_permission_revoke',
+        {},
+      ),
+    ).toBeUndefined();
+  });
+
   it('prefers selected skill action capabilities over raw Bash command suggestions', () => {
     expect(
       scheduledPermissionSuggestions(
@@ -309,6 +341,9 @@ describe('scheduledPermissionSuggestions', () => {
     expect(synthesizePermissionSuggestions('LS', {})).toBeUndefined();
     expect(
       synthesizePermissionSuggestions('mcp__github__search', {}),
+    ).toBeUndefined();
+    expect(
+      synthesizePermissionSuggestions('mcp__gantry__request_access', {}),
     ).toBeUndefined();
     expect(
       scheduledPermissionSuggestions('mcp__github__*', undefined, {}),

--- a/apps/core/test/unit/runtime/generative-ui-rich-contract.test.ts
+++ b/apps/core/test/unit/runtime/generative-ui-rich-contract.test.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import { ALL_GANTRY_MCP_TOOL_NAMES } from '@core/shared/admin-mcp-tools.js';
+
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../../../../..',
@@ -71,11 +73,10 @@ describe('generative UI rich interaction contract', () => {
   });
 
   it('registers rich render tools separately from send_message', () => {
-    const toolSurface = read('apps/core/src/runner/gantry-mcp-tool-surface.ts');
     const messagingTools = read('apps/core/src/runner/mcp/tools/messaging.ts');
 
     for (const toolName of richToolNames) {
-      expect(toolSurface).toContain(`'${toolName}'`);
+      expect(ALL_GANTRY_MCP_TOOL_NAMES).toContain(toolName);
       expect(messagingTools).toContain(`'${toolName}'`);
     }
 

--- a/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
+++ b/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
@@ -289,7 +289,7 @@ describe('ipc-interaction-handler', () => {
     fs.writeFileSync(claimedPath, '{}');
     const toolRepository = {
       getTool: vi.fn(async () => ({
-        id: 'tool:mcp__gantry__service_restart',
+        id: 'tool:mcp__gantry__admin_permission_list',
         appId: 'app:test',
         status: 'active',
         selectable: true,
@@ -310,7 +310,7 @@ describe('ipc-interaction-handler', () => {
         sourceAgentFolder: 'main_agent',
         runHandle: 'agent-run-1',
         targetJid: 'tg:team',
-        toolName: 'mcp__gantry__service_restart',
+        toolName: 'mcp__gantry__admin_permission_list',
         toolInput: { service: 'api' },
       },
       sourceAgentFolder: 'main_agent',
@@ -324,7 +324,7 @@ describe('ipc-interaction-handler', () => {
             {
               type: 'addRules',
               behavior: 'allow',
-              rules: [{ toolName: 'mcp__gantry__service_restart' }],
+              rules: [{ toolName: 'mcp__gantry__admin_permission_list' }],
             },
           ],
         })),
@@ -351,10 +351,10 @@ describe('ipc-interaction-handler', () => {
           'utf-8',
         ),
       ),
-    ).toEqual(['mcp__gantry__service_restart']);
+    ).toEqual(['mcp__gantry__admin_permission_list']);
     expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledWith(
       'main_agent',
-      ['mcp__gantry__service_restart'],
+      ['mcp__gantry__admin_permission_list'],
       { appId: 'app:test' },
     );
     expect(mirrorAgentToolRulesToSettings).toHaveBeenCalledOnce();
@@ -369,7 +369,7 @@ describe('ipc-interaction-handler', () => {
     const sendMessage = vi.fn(async () => undefined);
     const toolRepository = {
       getTool: vi.fn(async () => ({
-        id: 'tool:mcp__gantry__service_restart',
+        id: 'tool:mcp__gantry__admin_permission_list',
         appId: 'app:test',
         status: 'active',
         selectable: true,
@@ -389,7 +389,7 @@ describe('ipc-interaction-handler', () => {
         runHandle: 'agent-run-thread',
         targetJid: 'tg:team',
         threadId: 'topic-7',
-        toolName: 'mcp__gantry__service_restart',
+        toolName: 'mcp__gantry__admin_permission_list',
         toolInput: { service: 'api' },
       },
       sourceAgentFolder: 'main_agent',
@@ -404,7 +404,7 @@ describe('ipc-interaction-handler', () => {
             {
               type: 'addRules',
               behavior: 'allow',
-              rules: [{ toolName: 'mcp__gantry__service_restart' }],
+              rules: [{ toolName: 'mcp__gantry__admin_permission_list' }],
             },
           ],
         })),

--- a/apps/core/test/unit/shared/admin-mcp-tools.test.ts
+++ b/apps/core/test/unit/shared/admin-mcp-tools.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ADMIN_MCP_TOOL_FULL_NAMES,
+  ALL_GANTRY_MCP_TOOL_NAMES,
+  AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
+  classifyDurableGantryMcpToolName,
+  DECISION_ACTOR_GANTRY_MCP_TOOL_NAMES,
+  DELEGATION_DISPATCHERS,
+  type DurableGantryMcpToolBucket,
+  DURABLE_GRANT_EXCLUDED_DISPATCHERS,
+  GATED_GANTRY_MCP_TOOL_NAMES,
+  GRANTABLE_EXACT_GANTRY_MCP_TOOL_NAMES,
+  SEEDED_SCHEDULER_MCP_TOOL_FULL_NAMES,
+  isSeededGantryMcpToolFullName,
+} from '@core/shared/admin-mcp-tools.js';
+
+describe('admin MCP tools', () => {
+  it('identifies exactly the fixed-ID Gantry seed families', () => {
+    for (const fullName of ADMIN_MCP_TOOL_FULL_NAMES) {
+      expect(isSeededGantryMcpToolFullName(fullName)).toBe(true);
+    }
+    for (const fullName of SEEDED_SCHEDULER_MCP_TOOL_FULL_NAMES) {
+      expect(isSeededGantryMcpToolFullName(fullName)).toBe(true);
+    }
+
+    expect(
+      isSeededGantryMcpToolFullName('mcp__gantry__scheduler_resume_job'),
+    ).toBe(false);
+    expect(isSeededGantryMcpToolFullName('mcp__gantry__task_cancel')).toBe(
+      false,
+    );
+  });
+
+  it('classifies every Gantry MCP tool into exactly one durable-grant bucket', () => {
+    const buckets: readonly [DurableGantryMcpToolBucket, readonly string[]][] =
+      [
+        ['grantable-exact', GRANTABLE_EXACT_GANTRY_MCP_TOOL_NAMES],
+        ['runtime-projection', GATED_GANTRY_MCP_TOOL_NAMES],
+        ['unscoped-dispatcher', DURABLE_GRANT_EXCLUDED_DISPATCHERS],
+        ['delegation', DELEGATION_DISPATCHERS],
+        ['authority-changing', AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES],
+        ['decision-actor', DECISION_ACTOR_GANTRY_MCP_TOOL_NAMES],
+      ];
+
+    expect(new Set(ALL_GANTRY_MCP_TOOL_NAMES).size).toBe(
+      ALL_GANTRY_MCP_TOOL_NAMES.length,
+    );
+    for (const toolName of ALL_GANTRY_MCP_TOOL_NAMES) {
+      const memberships = buckets
+        .filter(([, names]) => names.includes(toolName))
+        .map(([bucket]) => bucket);
+      expect(memberships, toolName).toEqual([
+        classifyDurableGantryMcpToolName(toolName),
+      ]);
+    }
+  });
+});

--- a/apps/core/test/unit/shared/durable-access-policy.test.ts
+++ b/apps/core/test/unit/shared/durable-access-policy.test.ts
@@ -1,11 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  DURABLE_ACCESS_RULE_REJECTION_REASON,
+  BROWSER_PROJECTED_MCP_RULE_REJECTION_REASON,
+  PROJECTED_BROWSER_MCP_TOOL_NAMES,
+} from '@core/shared/agent-tool-references.js';
+import {
+  AUTHORITY_CHANGING_GANTRY_MCP_TOOL_REJECTION_REASON,
+  DECISION_ACTOR_GANTRY_MCP_TOOL_REJECTION_REASON,
+  DELEGATION_DISPATCHER_REJECTION_REASON,
+  DURABLE_GRANT_EXCLUDED_DISPATCHER_REJECTION_REASON,
   formatDurableAccessRulesForUser,
   isDurableAccessRuleAllowed,
   validateDurableAccessRule,
 } from '@core/shared/durable-access-policy.js';
+import {
+  AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
+  DECISION_ACTOR_GANTRY_MCP_TOOL_NAMES,
+  DELEGATION_DISPATCHERS,
+  DURABLE_GRANT_EXCLUDED_DISPATCHERS,
+  GRANTABLE_EXACT_GANTRY_MCP_TOOL_NAMES,
+} from '@core/shared/admin-mcp-tools.js';
 import type { SemanticCapabilityDefinition } from '@core/shared/semantic-capabilities.js';
 
 const skillActionDefinition: SemanticCapabilityDefinition = {
@@ -69,33 +83,182 @@ describe('durable access policy', () => {
     ).toEqual({ ok: true });
   });
 
-  it('allows exact Gantry scheduler tools as durable access rules', () => {
+  it('allows scheduler resume as a durable access rule', () => {
     expect(
-      validateDurableAccessRule('mcp__gantry__scheduler_list_jobs'),
-    ).toEqual({
-      ok: true,
-    });
-    expect(validateDurableAccessRule('mcp__gantry__scheduler_run_now')).toEqual(
+      validateDurableAccessRule('mcp__gantry__scheduler_resume_job'),
+    ).toEqual({ ok: true });
+  });
+
+  it('allows every canonical Gantry tool except durable exclusions and runtime projections', () => {
+    for (const toolName of GRANTABLE_EXACT_GANTRY_MCP_TOOL_NAMES) {
+      expect(
+        validateDurableAccessRule(`mcp__gantry__${toolName}`),
+        toolName,
+      ).toEqual({ ok: true });
+    }
+  });
+
+  it('rejects async_run_command with the dispatcher reason', () => {
+    expect(validateDurableAccessRule('mcp__gantry__async_run_command')).toEqual(
       {
-        ok: true,
+        ok: false,
+        reason: DURABLE_GRANT_EXCLUDED_DISPATCHER_REJECTION_REASON,
       },
     );
-    expect(
-      formatDurableAccessRulesForUser(['mcp__gantry__scheduler_run_now']),
-    ).toBe('Scheduler Run Now');
   });
 
-  it('rejects exact third-party MCP tools', () => {
-    expect(validateDurableAccessRule('mcp__github__get_issue')).toEqual({
+  it('rejects every durable-grant-excluded dispatcher by the shared constant', () => {
+    for (const toolName of DURABLE_GRANT_EXCLUDED_DISPATCHERS) {
+      expect(validateDurableAccessRule(`mcp__gantry__${toolName}`)).toEqual({
+        ok: false,
+        reason: DURABLE_GRANT_EXCLUDED_DISPATCHER_REJECTION_REASON,
+      });
+    }
+  });
+
+  it('rejects delegation dispatchers as durable access rules', () => {
+    for (const toolName of DELEGATION_DISPATCHERS) {
+      expect(
+        validateDurableAccessRule(`mcp__gantry__${toolName}`),
+        toolName,
+      ).toEqual({
+        ok: false,
+        reason: DELEGATION_DISPATCHER_REJECTION_REASON,
+      });
+    }
+  });
+
+  it('rejects scoped forms of excluded Gantry tools by the underlying exact name', () => {
+    expect(
+      validateDurableAccessRule('mcp__gantry__request_access(capability:test)'),
+    ).toEqual({
       ok: false,
-      reason: DURABLE_ACCESS_RULE_REJECTION_REASON,
+      reason: AUTHORITY_CHANGING_GANTRY_MCP_TOOL_REJECTION_REASON,
     });
   });
 
-  it('rejects non-admin Gantry MCP tools as durable access rules', () => {
+  it('rejects a fabricated Gantry tool name', () => {
     expect(
-      validateDurableAccessRule('mcp__gantry__send_message'),
+      validateDurableAccessRule('mcp__gantry__does_not_exist'),
     ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a typo of a canonical Gantry tool name', () => {
+    expect(
+      validateDurableAccessRule('mcp__gantry__scheduler_resume_jobb'),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects every authority-changing Gantry tool by the shared constant', () => {
+    for (const toolName of AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES) {
+      expect(
+        validateDurableAccessRule(`mcp__gantry__${toolName}`),
+        toolName,
+      ).toEqual({
+        ok: false,
+        reason: AUTHORITY_CHANGING_GANTRY_MCP_TOOL_REJECTION_REASON,
+      });
+    }
+  });
+
+  it('rejects authority, config, topology, and restart mutations outside the request family', () => {
+    for (const toolName of [
+      'admin_permission_revoke',
+      'register_agent',
+      'request_settings_update',
+      'service_restart',
+    ]) {
+      expect(
+        validateDurableAccessRule(`mcp__gantry__${toolName}`),
+        toolName,
+      ).toEqual({
+        ok: false,
+        reason: AUTHORITY_CHANGING_GANTRY_MCP_TOOL_REJECTION_REASON,
+      });
+    }
+  });
+
+  it('rejects tools that record durable user consent or review decisions', () => {
+    for (const toolName of DECISION_ACTOR_GANTRY_MCP_TOOL_NAMES) {
+      expect(
+        validateDurableAccessRule(`mcp__gantry__${toolName}`),
+        toolName,
+      ).toEqual({
+        ok: false,
+        reason: DECISION_ACTOR_GANTRY_MCP_TOOL_REJECTION_REASON,
+      });
+    }
+  });
+
+  it('keeps read-only admin and settings tools grantable', () => {
+    for (const toolName of [
+      'admin_permission_list',
+      'guided_action_preview',
+      'settings_desired_state',
+    ]) {
+      expect(
+        validateDurableAccessRule(`mcp__gantry__${toolName}`),
+        toolName,
+      ).toEqual({ ok: true });
+    }
+  });
+
+  it('keeps reads, scheduler job CRUD, memory writes, and task cancellation grantable', () => {
+    for (const toolName of [
+      'task_get',
+      'task_list',
+      'task_cancel',
+      'scheduler_get_job',
+      'scheduler_list_jobs',
+      'scheduler_upsert_job',
+      'scheduler_update_job',
+      'scheduler_delete_job',
+      'scheduler_pause_job',
+      'scheduler_resume_job',
+      'memory_search',
+      'memory_save',
+      'memory_patch',
+      'memory_demote',
+      'memory_dream',
+      'memory_consolidate',
+      'brain_write',
+    ]) {
+      expect(
+        validateDurableAccessRule(`mcp__gantry__${toolName}`),
+        toolName,
+      ).toEqual({ ok: true });
+    }
+  });
+
+  it('rejects projected Gantry browser tools in favor of canonical Browser', () => {
+    for (const toolName of PROJECTED_BROWSER_MCP_TOOL_NAMES) {
+      expect(validateDurableAccessRule(toolName), toolName).toEqual({
+        ok: false,
+        reason: BROWSER_PROJECTED_MCP_RULE_REJECTION_REASON,
+      });
+    }
+  });
+
+  it('renders readable names for newly durable Gantry tools', () => {
+    expect(
+      formatDurableAccessRulesForUser([
+        'mcp__gantry__scheduler_resume_job',
+        'mcp__gantry__task_cancel',
+        'mcp__gantry__memory_patch',
+      ]),
+    ).toBe('Scheduler Resume Job, Task Cancel, Memory Patch');
+  });
+
+  it('rejects arbitrary non-Gantry tool names', () => {
+    for (const toolName of [
+      'mcp__github__get_issue',
+      'mcp__other__tool',
+      'random string',
+    ]) {
+      expect(validateDurableAccessRule(toolName), toolName).toMatchObject({
+        ok: false,
+      });
+    }
   });
 
   it('still rejects scoped non-command Gantry facade rules', () => {
@@ -185,25 +348,6 @@ describe('durable access policy', () => {
       ok: false,
       reason:
         'Persistent RunCommand rules cannot reference generated runtime paths; use a reviewed stable capability or let Gantry-owned runtime scratch reads stay internal.',
-    });
-  });
-
-  it('rejects scheduler mutation tools as durable exact tool rules', () => {
-    expect(
-      validateDurableAccessRule('mcp__gantry__scheduler_upsert_job'),
-    ).toEqual({
-      ok: false,
-      reason: expect.stringContaining(
-        'Persistent access approvals support only',
-      ),
-    });
-    expect(
-      validateDurableAccessRule('mcp__gantry__scheduler_delete_job'),
-    ).toEqual({
-      ok: false,
-      reason: expect.stringContaining(
-        'Persistent access approvals support only',
-      ),
     });
   });
 

--- a/apps/core/test/unit/shared/tool-execution-policy-service.test.ts
+++ b/apps/core/test/unit/shared/tool-execution-policy-service.test.ts
@@ -122,10 +122,10 @@ describe('ToolExecutionPolicyService', () => {
     ).not.toContain('scheduler_grant_tool');
   });
 
-  it('recovers admin tool denials through reviewed capability guidance', () => {
+  it('recovers admin tool denials through exact persistent tool approval', () => {
     const request = classifier.classify({
       origin: 'mcp',
-      toolName: 'mcp__gantry__service_restart',
+      toolName: 'mcp__gantry__settings_desired_state',
       toolInput: {},
       executionMode: 'autonomous',
       runContext: { jobId: 'job-1' },
@@ -136,13 +136,28 @@ describe('ToolExecutionPolicyService', () => {
     ).toEqual(
       expect.objectContaining({
         status: 'deny',
-        recoveryAction: expect.stringContaining('reviewed admin capability'),
+        recoveryAction: expect.stringContaining(
+          '"name": "mcp__gantry__settings_desired_state"',
+        ),
       }),
     );
     expect(
       policy.evaluate({ request, autonomousAllowedToolRules: [] })
         .recoveryAction,
-    ).toContain('exact tool grants are not accepted');
+    ).toContain('exact Gantry tool access');
+  });
+
+  it('does not auto-allow newly durable-grantable exact Gantry tools', () => {
+    const request = classifier.classify({
+      origin: 'mcp',
+      toolName: 'mcp__gantry__scheduler_resume_job',
+      toolInput: { jobId: 'job-1' },
+    });
+
+    expect(policy.evaluate({ request })).toMatchObject({
+      status: 'not_applicable',
+      reason: 'No canonical tool execution policy matched.',
+    });
   });
 
   it('denies protected capability file targets through canonical policy', () => {
@@ -436,7 +451,7 @@ describe('ToolExecutionPolicyService', () => {
           'Tool not on autonomous run allowlist: mcp__gantry__scheduler_run_now.',
         ),
         recoveryAction:
-          'request_access { "target": { "kind": "tool", "name": "mcp__gantry__scheduler_run_now" }, "temporaryOnly": false, "reason": "This autonomous run needs scheduler access." }',
+          'request_access { "target": { "kind": "tool", "name": "mcp__gantry__scheduler_run_now" }, "temporaryOnly": false, "reason": "This autonomous run needs exact Gantry tool access." }',
       }),
     );
   });

--- a/apps/core/test/unit/storage/storage-service.test.ts
+++ b/apps/core/test/unit/storage/storage-service.test.ts
@@ -149,14 +149,22 @@ describe('storage-service', () => {
     await service.close();
   });
 
-  it('seeds durable scheduler tools as selectable built-in catalog entries', () => {
-    const seededToolNames = new Set(
-      DEFAULT_TOOL_CATALOG.map((tool) => tool.name),
+  it('preserves global admin seeds without globally seeding newly durable scheduler tools', () => {
+    const seededToolsByName = new Map(
+      DEFAULT_TOOL_CATALOG.map((tool) => [tool.name, tool]),
     );
 
-    expect(seededToolNames.has('mcp__gantry__scheduler_run_now')).toBe(true);
-    expect(seededToolNames.has('mcp__gantry__scheduler_list_jobs')).toBe(true);
-    expect(seededToolNames.has('mcp__gantry__scheduler_upsert_job')).toBe(
+    expect(
+      seededToolsByName.get('mcp__gantry__settings_desired_state')?.id,
+    ).toBe('tool:mcp__gantry__settings_desired_state');
+    expect(seededToolsByName.has('mcp__gantry__scheduler_run_now')).toBe(true);
+    expect(seededToolsByName.has('mcp__gantry__scheduler_list_jobs')).toBe(
+      true,
+    );
+    expect(seededToolsByName.has('mcp__gantry__scheduler_upsert_job')).toBe(
+      false,
+    );
+    expect(seededToolsByName.has('mcp__gantry__scheduler_resume_job')).toBe(
       false,
     );
   });

--- a/docs/decisions/0065-perm8-client-signoff.md
+++ b/docs/decisions/0065-perm8-client-signoff.md
@@ -1,0 +1,48 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-26
+---
+
+# Perm8 Client Signoff
+
+## Context
+Ravi tried to grant "allow for future" for `scheduler_resume_job` and the button was not
+there. The last prompt's stored options were `["allow_once","cancel"]`.
+
+Why: the prompt offers the persistent option only when the suggestion synthesizer emits a
+persistent suggestion, which requires `validateDurableAccessRule` to accept the tool name.
+That validator accepts a hand-maintained list — `DURABLE_SCHEDULER_MCP_TOOL_NAMES`
+(`shared/admin-mcp-tools.ts:32`) — containing the scheduler reads plus `run_now`, and no other
+mutation. Its own rejection message claims exact scheduler tools are supported. So today you
+can durably grant "run this job now" but not "resume this job", which is an unfinished list,
+not a policy.
+
+An audit of every model-visible tool against the real validator showed the problem is
+system-wide: only scheduler reads, `run_now`, Browser, file tools and scoped `RunCommand(...)`
+can ever receive the button. Every scheduler mutation, the task lifecycle tools,
+`delegate_task`, the async commands, memory mutations, `mcp_call_tool` and the `request_*`
+family are allow-once forever — no grant a human makes can stick.
+
+## Decision
+Ravi decided on 2026-07-26: **every exact gantry tool becomes durable-grantable, except the
+authority-changing `request_*` family** (`AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES`). Those
+change what the agent is even capable of — install skills, add servers, request new access —
+and keep asking every time.
+
+The line moves from a hand-maintained list to a single rule, so it cannot drift out of step
+with the tool surface again.
+
+The button only appears; nothing is granted until the human taps it. Auto-allow policy
+(birthright, rails, classifier) is untouched.
+
+## Consequences
+- A durable grant is a standing human decision. The risk accepted is a fat-fingered permanent
+  grant on a destructive tool (e.g. `scheduler_delete_job`); the mitigations are that the
+  prompt names the tool and the risk label, and revocation exists.
+- `request_*` stays allow-once by design. If that ever changes it is its own decision.
+- Existing granted rules and their matching are unchanged; this widens only what MAY be
+  granted.
+- Free-form MCP passthrough (`mcp_call_tool`) becomes grantable as an exact tool name; the
+  grant covers the passthrough tool itself, not any specific remote tool behind it. If
+  per-remote-tool scoping is wanted later, that is a rule-grammar extension, not this change.


### PR DESCRIPTION
Fixes the bug you hit: the "Allow for future" button was missing for almost every tool. You could permanently allow "run this job now" but not "resume this job."

## Why it was broken

The button only showed for a hand-kept list of ~10 tools (scheduler reads + admin). Everything else could only ever be "allow once." An unfinished list, not a policy.

## The fix — decide by category, not by list

Every tool can now be durably granted **except four kinds** whose damage isn't bounded by the tool name:

| Category | Examples | Why excluded |
|---|---|---|
| Dispatchers | `mcp_call_tool`, `async_run_command`, `async_mcp_call` | reach arbitrary tools/commands |
| Delegation | `delegate_task`, `task_message` | start or steer another agent |
| Authority-changing | `request_*`, `admin_permission_revoke`, `register_agent`, `request_settings_update`, `service_restart` | change permissions, config, topology, or restart the service |
| Decision-actors | `memory_review_decision`, `pattern_candidate_decision`, `proactive_surfacing_consent` | auto-approve a pending human decision |

**53 tools grantable, 18 excluded, every one of the 71 classified.** A test asserts the partition is total — a newly added tool fails the test until it's placed in a bucket, so nothing can silently become grantable. That's why this converges where a denylist didn't: over the review it took ten passes to stop finding leaks in a per-tool denylist; the category rule closes them by construction.

## What this does *not* change

Nothing is auto-allowed. The button only **appears** — every grant still needs your tap. Birthright, the rails, and the classifier are untouched.

## Correctness details (each found and fixed under review)

- The tool registry moved to the shared layer as a single source of truth, so grant validation can't drift from the tool surface. Fabricated/typo tool names are now **rejected** (fail-closed) instead of accepted as future-shaped tools.
- Catalog IDs split **seeded vs unseeded**: admin and the 9 seeded scheduler tools reuse their seed row (no duplicate); every other tool gets an app-scoped ID, so two apps can each grant the same tool.
- **Revocation** looks up both ID forms, so tightening grants didn't strip the ability to revoke an existing high-authority binding.
- Exclusion checks run on the **normalized** tool name, so a scoped form like `request_access(...)` can't slip past them.

Stale contract tests were updated to the new behaviour; the two "rejects scoped/projected approval" guards still pass unchanged, and one genuine regression surfaced by the full suite was fixed (not silenced).

`verify.py` passes in full.

Refs `docs/decisions/0065-perm8-client-signoff.md`.
