### PR TITLE
test: restore response-latency prerequisite gates

### DIFF
--- a/apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts
+++ b/apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts
@@ -570,6 +570,7 @@ async function runRunner(input: {
 const tempRoots: string[] = [];
 const checkpointSchemas: string[] = [];
 let checkpointCounter = 0;
+const SHELL_PERMISSION_REQUEST_WAIT_MS = 30_000;
 // Stub MCP servers must resolve @modelcontextprotocol/sdk from the repo
 // node_modules, so the temp tree lives under the repo (not os.tmpdir()).
 const REPO_TMP_BASE = path.resolve(__dirname, '../.tmp-deepagents-int');
@@ -613,7 +614,7 @@ async function approveNextShellRequestViaHostCoordinator(input: {
   );
   const startedAt = Date.now();
   let rawRequest: Record<string, unknown> | undefined;
-  while (Date.now() - startedAt < 5_000) {
+  while (Date.now() - startedAt < SHELL_PERMISSION_REQUEST_WAIT_MS) {
     const requestFile = fs.existsSync(requestDir)
       ? fs.readdirSync(requestDir).find((entry) => entry.endsWith('.json'))
       : undefined;

--- a/apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts
+++ b/apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts
@@ -40,6 +40,10 @@ import {
   clearMcpToolProxyInventoryCache,
   McpToolProxy,
 } from '@core/application/mcp/mcp-tool-proxy.js';
+import {
+  semanticCapabilityInputSchema,
+  type SemanticCapabilityDefinition,
+} from '@core/shared/semantic-capabilities.js';
 
 import {
   createPostgresIntegrationRuntime,
@@ -74,8 +78,9 @@ const APP_ID = 'app-mcp-hot-path';
 const OTHER_APP_ID = 'app-mcp-distractor';
 const HOT_AGENT_ID = 'agent-mcp-hot-path';
 const HOT_SERVER_ID = 'mcp-hot-server-3';
-const HOT_SERVER_NAME = 'server_000001';
+const HOT_SERVER_NAME = 'server_000003';
 const HOT_TOOL_NAME = 'tool_001';
+const HOT_CAPABILITY_ID = 'mcp.hot-tool.read';
 
 type QueryCase = {
   name: string;
@@ -179,13 +184,6 @@ function planVerdict(input: {
         ? 'acceptable_evidence'
         : 'follow_up_required',
   };
-}
-
-function emptyToolRepository() {
-  return {
-    listAgentToolBindings: async () => [],
-    getTool: async () => null,
-  } as never;
 }
 
 maybeDescribe('Postgres MCP inventory and audit plans', () => {
@@ -371,6 +369,55 @@ maybeDescribe('Postgres MCP inventory and audit plans', () => {
        FROM generate_series(1, $1::integer) AS series(n)`,
       [OTHER_BINDING_COUNT, OTHER_APP_ID, DISTRACTOR_SERVER_COUNT, now],
     );
+
+    const hotServer = await runtime.repositories.mcpServers.getServerByName({
+      appId: APP_ID as never,
+      name: HOT_SERVER_NAME,
+    });
+    expect(hotServer?.id).toBe(HOT_SERVER_ID);
+    const reviewedCapability: SemanticCapabilityDefinition = {
+      capabilityId: HOT_CAPABILITY_ID,
+      displayName: 'MCP hot-path tool read',
+      category: 'mcp',
+      risk: 'read',
+      can: `Call ${HOT_TOOL_NAME} on ${HOT_SERVER_NAME}.`,
+      cannot: 'Call any other MCP tool.',
+      credentialSource: 'none',
+      implementationBindings: [
+        {
+          kind: 'mcp_pattern',
+          mcpServer: HOT_SERVER_NAME,
+          mcpToolPatterns: [HOT_TOOL_NAME],
+        },
+      ],
+      preflight: { kind: 'none' },
+    };
+    const hotToolId = `tool:capability:${HOT_CAPABILITY_ID}` as never;
+    await runtime.repositories.tools.saveTool({
+      id: hotToolId,
+      appId: APP_ID as never,
+      name: `capability:${HOT_CAPABILITY_ID}`,
+      kind: 'host',
+      provider: 'gantry',
+      displayName: reviewedCapability.displayName,
+      category: 'mcp',
+      inputSchema: semanticCapabilityInputSchema(reviewedCapability),
+      risk: 'low',
+      selectable: true,
+      status: 'active',
+      adapterRef: `capability/${HOT_CAPABILITY_ID}`,
+      createdAt: now as never,
+      updatedAt: now as never,
+    });
+    await runtime.repositories.tools.saveAgentToolBinding({
+      id: `agent-tool-binding:${HOT_AGENT_ID}:${hotToolId}` as never,
+      appId: APP_ID as never,
+      agentId: HOT_AGENT_ID as never,
+      toolId: hotToolId,
+      status: 'active',
+      createdAt: now as never,
+      updatedAt: now as never,
+    });
 
     await runtime.service.pool.query(
       `INSERT INTO ${auditTable} (
@@ -739,7 +786,7 @@ maybeDescribe('Postgres MCP inventory and audit plans', () => {
         ],
       });
     const proxy = new McpToolProxy(runtime.repositories.mcpServers, {
-      tools: emptyToolRepository(),
+      tools: runtime.repositories.tools,
       liveToolRules: [
         `mcp__${HOT_SERVER_NAME}__${HOT_TOOL_NAME}`,
         `mcp__${HOT_SERVER_NAME}__tool_002`,
@@ -775,6 +822,19 @@ maybeDescribe('Postgres MCP inventory and audit plans', () => {
     });
     const describeMs = elapsedMs(describeStartedAt);
 
+    await expect(
+      proxy.callTool({
+        appId: APP_ID as never,
+        agentId: HOT_AGENT_ID as never,
+        serverName: HOT_SERVER_NAME,
+        toolName: 'tool_002',
+      }),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringContaining(`mcp__${HOT_SERVER_NAME}__tool_002`),
+    });
+    expect(mcpSdkMocks.client.callTool).not.toHaveBeenCalled();
+
     const callStartedAt = process.hrtime.bigint();
     await proxy.callTool({
       appId: APP_ID as never,
@@ -797,6 +857,21 @@ maybeDescribe('Postgres MCP inventory and audit plans', () => {
       });
       warmInventorySamples.push(elapsedMs(startedAt));
     }
+
+    const proxyAuditResult = await runtime.service.pool.query<{
+      audit_events_written: number;
+    }>(
+      `SELECT COUNT(*)::int AS audit_events_written
+       FROM ${auditTable}
+       WHERE app_id = $1
+         AND agent_id = $2
+         AND actor_id = $3`,
+      [APP_ID, HOT_AGENT_ID, 'mcp-tool-proxy'],
+    );
+    const proxyAuditEventsWritten = Number(
+      proxyAuditResult.rows[0]?.audit_events_written ?? 0,
+    );
+    expect(proxyAuditEventsWritten).toBe(4);
 
     const repositoryTiming = {
       queryElapsedMs: timingSummary(
@@ -864,7 +939,7 @@ maybeDescribe('Postgres MCP inventory and audit plans', () => {
             0,
             mcpSdkMocks.client.listTools.mock.calls.length - 3,
           ),
-          auditEventsWritten: 2,
+          auditEventsWritten: proxyAuditEventsWritten,
           outputSchemaFromCachedDetail: true,
           rawArgumentsIncluded: false,
         },

--- a/docs/decisions/0064-client-signoff.md
+++ b/docs/decisions/0064-client-signoff.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+confirmed_by: "vrknetha"
+date: 2026-07-27
+---
+
+# LAT-GATE-0 Client Signoff
+
+## Context
+The response-latency program cannot be shipped cleanly until the current-main
+validation gates are trustworthy. Three fixture defects currently block that
+prerequisite: a five-second DeepAgents permission-request wait, an MCP hot-path
+fixture missing reviewed capability evidence, and a hermetic job-lifecycle fake
+Claude executable that waits for a stale startup trigger.
+
+The client asked for all response-latency phases to proceed autonomously, with
+each PR reviewed, locally verified, CI-green, and the KnackLabs lead-gen job
+passing before merge. This bounded prerequisite is required before the first
+latency PR can honestly meet those gates.
+
+## Decision
+Approve LAT-GATE-0 to repair exactly those three current-main validation
+fixtures before continuing the response-latency PR train.
+
+## Consequences
+The repair is test-only. It must not change production authorization, runtime
+behavior, lint policy, or the LAT-0 latency harness branch. Existing signed IPC,
+reviewed MCP capability, sandbox, and scheduler boundaries remain authoritative.

--- a/docs/decisions/0066-client-signoff.md
+++ b/docs/decisions/0066-client-signoff.md
@@ -1,0 +1,47 @@
+---
+status: accepted
+confirmed_by: "vrknetha"
+date: 2026-07-27
+---
+
+# LAT-GATE-0 Revised Client Signoff
+
+## Context
+`docs/decisions/0064-client-signoff.md` accepted the original LAT-GATE-0
+prerequisite scope as three fixture repairs. Forge contradiction signal
+`S-0001-8d39` invalidated the job-lifecycle fixture premise on macOS: the
+packaged runner strips `HOME`, so `allowedOuterSandboxClaudeExecutable` rejects
+the fake executable under `fakeHome/.local/bin/claude`.
+
+Changing that executable-trust boundary would require production sandbox/runtime
+scope. The user explicitly authorized autonomous all-phase delivery with reviewed,
+green, merge-ready PRs, but did not authorize production executable-trust changes
+inside this prerequisite fixture repair.
+
+## Decision
+Revise LAT-GATE-0 to repair exactly two fixtures: the DeepAgents RunCommand wait
+and the MCP inventory/audit hot-path reviewed-capability fixture.
+
+The job-lifecycle E2E must return to unchanged baseline and remain a required
+evidence gate in a disposable Linux/CI-parity Node 25 worktree or container. The
+macOS host result is documented as a platform mismatch, not as a fixture defect.
+
+This decision does not authorize executable-trust, sandbox, `HOME`, packaged
+runner, provider, scheduler, or job-lifecycle fake-Claude production changes.
+
+## Consequences
+The LAT-GATE-0 implementation remains test-only and production source remains
+out of scope. The implementer may edit only the DeepAgents and MCP fixture files,
+plus restore any job-lifecycle test/helper changes made in this prerequisite
+worktree back to baseline.
+
+Linux/CI-parity Node 25 hermetic job E2E evidence is recorded from unchanged
+base `5fff01d0f` in a Node 25 container with a container-local Postgres proxy:
+1 file / 1 test passed, 0 skipped, 38.03s. The branch cannot be PR-ready unless
+that Linux/CI-parity gate is repeated for the branch, local
+integration/Postgres/hot-path gates pass, Ponytail and autoreview are clean, CI
+is green, and the checkout-bound KnackLabs smoke passes.
+
+Forge acceptance of this revised signoff is recorded by this accepted decision.
+It does not bypass decomposition, verification, review, PR-ready, CI, Linux E2E,
+or checkout-bound smoke gates.

--- a/plans/LAT-GATE-0-response-latency-prerequisite-gates-plan.md
+++ b/plans/LAT-GATE-0-response-latency-prerequisite-gates-plan.md
@@ -2,12 +2,32 @@
 
 ## Problem
 
-The response-latency program requires clean local integration and agent E2E gates before any latency PR can be merged. Current main has three fixture-level blockers that make those gates unreliable:
+The response-latency program requires trustworthy local integration, Postgres
+hot-path, agent E2E, CI, review, and live-smoke gates before any latency PR can
+merge. After Forge contradiction signal `S-0001-8d39`, LAT-GATE-0 is narrowed to
+two fixture repairs:
 
-1. `apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts` has a host-side RunCommand approval helper with a fixed 5 second wait for the permission request. Cold DeepAgents/Postgres startup can exceed that helper budget even when the production path is correct.
-2. `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts` seeds and exercises the Postgres MCP inventory/audit hot-path without the reviewed semantic capability evidence required by the current MCP action-authority contract.
-3. `apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts` uses a hermetic fake Claude executable installed by the test, but the fake trigger path waits for `control_request.initialize` or EOF before it emits the transcript needed by the current packaged runtime runner path.
-4. `npm run lint` currently reports a current-main baseline of 43 errors and 1047 warnings outside this fixture-repair scope.
+1. `apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts`
+   has a host-side RunCommand approval helper with a fixed 5 second wait for the
+   permission request. Cold DeepAgents/Postgres startup can exceed that helper
+   budget even when the production path is correct.
+2. `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`
+   seeds and exercises the Postgres MCP inventory/audit hot-path without the
+   reviewed semantic capability evidence required by the current MCP
+   action-authority contract.
+
+The prior job-lifecycle fixture premise is rejected. On macOS, the packaged
+runner strips `HOME`, so `allowedOuterSandboxClaudeExecutable` rejects
+`fakeHome/.local/bin/claude`. Changing executable trust is production scope and
+is not authorized for this prerequisite. The job-lifecycle test must return to
+the unchanged baseline and be proven in a disposable Linux/CI-parity Node 25
+worktree or container. That baseline evidence is now recorded from unchanged
+base `5fff01d0f` in a Node 25 container with a container-local Postgres proxy:
+job-lifecycle E2E, 1 file / 1 test passed, 0 skipped, 38.03s. The macOS host
+failure is recorded as a platform mismatch, not a fixture defect.
+
+`npm run lint` currently reports a current-main baseline of 43 errors and 1047
+warnings outside this fixture-repair scope.
 
 This is a prerequisite gate repair, not a response-latency optimization phase.
 
@@ -15,43 +35,83 @@ This is a prerequisite gate repair, not a response-latency optimization phase.
 
 In scope:
 
-- Fixture-only repair for the three blockers above.
-- Preserve the current security model: reviewed semantic capabilities remain required for third-party MCP action authority, and RunCommand remains mediated through signed IPC and the host permission coordinator.
-- Preserve the packaged-runtime E2E contract: fresh `GANTRY_HOME`, disposable Postgres, no live user runtime, no persistent developer database, and no real model provider.
-- Record Forge artifacts before implementation.
-- Record the current-main lint baseline and raise a Forge signal if the baseline still blocks PR-ready after the fixture repairs.
+- Fixture-only repair for the two blockers above.
+- Restore the job-lifecycle test and any job-lifecycle fake-Claude helper edits
+  to the unchanged baseline; job-lifecycle remains an evidence gate, not an
+  implementation target.
+- Preserve the current security model: reviewed semantic capabilities remain
+  required for third-party MCP action authority, and RunCommand remains mediated
+  through signed IPC and the host permission coordinator.
+- Preserve the packaged-runtime E2E contract: fresh `GANTRY_HOME`, disposable
+  Postgres, no live user runtime, no persistent developer database, and no real
+  model provider.
+- Record the current-main lint baseline and raise a Forge signal if the baseline
+  still blocks PR-ready after the fixture repairs.
 
 Non-goals:
 
-- No production source changes. If a fixture cannot model current production behavior, raise a Forge signal and stop for a revised plan and new client signoff.
-- No lint cleanup, architecture exception changes, broad timeout rewrites, or unrelated flaky-test fixes.
+- No production source changes. If these two fixtures cannot model current
+  production behavior, raise a Forge signal and stop for a revised plan and new
+  client signoff.
+- No executable-trust, sandbox, `HOME`, `allowedOuterSandboxClaudeExecutable`,
+  packaged-runner, provider, scheduler, or job-lifecycle fake-Claude changes.
+- No lint cleanup, architecture exception changes, broad timeout rewrites, or
+  unrelated flaky-test fixes.
 - No edits to the LAT-0 latency harness branch/files.
-- No weakening of auth, signed IPC replay checks, permission decision precedence, sandbox projection, MCP reviewed-capability rules, or scheduler/job state transitions.
-- No changes to the local KnackLabs runtime or lead-gen job in this prerequisite branch.
+- No weakening of auth, signed IPC replay checks, permission decision
+  precedence, sandbox projection, MCP reviewed-capability rules, or
+  scheduler/job state transitions.
+- No changes to the local KnackLabs runtime or lead-gen job in this prerequisite
+  branch.
 
 ## Acceptance Criteria
 
-- DeepAgents RunCommand Postgres integration no longer fails solely because the test helper times out before the cold runner creates its permission request.
-- The helper wait budget is scoped to the test helper and remains bounded; it does not change production runner, permission, or model timeouts.
-- The MCP hot-path Postgres fixture includes reviewed semantic capability data for `HOT_SERVER_ID`, `HOT_SERVER_NAME`, and `HOT_TOOL_NAME` rather than relying on stale exact third-party MCP grants.
-- The MCP fixture still preserves source-inventory versus action-authority separation: hot-path inventory/search evidence remains available, and any call authority comes from reviewed semantic capability evidence.
-- The job-lifecycle fake Claude executable speaks the current runner protocol sufficiently for the packaged runtime test to prove pause, resume, trigger, completion, delivery, and persisted evidence. Concretely, after handling required control responses and receiving the first prompt-stream input item, it emits the existing deterministic transcript: `system`/`init` with connected Gantry MCP status, assistant text, and `result`/`success`.
-- The job-lifecycle scenario stays hermetic: no real provider credential, no real `~/gantry`, disposable Postgres only, no live user or persistent developer database, and no model phrasing assertions.
-- `npm run lint` is run and its 43-error/1047-warning current-main baseline is recorded. If still present, implementation raises a Forge signal and does not widen this PR to clean unrelated lint debt.
-- Before merge, the checkout-bound local runtime smoke passes for the canonical KnackLabs lead-maintenance job. Evidence must prove the running local service was built/installed from the active PR worktree, then run `scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e` and record terminal health `completed`.
-- Targeted gates pass:
+- DeepAgents RunCommand Postgres integration no longer fails solely because the
+  test helper times out before the cold runner creates its permission request.
+- The helper wait budget is scoped to the test helper and remains bounded; it
+  does not change production runner, permission, model, sandbox, or provider
+  timeouts.
+- The MCP hot-path Postgres fixture includes reviewed semantic capability data
+  for `HOT_SERVER_ID`, `HOT_SERVER_NAME`, and `HOT_TOOL_NAME` rather than relying
+  on stale exact third-party MCP grants.
+- The MCP fixture still preserves source-inventory versus action-authority
+  separation: hot-path inventory/search evidence remains available, and any call
+  authority comes from reviewed semantic capability evidence.
+- The job-lifecycle E2E test and its fake-Claude helper are unchanged from the
+  baseline. No job-lifecycle file is part of this PR's write scope.
+- The macOS packaged-runner failure from `fakeHome/.local/bin/claude` rejection
+  is documented as platform mismatch evidence from `S-0001-8d39`, not as a
+  fixture defect or pass/fail claim.
+- Hermetic job-lifecycle E2E has recorded Linux/CI-parity baseline evidence from
+  unchanged base `5fff01d0f`: Node 25 container, container-local Postgres proxy,
+  1 file / 1 test passed, 0 skipped, 38.03s. Repeat this gate for the branch and
+  in CI before PR-ready.
+- `npm run lint` is run and its 43-error/1047-warning current-main baseline is
+  recorded. If still present, implementation raises a Forge signal and does not
+  widen this PR to clean unrelated lint debt.
+- Before merge, the checkout-bound local runtime smoke passes for the canonical
+  KnackLabs lead-maintenance job. Evidence must prove the running local service
+  was built/installed from the active PR worktree, then run
+  `scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e` and
+  record terminal health `completed`.
+- CI is green before merge.
+- Targeted local gates pass:
   - `npm run test:integration:postgres -- apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts`
   - `GANTRY_POSTGRES_HOT_PATH=1 npm run test:integration:postgres:hot-path -- apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`
   - `npm run build:runtime`
+- Linux/CI-parity Node 25 gate is repeated before PR-ready:
   - `npm run test:e2e:agent:hermetic -- apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
-- Final branch gates for this prerequisite PR pass before it is treated as unblocking the latency program:
+- Final branch gates for this prerequisite PR pass before it is treated as
+  unblocking the latency program:
   - `npm run format:check`
   - `npm run typecheck`
-  - `npm run lint` or a recorded Forge signal that the confirmed 43-error/1047-warning current-main lint baseline remains outside this PR's scope
+  - `npm run lint` or a recorded Forge signal that the confirmed
+    43-error/1047-warning current-main lint baseline remains outside this PR's
+    scope
   - `npm run test:unit`
   - `npm run test:integration`
   - `npm run test:integration:postgres`
-  - `npm run test:e2e:agent:hermetic`
+  - `npm run test:e2e:agent:hermetic` in Linux/CI-parity Node 25
   - `npm run check:architecture`
   - `/opt/homebrew/bin/python3 .agents/scripts/verify.py`
 
@@ -61,39 +121,56 @@ Use the smallest fixture repairs that match current runtime truth.
 
 1. DeepAgents RunCommand helper
    - Update only the test helper that waits for the host permission request.
-   - Replace the fixed 5 second polling deadline with a bounded helper parameter or local constant aligned with the surrounding 120 second test timeout.
-   - Keep the signed request parse, `coordinatePermissionDecision`, reviewed rule decision, and signed response write unchanged.
-   - Add/retain a targeted assertion that the host decision is still `reviewed_rule` for `RunCommand(echo *)`.
+   - Replace the fixed 5 second polling deadline with a bounded helper parameter
+     or local constant aligned with the surrounding 120 second test timeout.
+   - Keep the signed request parse, `coordinatePermissionDecision`, reviewed
+     rule decision, and signed response write unchanged.
+   - Add or retain a targeted assertion that the host decision is still
+     `reviewed_rule` for `RunCommand(echo *)`.
 
 2. MCP hot-path fixture
-   - Update `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`.
-   - Add reviewed semantic capability fixture data for the actual hot-path constants: `HOT_SERVER_ID`, `HOT_SERVER_NAME`, and `HOT_TOOL_NAME`.
-   - Keep `GANTRY_POSTGRES_HOT_PATH=1` as part of the targeted verification so the row-volume hot-path scenario actually runs.
+   - Update
+     `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`.
+   - Add reviewed semantic capability fixture data for the actual hot-path
+     constants: `HOT_SERVER_ID`, `HOT_SERVER_NAME`, and `HOT_TOOL_NAME`.
+   - Keep `GANTRY_POSTGRES_HOT_PATH=1` and the dedicated hot-path script as part
+     of targeted verification so the row-volume hot-path scenario actually runs.
    - Do not restore legacy exact third-party MCP action grants as authority.
    - Preserve inventory/audit hot-path evidence and source/action separation.
 
-3. Hermetic job-lifecycle fake Claude
-   - Re-resolve the fake executable path installed by `installHermeticRunnerTools`.
-   - Update the fake to retain required control responses and, on the first prompt-stream input item, emit the current deterministic runner transcript expected by packaged runtime jobs: `system`/`init` with connected Gantry MCP status, assistant text, and `result`/`success`.
-   - Assert scheduler behavior through API state, job events, run status, and delivery persistence; do not assert natural-language model text.
-   - Keep all credentials fake and scoped through the existing harness `env` path.
+3. Job-lifecycle E2E evidence
+   - Restore `apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
+     and any job-lifecycle fake-Claude helper edits to the unchanged baseline.
+   - Do not change executable trust, sandbox path admission, `HOME` handling, or
+     packaged-runner production behavior in this prerequisite.
+   - Use the recorded baseline approach for hermetic job-lifecycle E2E evidence:
+     unchanged base `5fff01d0f`, Node 25 container, and container-local Postgres
+     proxy. The recorded baseline result is 1 file / 1 test passed, 0 skipped,
+     38.03s. Repeat the same gate for this branch and in CI before PR-ready.
+   - Record the macOS host result as the `S-0001-8d39` platform mismatch:
+     packaged runner strips `HOME`, so
+     `allowedOuterSandboxClaudeExecutable(fakeHome/.local/bin/claude)` rejects
+     the fake executable.
 
 4. Lint baseline
    - Run `npm run lint` before final gate claims.
-   - If it still reports the confirmed current-main 43 errors and 1047 warnings, record the exact output summary and raise a Forge signal instead of editing unrelated files.
-   - Do not expand the fixture repair to lint-clean production or unrelated test files.
+   - If it still reports the confirmed current-main 43 errors and 1047 warnings,
+     record the exact output summary and raise a Forge signal instead of editing
+     unrelated files.
+   - Do not expand the fixture repair to lint-clean production or unrelated test
+     files.
 
 ## Surface Impact
 
 | Surface | Classification | Reason |
 | --- | --- | --- |
-| Runtime behavior | Unchanged by design | Fixture repairs only; production runner and scheduler contracts remain the source of truth. |
-| API | Read-only/observable | Job E2E exercises existing control endpoints without route or contract changes. |
-| Data/schema | Read-only/observable | Postgres suites are used to prove current behavior; no schema, migration, or repository edits planned. |
-| CLI/ops | Read-only/observable | The KnackLabs smoke uses existing `gantry` CLI/service operations; no CLI behavior or launchd ownership change. |
+| Runtime behavior | Unchanged by design | Fixture repairs only; production runner, sandbox, executable trust, provider, and scheduler contracts remain unchanged. |
+| API | Read-only/observable | Job E2E and KnackLabs smoke exercise existing control endpoints without route or contract changes. |
+| Data/schema | Read-only/observable | Postgres suites prove current behavior; no schema, migration, or repository edits planned. |
+| CLI/ops | Read-only/observable | KnackLabs smoke uses existing `gantry` CLI/service operations; no CLI behavior or launchd ownership change. |
 | UI | Not applicable | No user-interface surface is touched. |
-| Docs | Changed | This plan and the accepted signoff decision record are added. |
-| Tests | Changed | Exactly the targeted validation fixtures are repaired. |
+| Docs | Changed | This plan and revised signoff decision record are added. |
+| Tests | Changed | Exactly the two targeted validation fixtures are repaired; job-lifecycle returns to unchanged baseline. |
 
 Cleanup search terms for the implementer:
 
@@ -103,18 +180,17 @@ Cleanup search terms for the implementer:
 - `HOT_SERVER_NAME`
 - `HOT_TOOL_NAME`
 - `mcp-inventory-audit-explain-itest`
+- `job-lifecycle.agent-e2e.test.ts`
 - `installHermeticRunnerTools`
-- `system`
-- `init`
-- `Final Job Report`
+- `allowedOuterSandboxClaudeExecutable`
+- `fakeHome/.local/bin/claude`
 
 ## Decisions
 
-No new decisions.
-
-Existing gate record: `docs/decisions/0064-client-signoff.md` records the
-accepted client signoff for this prerequisite branch through the normal Forge
-gate.
+- `docs/decisions/0064-client-signoff.md` records the original accepted
+  LAT-GATE-0 signoff for three fixture repairs.
+- `docs/decisions/0066-client-signoff.md` records the accepted revised signoff
+  for the narrowed two-fixture plan and Linux/CI-parity hermetic E2E gate.
 
 ## Task Decomposition
 
@@ -122,22 +198,41 @@ One bounded implementation stage is sufficient.
 
 Stage `LAT-GATE-0-FIXTURES`
 
-- Objective: repair the three validation fixtures without production behavior changes.
+- Objective: repair the DeepAgents wait and MCP reviewed-capability fixtures
+  without production behavior changes.
 - Write scope:
   - `apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts`
   - `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`
+- Restore scope:
   - `apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
-  - Any existing test-only helper directly owned by the job-lifecycle scenario, only if the fake executable is defined there.
-- Acceptance: all criteria above pass with no production file edits. If a fixture cannot model current behavior within the test-only scope, raise a Forge signal and stop for a revised plan and new client signoff.
-- Reviewer focus: fixture faithfulness to production contracts, no timeout masking of real hangs, no MCP authorization weakening, no accidental use of real model/runtime state.
+  - Any job-lifecycle fake-Claude helper changed in this prerequisite worktree
+- Acceptance: all criteria above pass with no production file edits and no
+  job-lifecycle fixture changes. If either target fixture cannot model current
+  behavior within the test-only scope, raise a Forge signal and stop for a
+  revised plan and new client signoff.
+- Reviewer focus: fixture faithfulness to production contracts, no timeout
+  masking of real hangs, no MCP authorization weakening, no executable-trust
+  or sandbox relaxation, no accidental use of real model/runtime state, and
+  Ponytail simplest-sufficient scope inside the single autoreview quality lens
+  or a non-recorded local checklist.
 
 ## Risks
 
-- A longer helper wait could hide a real deadlock if it is applied broadly. Mitigation: change only the specific permission-request wait and keep test-level timeout bounded.
-- The MCP fixture could accidentally re-authorize exact third-party MCP tools. Mitigation: add reviewed semantic capability data instead of removing negative stale-rule coverage.
-- The fake Claude update could become a parallel runner implementation. Mitigation: emit only the minimum frames needed for job-lifecycle state assertions.
-- E2E may still fail from environment prerequisites such as missing disposable Postgres, missing build output, or port conflicts. Mitigation: report those as environment blockers, not as passing evidence.
-- The local KnackLabs smoke can give false confidence if `com.gantry` is still running from another checkout. Mitigation: record service/worktree proof before triggering `job-knacklabs-lead-maintenance-43527c192a6e`.
+- A longer helper wait could hide a real deadlock if it is applied broadly.
+  Mitigation: change only the specific permission-request wait and keep
+  test-level timeout bounded.
+- The MCP fixture could accidentally re-authorize exact third-party MCP tools.
+  Mitigation: add reviewed semantic capability data instead of removing
+  negative stale-rule coverage.
+- Linux hermetic E2E must stay representative of CI rather than macOS host
+  behavior. Mitigation: repeat the recorded Node 25 container plus
+  container-local Postgres proxy approach for this branch and CI.
+- macOS packaged-runner behavior can be mistaken for a job-lifecycle fixture
+  defect. Mitigation: document `S-0001-8d39` as a platform mismatch and do not
+  change executable trust in this prerequisite.
+- The local KnackLabs smoke can give false confidence if `com.gantry` is still
+  running from another checkout. Mitigation: record service/worktree proof
+  before triggering `job-knacklabs-lead-maintenance-43527c192a6e`.
 
 ## Verify Plan
 
@@ -146,31 +241,47 @@ Before implementation:
 - `/opt/homebrew/bin/python3 .agents/scripts/forge.py next`
 - `/opt/homebrew/bin/python3 .agents/scripts/forge.py decision list --active`
 - Re-resolve every cited symbol with `rg`/file reads.
+- Confirm Forge is back to planning and contradiction signal `S-0001-8d39` is
+  resolved by accepted `docs/decisions/0066-client-signoff.md` before
+  implementation proceeds.
 
 During implementation:
 
 - `npm run test:integration:postgres -- apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts`
 - `GANTRY_POSTGRES_HOT_PATH=1 npm run test:integration:postgres:hot-path -- apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`
 - `npm run build:runtime`
-- `npm run test:e2e:agent:hermetic -- apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
-- `npm run lint` to record whether the confirmed current-main 43-error/1047-warning lint baseline remains
+- `npm run lint` to record whether the confirmed current-main
+  43-error/1047-warning lint baseline remains
+- Restore or confirm unchanged baseline for
+  `apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
 
 Before PR-ready:
 
 - `npm run format:check`
 - `npm run typecheck`
-- `npm run lint` or a Forge signal documenting the confirmed current-main lint baseline as outside this PR's write scope
+- `npm run lint` or a Forge signal documenting the confirmed current-main lint
+  baseline as outside this PR's write scope
 - `npm run test:unit`
 - `npm run test:integration`
 - `npm run test:integration:postgres`
-- `npm run test:e2e:agent:hermetic`
+- Linux/CI-parity Node 25, repeating the recorded unchanged-base `5fff01d0f`
+  container-local Postgres proxy approach:
+  `npm run test:e2e:agent:hermetic -- apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
 - `npm run check:architecture`
 - `/opt/homebrew/bin/python3 .agents/scripts/verify.py`
 - One autoreview helper run with quality, performance, and security lenses.
+  The quality lens should include Ponytail simplest-sufficient scope review, or
+  the implementer may run a non-recorded local Ponytail checklist before the
+  single required autoreview.
 - Record automated tests and reviews through the Forge recorders.
 
 Before merge:
 
-- Prove the local Gantry service is built/installed from the active PR worktree, not another checkout, by recording service/worktree evidence alongside `gantry status`.
-- Run `scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e` from the active checkout.
-- Record the canonical job's terminal health as `completed`; if setup/auth blocks the live smoke, report the blocker and do not merge.
+- CI green.
+- Prove the local Gantry service is built/installed from the active PR worktree,
+  not another checkout, by recording service/worktree evidence alongside
+  `gantry status`.
+- Run `scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e`
+  from the active checkout.
+- Record the canonical job's terminal health as `completed`; if setup/auth
+  blocks the live smoke, report the blocker and do not merge.

--- a/plans/LAT-GATE-0-response-latency-prerequisite-gates-plan.md
+++ b/plans/LAT-GATE-0-response-latency-prerequisite-gates-plan.md
@@ -1,0 +1,176 @@
+# LAT-GATE-0 Response Latency Prerequisite Gates Plan
+
+## Problem
+
+The response-latency program requires clean local integration and agent E2E gates before any latency PR can be merged. Current main has three fixture-level blockers that make those gates unreliable:
+
+1. `apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts` has a host-side RunCommand approval helper with a fixed 5 second wait for the permission request. Cold DeepAgents/Postgres startup can exceed that helper budget even when the production path is correct.
+2. `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts` seeds and exercises the Postgres MCP inventory/audit hot-path without the reviewed semantic capability evidence required by the current MCP action-authority contract.
+3. `apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts` uses a hermetic fake Claude executable installed by the test, but the fake trigger path waits for `control_request.initialize` or EOF before it emits the transcript needed by the current packaged runtime runner path.
+4. `npm run lint` currently reports a current-main baseline of 43 errors and 1047 warnings outside this fixture-repair scope.
+
+This is a prerequisite gate repair, not a response-latency optimization phase.
+
+## Scope / Non-goals
+
+In scope:
+
+- Fixture-only repair for the three blockers above.
+- Preserve the current security model: reviewed semantic capabilities remain required for third-party MCP action authority, and RunCommand remains mediated through signed IPC and the host permission coordinator.
+- Preserve the packaged-runtime E2E contract: fresh `GANTRY_HOME`, disposable Postgres, no live user runtime, no persistent developer database, and no real model provider.
+- Record Forge artifacts before implementation.
+- Record the current-main lint baseline and raise a Forge signal if the baseline still blocks PR-ready after the fixture repairs.
+
+Non-goals:
+
+- No production source changes. If a fixture cannot model current production behavior, raise a Forge signal and stop for a revised plan and new client signoff.
+- No lint cleanup, architecture exception changes, broad timeout rewrites, or unrelated flaky-test fixes.
+- No edits to the LAT-0 latency harness branch/files.
+- No weakening of auth, signed IPC replay checks, permission decision precedence, sandbox projection, MCP reviewed-capability rules, or scheduler/job state transitions.
+- No changes to the local KnackLabs runtime or lead-gen job in this prerequisite branch.
+
+## Acceptance Criteria
+
+- DeepAgents RunCommand Postgres integration no longer fails solely because the test helper times out before the cold runner creates its permission request.
+- The helper wait budget is scoped to the test helper and remains bounded; it does not change production runner, permission, or model timeouts.
+- The MCP hot-path Postgres fixture includes reviewed semantic capability data for `HOT_SERVER_ID`, `HOT_SERVER_NAME`, and `HOT_TOOL_NAME` rather than relying on stale exact third-party MCP grants.
+- The MCP fixture still preserves source-inventory versus action-authority separation: hot-path inventory/search evidence remains available, and any call authority comes from reviewed semantic capability evidence.
+- The job-lifecycle fake Claude executable speaks the current runner protocol sufficiently for the packaged runtime test to prove pause, resume, trigger, completion, delivery, and persisted evidence. Concretely, after handling required control responses and receiving the first prompt-stream input item, it emits the existing deterministic transcript: `system`/`init` with connected Gantry MCP status, assistant text, and `result`/`success`.
+- The job-lifecycle scenario stays hermetic: no real provider credential, no real `~/gantry`, disposable Postgres only, no live user or persistent developer database, and no model phrasing assertions.
+- `npm run lint` is run and its 43-error/1047-warning current-main baseline is recorded. If still present, implementation raises a Forge signal and does not widen this PR to clean unrelated lint debt.
+- Before merge, the checkout-bound local runtime smoke passes for the canonical KnackLabs lead-maintenance job. Evidence must prove the running local service was built/installed from the active PR worktree, then run `scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e` and record terminal health `completed`.
+- Targeted gates pass:
+  - `npm run test:integration:postgres -- apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts`
+  - `GANTRY_POSTGRES_HOT_PATH=1 npm run test:integration:postgres:hot-path -- apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`
+  - `npm run build:runtime`
+  - `npm run test:e2e:agent:hermetic -- apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
+- Final branch gates for this prerequisite PR pass before it is treated as unblocking the latency program:
+  - `npm run format:check`
+  - `npm run typecheck`
+  - `npm run lint` or a recorded Forge signal that the confirmed 43-error/1047-warning current-main lint baseline remains outside this PR's scope
+  - `npm run test:unit`
+  - `npm run test:integration`
+  - `npm run test:integration:postgres`
+  - `npm run test:e2e:agent:hermetic`
+  - `npm run check:architecture`
+  - `/opt/homebrew/bin/python3 .agents/scripts/verify.py`
+
+## Technical Approach
+
+Use the smallest fixture repairs that match current runtime truth.
+
+1. DeepAgents RunCommand helper
+   - Update only the test helper that waits for the host permission request.
+   - Replace the fixed 5 second polling deadline with a bounded helper parameter or local constant aligned with the surrounding 120 second test timeout.
+   - Keep the signed request parse, `coordinatePermissionDecision`, reviewed rule decision, and signed response write unchanged.
+   - Add/retain a targeted assertion that the host decision is still `reviewed_rule` for `RunCommand(echo *)`.
+
+2. MCP hot-path fixture
+   - Update `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`.
+   - Add reviewed semantic capability fixture data for the actual hot-path constants: `HOT_SERVER_ID`, `HOT_SERVER_NAME`, and `HOT_TOOL_NAME`.
+   - Keep `GANTRY_POSTGRES_HOT_PATH=1` as part of the targeted verification so the row-volume hot-path scenario actually runs.
+   - Do not restore legacy exact third-party MCP action grants as authority.
+   - Preserve inventory/audit hot-path evidence and source/action separation.
+
+3. Hermetic job-lifecycle fake Claude
+   - Re-resolve the fake executable path installed by `installHermeticRunnerTools`.
+   - Update the fake to retain required control responses and, on the first prompt-stream input item, emit the current deterministic runner transcript expected by packaged runtime jobs: `system`/`init` with connected Gantry MCP status, assistant text, and `result`/`success`.
+   - Assert scheduler behavior through API state, job events, run status, and delivery persistence; do not assert natural-language model text.
+   - Keep all credentials fake and scoped through the existing harness `env` path.
+
+4. Lint baseline
+   - Run `npm run lint` before final gate claims.
+   - If it still reports the confirmed current-main 43 errors and 1047 warnings, record the exact output summary and raise a Forge signal instead of editing unrelated files.
+   - Do not expand the fixture repair to lint-clean production or unrelated test files.
+
+## Surface Impact
+
+| Surface | Classification | Reason |
+| --- | --- | --- |
+| Runtime behavior | Unchanged by design | Fixture repairs only; production runner and scheduler contracts remain the source of truth. |
+| API | Read-only/observable | Job E2E exercises existing control endpoints without route or contract changes. |
+| Data/schema | Read-only/observable | Postgres suites are used to prove current behavior; no schema, migration, or repository edits planned. |
+| CLI/ops | Read-only/observable | The KnackLabs smoke uses existing `gantry` CLI/service operations; no CLI behavior or launchd ownership change. |
+| UI | Not applicable | No user-interface surface is touched. |
+| Docs | Changed | This plan and the accepted signoff decision record are added. |
+| Tests | Changed | Exactly the targeted validation fixtures are repaired. |
+
+Cleanup search terms for the implementer:
+
+- `while (Date.now() - startedAt < 5_000)`
+- `RunCommand(echo *)`
+- `HOT_SERVER_ID`
+- `HOT_SERVER_NAME`
+- `HOT_TOOL_NAME`
+- `mcp-inventory-audit-explain-itest`
+- `installHermeticRunnerTools`
+- `system`
+- `init`
+- `Final Job Report`
+
+## Decisions
+
+No new decisions.
+
+Existing gate record: `docs/decisions/0064-client-signoff.md` records the
+accepted client signoff for this prerequisite branch through the normal Forge
+gate.
+
+## Task Decomposition
+
+One bounded implementation stage is sufficient.
+
+Stage `LAT-GATE-0-FIXTURES`
+
+- Objective: repair the three validation fixtures without production behavior changes.
+- Write scope:
+  - `apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts`
+  - `apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`
+  - `apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
+  - Any existing test-only helper directly owned by the job-lifecycle scenario, only if the fake executable is defined there.
+- Acceptance: all criteria above pass with no production file edits. If a fixture cannot model current behavior within the test-only scope, raise a Forge signal and stop for a revised plan and new client signoff.
+- Reviewer focus: fixture faithfulness to production contracts, no timeout masking of real hangs, no MCP authorization weakening, no accidental use of real model/runtime state.
+
+## Risks
+
+- A longer helper wait could hide a real deadlock if it is applied broadly. Mitigation: change only the specific permission-request wait and keep test-level timeout bounded.
+- The MCP fixture could accidentally re-authorize exact third-party MCP tools. Mitigation: add reviewed semantic capability data instead of removing negative stale-rule coverage.
+- The fake Claude update could become a parallel runner implementation. Mitigation: emit only the minimum frames needed for job-lifecycle state assertions.
+- E2E may still fail from environment prerequisites such as missing disposable Postgres, missing build output, or port conflicts. Mitigation: report those as environment blockers, not as passing evidence.
+- The local KnackLabs smoke can give false confidence if `com.gantry` is still running from another checkout. Mitigation: record service/worktree proof before triggering `job-knacklabs-lead-maintenance-43527c192a6e`.
+
+## Verify Plan
+
+Before implementation:
+
+- `/opt/homebrew/bin/python3 .agents/scripts/forge.py next`
+- `/opt/homebrew/bin/python3 .agents/scripts/forge.py decision list --active`
+- Re-resolve every cited symbol with `rg`/file reads.
+
+During implementation:
+
+- `npm run test:integration:postgres -- apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts`
+- `GANTRY_POSTGRES_HOT_PATH=1 npm run test:integration:postgres:hot-path -- apps/core/test/integration/mcp-inventory-audit-explain.postgres.integration.test.ts`
+- `npm run build:runtime`
+- `npm run test:e2e:agent:hermetic -- apps/core/test/agent-e2e/scenarios/job-lifecycle.agent-e2e.test.ts`
+- `npm run lint` to record whether the confirmed current-main 43-error/1047-warning lint baseline remains
+
+Before PR-ready:
+
+- `npm run format:check`
+- `npm run typecheck`
+- `npm run lint` or a Forge signal documenting the confirmed current-main lint baseline as outside this PR's write scope
+- `npm run test:unit`
+- `npm run test:integration`
+- `npm run test:integration:postgres`
+- `npm run test:e2e:agent:hermetic`
+- `npm run check:architecture`
+- `/opt/homebrew/bin/python3 .agents/scripts/verify.py`
+- One autoreview helper run with quality, performance, and security lenses.
+- Record automated tests and reviews through the Forge recorders.
+
+Before merge:
+
+- Prove the local Gantry service is built/installed from the active PR worktree, not another checkout, by recording service/worktree evidence alongside `gantry status`.
+- Run `scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e` from the active checkout.
+- Record the canonical job's terminal health as `completed`; if setup/auth blocks the live smoke, report the blocker and do not merge.


### PR DESCRIPTION
This restores the deterministic integration gates that the response-latency
program depends on, so later latency PRs can distinguish real regressions from
stale test fixtures. The change is intentionally test-only: production runtime,
sandbox, executable-trust, authorization, and scheduler behavior are untouched.

## What changed

- Give the DeepAgents signed permission-request fixture a bounded 30-second
  polling window while preserving the production timeouts and signed IPC path.
- Seed the MCP hot-path fixture with the reviewed semantic capability now
  required by production authorization.
- Prove an inventory-visible but unreviewed MCP tool is denied before remote
  execution, while the reviewed tool succeeds.
- Measure and assert the four durable proxy audit rows outside the timed sample.
- Record the revised Forge signoff and implementation plan after the
  macOS-only fake-Claude proposal was disproved and removed from scope.

## Validation

- Forge deterministic verify: pass at `7a5776cd6`
- Autoreview: clean, patch correct, confidence 0.97
- Format, typecheck, architecture: pass
- Unit: 568 files, 7,393 tests passed
- Integration: 12 active files, 86 tests passed
- Postgres integration: 39 files, 207 passed, 1 skipped
- Postgres hot path: 4 files, 5 tests passed
- Linux Node 25 hermetic agent E2E: 4 files / 6 tests passed; 2 files /
  3 model-backed tests skipped because `E2E_MODEL_API_KEY` is unavailable;
  0 failed
- Focused DeepAgents Postgres: 12/12 passed
- Focused MCP hot path: 1/1 passed

The repository-wide lint command still reproduces the unchanged main baseline
of 43 errors and 1,047 warnings. This branch changes no file targeted by that
lint command and adds no changed-file lint finding.

## Runtime behavior

No production runtime behavior changes. The agent E2E delta is restored gate
reliability: the unchanged job-lifecycle scenario passes in Linux/CI parity.
