### PR TITLE
fix: preserve reviewed-rule job health

### DIFF
--- a/apps/core/src/jobs/execution-diagnostics.ts
+++ b/apps/core/src/jobs/execution-diagnostics.ts
@@ -176,7 +176,14 @@ export function updateDiagnosticsFromRuntimeEvent(
         stringValue(payload.recovery_action) ?? matchingWait?.recoveryAction,
     };
   }
-  if (phase === 'permission_allowed' && tool && mode === 'allow_once') {
+  const decidedBy =
+    stringValue(payload.decidedBy) ?? stringValue(payload.decided_by);
+  if (
+    phase === 'permission_allowed' &&
+    tool &&
+    mode === 'allow_once' &&
+    decidedBy !== 'reviewed_rule'
+  ) {
     const matchingWait =
       diagnostics.lastPermissionWait?.toolName === tool
         ? diagnostics.lastPermissionWait

--- a/apps/core/test/unit/jobs/execution-diagnostics.test.ts
+++ b/apps/core/test/unit/jobs/execution-diagnostics.test.ts
@@ -86,6 +86,54 @@ describe('execution diagnostics', () => {
     ]);
   });
 
+  it('keeps explicit human and user allow_once approvals transient', () => {
+    for (const decidedBy of ['human', 'user:approver']) {
+      const diagnostics = createJobRunDiagnostics();
+
+      updateDiagnosticsFromRuntimeEvent(
+        diagnostics,
+        RUNTIME_EVENT_TYPES.JOB_TOOL_ACTIVITY,
+        {
+          phase: 'permission_allowed',
+          tool: 'Bash',
+          mode: 'allow_once',
+          decidedBy,
+          ok: true,
+        },
+      );
+
+      expect(diagnostics.transientPermissionApprovals).toEqual([
+        {
+          toolName: 'Bash',
+          mode: 'allow_once',
+        },
+      ]);
+    }
+  });
+
+  it('does not classify reviewed-rule allow_once approvals as transient', () => {
+    for (const provenance of [
+      { decidedBy: 'reviewed_rule' },
+      { decided_by: 'reviewed_rule' },
+    ]) {
+      const diagnostics = createJobRunDiagnostics();
+
+      updateDiagnosticsFromRuntimeEvent(
+        diagnostics,
+        RUNTIME_EVENT_TYPES.JOB_TOOL_ACTIVITY,
+        {
+          phase: 'permission_allowed',
+          tool: 'Bash',
+          mode: 'allow_once',
+          ok: true,
+          ...provenance,
+        },
+      );
+
+      expect(diagnostics.transientPermissionApprovals).toEqual([]);
+    }
+  });
+
   it('aggregates startup diagnostics with sanitized count and timing fields', () => {
     const diagnostics = createJobRunDiagnostics();
 

--- a/apps/core/test/unit/jobs/execution-finalization.test.ts
+++ b/apps/core/test/unit/jobs/execution-finalization.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { RUNTIME_EVENT_TYPES } from '@core/domain/events/runtime-event-types.js';
 import { finalizeSchedulerJobRun } from '@core/jobs/execution-finalization.js';
-import { createJobRunDiagnostics } from '@core/jobs/execution-diagnostics.js';
+import {
+  createJobRunDiagnostics,
+  updateDiagnosticsFromRuntimeEvent,
+} from '@core/jobs/execution-diagnostics.js';
 import type { SchedulerDependencies } from '@core/jobs/types.js';
 import type { Job } from '@core/domain/types.js';
 
@@ -124,6 +128,99 @@ describe('finalizeSchedulerJobRun — permission ASK on a fenced job', () => {
     expect(updateJob).toHaveBeenCalledWith(
       'job-1',
       expect.objectContaining({ status: 'paused' }),
+    );
+  });
+});
+
+describe('finalizeSchedulerJobRun — transient permission approvals', () => {
+  it('keeps a successful recurring job active after reviewed-rule allow_once', async () => {
+    const { deps, updateJob } = makeDeps();
+    const diagnostics = createJobRunDiagnostics();
+    updateDiagnosticsFromRuntimeEvent(
+      diagnostics,
+      RUNTIME_EVENT_TYPES.JOB_TOOL_ACTIVITY,
+      {
+        phase: 'permission_allowed',
+        tool: 'Bash',
+        mode: 'allow_once',
+        decidedBy: 'reviewed_rule',
+        ok: true,
+      },
+    );
+
+    const state = await finalizeSchedulerJobRun({
+      currentJob: makeJob({
+        schedule_type: 'interval',
+        schedule_value: '60000',
+      }),
+      deps,
+      scheduledFor: '2024-01-01T00:00:00.000Z',
+      now: '2024-01-01T00:00:01.000Z',
+      error: null,
+      diagnostics,
+      pausedForSetupDuringRun: false,
+      deletedDuringRun: false,
+      runtimeAppId: 'default',
+      runId: 'run-reviewed-rule',
+      publishRuntimeEvent: vi.fn(async () => undefined),
+    });
+
+    expect(state.runStatus).toBe('completed');
+    expect(state.pauseReason).toBeNull();
+    expect(updateJob).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({
+        status: 'active',
+        pause_reason: null,
+      }),
+    );
+    expect(updateJob).not.toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({ status: 'paused' }),
+    );
+  });
+
+  it('pauses a successful recurring job after human allow_once', async () => {
+    const { deps, updateJob } = makeDeps();
+    const diagnostics = createJobRunDiagnostics();
+    updateDiagnosticsFromRuntimeEvent(
+      diagnostics,
+      RUNTIME_EVENT_TYPES.JOB_TOOL_ACTIVITY,
+      {
+        phase: 'permission_allowed',
+        tool: 'Bash',
+        mode: 'allow_once',
+        decidedBy: 'human',
+        ok: true,
+      },
+    );
+
+    const state = await finalizeSchedulerJobRun({
+      currentJob: makeJob({
+        schedule_type: 'interval',
+        schedule_value: '60000',
+      }),
+      deps,
+      scheduledFor: '2024-01-01T00:00:00.000Z',
+      now: '2024-01-01T00:00:01.000Z',
+      error: null,
+      diagnostics,
+      pausedForSetupDuringRun: false,
+      deletedDuringRun: false,
+      runtimeAppId: 'default',
+      runId: 'run-human',
+      publishRuntimeEvent: vi.fn(async () => undefined),
+    });
+
+    expect(state.runStatus).toBe('completed');
+    expect(state.pauseReason).toBe('Setup required');
+    expect(updateJob).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({
+        status: 'paused',
+        next_run: null,
+        pause_reason: 'Setup required',
+      }),
     );
   });
 });


### PR DESCRIPTION
This keeps successful recurring jobs healthy when Gantry's host has already admitted a tool through durable reviewed policy. Today that admission is emitted as `allow_once`, so job finalization mistakes it for a human one-shot approval and pauses an otherwise successful job as setup-required.

## What changed

- Exclude exact `reviewed_rule` provenance from transient `allow_once` job diagnostics.
- Preserve the existing transient behavior for human, user, missing, unknown, and every other provenance.
- Accept both canonical `decidedBy` and compatibility `decided_by` event fields.
- Add regression coverage at diagnostic and recurring-job finalization boundaries.
- Leave permission admission, PERM-2 authority, runtime event forwarding, schemas, APIs, and scheduler state machines unchanged.

## Validation

- Forge deterministic verify: pass
- Final autoreview: clean, patch correct, confidence 0.97; quality/performance/security 10/10
- Format and architecture: pass
- Typecheck: pass
- Unit: 568 files / 7,397 tests passed
- Active integration: 12 files / 86 tests passed
- Postgres integration: 39 files / 207 passed, 1 skipped
- Postgres hot path: 4 files / 5 tests passed
- Linux Node 25 hermetic agent E2E: 4 files / 6 tests passed; 2 files / 3 model-key tests skipped; 0 failed
- Focused regression: 2 files / 12 tests passed

The repository-wide lint command still reproduces the unchanged main baseline of 43 errors and 1,047 warnings. The touched production file has zero lint errors.

## Checkout-bound runtime proof

Built and rebound the local launchd service to the reviewed checkout. KnackLabs job run `0c6518c3-bd33-4d85-bfce-d6d197599dde` completed in 480.824 seconds; `scripts/agent-job-smoke.sh` exited 0 with `[smoke] PASS`. Final job state: active, health completed, setup ready.

The published head tree `238130d35e14dff29988c2763fd0b2f3c2fe5bb5` exactly matches locally reviewed commit `90b826f59d8474a0e868cb933930206d7db06099`; GitHub normalized commit timestamps while reconstructing the reviewed commits through its Git data API.
