### PR TITLE
fix(observer): digest action buttons were stripped on durable send (#313 regression)

### DIFF
--- a/apps/core/src/domain/messages/retry-tail-provider-payload.ts
+++ b/apps/core/src/domain/messages/retry-tail-provider-payload.ts
@@ -2,6 +2,23 @@ const MAX_ID_LENGTH = 256;
 const MAX_WARNING_LENGTH = 160;
 const MAX_LIST_ITEMS = 20;
 const MAX_PART_COUNT = 10_000;
+// Observer digest view caps. The view is a small top-N (schedule.maxInsights)
+// with a fixed 4-affordance set per insight; these bound the persisted blob so
+// a malformed/oversized one fails safe to text-only rather than bloating the row.
+const MAX_DIGEST_INSIGHTS = 50;
+const MAX_DIGEST_AFFORDANCES = 8;
+const MAX_DIGEST_TITLE = 200;
+const MAX_DIGEST_SUMMARY = 1_000;
+const MAX_DIGEST_LABEL = 80;
+const MAX_DIGEST_SHORT = 64;
+// Mirrors ObserverFeedbackAction; kept literal here so the domain->messages dir
+// stays leaf (no cross-dir import for four string constants).
+const OBSERVER_FEEDBACK_ACTIONS = new Set([
+  'resolve',
+  'dismiss',
+  'snooze',
+  'less_like_this',
+]);
 const SAFE_WARNING_CODE = /^[a-z0-9]+(?:[._][a-z0-9]+)+(?::[0-9]{1,6})*$/;
 const SECRET_LIKE_WARNING_TEXT =
   /\b(token|secret|authorization|bearer|api[_-]?key|password)\b|sk-[a-z0-9_-]{8,}|xox[a-z]-[a-z0-9-]{8,}/i;
@@ -21,6 +38,35 @@ export interface RetryTailProviderPayload {
   totalParts?: number;
   warnings?: string[];
   fallbackArtifactId?: string;
+  // Bounded, structurally-validated mirror of ObserverDigestMessageView so the
+  // digest's native per-insight action buttons survive persist + recovery
+  // dispatch (the recovery loop reads providerPayload.observerDigestView). Not
+  // free-form provider content — every field is capped and the affordance action
+  // is allowlisted; malformed input drops the field/element, never throws.
+  observerDigestView?: SanitizedObserverDigestView;
+}
+
+export interface SanitizedObserverDigestView {
+  localDay: string;
+  recipient?: string;
+  insights: SanitizedObserverDigestInsight[];
+}
+
+export interface SanitizedObserverDigestInsight {
+  insightId: string;
+  title?: string;
+  summary?: string;
+  type?: string;
+  stateMarker?: string;
+  affordances: SanitizedObserverFeedbackAffordance[];
+}
+
+export interface SanitizedObserverFeedbackAffordance {
+  kind: 'observer_feedback';
+  label: string;
+  insightId: string;
+  action: string;
+  localDay: string;
 }
 
 export function sanitizeRetryTailProviderPayload(
@@ -76,6 +122,8 @@ export function sanitizeRetryTailProviderPayload(
   if (deliveredParts !== undefined) sanitized.deliveredParts = deliveredParts;
   const totalParts = readInt(source.totalParts);
   if (totalParts !== undefined) sanitized.totalParts = totalParts;
+  const observerDigestView = readObserverDigestView(source.observerDigestView);
+  if (observerDigestView) sanitized.observerDigestView = observerDigestView;
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
@@ -122,6 +170,89 @@ function readWarningCodeArray(
     (entry) =>
       SAFE_WARNING_CODE.test(entry) && !SECRET_LIKE_WARNING_TEXT.test(entry),
   );
+}
+
+function readObserverDigestView(
+  value: unknown,
+): SanitizedObserverDigestView | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const source = value as Record<string, unknown>;
+  const localDay = readString(source.localDay, { maxLength: MAX_DIGEST_SHORT });
+  // localDay is the digest's identity (it rides every callback token); without a
+  // valid one the view can't render actionable buttons — fail safe to text-only.
+  if (!localDay) return undefined;
+  const view: SanitizedObserverDigestView = { localDay, insights: [] };
+  const recipient = readString(source.recipient, { maxLength: MAX_ID_LENGTH });
+  if (recipient) view.recipient = recipient;
+  if (Array.isArray(source.insights)) {
+    for (const entry of source.insights) {
+      const insight = readObserverDigestInsight(entry);
+      if (!insight) continue;
+      view.insights.push(insight);
+      if (view.insights.length >= MAX_DIGEST_INSIGHTS) break;
+    }
+  }
+  return view;
+}
+
+function readObserverDigestInsight(
+  value: unknown,
+): SanitizedObserverDigestInsight | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const source = value as Record<string, unknown>;
+  const insightId = readString(source.insightId, { maxLength: MAX_ID_LENGTH });
+  if (!insightId) return undefined;
+  const insight: SanitizedObserverDigestInsight = {
+    insightId,
+    affordances: [],
+  };
+  const title = readString(source.title, { maxLength: MAX_DIGEST_TITLE });
+  if (title) insight.title = title;
+  const summary = readString(source.summary, { maxLength: MAX_DIGEST_SUMMARY });
+  if (summary) insight.summary = summary;
+  const type = readString(source.type, { maxLength: MAX_DIGEST_SHORT });
+  if (type) insight.type = type;
+  const stateMarker = readString(source.stateMarker, {
+    maxLength: MAX_DIGEST_SHORT,
+  });
+  if (stateMarker) insight.stateMarker = stateMarker;
+  if (Array.isArray(source.affordances)) {
+    for (const entry of source.affordances) {
+      const affordance = readObserverFeedbackAffordance(entry);
+      if (!affordance) continue;
+      insight.affordances.push(affordance);
+      if (insight.affordances.length >= MAX_DIGEST_AFFORDANCES) break;
+    }
+  }
+  return insight;
+}
+
+function readObserverFeedbackAffordance(
+  value: unknown,
+): SanitizedObserverFeedbackAffordance | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const source = value as Record<string, unknown>;
+  if (source.kind !== 'observer_feedback') return undefined;
+  const label = readString(source.label, { maxLength: MAX_DIGEST_LABEL });
+  const insightId = readString(source.insightId, { maxLength: MAX_ID_LENGTH });
+  const action = readString(source.action, { maxLength: MAX_DIGEST_SHORT });
+  const localDay = readString(source.localDay, { maxLength: MAX_DIGEST_SHORT });
+  if (
+    !label ||
+    !insightId ||
+    !action ||
+    !localDay ||
+    !OBSERVER_FEEDBACK_ACTIONS.has(action)
+  ) {
+    return undefined;
+  }
+  return { kind: 'observer_feedback', label, insightId, action, localDay };
 }
 
 function readInt(value: unknown): number | undefined {

--- a/apps/core/src/domain/messages/retry-tail-provider-payload.ts
+++ b/apps/core/src/domain/messages/retry-tail-provider-payload.ts
@@ -140,6 +140,23 @@ function readString(
   return trimmed.slice(0, options.maxLength);
 }
 
+// Identity-bearing fields (insightId, localDay) drive callback tokens, so an
+// oversized value must be REJECTED, not truncated: a truncated id could collide
+// with another insight's id (the binding equality would still pass) and settle
+// the WRONG insight on click. Over-limit/empty/non-string -> undefined, dropping
+// the owning element. Display fields keep truncation via readString.
+function readIdentity(
+  value: unknown,
+  options: {
+    maxLength: number;
+  },
+): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > options.maxLength) return undefined;
+  return trimmed;
+}
+
 function readStringArray(
   value: unknown,
   options: {
@@ -179,7 +196,9 @@ function readObserverDigestView(
     return undefined;
   }
   const source = value as Record<string, unknown>;
-  const localDay = readString(source.localDay, { maxLength: MAX_DIGEST_SHORT });
+  const localDay = readIdentity(source.localDay, {
+    maxLength: MAX_DIGEST_SHORT,
+  });
   // localDay is the digest's identity (it rides every callback token); without a
   // valid one the view can't render actionable buttons — fail safe to text-only.
   if (!localDay) return undefined;
@@ -205,7 +224,9 @@ function readObserverDigestInsight(
     return undefined;
   }
   const source = value as Record<string, unknown>;
-  const insightId = readString(source.insightId, { maxLength: MAX_ID_LENGTH });
+  const insightId = readIdentity(source.insightId, {
+    maxLength: MAX_ID_LENGTH,
+  });
   if (!insightId) return undefined;
   const insight: SanitizedObserverDigestInsight = {
     insightId,
@@ -247,9 +268,13 @@ function readObserverFeedbackAffordance(
   const source = value as Record<string, unknown>;
   if (source.kind !== 'observer_feedback') return undefined;
   const label = readString(source.label, { maxLength: MAX_DIGEST_LABEL });
-  const insightId = readString(source.insightId, { maxLength: MAX_ID_LENGTH });
+  const insightId = readIdentity(source.insightId, {
+    maxLength: MAX_ID_LENGTH,
+  });
   const action = readString(source.action, { maxLength: MAX_DIGEST_SHORT });
-  const localDay = readString(source.localDay, { maxLength: MAX_DIGEST_SHORT });
+  const localDay = readIdentity(source.localDay, {
+    maxLength: MAX_DIGEST_SHORT,
+  });
   if (
     !label ||
     !insightId ||

--- a/apps/core/src/domain/messages/retry-tail-provider-payload.ts
+++ b/apps/core/src/domain/messages/retry-tail-provider-payload.ts
@@ -188,7 +188,7 @@ function readObserverDigestView(
   if (recipient) view.recipient = recipient;
   if (Array.isArray(source.insights)) {
     for (const entry of source.insights) {
-      const insight = readObserverDigestInsight(entry);
+      const insight = readObserverDigestInsight(entry, localDay);
       if (!insight) continue;
       view.insights.push(insight);
       if (view.insights.length >= MAX_DIGEST_INSIGHTS) break;
@@ -199,6 +199,7 @@ function readObserverDigestView(
 
 function readObserverDigestInsight(
   value: unknown,
+  viewLocalDay: string,
 ): SanitizedObserverDigestInsight | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -222,7 +223,11 @@ function readObserverDigestInsight(
   if (stateMarker) insight.stateMarker = stateMarker;
   if (Array.isArray(source.affordances)) {
     for (const entry of source.affordances) {
-      const affordance = readObserverFeedbackAffordance(entry);
+      const affordance = readObserverFeedbackAffordance(
+        entry,
+        insightId,
+        viewLocalDay,
+      );
       if (!affordance) continue;
       insight.affordances.push(affordance);
       if (insight.affordances.length >= MAX_DIGEST_AFFORDANCES) break;
@@ -233,6 +238,8 @@ function readObserverDigestInsight(
 
 function readObserverFeedbackAffordance(
   value: unknown,
+  parentInsightId: string,
+  viewLocalDay: string,
 ): SanitizedObserverFeedbackAffordance | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -248,7 +255,13 @@ function readObserverFeedbackAffordance(
     !insightId ||
     !action ||
     !localDay ||
-    !OBSERVER_FEEDBACK_ACTIONS.has(action)
+    !OBSERVER_FEEDBACK_ACTIONS.has(action) ||
+    // A button drives a callback that mutates (insightId, localDay). Bind it to
+    // its container so a corrupted payload can't render a button beside insight
+    // A whose click settles insight B (or a different digest day). Mismatch
+    // drops just this affordance — fail safe, never throw.
+    insightId !== parentInsightId ||
+    localDay !== viewLocalDay
   ) {
     return undefined;
   }

--- a/apps/core/src/domain/messages/retry-tail-provider-payload.ts
+++ b/apps/core/src/domain/messages/retry-tail-provider-payload.ts
@@ -140,11 +140,13 @@ function readString(
   return trimmed.slice(0, options.maxLength);
 }
 
-// Identity-bearing fields (insightId, localDay) drive callback tokens, so an
-// oversized value must be REJECTED, not truncated: a truncated id could collide
-// with another insight's id (the binding equality would still pass) and settle
-// the WRONG insight on click. Over-limit/empty/non-string -> undefined, dropping
-// the owning element. Display fields keep truncation via readString.
+// Identity-bearing fields (insightId, localDay) drive callback tokens, so the
+// value must be VERBATIM: neither truncated nor trim-normalized. Normalizing
+// " x " -> "x" could match a DIFFERENT insight's real id and settle the wrong
+// target on click — the same risk truncation had. Reject (drop the owning
+// element) if the RAW value is empty, non-string, over the max, or would change
+// under trim; else return the ORIGINAL string. Display fields keep truncation
+// via readString.
 function readIdentity(
   value: unknown,
   options: {
@@ -152,9 +154,10 @@ function readIdentity(
   },
 ): string | undefined {
   if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.length > options.maxLength) return undefined;
-  return trimmed;
+  if (!value || value.length > options.maxLength || value !== value.trim()) {
+    return undefined;
+  }
+  return value;
 }
 
 function readStringArray(
@@ -206,11 +209,11 @@ function readObserverDigestView(
   const recipient = readString(source.recipient, { maxLength: MAX_ID_LENGTH });
   if (recipient) view.recipient = recipient;
   if (Array.isArray(source.insights)) {
-    for (const entry of source.insights) {
+    // Bound entries INSPECTED, not just accepted: a malformed array of millions
+    // of invalid entries must not be traversed in full (DoS on enqueue/recovery).
+    for (const entry of source.insights.slice(0, MAX_DIGEST_INSIGHTS)) {
       const insight = readObserverDigestInsight(entry, localDay);
-      if (!insight) continue;
-      view.insights.push(insight);
-      if (view.insights.length >= MAX_DIGEST_INSIGHTS) break;
+      if (insight) view.insights.push(insight);
     }
   }
   return view;
@@ -243,15 +246,15 @@ function readObserverDigestInsight(
   });
   if (stateMarker) insight.stateMarker = stateMarker;
   if (Array.isArray(source.affordances)) {
-    for (const entry of source.affordances) {
+    // Bound entries INSPECTED (see insights loop): each insight can carry an
+    // arbitrarily large invalid affordance array.
+    for (const entry of source.affordances.slice(0, MAX_DIGEST_AFFORDANCES)) {
       const affordance = readObserverFeedbackAffordance(
         entry,
         insightId,
         viewLocalDay,
       );
-      if (!affordance) continue;
-      insight.affordances.push(affordance);
-      if (insight.affordances.length >= MAX_DIGEST_AFFORDANCES) break;
+      if (affordance) insight.affordances.push(affordance);
     }
   }
   return insight;

--- a/apps/core/test/unit/application/outbound-delivery-service.test.ts
+++ b/apps/core/test/unit/application/outbound-delivery-service.test.ts
@@ -157,6 +157,57 @@ describe('OutboundDeliveryService', () => {
     ]);
   });
 
+  it('carries an observerDigestView through enqueue sanitize so recovery dispatch can render buttons', async () => {
+    const repository = new MemoryOutboundDeliveryRepository();
+    const observerDigestView = {
+      localDay: '2026-07-25',
+      recipient: 'owner:happy',
+      insights: [
+        {
+          insightId: 'i-1',
+          title: 'First',
+          summary: 'One',
+          type: 'commitment',
+          affordances: [
+            {
+              kind: 'observer_feedback',
+              label: 'Resolve',
+              insightId: 'i-1',
+              action: 'resolve',
+              localDay: '2026-07-25',
+            },
+          ],
+        },
+      ],
+    };
+    const profile = createProfile(() => ({
+      parts: [
+        { canonicalText: 'digest', providerPayload: { observerDigestView } },
+      ],
+      canonicalFinalText: 'digest',
+    }));
+    const service = new OutboundDeliveryService({
+      repository,
+      profiles: new MemoryProfileRegistry(profile),
+      now: () => '2026-05-08T00:00:00.000Z',
+      createId: () => 'seed-id',
+      hashSha256Hex,
+    });
+
+    await service.enqueue({
+      appId: 'app:test' as never,
+      conversationId: 'conversation:test' as never,
+      profileId: 'profile:test',
+      idempotencyKey: 'idem:digest',
+      text: 'ignored',
+    });
+
+    const persisted = repository.enqueues[0]!.items[0]!.providerPayload as {
+      observerDigestView?: typeof observerDigestView;
+    };
+    expect(persisted.observerDigestView).toEqual(observerDigestView);
+  });
+
   it('can enqueue a single delivery item as initially claimed for immediate durable sends', async () => {
     const repository = new MemoryOutboundDeliveryRepository();
     const profile = createProfile(() => ({

--- a/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
+++ b/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
@@ -84,6 +84,56 @@ describe('sanitizeRetryTailProviderPayload observerDigestView passthrough', () =
     expect(actions).toEqual(['resolve', 'dismiss', 'snooze', 'less_like_this']);
   });
 
+  it('drops affordances whose insightId or localDay does not match their container', () => {
+    const view = wellFormedView();
+    const out = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [
+          {
+            ...view.insights[0],
+            affordances: [
+              // Foreign insightId: click would settle a DIFFERENT insight.
+              {
+                kind: 'observer_feedback',
+                label: 'Resolve',
+                insightId: 'i-2',
+                action: 'resolve',
+                localDay: '2026-07-25',
+              },
+              // Foreign localDay: click would settle a different digest day.
+              {
+                kind: 'observer_feedback',
+                label: 'Dismiss',
+                insightId: 'i-1',
+                action: 'dismiss',
+                localDay: '2026-07-26',
+              },
+              // Correctly bound: survives.
+              {
+                kind: 'observer_feedback',
+                label: 'Snooze',
+                insightId: 'i-1',
+                action: 'snooze',
+                localDay: '2026-07-25',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const survived = out?.observerDigestView?.insights[0].affordances;
+    expect(survived).toEqual([
+      {
+        kind: 'observer_feedback',
+        label: 'Snooze',
+        insightId: 'i-1',
+        action: 'snooze',
+        localDay: '2026-07-25',
+      },
+    ]);
+  });
+
   it('drops the whole view when localDay is missing (fail safe to text-only)', () => {
     const view = wellFormedView();
     const { localDay: _drop, ...noDay } = view;

--- a/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
+++ b/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildObserverDigestMessageView } from '@core/domain/observer-digest-view.js';
+import { sanitizeRetryTailProviderPayload } from '@core/domain/messages/retry-tail-provider-payload.js';
+
+function wellFormedView() {
+  return buildObserverDigestMessageView({
+    localDay: '2026-07-25',
+    recipient: 'owner:happy',
+    insights: [
+      { id: 'i-1', title: 'First', summary: 'One', insightType: 'commitment' },
+      { id: 'i-2', title: 'Second', summary: 'Two', insightType: 'commitment' },
+    ],
+  });
+}
+
+describe('sanitizeRetryTailProviderPayload observerDigestView passthrough', () => {
+  it('carries a well-formed view through with insights + affordances intact', () => {
+    const view = wellFormedView();
+    const out = sanitizeRetryTailProviderPayload({ observerDigestView: view });
+
+    const survived = out?.observerDigestView;
+    expect(survived?.localDay).toBe('2026-07-25');
+    expect(survived?.recipient).toBe('owner:happy');
+    expect(survived?.insights.map((i) => i.insightId)).toEqual(['i-1', 'i-2']);
+    for (const insight of survived!.insights) {
+      expect(insight.affordances.map((a) => a.action)).toEqual([
+        'resolve',
+        'dismiss',
+        'snooze',
+        'less_like_this',
+      ]);
+      for (const affordance of insight.affordances) {
+        expect(affordance.kind).toBe('observer_feedback');
+        expect(affordance.insightId).toBe(insight.insightId);
+        expect(affordance.localDay).toBe('2026-07-25');
+      }
+    }
+  });
+
+  it('strips unknown extra keys inside the view, insight, and affordance', () => {
+    const view = wellFormedView();
+    const out = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        junkTop: 'x',
+        insights: [{ ...view.insights[0], junkInsight: 'y' }],
+      },
+    });
+
+    const survived = out?.observerDigestView as Record<string, unknown>;
+    expect(survived).toBeDefined();
+    expect(survived.junkTop).toBeUndefined();
+    const insight = (survived.insights as Record<string, unknown>[])[0];
+    expect(insight.junkInsight).toBeUndefined();
+    expect(insight.insightId).toBe('i-1');
+  });
+
+  it('drops an affordance with an unknown action', () => {
+    const view = wellFormedView();
+    const out = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [
+          {
+            ...view.insights[0],
+            affordances: [
+              ...view.insights[0].affordances,
+              {
+                kind: 'observer_feedback',
+                label: 'Nuke',
+                insightId: 'i-1',
+                action: 'delete_everything',
+                localDay: '2026-07-25',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const actions = out?.observerDigestView?.insights[0].affordances.map(
+      (a) => a.action,
+    );
+    expect(actions).toEqual(['resolve', 'dismiss', 'snooze', 'less_like_this']);
+  });
+
+  it('drops the whole view when localDay is missing (fail safe to text-only)', () => {
+    const view = wellFormedView();
+    const { localDay: _drop, ...noDay } = view;
+    const out = sanitizeRetryTailProviderPayload({ observerDigestView: noDay });
+    expect(out?.observerDigestView).toBeUndefined();
+  });
+
+  it('drops an insight missing its insightId but keeps the valid siblings', () => {
+    const view = wellFormedView();
+    const out = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [{ title: 'orphan', affordances: [] }, view.insights[1]],
+      },
+    });
+    expect(out?.observerDigestView?.insights.map((i) => i.insightId)).toEqual([
+      'i-2',
+    ]);
+  });
+
+  it('bounds oversized fields and array counts', () => {
+    const big = 'a'.repeat(5_000);
+    const affordances = Array.from({ length: 40 }, () => ({
+      kind: 'observer_feedback',
+      label: 'Resolve',
+      insightId: 'i-1',
+      action: 'resolve',
+      localDay: '2026-07-25',
+    }));
+    const insights = Array.from({ length: 200 }, (_unused, idx) => ({
+      insightId: `i-${idx}`,
+      title: big,
+      summary: big,
+      type: 'commitment',
+      affordances,
+    }));
+    const out = sanitizeRetryTailProviderPayload({
+      observerDigestView: { localDay: '2026-07-25', insights },
+    });
+    const survived = out!.observerDigestView!;
+    expect(survived.insights.length).toBeLessThanOrEqual(50);
+    expect(survived.insights[0].title!.length).toBeLessThanOrEqual(200);
+    expect(survived.insights[0].summary!.length).toBeLessThanOrEqual(1_000);
+    expect(survived.insights[0].affordances.length).toBeLessThanOrEqual(8);
+  });
+
+  it('ignores a non-object view entirely', () => {
+    expect(
+      sanitizeRetryTailProviderPayload({ observerDigestView: 'nope' }),
+    ).toBeUndefined();
+    expect(
+      sanitizeRetryTailProviderPayload({ observerDigestView: [1, 2, 3] }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
+++ b/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
@@ -134,6 +134,64 @@ describe('sanitizeRetryTailProviderPayload observerDigestView passthrough', () =
     ]);
   });
 
+  it('rejects (does not trim-normalize) identity fields with surrounding whitespace', () => {
+    const view = wellFormedView();
+
+    // Insight insightId with whitespace -> insight dropped (not normalized+kept).
+    const insightSpaced = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [
+          { ...view.insights[0], insightId: ' i-1 ' },
+          view.insights[1],
+        ],
+      },
+    });
+    expect(
+      insightSpaced?.observerDigestView?.insights.map((i) => i.insightId),
+    ).toEqual(['i-2']);
+
+    // View localDay with whitespace -> whole view dropped.
+    const viewSpaced = sanitizeRetryTailProviderPayload({
+      observerDigestView: { ...view, localDay: ' 2026-07-25 ' },
+    });
+    expect(viewSpaced?.observerDigestView).toBeUndefined();
+
+    // Over-limit ONLY because of surrounding whitespace -> still dropped
+    // (length is measured on the RAW value, not the trimmed one).
+    const paddedOverLimit = ' '.repeat(60) + 'day' + ' '.repeat(60); // >64 raw
+    const dayPadded = sanitizeRetryTailProviderPayload({
+      observerDigestView: { ...view, localDay: paddedOverLimit },
+    });
+    expect(dayPadded?.observerDigestView).toBeUndefined();
+  });
+
+  it('bounds the number of INSPECTED entries, not just accepted ones', () => {
+    const view = wellFormedView();
+    // 50 invalid entries (null) fill the inspection budget; a VALID insight sits
+    // at index 50. If the loop bounded only ACCEPTED entries it would inspect all
+    // 51 and keep the valid one; bounding INSPECTED entries stops at 50, so the
+    // valid entry beyond the cap is never reached -> zero insights.
+    const insights = [...Array(50).fill(null), view.insights[0]];
+    const out = sanitizeRetryTailProviderPayload({
+      observerDigestView: { ...view, insights },
+    });
+    expect(out?.observerDigestView?.insights).toEqual([]);
+
+    // Same for affordances: 8 invalid then a valid one beyond the cap -> dropped.
+    const affordances = [
+      ...Array(8).fill(null),
+      view.insights[0].affordances[0],
+    ];
+    const affOut = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [{ ...view.insights[0], affordances }],
+      },
+    });
+    expect(affOut?.observerDigestView?.insights[0].affordances).toEqual([]);
+  });
+
   it('rejects (does not truncate) oversized identity fields', () => {
     const view = wellFormedView();
     const bigId = 'x'.repeat(300); // > MAX_ID_LENGTH (256)

--- a/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
+++ b/apps/core/test/unit/domain/messages/retry-tail-provider-payload.test.ts
@@ -134,6 +134,75 @@ describe('sanitizeRetryTailProviderPayload observerDigestView passthrough', () =
     ]);
   });
 
+  it('rejects (does not truncate) oversized identity fields', () => {
+    const view = wellFormedView();
+    const bigId = 'x'.repeat(300); // > MAX_ID_LENGTH (256)
+    const bigDay = 'd'.repeat(65); // > MAX_DIGEST_SHORT (64)
+
+    // Oversized insight insightId -> that insight is dropped, sibling survives.
+    const insightDropped = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [{ ...view.insights[0], insightId: bigId }, view.insights[1]],
+      },
+    });
+    expect(
+      insightDropped?.observerDigestView?.insights.map((i) => i.insightId),
+    ).toEqual(['i-2']);
+
+    // Oversized affordance insightId -> the owning insight (same oversized id)
+    // drops entirely, proving the id was never truncated-and-kept.
+    const affDropped = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [
+          {
+            ...view.insights[0],
+            insightId: bigId,
+            affordances: [
+              {
+                kind: 'observer_feedback',
+                label: 'Resolve',
+                insightId: bigId,
+                action: 'resolve',
+                localDay: '2026-07-25',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(affDropped?.observerDigestView?.insights).toEqual([]);
+
+    // Oversized affordance localDay -> that affordance dropped, insight kept.
+    const dayDropped = sanitizeRetryTailProviderPayload({
+      observerDigestView: {
+        ...view,
+        insights: [
+          {
+            ...view.insights[0],
+            affordances: [
+              {
+                kind: 'observer_feedback',
+                label: 'Resolve',
+                insightId: 'i-1',
+                action: 'resolve',
+                localDay: bigDay,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(dayDropped?.observerDigestView?.insights[0].affordances).toEqual([]);
+
+    // Oversized view localDay -> no view at all.
+    const viewDropped = sanitizeRetryTailProviderPayload({
+      observerDigestView: { ...view, localDay: bigDay },
+    });
+    expect(viewDropped?.observerDigestView).toBeUndefined();
+  });
+
   it('drops the whole view when localDay is missing (fail safe to text-only)', () => {
     const view = wellFormedView();
     const { localDay: _drop, ...noDay } = view;


### PR DESCRIPTION
## What & why

The observer digest (shipped in #313) is meant to arrive in the owner's DM with **Resolve / Dismiss / Snooze / Less-like-this** buttons on each insight. In production it arrives **without any buttons** — so the owner can't act on it, and the whole "act on your digest" feature is inert.

## Root cause

The digest is delivered only by the durable outbound-delivery **recovery-loop dispatch**, which renders its native buttons from `providerPayload.observerDigestView`. But every outbound item's `providerPayload` is run through `sanitizeRetryTailProviderPayload` — a strict allowlist — at persist time, and `observerDigestView` was **not on the allowlist**, so it was stripped before the dispatch ever saw it. Net: the persisted item has no view, the dispatch renders no buttons.

The Phase-2 tests missed this because they passed the view straight to fake channel clients and asserted the reservation row — never exercising the outbound `providerPayload` persist→sanitize→dispatch path the real send uses.

## The fix

A **bounded, allowlisted** `observerDigestView` passthrough in the sanitizer, so the view (and its buttons) survives persistence and recovery dispatch. Because this object is persisted and later drives real action callbacks, it is validated defensively:

- **Structurally rebuilt** at every level (view → insights → affordances) — unknown keys are dropped, never spread through.
- **Bounded**: ≤50 insights, ≤8 affordances each; and the number of source entries *inspected* is capped (not just accepted), so a malformed array of millions of junk entries can't cause unbounded work.
- **Identity-safe**: `insightId` / `localDay` (the fields that ride the callback token) are taken **verbatim or dropped** — never trimmed or truncated, since a normalized/shortened id could collide with a *different* insight and settle the wrong target. Display fields (title/summary/etc.) may still truncate.
- **Binding-checked**: an affordance is dropped unless its `insightId` matches its containing insight and its `localDay` matches the view — so a corrupted payload can't render a button beside insight A that acts on insight B.
- `action` constrained to the known feedback actions; malformed input fails safe to text-only, never throws.

## Surface impact

| Surface | Class | Notes |
|---|---|---|
| Runtime | Fixed | observer digest now delivers with its action buttons (were silently stripped) |
| Data/schema | Unchanged | allowlist-only change in the retry-tail sanitizer |
| Tests | Added | sanitizer unit cases (survives, bounded, verbatim identity, binding, oversize-drop) + an enqueue→persist assertion that the view survives |

## Verification

`typecheck` clean, `check:architecture` exit 0, retry-tail + outbound-delivery suites green. Each of the 4 commits was autoreviewed to clean and the branch reviewed end-to-end (the hardening above came out of that review). No sibling gap: `observerDigestView` is the only interactive view persisted through this path — memory-review and other affordances are delivered live, not via this sanitizer.
