### PR TITLE
feat(brain): dreaming proposer emits destructive graph ops (T-PROP — completes Phase 3 v1)

### DIFF
--- a/apps/core/src/brain/brain-dream-proposer.ts
+++ b/apps/core/src/brain/brain-dream-proposer.ts
@@ -1,12 +1,13 @@
 import { getMemoryModelRuntimeConfig } from '../config/index.js';
 import type { AppId } from '../domain/app/app.js';
 import { getMemoryLlmClient } from '../memory/memory-llm-port.js';
-import type { BrainPage } from './brain-types.js';
+import type { BrainGraph, BrainPage } from './brain-types.js';
 
 export interface BrainDreamProposalPort {
   propose(input: {
     appId: string;
     pages: BrainPage[];
+    graph?: BrainGraph;
     observerEnabled?: boolean;
     signal?: AbortSignal;
     timeoutMs?: number;
@@ -18,13 +19,19 @@ export interface BrainDreamProposal {
   surfaceableInsights: unknown[];
 }
 
-const BRAIN_OPERATION_PROMPT_LINES = [
+export const BRAIN_OPERATION_PROMPT_LINES = [
   'Allowed additive operations:',
   '{"action":"upsert_entity","kind":"person|company|project|topic","name":"name"}',
   '{"action":"upsert_edge","type":"works_at|member_of|mentions|authored|assigned_to|relates_to","from":{"kind":"person|company|project|topic","name":"name"},"to":{"kind":"person|company|project|topic","name":"name"},"evidencePageId":"page id"}',
   '{"action":"write_fact_page","topic":"stable topic","title":"title","markdown":"short durable fact page","evidencePageIds":["page id"]}',
   '{"action":"enrich_entity_page","kind":"person|company|project|topic","name":"name","markdown":"short entity summary","evidencePageIds":["page id"]}',
-  'Destructive operations may be proposed, but the host journals them without applying.',
+  'Destructive operations are PROPOSALS that require owner approval; the host never auto-applies them.',
+  'Copy every id verbatim from the supplied pages/entities/edges context. Never invent an id.',
+  '{"action":"delete_page","page_id":"page id"}',
+  '{"action":"rewrite_page","page_id":"page id","title":"optional title","markdown":"replacement page body"}',
+  '{"action":"delete_entity","entity_id":"entity id"}',
+  '{"action":"delete_edge","edge_id":"edge id"}',
+  '{"action":"merge_entities","source_entity_id":"entity id","target_entity_id":"different entity id"}',
 ] as const;
 
 const BRAIN_DREAM_PROMPT = [
@@ -50,6 +57,7 @@ export class MemoryLlmBrainDreamProposer implements BrainDreamProposalPort {
   async propose(input: {
     appId: string;
     pages: BrainPage[];
+    graph?: BrainGraph;
     observerEnabled?: boolean;
     signal?: AbortSignal;
     timeoutMs?: number;
@@ -68,6 +76,7 @@ export class MemoryLlmBrainDreamProposer implements BrainDreamProposalPort {
         markdown: dreamMarkdownWindow(page.markdown),
         metadata: page.metadata,
       })),
+      ...buildGraphPayload(input.graph),
     };
     const prompt = input.observerEnabled
       ? OBSERVER_BRAIN_DREAM_PROMPT
@@ -86,6 +95,34 @@ export class MemoryLlmBrainDreamProposer implements BrainDreamProposalPort {
       ? parseJsonProposal(text)
       : parseJsonArray(text);
   }
+}
+
+// Surface the page's graph slice so the model can name a real entity/edge id
+// for delete_entity / delete_edge / merge_entities. Labels (entity name/kind,
+// edge type + endpoint names) give the model enough context to choose sensibly.
+// ponytail: hard cap 50 each — a huge graph would otherwise blow the context;
+// raise the cap (or rank by relevance) only if real graphs exceed it.
+export function buildGraphPayload(graph: BrainGraph | undefined): {
+  entities: Array<{ id: string; kind: string; name: string }>;
+  edges: Array<{ id: string; type: string; from: string; to: string }>;
+} {
+  const CAP = 50;
+  const entities = graph?.entities ?? [];
+  const edges = graph?.edges ?? [];
+  const nameById = new Map(entities.map((e) => [e.id, e.name]));
+  return {
+    entities: entities.slice(0, CAP).map((e) => ({
+      id: e.id,
+      kind: e.kind,
+      name: e.name,
+    })),
+    edges: edges.slice(0, CAP).map((e) => ({
+      id: e.id,
+      type: e.type,
+      from: nameById.get(e.fromEntityId) ?? e.fromEntityId,
+      to: nameById.get(e.toEntityId) ?? e.toEntityId,
+    })),
+  };
 }
 
 // ponytail: bounded recency window — new harvest lines append at the tail,

--- a/apps/core/src/brain/brain-dreaming.ts
+++ b/apps/core/src/brain/brain-dreaming.ts
@@ -29,6 +29,7 @@ import {
 } from './brain-types.js';
 
 export {
+  buildGraphPayload,
   dreamMarkdownWindow,
   MemoryLlmBrainDreamProposer,
   type BrainDreamProposal,
@@ -95,9 +96,11 @@ export async function runBrainDreamBatch(input: {
   };
   for (const page of pages) {
     input.signal?.throwIfAborted();
+    const graph = await input.repository.graphForPages(input.appId, [page.id]);
     const ops = (await proposer.propose({
       appId: input.appId,
       pages: [page],
+      graph,
       signal: input.signal,
       timeoutMs: input.timeoutMs,
     })) as unknown[];
@@ -183,9 +186,11 @@ async function runObserverBrainDreamBatch(input: {
 
   for (const page of pages) {
     input.signal?.throwIfAborted();
+    const graph = await input.repository.graphForPages(input.appId, [page.id]);
     const rawProposal = await proposer.propose({
       appId: input.appId,
       pages: [page],
+      graph,
       observerEnabled: true,
       signal: input.signal,
       timeoutMs: input.timeoutMs,

--- a/apps/core/test/unit/brain/brain-dream-proposer-graph-ops.test.ts
+++ b/apps/core/test/unit/brain/brain-dream-proposer-graph-ops.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BRAIN_DESTRUCTIVE_V1_ACTIONS,
+  parseDestructiveOp,
+} from '@core/brain/brain-dream-op-schema.js';
+import {
+  BRAIN_OPERATION_PROMPT_LINES,
+  buildGraphPayload,
+} from '@core/brain/brain-dream-proposer.js';
+import type { BrainGraph } from '@core/brain/brain-types.js';
+
+// The JSON object shapes documented in the prompt, keyed by their action.
+function documentedShapes(): Map<string, Record<string, unknown>> {
+  return new Map(
+    BRAIN_OPERATION_PROMPT_LINES.filter((line) => line.trim().startsWith('{'))
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((op) => typeof op.action === 'string')
+      .map((op) => [op.action as string, op]),
+  );
+}
+
+// The required snake_case field names each destructive shape MUST document
+// (mirrors brain-dream-op-schema.ts; title is optional so it is not required).
+const REQUIRED_FIELDS: Record<string, string[]> = {
+  delete_page: ['page_id'],
+  rewrite_page: ['page_id', 'markdown'],
+  delete_entity: ['entity_id'],
+  delete_edge: ['edge_id'],
+  merge_entities: ['source_entity_id', 'target_entity_id'],
+};
+
+describe('brain dream proposer destructive graph ops', () => {
+  it('documents all five v1 destructive shapes with the exact schema field names', () => {
+    const shapes = documentedShapes();
+    for (const action of BRAIN_DESTRUCTIVE_V1_ACTIONS) {
+      const shape = shapes.get(action);
+      expect(shape, `prompt must document ${action}`).toBeDefined();
+      for (const field of REQUIRED_FIELDS[action]) {
+        expect(
+          Object.keys(shape as Record<string, unknown>),
+          `${action} must document ${field}`,
+        ).toContain(field);
+      }
+    }
+  });
+
+  it('every documented destructive shape parses under the schema (prompt<->schema alignment)', () => {
+    for (const [action, shape] of documentedShapes()) {
+      if (!(BRAIN_DESTRUCTIVE_V1_ACTIONS as readonly string[]).includes(action))
+        continue;
+      const result = parseDestructiveOp(shape);
+      expect(result.ok, `${action}: ${JSON.stringify(result)}`).toBe(true);
+    }
+  });
+
+  it('surfaces entity and edge ids (with labels) in the model payload', () => {
+    const payload = buildGraphPayload(graph);
+    expect(payload.entities).toEqual([
+      { id: 'ent-alice', kind: 'person', name: 'Alice' },
+      { id: 'ent-acme', kind: 'company', name: 'Acme' },
+    ]);
+    expect(payload.edges).toEqual([
+      { id: 'edge-1', type: 'works_at', from: 'Alice', to: 'Acme' },
+    ]);
+  });
+
+  it('round-trips model-emitted graph-op JSON through parseDestructiveOp', () => {
+    const emitted = [
+      { action: 'delete_entity', entity_id: 'ent-acme' },
+      { action: 'delete_edge', edge_id: 'edge-1' },
+      {
+        action: 'merge_entities',
+        source_entity_id: 'ent-alice',
+        target_entity_id: 'ent-acme',
+      },
+    ];
+    for (const op of emitted) {
+      const result = parseDestructiveOp(op);
+      expect(result.ok, `${op.action}: ${JSON.stringify(result)}`).toBe(true);
+    }
+  });
+});
+
+const graph: BrainGraph = {
+  entities: [
+    {
+      id: 'ent-alice',
+      appId: 'default',
+      kind: 'person',
+      name: 'Alice',
+      normalizedName: 'alice',
+      createdAt: '2026-07-22T00:00:00.000Z',
+      updatedAt: '2026-07-22T00:00:00.000Z',
+    },
+    {
+      id: 'ent-acme',
+      appId: 'default',
+      kind: 'company',
+      name: 'Acme',
+      normalizedName: 'acme',
+      createdAt: '2026-07-22T00:00:00.000Z',
+      updatedAt: '2026-07-22T00:00:00.000Z',
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-1',
+      appId: 'default',
+      type: 'works_at',
+      fromEntityId: 'ent-alice',
+      toEntityId: 'ent-acme',
+      evidencePageId: 'page-1',
+      createdAt: '2026-07-22T00:00:00.000Z',
+      updatedAt: '2026-07-22T00:00:00.000Z',
+    },
+  ],
+};


### PR DESCRIPTION
## What & why

Phase 3 (#319) shipped the owner review + safe execution for destructive brain proposals, but only `delete_page`/`rewrite_page` could actually reach it — the dreaming model was never told the *shapes* of the graph operations, and the context it saw included page ids but no entity/edge ids, so it literally couldn't name an entity or edge to act on.

This is **T-PROP**: it lets the dreaming model propose the graph operations (`delete_entity`, `delete_edge`, `merge_entities`) too, completing the destructive-review feature to its full v1 scope.

**Safe by construction:** every op the model proposes still goes through the merged Phase-3 gate — owner review, content-hash drift check under lock, all-or-nothing execution. This PR only changes what can be *proposed*; nothing executes without owner approval.

## How

- **Prompt** — `BRAIN_OPERATION_PROMPT_LINES` now defines each of the 5 v1 destructive-op shapes with the exact snake_case fields the intake schema requires (`page_id` / `entity_id` / `edge_id` / `source_entity_id`+`target_entity_id`), plus framing that these are proposals requiring approval and that ids must be copied verbatim from context, never invented. (`retire_page` stays unsupported.)
- **Payload** — the proposer now surfaces the page's graph slice (entities `{id,kind,name}` and edges `{id,type,from→to}` with endpoints resolved to names), via the existing `graphForPages` read, capped at 50/50 (bounded, ponytail-noted). No new brain read needed.
- **No intake change** — emitted ids flow unchanged through `parseDestructiveOp`; the schema stays the contract.

## Verification

`typecheck` clean, `check:architecture` exit 0, brain proposer/dreaming + op-schema suites green. A **drift-guard test** asserts every op shape documented in the prompt actually parses under the real `parseDestructiveOp` — so the prompt and the schema can't silently diverge — plus payload-contains-ids and model-emitted-JSON round-trip tests.

### Agent-e2e delta (honest)

This is the piece that unblocks the cron-driven hermetic agent-e2e for the graph ops (dreaming proposes a `delete_entity`/`merge_entities` → it surfaces as an owner review → gets decided → executes). That end-to-end flow is now *possible* but the hermetic CI lane is **not** included here and remains to be flipped in CI; this PR is covered by unit tests (prompt↔schema alignment, payload, round-trip). No live-LLM test added.

Completes the review-revamp initiative's Phase 3 (#319) to full v1 op scope.
