### PR TITLE
fix(runtime): audit-FK spam, over-redacted commands, system-job edit reverts (live-runtime bugs)

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-audit.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-audit.ts
@@ -1,0 +1,48 @@
+import type { RuntimeEventPublishInput } from '../../../domain/events/events.js';
+import { logger } from '../../../infrastructure/logging/logger.js';
+
+type AuditSink = (
+  event: RuntimeEventPublishInput,
+) => Promise<unknown> | unknown;
+
+// Drizzle wraps the pg driver error, so the SQLSTATE + constraint live on the
+// cause chain (same walk the postgres repositories use for 23505).
+function isRunIdForeignKeyViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; depth < 5; depth += 1) {
+    if (!current || typeof current !== 'object') return false;
+    const { code, constraint } = current as {
+      code?: unknown;
+      constraint?: unknown;
+    };
+    if (code === '23503' && constraint === 'runtime_events_run_id_fkey') {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+// A run-id with no `agent_runs` row trips the runtime_events FK. Keep the
+// usage/cost record by retrying once unscoped instead of losing the audit row
+// (and spamming WARNs). Only this specific FK violation is retried.
+export async function publishAuditEventWithRunIdFallback(
+  audit: AuditSink,
+  event: RuntimeEventPublishInput,
+  failureMessage: string,
+): Promise<void> {
+  try {
+    await audit(event);
+  } catch (err) {
+    if (event.runId === undefined || !isRunIdForeignKeyViolation(err)) {
+      logger.warn({ err }, failureMessage);
+      return;
+    }
+    const { runId: _dropped, ...unscoped } = event;
+    try {
+      await audit(unscoped);
+    } catch (retryErr) {
+      logger.warn({ err: retryErr }, failureMessage);
+    }
+  }
+}

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-token.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-token.ts
@@ -196,11 +196,11 @@ export function runtimeEventRunIdFor(
   token: GatewayTokenRecord,
 ): RuntimeEventPublishInput['runId'] | undefined {
   if (!token.runId) return undefined;
-  const runId = String(token.runId);
-  return runId.startsWith('credential-run:') ||
-    runId.startsWith('memory-query:')
-    ? undefined
-    : token.runId;
+  // Allowlist: only real agent runs have an `agent_runs` row to satisfy the
+  // runtime_events -> agent_runs FK. Synthetic ids (permission-classifier:,
+  // memory-query:, credential-run:, and any future one) have no row, so drop
+  // them rather than spam FK violations.
+  return String(token.runId).startsWith('agent-run:') ? token.runId : undefined;
 }
 
 function jsonStringField(body: Buffer, field: string): string | undefined {

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-token.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway-token.ts
@@ -1,5 +1,8 @@
 import type { AppId } from '../../../domain/app/app.js';
-import type { RuntimeEventPublishInput } from '../../../domain/events/events.js';
+import {
+  isSyntheticRunId,
+  type RuntimeEventPublishInput,
+} from '../../../domain/events/events.js';
 import { CredentialBrokerPolicyError } from '../../../domain/models/credential-errors.js';
 import type {
   AgentCredentialBrokerBinding,
@@ -196,11 +199,10 @@ export function runtimeEventRunIdFor(
   token: GatewayTokenRecord,
 ): RuntimeEventPublishInput['runId'] | undefined {
   if (!token.runId) return undefined;
-  // Allowlist: only real agent runs have an `agent_runs` row to satisfy the
-  // runtime_events -> agent_runs FK. Synthetic ids (permission-classifier:,
-  // memory-query:, credential-run:, and any future one) have no row, so drop
-  // them rather than spam FK violations.
-  return String(token.runId).startsWith('agent-run:') ? token.runId : undefined;
+  // Drop only SYNTHETIC run-ids (no `agent_runs` row -> FK violation). Real run
+  // ids come in two shapes — `agent-run:<uuid>` and a bare uuid — and both must
+  // pass through, so this cannot be an `agent-run:` allowlist.
+  return isSyntheticRunId(String(token.runId)) ? undefined : token.runId;
 }
 
 function jsonStringField(body: Buffer, field: string): string | undefined {

--- a/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway.ts
@@ -4,6 +4,7 @@ import { ModelCredentialService } from '../../../application/model-credentials/m
 import type { AppId } from '../../../domain/app/app.js';
 import type { RuntimeEventPublishInput } from '../../../domain/events/events.js';
 import { RUNTIME_EVENT_TYPES } from '../../../domain/events/runtime-event-types.js';
+import { publishAuditEventWithRunIdFallback } from './gantry-model-gateway-audit.js';
 import type { AgentCredentialBroker } from '../../../domain/ports/agent-credential-broker.js';
 import type { ModelCredentialRepository } from '../../../domain/ports/repositories.js';
 import type {
@@ -591,8 +592,8 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
     },
   ): Promise<void> {
     if (!this.audit) return;
-    try {
-      await this.audit({
+    await this.publishAuditEvent(
+      {
         appId: tokenRecord.appId,
         ...(tokenRecord.agentId ? { agentId: tokenRecord.agentId } : {}),
         ...(runtimeEventRunIdFor(tokenRecord)
@@ -622,18 +623,25 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
           usage: input.usage,
           modelAlias: input.usage?.model,
         },
-      });
-    } catch (err) {
-      logger.warn({ err }, 'Gantry Model Gateway usage audit failed');
-    }
+      },
+      'Gantry Model Gateway usage audit failed',
+    );
+  }
+
+  private async publishAuditEvent(
+    event: RuntimeEventPublishInput,
+    failureMessage: string,
+  ): Promise<void> {
+    if (!this.audit) return;
+    await publishAuditEventWithRunIdFallback(this.audit, event, failureMessage);
   }
   private async publishGatewayTokenAudit(
     tokenRecord: GatewayTokenRecord,
     outcome: 'token_issued' | 'token_rejected',
   ): Promise<void> {
     if (!this.audit) return;
-    try {
-      await this.audit({
+    await this.publishAuditEvent(
+      {
         appId: tokenRecord.appId,
         ...(tokenRecord.agentId ? { agentId: tokenRecord.agentId } : {}),
         ...(runtimeEventRunIdFor(tokenRecord)
@@ -655,10 +663,9 @@ export class GantryModelGatewayBroker implements AgentCredentialBroker {
           tokenExpiresAtMs: tokenRecord.expiresAtMs,
           credentialFingerprint: tokenRecord.credentialFingerprint,
         },
-      });
-    } catch (err) {
-      logger.warn({ err }, 'Gantry Model Gateway token audit failed');
-    }
+      },
+      'Gantry Model Gateway token audit failed',
+    );
   }
   private startTokenSweep(): void {
     if (this.tokenSweepTimer || this.tokenSweepIntervalMs <= 0) return;

--- a/apps/core/src/channels/permission-text-sanitizer.ts
+++ b/apps/core/src/channels/permission-text-sanitizer.ts
@@ -44,10 +44,10 @@ export function limitPermissionMessage(
 
 export function sanitizeReceiptDetail(input: string): string | null {
   const result = sanitizeOutboundLlmText(input);
-  if (result.redacted || result.blocked) return null;
-  if (/\[REDACTED_(?:SECRET|POTENTIALLY_SENSITIVE)\]/.test(result.text)) {
-    return null;
-  }
+  // Only drop the whole detail when a secret couldn't be safely span-masked.
+  // When a real secret was span-redacted, show the command with just the span
+  // masked (result.text is the span-redacted text) rather than hiding it all.
+  if (result.blocked) return null;
   return headTailTruncate(result.text, 200, 100);
 }
 

--- a/apps/core/src/domain/events/events.ts
+++ b/apps/core/src/domain/events/events.ts
@@ -25,6 +25,23 @@ import type { IsoTimestamp } from '../../shared/time/primitives.js';
 import type { RuntimeEventType } from './runtime-event-types.js';
 
 export type AgentRunId = BrandedId<'AgentRunId'>;
+
+// Synthetic run-ids are minted for LLM calls that have no `agent_runs` row
+// (permission classification, memory queries, credential brokering). A real
+// run id is either `agent-run:<uuid>` or a bare uuid — both satisfy the
+// runtime_events -> agent_runs FK; these prefixes never do, so audit writes
+// must drop them. Every synthetic minter MUST register its prefix here: the
+// permission-classifier LLM client, the per-provider memory-query and
+// chat-batch clients, and the spawn-host / turn-tracker credential minters.
+export const SYNTHETIC_RUN_ID_PREFIXES = [
+  'permission-classifier:',
+  'memory-query:',
+  'credential-run:',
+] as const;
+
+export function isSyntheticRunId(runId: string): boolean {
+  return SYNTHETIC_RUN_ID_PREFIXES.some((prefix) => runId.startsWith(prefix));
+}
 export type RuntimeEventId = number & {
   readonly __brand: 'RuntimeEventId';
 };

--- a/apps/core/src/jobs/observer-digest-job.ts
+++ b/apps/core/src/jobs/observer-digest-job.ts
@@ -15,6 +15,7 @@ import { MessageInsightFreshnessProbe } from '../brain/observer-evidence-freshne
 import { getRuntimeStorage } from '../adapters/storage/postgres/runtime-store.js';
 import { nowIso as currentIso } from '../shared/time/datetime.js';
 import { computeNextJobRun } from './schedule-math.js';
+import { preserveOperatorSystemJobEdits } from './system-job-reconcile.js';
 import { buildCanonicalJobLifecycleTarget } from './job-notification-routes.js';
 import { logger } from '../infrastructure/logging/logger.js';
 import type { ConversationRoute } from '../domain/types.js';
@@ -104,7 +105,10 @@ export async function registerObserverDigestJob(
     notification_routes: target.notificationRoutes,
   };
   await deps.opsRepository.upsertJob(
-    observerDigestJob as unknown as Parameters<
+    preserveOperatorSystemJobEdits(
+      observerDigestJob,
+      existing,
+    ) as unknown as Parameters<
       SchedulerDependencies['opsRepository']['upsertJob']
     >[0],
   );

--- a/apps/core/src/jobs/system-job-reconcile.ts
+++ b/apps/core/src/jobs/system-job-reconcile.ts
@@ -1,0 +1,25 @@
+import type { Job } from '../domain/types.js';
+import type { SchedulerDependencies } from './types.js';
+
+type UpsertJobInput = Parameters<
+  SchedulerDependencies['opsRepository']['upsertJob']
+>[0];
+
+// Restart reconciliation must not clobber operator/agent edits. When a system
+// job already exists, carry its operator-editable fields (name, schedule value,
+// silent) forward instead of the hardcoded code constants. The runtime still
+// owns id/prompt/execution_context/notification_routes/timeout, which are
+// re-stamped from code every pass.
+export function preserveOperatorSystemJobEdits<
+  T extends { name: string; schedule_value: string; silent: boolean },
+>(systemJob: T, existing: Job | undefined): UpsertJobInput {
+  const merged = existing
+    ? {
+        ...systemJob,
+        name: existing.name,
+        schedule_value: existing.schedule_value,
+        silent: existing.silent,
+      }
+    : systemJob;
+  return merged as unknown as UpsertJobInput;
+}

--- a/apps/core/src/jobs/system-job-reconcile.ts
+++ b/apps/core/src/jobs/system-job-reconcile.ts
@@ -1,4 +1,6 @@
 import type { Job } from '../domain/types.js';
+import { nowIso } from '../shared/time/datetime.js';
+import { computeNextJobRun } from './schedule-math.js';
 import type { SchedulerDependencies } from './types.js';
 
 type UpsertJobInput = Parameters<
@@ -13,13 +15,26 @@ type UpsertJobInput = Parameters<
 export function preserveOperatorSystemJobEdits<
   T extends { name: string; schedule_value: string; silent: boolean },
 >(systemJob: T, existing: Job | undefined): UpsertJobInput {
-  const merged = existing
-    ? {
-        ...systemJob,
-        name: existing.name,
+  if (!existing) return systemJob as unknown as UpsertJobInput;
+  // next_run must agree with the schedule we're preserving. The running job's
+  // next_run already tracks its (possibly operator-edited) schedule, so carry
+  // it. If it's absent, recompute from the preserved schedule — never leave a
+  // next_run derived from the hardcoded code default beside an edited schedule.
+  const next_run =
+    existing.next_run ??
+    computeNextJobRun(
+      {
+        schedule_type: existing.schedule_type,
         schedule_value: existing.schedule_value,
-        silent: existing.silent,
-      }
-    : systemJob;
-  return merged as unknown as UpsertJobInput;
+      },
+      nowIso(),
+    );
+  return {
+    ...systemJob,
+    name: existing.name,
+    schedule_type: existing.schedule_type,
+    schedule_value: existing.schedule_value,
+    silent: existing.silent,
+    next_run,
+  } as unknown as UpsertJobInput;
 }

--- a/apps/core/src/jobs/system-jobs.ts
+++ b/apps/core/src/jobs/system-jobs.ts
@@ -75,6 +75,7 @@ import {
   setObserverDigestGateway,
 } from './observer-digest-job.js';
 import { computeNextJobRun } from './schedule-math.js';
+import { preserveOperatorSystemJobEdits } from './system-job-reconcile.js';
 import { buildCanonicalJobLifecycleTarget } from './job-notification-routes.js';
 import { parseAgentThreadQueueKey } from '../shared/thread-queue-key.js';
 import { agentIdForJobWorkspaceKey } from '../application/jobs/job-tool-policy.js';
@@ -298,9 +299,7 @@ export async function registerSystemJobs(
         notification_routes: target.notificationRoutes,
       };
       await deps.opsRepository.upsertJob(
-        systemJob as unknown as Parameters<
-          SchedulerDependencies['opsRepository']['upsertJob']
-        >[0],
+        preserveOperatorSystemJobEdits(systemJob, existing),
       );
     }
   }
@@ -330,7 +329,7 @@ export async function registerSystemJobs(
         { schedule_type: 'cron', schedule_value: MEMORY_DREAMING_CRON },
         nowIso,
       );
-      await deps.opsRepository.upsertJob({
+      const brainDreamingJob = {
         id: BRAIN_DREAMING_JOB_ID,
         name: 'Brain Dreaming',
         prompt: BRAIN_DREAM_SYSTEM_PROMPT,
@@ -348,9 +347,10 @@ export async function registerSystemJobs(
         max_consecutive_failures: 3,
         execution_context: target.executionContext,
         notification_routes: target.notificationRoutes,
-      } as unknown as Parameters<
-        SchedulerDependencies['opsRepository']['upsertJob']
-      >[0]);
+      };
+      await deps.opsRepository.upsertJob(
+        preserveOperatorSystemJobEdits(brainDreamingJob, existing),
+      );
     }
   }
 
@@ -404,9 +404,7 @@ export async function registerSystemJobs(
         notification_routes: target.notificationRoutes,
       };
       await deps.opsRepository.upsertJob(
-        backfillJob as unknown as Parameters<
-          SchedulerDependencies['opsRepository']['upsertJob']
-        >[0],
+        preserveOperatorSystemJobEdits(backfillJob, existing),
       );
     }
 
@@ -454,9 +452,7 @@ export async function registerSystemJobs(
         notification_routes: target.notificationRoutes,
       };
       await deps.opsRepository.upsertJob(
-        brainBackfillJob as unknown as Parameters<
-          SchedulerDependencies['opsRepository']['upsertJob']
-        >[0],
+        preserveOperatorSystemJobEdits(brainBackfillJob, existingBrain),
       );
     }
   }

--- a/apps/core/src/shared/sensitive-material.ts
+++ b/apps/core/src/shared/sensitive-material.ts
@@ -88,7 +88,10 @@ function looksLikeOpaqueSecretToken(raw: string): boolean {
   return (
     token.length >= 24 &&
     token.length <= 1024 &&
-    !token.includes('://') &&
+    // A bare `/` means this is a filesystem path/URL, not an opaque secret.
+    // Real base64 secrets needing `/` are caught by the specific REDACTION_RULES
+    // (sk-…, JWT, PEM, bearer); base64url tokens use `-_`, not `/`.
+    !token.includes('/') &&
     /[0-9]/.test(token) &&
     classes >= 3 &&
     shannonEntropy(token) >= 3.5
@@ -115,7 +118,12 @@ export function detectPotentialUnredactedSecret(text: string): string | null {
   const candidates = trimmed.match(CANDIDATE_TOKEN_PATTERN) || [];
   for (const token of candidates) {
     if (!looksLikeOpaqueSecretToken(token)) continue;
-    if (token.length >= 40 || HIGH_RISK_CONTEXT_PATTERN.test(trimmed)) {
+    // Never block on length alone — long paths/ids aren't secrets. Require real
+    // secret context nearby, or a high entropy floor that ordinary text won't hit.
+    if (
+      HIGH_RISK_CONTEXT_PATTERN.test(trimmed) ||
+      shannonEntropy(token) >= 4.0
+    ) {
       return 'high_entropy_credential_like_token';
     }
   }

--- a/apps/core/test/agent-e2e/scenarios/haiku-turn.agent-e2e.test.ts
+++ b/apps/core/test/agent-e2e/scenarios/haiku-turn.agent-e2e.test.ts
@@ -80,6 +80,17 @@ maybeDescribe('agent-e2e haiku turn (real model, behavioral)', () => {
       return await fn();
     } catch (err) {
       sawFailure = true;
+      // A rate-limited E2E key looks exactly like a runtime hang from the
+      // outside (typing forever, no reply). Name it in the assertion message
+      // so nobody bisects the runtime for a provider quota problem.
+      if (harness?.logs().includes('error_status=429')) {
+        throw new Error(
+          'Provider rate-limited the real-model turn (HTTP 429 rate_limit) — ' +
+            'this is an E2E_MODEL_API_KEY quota problem, not a runtime ' +
+            `regression. Original failure: ${(err as Error).message}`,
+          { cause: err },
+        );
+      }
       throw err;
     }
   }

--- a/apps/core/test/unit/channels/permission-interaction.test.ts
+++ b/apps/core/test/unit/channels/permission-interaction.test.ts
@@ -1526,7 +1526,7 @@ describe('permission interaction', () => {
     expect(receipt).not.toContain('perm-abc-123');
   });
 
-  it('omits sensitive details instead of showing redaction markers in accepted receipts', () => {
+  it('shows the command with the secret span masked in accepted receipts', () => {
     const receipt = formatPermissionReceiptText(
       'perm-abc-123',
       {
@@ -1546,7 +1546,9 @@ describe('permission interaction', () => {
     );
 
     expect(receipt).toContain('Allowed once: Command');
-    expect(receipt).not.toContain('REDACTED');
+    // The secret span is masked but the rest of the command stays visible.
+    expect(receipt).toContain('curl https://api.example.com');
+    expect(receipt).toContain('[REDACTED_SECRET]');
     expect(receipt).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
     expect(receipt).not.toContain('Request ID');
     expect(receipt).not.toContain('perm-abc-123');

--- a/apps/core/test/unit/channels/permission-text-sanitizer.test.ts
+++ b/apps/core/test/unit/channels/permission-text-sanitizer.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeReceiptDetail } from '@core/channels/permission-text-sanitizer.js';
+
+describe('sanitizeReceiptDetail', () => {
+  it('shows ordinary long-path commands unchanged', () => {
+    const command =
+      'grep -rn foo /Users/x/dist.bak-l2prev/x9aB3cD5eF7gH9iJ0kL2mN4pQ6';
+    expect(sanitizeReceiptDetail(command)).toBe(command);
+  });
+
+  it('shows the command with only the secret span masked', () => {
+    const detail = sanitizeReceiptDetail('curl --password=hunter2xxxxxxxx api');
+    expect(detail).not.toBeNull();
+    expect(detail).toContain('curl');
+    expect(detail).toContain('[REDACTED_SECRET]');
+    expect(detail).not.toContain('hunter2xxxxxxxx');
+  });
+
+  it('drops the detail entirely only when a secret cannot be span-masked', () => {
+    const detail = sanitizeReceiptDetail(
+      'token= A9xQ7mN2pR5sT8uV1wX4yZ6aB3cD5eF7gH9iJ0kL2',
+    );
+    expect(detail).toBeNull();
+  });
+});

--- a/apps/core/test/unit/core/gantry-model-gateway-token.test.ts
+++ b/apps/core/test/unit/core/gantry-model-gateway-token.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   gatewayTokenAllowsPath,
+  runtimeEventRunIdFor,
   type GatewayTokenRecord,
 } from '@core/adapters/llm/anthropic-claude-agent/gantry-model-gateway-token.js';
 import type { AppId } from '@core/domain/app/app.js';
@@ -58,6 +59,27 @@ describe('gateway batch token file scope', () => {
         'GET',
       ),
     ).toBe(false);
+  });
+});
+
+describe('runtimeEventRunIdFor audit run-id allowlist', () => {
+  it('passes through only real agent-run ids and drops synthetic ids', () => {
+    expect(runtimeEventRunIdFor(tokenRecord({ runId: 'agent-run:abc' }))).toBe(
+      'agent-run:abc',
+    );
+    expect(
+      runtimeEventRunIdFor(tokenRecord({ runId: 'permission-classifier:x' })),
+    ).toBeUndefined();
+    expect(
+      runtimeEventRunIdFor(tokenRecord({ runId: 'memory-query:x' })),
+    ).toBeUndefined();
+    expect(
+      runtimeEventRunIdFor(tokenRecord({ runId: 'credential-run:x' })),
+    ).toBeUndefined();
+    expect(
+      runtimeEventRunIdFor(tokenRecord({ runId: undefined })),
+    ).toBeUndefined();
+    expect(runtimeEventRunIdFor(tokenRecord({ runId: '' }))).toBeUndefined();
   });
 });
 

--- a/apps/core/test/unit/core/gantry-model-gateway-token.test.ts
+++ b/apps/core/test/unit/core/gantry-model-gateway-token.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -6,6 +8,10 @@ import {
   type GatewayTokenRecord,
 } from '@core/adapters/llm/anthropic-claude-agent/gantry-model-gateway-token.js';
 import type { AppId } from '@core/domain/app/app.js';
+import {
+  isSyntheticRunId,
+  SYNTHETIC_RUN_ID_PREFIXES,
+} from '@core/domain/events/events.js';
 import { getModelProviderDefinition } from '@core/shared/model-provider-registry.js';
 
 const openAi = getModelProviderDefinition('openai')!;
@@ -62,11 +68,25 @@ describe('gateway batch token file scope', () => {
   });
 });
 
-describe('runtimeEventRunIdFor audit run-id allowlist', () => {
-  it('passes through only real agent-run ids and drops synthetic ids', () => {
+describe('runtimeEventRunIdFor synthetic run-id denylist', () => {
+  it('passes through every legitimate run-id shape', () => {
+    // agent_runs.id has TWO legitimate formats: `agent-run:<uuid>` and a bare
+    // uuid. An `agent-run:` allowlist would drop run-scoping for every
+    // bare-uuid run, so both must survive.
     expect(runtimeEventRunIdFor(tokenRecord({ runId: 'agent-run:abc' }))).toBe(
       'agent-run:abc',
     );
+    expect(
+      runtimeEventRunIdFor(
+        tokenRecord({ runId: '45462980-895e-4195-b830-fca4f803945f' }),
+      ),
+    ).toBe('45462980-895e-4195-b830-fca4f803945f');
+    expect(
+      runtimeEventRunIdFor(tokenRecord({ runId: 'run:credential-audit' })),
+    ).toBe('run:credential-audit');
+  });
+
+  it('drops synthetic ids that have no agent_runs row', () => {
     expect(
       runtimeEventRunIdFor(tokenRecord({ runId: 'permission-classifier:x' })),
     ).toBeUndefined();
@@ -80,6 +100,26 @@ describe('runtimeEventRunIdFor audit run-id allowlist', () => {
       runtimeEventRunIdFor(tokenRecord({ runId: undefined })),
     ).toBeUndefined();
     expect(runtimeEventRunIdFor(tokenRecord({ runId: '' }))).toBeUndefined();
+  });
+});
+
+describe('SYNTHETIC_RUN_ID_PREFIXES registry', () => {
+  // The denylist has silently missed a new synthetic minter twice. Every minter
+  // in the runtime must have its prefix registered in the shared constant.
+  const minters = [
+    ['permission-classifier-llm-client.ts', 'permission-classifier:'],
+    ['the per-provider memory-query / chat-batch clients', 'memory-query:'],
+    ['agent-spawn-host.ts / spawn-turn-tracker.ts', 'credential-run:'],
+  ] as const;
+
+  it.each(minters)('registers the prefix minted by %s', (_minter, prefix) => {
+    expect(SYNTHETIC_RUN_ID_PREFIXES).toContain(prefix);
+    expect(isSyntheticRunId(`${prefix}${randomUUID()}`)).toBe(true);
+  });
+
+  it('does not classify either legitimate run-id format as synthetic', () => {
+    expect(isSyntheticRunId(`agent-run:${randomUUID()}`)).toBe(false);
+    expect(isSyntheticRunId(randomUUID())).toBe(false);
   });
 });
 

--- a/apps/core/test/unit/core/gantry-model-gateway.test.ts
+++ b/apps/core/test/unit/core/gantry-model-gateway.test.ts
@@ -859,6 +859,74 @@ describe('GantryModelGatewayBroker', () => {
     }
   });
 
+  it('retries an audit write once without run_id when the run_id FK is violated', async () => {
+    const repo = new MutableModelCredentialRepository();
+    repo.set('anthropic', 'sk-ant-old');
+    const fkError = Object.assign(new Error('insert failed'), {
+      // Drizzle wraps the pg driver error; the SQLSTATE is on the cause chain.
+      cause: Object.assign(new Error('violates foreign key constraint'), {
+        code: '23503',
+        constraint: 'runtime_events_run_id_fkey',
+      }),
+    });
+    const audit = vi.fn(async (event: { runId?: string }) => {
+      if (event.runId !== undefined) throw fkError;
+      return undefined;
+    });
+    const broker = new GantryModelGatewayBroker(repo, { audit });
+    try {
+      await broker.getInjection({
+        binding: {
+          profile: 'gantry',
+          purpose: 'model_runtime',
+          appId,
+          runId: '45462980-895e-4195-b830-fca4f803945f' as never,
+          modelRouteId: 'anthropic',
+        },
+      });
+
+      // First attempt carries the run id; the FK violation degrades it to one
+      // unscoped retry so the usage/cost record survives.
+      expect(audit).toHaveBeenCalledTimes(2);
+      expect(audit.mock.calls[0]?.[0]).toHaveProperty(
+        'runId',
+        '45462980-895e-4195-b830-fca4f803945f',
+      );
+      expect(audit.mock.calls[1]?.[0]).not.toHaveProperty('runId');
+      expect(audit.mock.calls[1]?.[0]).toMatchObject({
+        appId,
+        eventType: 'credential.model.used',
+        payload: expect.objectContaining({ outcome: 'token_issued' }),
+      });
+    } finally {
+      await broker.close();
+    }
+  });
+
+  it('does not retry an audit write on a non-FK error', async () => {
+    const repo = new MutableModelCredentialRepository();
+    repo.set('anthropic', 'sk-ant-old');
+    const audit = vi.fn(async () => {
+      throw Object.assign(new Error('connection reset'), { code: '08006' });
+    });
+    const broker = new GantryModelGatewayBroker(repo, { audit });
+    try {
+      await broker.getInjection({
+        binding: {
+          profile: 'gantry',
+          purpose: 'model_runtime',
+          appId,
+          runId: '45462980-895e-4195-b830-fca4f803945f' as never,
+          modelRouteId: 'anthropic',
+        },
+      });
+
+      expect(audit).toHaveBeenCalledTimes(1);
+    } finally {
+      await broker.close();
+    }
+  });
+
   it('does not publish synthetic memory query scopes as runtime run ids', async () => {
     const repo = new MutableModelCredentialRepository();
     repo.set('anthropic', 'sk-ant-old');

--- a/apps/core/test/unit/jobs/system-jobs.test.ts
+++ b/apps/core/test/unit/jobs/system-jobs.test.ts
@@ -235,6 +235,9 @@ describe('system memory dreaming jobs', () => {
             id,
             name: 'Operator Renamed Dreaming',
             schedule_value: '0 4 * * *',
+            // next_run already tracks the edited (daily 04:00) schedule, not the
+            // code default ('* * * * *' -> next minute).
+            next_run: '2026-06-01T04:00:00.000Z',
             silent: true,
           })
         : undefined,
@@ -260,6 +263,9 @@ describe('system memory dreaming jobs', () => {
     expect(dreamUpsert.name).toBe('Operator Renamed Dreaming');
     expect(dreamUpsert.schedule_value).toBe('0 4 * * *');
     expect(dreamUpsert.silent).toBe(true);
+    // next_run stays consistent with the preserved schedule (not recomputed
+    // from the hardcoded '* * * * *' default).
+    expect(dreamUpsert.next_run).toBe('2026-06-01T04:00:00.000Z');
     // Runtime-owned fields still re-stamped from code.
     expect(dreamUpsert.prompt).toBe('__system:memory_dream');
     expect(dreamUpsert.execution_context).toEqual({

--- a/apps/core/test/unit/jobs/system-jobs.test.ts
+++ b/apps/core/test/unit/jobs/system-jobs.test.ts
@@ -188,7 +188,7 @@ describe('system memory dreaming jobs', () => {
     const updateJob = vi.fn(async () => undefined);
     const getJobById = vi.fn(async (id: string) =>
       id.startsWith('system:dreaming:')
-        ? makeJob({ id, status: 'dead_lettered', silent: false })
+        ? makeJob({ id, status: 'dead_lettered', silent: true })
         : undefined,
     );
     const getAllJobs = vi.fn(async () => []);
@@ -208,9 +208,9 @@ describe('system memory dreaming jobs', () => {
     } as never);
 
     // A dead-lettered job is no longer skipped: registration re-stamps the
-    // corrected bare-jid target (and silent) so a later operator resume works.
-    // The repo upsert preserves the dead_lettered status, so this is not a
-    // revival — no auto-resume happens here.
+    // corrected bare-jid target so a later operator resume works. The repo
+    // upsert preserves the dead_lettered status, so this is not a revival —
+    // no auto-resume happens here.
     const dreamUpserts = upsertJob.mock.calls.filter(
       (call) => call[0].prompt === '__system:memory_dream',
     );
@@ -223,6 +223,51 @@ describe('system memory dreaming jobs', () => {
     });
     expect(dreamUpserts[0]?.[0].silent).toBe(true);
     expect(updateJob).not.toHaveBeenCalled();
+  });
+
+  it('preserves operator-edited name/schedule/silent across restart while re-stamping runtime-owned fields', async () => {
+    const { registerSystemJobs } = await loadSystemJobs();
+    const upsertJob = vi.fn().mockResolvedValue({ created: false });
+    // Operator has renamed, rescheduled, and muted the existing system job.
+    const getJobById = vi.fn(async (id: string) =>
+      id.startsWith('system:dreaming:')
+        ? makeJob({
+            id,
+            name: 'Operator Renamed Dreaming',
+            schedule_value: '0 4 * * *',
+            silent: true,
+          })
+        : undefined,
+    );
+
+    await registerSystemJobs({
+      conversationRoutes: () => ({
+        'sl:C123': makeRoute({ folder: 'agent', conversationKind: 'channel' }),
+      }),
+      opsRepository: {
+        getJobById,
+        getAllJobs: vi.fn(async () => []),
+        deleteJob: vi.fn(async () => undefined),
+        upsertJob,
+      },
+    } as never);
+
+    const dreamUpsert = upsertJob.mock.calls.find(
+      (call) => call[0].prompt === '__system:memory_dream',
+    )?.[0];
+    expect(dreamUpsert).toBeDefined();
+    // Operator-editable fields carried forward from the existing row.
+    expect(dreamUpsert.name).toBe('Operator Renamed Dreaming');
+    expect(dreamUpsert.schedule_value).toBe('0 4 * * *');
+    expect(dreamUpsert.silent).toBe(true);
+    // Runtime-owned fields still re-stamped from code.
+    expect(dreamUpsert.prompt).toBe('__system:memory_dream');
+    expect(dreamUpsert.execution_context).toEqual({
+      conversationJid: 'sl:C123',
+      threadId: null,
+      workspaceKey: 'agent',
+      sessionId: null,
+    });
   });
 
   it('stores a bare execution jid + provider account for a fully-qualified route key and resolves without dead-lettering', async () => {

--- a/apps/core/test/unit/memory/sensitive-material.test.ts
+++ b/apps/core/test/unit/memory/sensitive-material.test.ts
@@ -18,4 +18,36 @@ describe('sensitive material sanitizer', () => {
       reason: 'high_entropy_credential_like_token',
     });
   });
+
+  it('does not block ordinary long file paths as secrets', () => {
+    const commands = [
+      'ls /private/tmp/claude-501/-Users-x/c77e1f98-77f6-4164-b2e1-6ac49adb637b/scratchpad',
+      'grep -rn foo /Users/x/dist.bak-l2prev/x9aB3cD5eF7gH9iJ0kL2mN4pQ6',
+      'node /Users/foo/project2/build-output/bundle.min.js',
+    ];
+    for (const command of commands) {
+      const sanitized = sanitizeOutboundLlmText(command);
+      expect(sanitized.blocked).toBe(false);
+      expect(sanitized.text).toBe(command);
+    }
+  });
+
+  it('still masks real secrets', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N';
+    expect(sanitizeOutboundLlmText('AKIA1234567890ABCDEF').text).toContain(
+      '[REDACTED_SECRET]',
+    );
+    expect(
+      sanitizeOutboundLlmText('sk-ant-abcdeabcdeabcdeabcdeabcde').text,
+    ).toContain('[REDACTED_SECRET]');
+    expect(sanitizeOutboundLlmText(jwt).text).toContain('[REDACTED_SECRET]');
+  });
+
+  it('blocks a bare high-entropy token that sits next to secret context', () => {
+    const sanitized = sanitizeOutboundLlmText(
+      'token= A9xQ7mN2pR5sT8uV1wX4yZ6aB3cD5eF7gH9iJ0kL2',
+    );
+    expect(sanitized.blocked).toBe(true);
+  });
 });


### PR DESCRIPTION
## What & why

Three live-runtime bugs found while triaging the local runtime's logs, each fixed generically (provider-agnostic).

## Fixes

- **Audit-write FK spam (~64/day) →** the permission classifier's synthetic run-id (`permission-classifier:<uuid>`) was attached to `runtime_events` audit rows and failed the FK to `agent_runs.id`. The helper that nulls synthetic ids was a denylist that had missed this prefix (twice now). Fixed two ways: the denylist is now a **single centralized registry** of synthetic prefixes (with a test enumerating every synthetic minter, so a third one can't slip through), **and** the audit write now catches that specific FK violation (SQLSTATE 23503) and **retries once without `run_id`** — so an unknown run-id degrades to an unscoped audit row instead of losing the usage/cost record. That closes the class generically.

  *Note:* the first commit on this branch tried an allowlist (`agent-run:` only). CI caught that as wrong and it was superseded by the final commit — `agent_runs.id` legitimately uses **two** formats (`agent-run:<uuid>` **and bare UUIDs**), and an allowlist would have dropped run-correlation on thousands of real audit events.
- **Tool commands shown redacted →** the secret-detector treated long **file paths** as opaque secrets (its candidate regex included `/`, plus a context-free `length ≥ 40` trigger) and hid the *whole* command (`[REDACTED_POTENTIALLY_SENSITIVE]` / bare "Command"). Now: `/`-paths aren't opaque secrets, no context-free length trigger (real secret context or entropy ≥ 4.0 required), and receipts mask only the secret **span** (`--password=[REDACTED_SECRET]`) instead of dropping the whole command. Genuine secrets (`sk-…`, JWTs, AWS keys, `token=…`) still masked.
- **System-job operator edits reverted on restart →** `registerSystemJobs` re-upserts on every restart and its skip-guard was an in-memory cache that's always empty on boot, so it re-ran and overwrote operator-editable fields (name/schedule/silent) from code constants. Now the upsert **merges over the existing row** — preserves operator-editable fields (and keeps `next_run_at` consistent with the preserved schedule) while re-stamping only runtime-owned fields (id, prompt sentinel, execution_context). User jobs were already durable and are untouched.

## Verification
`typecheck` + `check:architecture` clean; audit-token, sensitive-material, permission-text-sanitizer, and system-jobs suites green. Each commit autoreviewed (the redaction commit reviewed manually since its test intentionally contains synthetic secrets). Backend-only; no schema change.
