### PR TITLE
LAT-0: deterministic response-latency baseline harness

### DIFF
--- a/apps/core/test/harness/response-latency-harness.ts
+++ b/apps/core/test/harness/response-latency-harness.ts
@@ -1,0 +1,435 @@
+export interface ManualClockMarker {
+  readonly name: string;
+  readonly atMs: number;
+}
+
+export interface ManualClock {
+  nowMs(): number;
+  advanceMs(durationMs: number): number;
+  mark(name: string): ManualClockMarker;
+  markers(): readonly ManualClockMarker[];
+}
+
+export function createManualClock(startMs = 0): ManualClock {
+  if (!Number.isFinite(startMs)) {
+    throw new Error('Manual clock start must be finite');
+  }
+
+  let currentMs = startMs;
+  const recordedMarkers: ManualClockMarker[] = [];
+
+  return {
+    nowMs: () => currentMs,
+    advanceMs(durationMs) {
+      if (!Number.isFinite(durationMs) || durationMs < 0) {
+        throw new Error(
+          'Manual clock advances must be finite and non-negative',
+        );
+      }
+      const nextMs = currentMs + durationMs;
+      if (!Number.isFinite(nextMs)) {
+        throw new Error('Manual clock result must be finite');
+      }
+      currentMs = nextMs;
+      return currentMs;
+    },
+    mark(name) {
+      const marker = Object.freeze({ name, atMs: currentMs });
+      recordedMarkers.push(marker);
+      return marker;
+    },
+    markers: () =>
+      Object.freeze(recordedMarkers.map((marker) => ({ ...marker }))),
+  };
+}
+
+export const RESPONSE_LATENCY_OPERATION_NAMES = [
+  'postgres_statements',
+  'postgres_transactions',
+  'get_messages_since_calls',
+  'provider_history_calls',
+  'memory_hydrate_calls',
+  'list_enabled_skills_calls',
+  'get_skill_calls',
+  'list_tool_bindings_calls',
+  'get_tool_calls',
+  'list_mcp_bindings_calls',
+  'get_mcp_server_calls',
+  's3_list_calls',
+  's3_get_calls',
+  'mcp_connect_calls',
+  'mcp_list_tools_calls',
+] as const;
+
+export interface OperationCounter {
+  increment(operation: string, count?: number): number;
+  get(operation: string): number;
+  snapshot(): Readonly<Record<string, number>>;
+}
+
+export function createOperationCounter(): OperationCounter {
+  const counts = new Map<string, number>(
+    RESPONSE_LATENCY_OPERATION_NAMES.map((name) => [name, 0]),
+  );
+
+  return {
+    increment(operation, count = 1) {
+      if (!Number.isInteger(count) || count < 0) {
+        throw new Error(
+          'Operation counter increments must be non-negative integers',
+        );
+      }
+      const next = (counts.get(operation) ?? 0) + count;
+      counts.set(operation, next);
+      return next;
+    },
+    get: (operation) => counts.get(operation) ?? 0,
+    snapshot: () => Object.freeze(Object.fromEntries(counts)),
+  };
+}
+
+export const RESPONSE_LATENCY_BOUNDARIES = [
+  'ingress_receipt',
+  'metadata_persistence',
+  'message_commit',
+  'admission_notification',
+  'replay_load',
+  'conversation_local_load',
+  'provider_history_hydration',
+  'provider_history_persistence',
+  'provisional_session_context',
+  'final_session_context',
+  'memory_hydration',
+  'access_row_load',
+  'access_projection',
+  'skill_artifact_projection',
+  'mcp_materialization',
+  'mcp_connect',
+  'mcp_discovery',
+  'adapter_prepare',
+  'provider_first_byte',
+  'channel_first_visible_delivery',
+] as const;
+
+export type ResponseLatencyBoundary =
+  (typeof RESPONSE_LATENCY_BOUNDARIES)[number];
+
+export interface BoundaryDelayInjector {
+  setDelayMs(boundary: ResponseLatencyBoundary, durationMs: number): void;
+  wait(boundary: ResponseLatencyBoundary): Promise<void>;
+  snapshot(): Readonly<Record<ResponseLatencyBoundary, number>>;
+}
+
+export function createBoundaryDelayInjector(input: {
+  clock: ManualClock;
+}): BoundaryDelayInjector {
+  const delays = new Map<ResponseLatencyBoundary, number>(
+    RESPONSE_LATENCY_BOUNDARIES.map((boundary) => [boundary, 0]),
+  );
+
+  return {
+    setDelayMs(boundary, durationMs) {
+      if (!Number.isFinite(durationMs) || durationMs < 0) {
+        throw new Error('Boundary delays must be finite and non-negative');
+      }
+      delays.set(boundary, durationMs);
+    },
+    async wait(boundary) {
+      input.clock.advanceMs(delays.get(boundary) ?? 0);
+    },
+    snapshot: () =>
+      Object.freeze(
+        Object.fromEntries(delays) as Record<ResponseLatencyBoundary, number>,
+      ),
+  };
+}
+
+export interface BarrierSnapshot {
+  readonly arrivals: number;
+  readonly active: number;
+  readonly completed: number;
+  readonly maximumActive: number;
+  readonly allArrived: boolean;
+}
+
+export interface BarrierParticipant {
+  readonly completed: Promise<void>;
+  release(): void;
+}
+
+export interface DeterministicBarrier {
+  arrive(): BarrierParticipant;
+  waitForArrivals(count: number): Promise<void>;
+  waitForAll(): Promise<void>;
+  snapshot(): BarrierSnapshot;
+}
+
+export function createDeterministicBarrier(
+  expectedArrivals: number,
+): DeterministicBarrier {
+  if (!Number.isInteger(expectedArrivals) || expectedArrivals < 1) {
+    throw new Error('Barrier expected arrivals must be a positive integer');
+  }
+
+  let arrivals = 0;
+  let active = 0;
+  let completed = 0;
+  let maximumActive = 0;
+  const waiters: Array<{ count: number; resolve: () => void }> = [];
+
+  const notifyWaiters = () => {
+    for (const waiter of waiters.splice(0)) {
+      if (arrivals >= waiter.count) {
+        waiter.resolve();
+      } else {
+        waiters.push(waiter);
+      }
+    }
+  };
+  const waitForArrivals = (count: number): Promise<void> => {
+    if (!Number.isInteger(count) || count < 0 || count > expectedArrivals) {
+      throw new Error(
+        'Barrier arrival wait must be between zero and expected arrivals',
+      );
+    }
+    if (arrivals >= count) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      waiters.push({ count, resolve });
+    });
+  };
+
+  return {
+    arrive() {
+      if (arrivals >= expectedArrivals) {
+        throw new Error('Barrier received more arrivals than expected');
+      }
+      let resolveCompleted: (() => void) | undefined;
+      const participantCompleted = new Promise<void>((resolve) => {
+        resolveCompleted = resolve;
+      });
+
+      arrivals += 1;
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      notifyWaiters();
+      let released = false;
+
+      return {
+        completed: participantCompleted,
+        release() {
+          if (released) return;
+          released = true;
+          active -= 1;
+          completed += 1;
+          resolveCompleted?.();
+        },
+      };
+    },
+    waitForArrivals,
+    waitForAll: () => waitForArrivals(expectedArrivals),
+    snapshot: () =>
+      Object.freeze({
+        arrivals,
+        active,
+        completed,
+        maximumActive,
+        allArrived: arrivals >= expectedArrivals,
+      }),
+  };
+}
+
+export type ResponseLatencyFrame =
+  | { readonly kind: 'session_init'; readonly sessionCreated: boolean }
+  | { readonly kind: 'runtime_event'; readonly eventType: string }
+  | { readonly kind: 'progress'; readonly status: string }
+  | { readonly kind: 'typing'; readonly active: boolean }
+  | {
+      readonly kind: 'usage';
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+    }
+  | { readonly kind: 'terminal'; readonly result: string | null }
+  | { readonly kind: 'content_part'; readonly text: string }
+  | { readonly kind: 'content_chunk'; readonly text: string };
+
+export function isContentBearingFrame(frame: ResponseLatencyFrame): boolean {
+  switch (frame.kind) {
+    case 'content_part':
+    case 'content_chunk':
+      return (
+        frame.text.replace(
+          /[\p{White_Space}\p{Default_Ignorable_Code_Point}\p{Cc}]/gu,
+          '',
+        ).length > 0
+      );
+    default:
+      return false;
+  }
+}
+
+export interface ScriptedFakeStreamingModel {
+  stream(
+    onFrame: (frame: ResponseLatencyFrame) => void | Promise<void>,
+  ): Promise<void>;
+}
+
+export function createScriptedFakeStreamingModel(input: {
+  preContentFrames?: readonly ResponseLatencyFrame[];
+  contentFrame: ResponseLatencyFrame;
+  delay: () => void | Promise<void>;
+}): ScriptedFakeStreamingModel {
+  if (!isContentBearingFrame(input.contentFrame)) {
+    throw new Error(
+      'Scripted fake streaming model requires one content-bearing frame',
+    );
+  }
+  if (input.preContentFrames?.some(isContentBearingFrame)) {
+    throw new Error(
+      'Scripted fake streaming model pre-content frames must be non-content',
+    );
+  }
+
+  return {
+    async stream(onFrame) {
+      for (const frame of input.preContentFrames ?? []) {
+        await onFrame(frame);
+      }
+      await input.delay();
+      await onFrame(input.contentFrame);
+    },
+  };
+}
+
+export type DeliverySettlement =
+  | 'completed'
+  | 'delivery_incomplete'
+  | 'not_delivered'
+  | 'rejected';
+
+export interface DeliveryFrameObservation {
+  readonly kind: ResponseLatencyFrame['kind'];
+  readonly contentBearing: boolean;
+  readonly delivered: boolean;
+}
+
+export interface DeliveryAttemptSnapshot {
+  readonly id: string;
+  readonly settlement?: DeliverySettlement;
+  readonly frames: readonly DeliveryFrameObservation[];
+  readonly candidateAtMs?: number;
+  readonly publishedAtMs?: number;
+}
+
+export interface DeliveryAttempt {
+  observe(frame: ResponseLatencyFrame, input: { delivered: boolean }): void;
+  settle(settlement: Exclude<DeliverySettlement, 'rejected'>): void;
+  reject(): void;
+  snapshot(): DeliveryAttemptSnapshot;
+}
+
+export interface FakeChannelDeliveryProbe {
+  beginAttempt(id: string): DeliveryAttempt;
+  firstContentAtMs(): number | undefined;
+  attempts(): readonly DeliveryAttemptSnapshot[];
+}
+
+export function createFakeChannelDeliveryProbe(input: {
+  nowMs: () => number;
+}): FakeChannelDeliveryProbe {
+  let firstContentAtMs: number | undefined;
+  const attempts: Array<{
+    id: string;
+    settlement?: DeliverySettlement;
+    frames: DeliveryFrameObservation[];
+    candidateAtMs?: number;
+    publishedAtMs?: number;
+  }> = [];
+
+  const snapshotAttempt = (
+    attempt: (typeof attempts)[number],
+  ): DeliveryAttemptSnapshot =>
+    Object.freeze({
+      id: attempt.id,
+      ...(attempt.settlement ? { settlement: attempt.settlement } : {}),
+      frames: Object.freeze(attempt.frames.map((frame) => ({ ...frame }))),
+      ...(attempt.candidateAtMs === undefined
+        ? {}
+        : { candidateAtMs: attempt.candidateAtMs }),
+      ...(attempt.publishedAtMs === undefined
+        ? {}
+        : { publishedAtMs: attempt.publishedAtMs }),
+    });
+
+  return {
+    beginAttempt(id) {
+      const attempt: (typeof attempts)[number] = { id, frames: [] };
+      attempts.push(attempt);
+
+      const finish = (settlement: DeliverySettlement) => {
+        if (attempt.settlement) {
+          throw new Error(`Delivery attempt ${id} already settled`);
+        }
+        attempt.settlement = settlement;
+        if (
+          attempt.candidateAtMs !== undefined &&
+          (settlement === 'completed' || settlement === 'delivery_incomplete')
+        ) {
+          attempt.publishedAtMs = attempt.candidateAtMs;
+          firstContentAtMs =
+            firstContentAtMs === undefined
+              ? attempt.candidateAtMs
+              : Math.min(firstContentAtMs, attempt.candidateAtMs);
+        }
+      };
+
+      return {
+        observe(frame, observation) {
+          if (attempt.settlement) {
+            throw new Error(`Delivery attempt ${id} already settled`);
+          }
+          const contentBearing = isContentBearingFrame(frame);
+          attempt.frames.push(
+            Object.freeze({
+              kind: frame.kind,
+              contentBearing,
+              delivered: observation.delivered,
+            }),
+          );
+          if (
+            attempt.candidateAtMs === undefined &&
+            contentBearing &&
+            observation.delivered
+          ) {
+            attempt.candidateAtMs = input.nowMs();
+          }
+        },
+        settle: finish,
+        reject: () => finish('rejected'),
+        snapshot: () => snapshotAttempt(attempt),
+      };
+    },
+    firstContentAtMs: () => firstContentAtMs,
+    attempts: () => Object.freeze(attempts.map(snapshotAttempt)),
+  };
+}
+
+export interface ResponseLatencyHarness {
+  readonly clock: ManualClock;
+  readonly operations: OperationCounter;
+  readonly delays: BoundaryDelayInjector;
+  readonly channel: FakeChannelDeliveryProbe;
+  createBarrier(expectedArrivals: number): DeterministicBarrier;
+}
+
+export function createResponseLatencyHarness(input?: {
+  startMs?: number;
+}): ResponseLatencyHarness {
+  const clock = createManualClock(input?.startMs);
+  return {
+    clock,
+    operations: createOperationCounter(),
+    delays: createBoundaryDelayInjector({ clock }),
+    channel: createFakeChannelDeliveryProbe({ nowMs: clock.nowMs }),
+    createBarrier: createDeterministicBarrier,
+  };
+}

--- a/apps/core/test/harness/response-latency-postgres.ts
+++ b/apps/core/test/harness/response-latency-postgres.ts
@@ -1,0 +1,208 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { Pool, PoolClient } from 'pg';
+
+import { createOperationCounter } from './response-latency-harness.js';
+
+const POSTGRES_TEST_DATABASE_URL_ENV = 'GANTRY_TEST_DATABASE_URL';
+const measuredPools = new WeakSet<Pool>();
+const measurementScope = new AsyncLocalStorage<symbol>();
+
+export type PostgresEvidenceAvailability =
+  | Readonly<{ status: 'ready' }>
+  | Readonly<{
+      status: 'blocked';
+      blocker: 'missing_gantry_test_database_url';
+    }>;
+
+export interface PostgresOperationCounts {
+  readonly postgres_statements: number;
+  readonly postgres_transactions: number;
+}
+
+export interface PostgresOperationMeasurement {
+  readonly counts: Readonly<PostgresOperationCounts>;
+}
+
+export function classifyPostgresEvidenceAvailability(
+  env: Partial<
+    Record<typeof POSTGRES_TEST_DATABASE_URL_ENV, string>
+  > = process.env,
+): PostgresEvidenceAvailability {
+  return env[POSTGRES_TEST_DATABASE_URL_ENV]?.trim()
+    ? Object.freeze({ status: 'ready' })
+    : Object.freeze({
+        status: 'blocked',
+        blocker: 'missing_gantry_test_database_url',
+      });
+}
+
+export async function measurePostgresOperations(
+  pool: Pool,
+  operation: () => Promise<unknown>,
+): Promise<PostgresOperationMeasurement> {
+  if (measuredPools.has(pool)) {
+    throw new Error('Postgres pool is already being measured');
+  }
+  if (pool.totalCount !== pool.idleCount || pool.waitingCount > 0) {
+    throw new Error('Postgres pool must be idle before measurement');
+  }
+  measuredPools.add(pool);
+
+  const counter = createOperationCounter();
+  const scope = Symbol('postgres-operation-measurement');
+  const instrumentation = instrumentPoolClients(pool, (query) => {
+    if (measurementScope.getStore() !== scope) return;
+    const command = postgresCommand(query);
+    if (command === 'transaction_start') {
+      counter.increment('postgres_transactions');
+    } else if (command === 'statement') {
+      counter.increment('postgres_statements');
+    }
+  });
+
+  try {
+    await measurementScope.run(scope, operation);
+    return Object.freeze({
+      counts: Object.freeze({
+        postgres_statements: counter.get('postgres_statements'),
+        postgres_transactions: counter.get('postgres_transactions'),
+      }),
+    });
+  } finally {
+    try {
+      instrumentation.restore();
+    } finally {
+      measuredPools.delete(pool);
+    }
+  }
+}
+
+type PoolConnectCallback = (
+  error: Error | undefined,
+  client: PoolClient | undefined,
+  done: (release?: unknown) => void,
+) => void;
+
+type UntypedQuery = (query: unknown, ...args: unknown[]) => unknown;
+
+function instrumentPoolClients(
+  pool: Pool,
+  onQuery: (query: unknown) => void,
+): { restore(): void } {
+  const originalConnect = pool.connect;
+  const patchedClients = new Map<
+    PoolClient,
+    { original: PoolClient['query']; patched: PoolClient['query'] }
+  >();
+
+  const patchClient = (client: PoolClient): PoolClient => {
+    if (patchedClients.has(client)) return client;
+
+    const original = client.query;
+    const untypedOriginal = original as unknown as UntypedQuery;
+    const patched = ((query: unknown, ...args: unknown[]) => {
+      onQuery(query);
+      return untypedOriginal.call(client, query, ...args);
+    }) as PoolClient['query'];
+    patchedClients.set(client, { original, patched });
+    client.query = patched;
+    return client;
+  };
+
+  const connectWithCallback = originalConnect as unknown as (
+    callback: PoolConnectCallback,
+  ) => void;
+  const connectWithPromise =
+    originalConnect as unknown as () => Promise<PoolClient>;
+  const patchedConnect = ((callback?: PoolConnectCallback) => {
+    if (callback) {
+      return connectWithCallback.call(pool, (error, client, done) =>
+        callback(error, client ? patchClient(client) : undefined, done),
+      );
+    }
+    return connectWithPromise.call(pool).then(patchClient);
+  }) as Pool['connect'];
+  pool.connect = patchedConnect;
+
+  let restored = false;
+  return {
+    restore() {
+      if (restored) return;
+      restored = true;
+      if (pool.connect === patchedConnect) {
+        pool.connect = originalConnect;
+      }
+      for (const [client, query] of patchedClients) {
+        if (client.query === query.patched) {
+          client.query = query.original;
+        }
+      }
+      patchedClients.clear();
+    },
+  };
+}
+
+type PostgresCommand =
+  | 'transaction_start'
+  | 'transaction_control'
+  | 'statement'
+  | 'empty';
+
+function postgresCommand(query: unknown): PostgresCommand {
+  const text =
+    typeof query === 'string'
+      ? query
+      : query &&
+          typeof query === 'object' &&
+          'text' in query &&
+          typeof query.text === 'string'
+        ? query.text
+        : null;
+  if (text === null) return 'statement';
+
+  const command = stripLeadingSqlComments(text).trimStart();
+  if (!command) return 'empty';
+  if (/^(?:BEGIN\b|START\s+TRANSACTION\b)/i.test(command)) {
+    return 'transaction_start';
+  }
+  if (
+    /^(?:COMMIT\b|END\b|ROLLBACK\b|ABORT\b|SAVEPOINT\b|RELEASE\b|PREPARE\s+TRANSACTION\b|SET\s+TRANSACTION\b)/i.test(
+      command,
+    )
+  ) {
+    return 'transaction_control';
+  }
+  return 'statement';
+}
+
+function stripLeadingSqlComments(sql: string): string {
+  let remaining = sql;
+  while (true) {
+    remaining = remaining.trimStart();
+    if (remaining.startsWith('--')) {
+      const newline = remaining.indexOf('\n');
+      remaining = newline === -1 ? '' : remaining.slice(newline + 1);
+      continue;
+    }
+    if (remaining.startsWith('/*')) {
+      let depth = 0;
+      let offset = 0;
+      while (offset < remaining.length) {
+        if (remaining.startsWith('/*', offset)) {
+          depth += 1;
+          offset += 2;
+        } else if (remaining.startsWith('*/', offset)) {
+          depth -= 1;
+          offset += 2;
+          if (depth === 0) break;
+        } else {
+          offset += 1;
+        }
+      }
+      remaining = depth === 0 ? remaining.slice(offset) : '';
+      continue;
+    }
+    return remaining;
+  }
+}

--- a/apps/core/test/harness/response-latency-scenarios.ts
+++ b/apps/core/test/harness/response-latency-scenarios.ts
@@ -1,0 +1,507 @@
+import {
+  createResponseLatencyHarness,
+  createScriptedFakeStreamingModel,
+  type OperationCounter,
+  type ResponseLatencyBoundary,
+} from './response-latency-harness.js';
+
+export type ResponseLatencyScenarioId =
+  | 'S1'
+  | 'S2'
+  | 'S3'
+  | 'S4'
+  | 'S5'
+  | 'S6'
+  | 'S7'
+  | 'S8'
+  | 'S9'
+  | 'S10'
+  | 'S11'
+  | 'S12';
+
+interface FakeScenario {
+  readonly id: Exclude<ResponseLatencyScenarioId, 'S11' | 'S12'>;
+  readonly name: string;
+  readonly kind: 'fake';
+  readonly routeCount: number;
+  readonly replayLoads?: number;
+  readonly threadMessageLoads?: number;
+  readonly conversationCount?: number;
+  readonly providerHistory?: boolean;
+  readonly memory?: boolean;
+  readonly provisionalSessionContext?: boolean;
+  readonly finalSessionContext?: boolean;
+  readonly adapterPrepare?: boolean;
+  readonly inputMessageCount?: number;
+  readonly skills?: {
+    readonly enabledCount: number;
+    readonly selectedCount: number;
+    readonly store: 'local' | 's3-like';
+  };
+  readonly mcpConnectDelaysMs?: readonly number[];
+  readonly modelRequestBytes?: number;
+  readonly booleans?: Readonly<Record<string, boolean>>;
+}
+
+interface RegressionScenario {
+  readonly id: 'S11' | 'S12';
+  readonly name: string;
+  readonly kind: 'regression';
+}
+
+type ScenarioDefinition = FakeScenario | RegressionScenario;
+
+// ponytail: one data table and one runner are enough for this test-only matrix.
+export const RESPONSE_LATENCY_SCENARIOS = [
+  {
+    id: 'S1',
+    name: 'warm top/no thread/no skill/no MCP/new session',
+    kind: 'fake',
+    routeCount: 1,
+    replayLoads: 1,
+    provisionalSessionContext: true,
+    finalSessionContext: true,
+    booleans: {
+      threaded: false,
+      newSession: true,
+      skillsEnabled: false,
+      mcpEnabled: false,
+    },
+  },
+  {
+    id: 'S2',
+    name: 'sparse top provider history',
+    kind: 'fake',
+    routeCount: 1,
+    replayLoads: 1,
+    providerHistory: true,
+    booleans: { threaded: false, providerHistoryHydrated: true },
+  },
+  {
+    id: 'S3',
+    name: 'sparse thread root+tail',
+    kind: 'fake',
+    routeCount: 1,
+    threadMessageLoads: 2,
+    booleans: { threaded: true },
+  },
+  {
+    id: 'S4',
+    name: 'resumed provider session+memory',
+    kind: 'fake',
+    routeCount: 1,
+    providerHistory: true,
+    memory: true,
+    finalSessionContext: true,
+    booleans: { resumedSession: true, memoryHydrated: true },
+  },
+  {
+    id: 'S5',
+    name: '10 enabled/3 selected/local store',
+    kind: 'fake',
+    routeCount: 1,
+    skills: { enabledCount: 10, selectedCount: 3, store: 'local' },
+    booleans: { localSkillStore: true },
+  },
+  {
+    id: 'S6',
+    name: '10 enabled/3 selected/delayed S3-like store',
+    kind: 'fake',
+    routeCount: 1,
+    skills: { enabledCount: 10, selectedCount: 3, store: 's3-like' },
+    booleans: { s3LikeSkillStore: true },
+  },
+  {
+    id: 'S7',
+    name: '3 MCP servers 100/200/300',
+    kind: 'fake',
+    routeCount: 1,
+    mcpConnectDelaysMs: [100, 200, 300],
+    booleans: { remoteMcp: true },
+  },
+  {
+    id: 'S8',
+    name: 'one message to 3 agents',
+    kind: 'fake',
+    routeCount: 3,
+    inputMessageCount: 1,
+    booleans: { multiAgent: true },
+  },
+  {
+    id: 'S9',
+    name: '10 conversations',
+    kind: 'fake',
+    routeCount: 10,
+    conversationCount: 10,
+  },
+  {
+    id: 'S10',
+    name: 'direct LLM streaming 1MiB',
+    kind: 'fake',
+    routeCount: 1,
+    modelRequestBytes: 1_048_576,
+    adapterPrepare: true,
+    booleans: { directLlmStreaming: true },
+  },
+  { id: 'S11', name: '500 jobs', kind: 'regression' },
+  { id: 'S12', name: 'IPC 5000 markers', kind: 'regression' },
+] as const satisfies readonly ScenarioDefinition[];
+
+export const RESPONSE_LATENCY_REGRESSION_ANCHORS = {
+  S11: {
+    sourceId:
+      'job-lifecycle.postgres.integration:projects-one-latest-non-session-run-for-500-jobs',
+    jobCount: 500,
+    queryCount: 2,
+    distinctOnQueryCount: 1,
+  },
+  S12: {
+    sourceId:
+      'ipc-auth-boundary:performs-bounded-filesystem-work-with-5000-replay-markers',
+    markerCount: 5_000,
+    replayStoreOperationCount: 4,
+    scanCount: 0,
+    readCount: 0,
+    removeCount: 0,
+  },
+} as const;
+
+export interface ResponseLatencyScenarioResult {
+  readonly scenarioId: ResponseLatencyScenarioId;
+  readonly status: 'completed' | 'current_baseline';
+  readonly counts: Readonly<Record<string, number>>;
+  readonly durationsMs: Readonly<Record<string, number>>;
+  readonly booleans: Readonly<Record<string, boolean>>;
+  readonly firstContentDurationMs?: number;
+}
+
+interface FakeScenarioObservations {
+  readonly operations: OperationCounter;
+  readonly loadedConversations: Set<string>;
+  readonly modeledConversations: Set<string>;
+}
+
+function createFakeScenarioDependencies(
+  harness: ReturnType<typeof createResponseLatencyHarness>,
+  durationsMs: Record<string, number>,
+  observations: FakeScenarioObservations,
+) {
+  const externalNetworkCalls = 0;
+  const observe = async (
+    boundary: ResponseLatencyBoundary,
+    operation: string,
+    delayMs = 0,
+  ) => {
+    observations.operations.increment(operation);
+    harness.delays.setDelayMs(boundary, delayMs);
+    await harness.delays.wait(boundary);
+    durationsMs[boundary] = (durationsMs[boundary] ?? 0) + delayMs;
+  };
+
+  return {
+    getMessagesSince: () => observe('replay_load', 'get_messages_since_calls'),
+    async getThreadMessages(conversationId: string) {
+      await observe('conversation_local_load', 'get_messages_since_calls');
+      observations.loadedConversations.add(conversationId);
+    },
+    hydrateProviderHistory: () =>
+      observe('provider_history_hydration', 'provider_history_calls'),
+    hydrateMemory: () => observe('memory_hydration', 'memory_hydrate_calls'),
+    loadProvisionalSessionContext: () =>
+      observe(
+        'provisional_session_context',
+        'provisional_session_context_calls',
+      ),
+    loadFinalSessionContext: () =>
+      observe('final_session_context', 'final_session_context_calls'),
+    prepareAdapter: () => observe('adapter_prepare', 'adapter_prepare_calls'),
+    recordInputMessages(messages: readonly number[]) {
+      observations.operations.increment('input_message_count', messages.length);
+    },
+    async listEnabledSkills(count: number) {
+      await observe('access_row_load', 'list_enabled_skills_calls');
+      const skills = Array.from({ length: count }, (_, id) => id);
+      observations.operations.increment('enabled_skill_count', skills.length);
+      return skills;
+    },
+    listS3SkillObjects: () => observe('access_projection', 's3_list_calls'),
+    async getSkill(skillId: number, store: 'local' | 's3-like') {
+      await observe(
+        'skill_artifact_projection',
+        'get_skill_calls',
+        store === 's3-like' ? 1 : 0,
+      );
+      observations.operations.increment(
+        store === 's3-like' ? 's3_get_calls' : 'local_skill_reads',
+      );
+      return skillId;
+    },
+    async listMcpBindings(count: number) {
+      await observe('mcp_materialization', 'list_mcp_bindings_calls');
+      const bindings = Array.from({ length: count }, (_, id) => id);
+      observations.operations.increment('mcp_server_count', bindings.length);
+      return bindings;
+    },
+    async getMcpServer(bindingId: number) {
+      await observe('mcp_materialization', 'get_mcp_server_calls');
+      return bindingId;
+    },
+    async connectMcp(serverId: number, delayMs: number) {
+      await observe('mcp_connect', 'mcp_connect_calls', delayMs);
+      return serverId;
+    },
+    async listMcpTools(serverId: number) {
+      await observe('mcp_discovery', 'mcp_list_tools_calls');
+      return serverId;
+    },
+    notifyAdmission: () =>
+      observe('admission_notification', 'admission_notification_calls'),
+    async streamModel(input: {
+      attemptId: string;
+      request: Uint8Array<ArrayBuffer>;
+      conversationId?: string;
+    }) {
+      observations.operations.increment('model_stream_calls');
+      observations.operations.increment(
+        'model_request_bytes',
+        input.request.byteLength,
+      );
+      const attempt = harness.channel.beginAttempt(input.attemptId);
+      observations.operations.increment('channel_delivery_attempts');
+      const model = createScriptedFakeStreamingModel({
+        preContentFrames: [{ kind: 'progress', status: 'working' }],
+        contentFrame: { kind: 'content_chunk', text: 'content' },
+        delay: () =>
+          observe('provider_first_byte', 'provider_first_byte_calls', 1),
+      });
+      await model.stream(async (frame) => {
+        if (frame.kind === 'content_chunk' || frame.kind === 'content_part') {
+          await observe(
+            'channel_first_visible_delivery',
+            'channel_first_visible_calls',
+            1,
+          );
+        }
+        attempt.observe(frame, { delivered: true });
+      });
+      attempt.settle('completed');
+      if (input.conversationId) {
+        observations.modeledConversations.add(input.conversationId);
+      }
+    },
+    externalNetworkCalls: () => externalNetworkCalls,
+    conversationSnapshot: () => ({
+      count: observations.modeledConversations.size,
+      independent:
+        observations.modeledConversations.size ===
+          observations.loadedConversations.size &&
+        [...observations.modeledConversations].every((id) =>
+          observations.loadedConversations.has(id),
+        ),
+    }),
+  };
+}
+
+export async function runResponseLatencyScenario(
+  scenarioId: ResponseLatencyScenarioId,
+): Promise<ResponseLatencyScenarioResult> {
+  const scenario = RESPONSE_LATENCY_SCENARIOS.find(
+    ({ id }) => id === scenarioId,
+  );
+  if (!scenario)
+    throw new Error(`Unknown response latency scenario ${scenarioId}`);
+
+  if (scenario.id === 'S11') {
+    // Reference-only by contract: the Postgres regression owns the executable
+    // 500-row fixture; duplicating it here would create a second source of truth.
+    const anchor = RESPONSE_LATENCY_REGRESSION_ANCHORS.S11;
+    return {
+      scenarioId,
+      status: 'current_baseline',
+      counts: {
+        jobs: anchor.jobCount,
+        postgres_statements: anchor.queryCount,
+        distinct_on_queries: anchor.distinctOnQueryCount,
+      },
+      durationsMs: {},
+      booleans: { regressionSourceReferenced: true },
+    };
+  }
+  if (scenario.id === 'S12') {
+    // Reference-only by contract: the IPC regression owns the executable
+    // 5,000-file fixture; duplicating it here would repeat expensive setup.
+    const anchor = RESPONSE_LATENCY_REGRESSION_ANCHORS.S12;
+    return {
+      scenarioId,
+      status: 'current_baseline',
+      counts: {
+        replay_markers: anchor.markerCount,
+        replay_store_operations: anchor.replayStoreOperationCount,
+        replay_scans: anchor.scanCount,
+        replay_reads: anchor.readCount,
+        replay_removes: anchor.removeCount,
+      },
+      durationsMs: {},
+      booleans: { regressionSourceReferenced: true },
+    };
+  }
+
+  const harness = createResponseLatencyHarness();
+  const durationsMs: Record<string, number> = {};
+  const observations: FakeScenarioObservations = {
+    operations: harness.operations,
+    loadedConversations: new Set(),
+    modeledConversations: new Set(),
+  };
+  const fake = createFakeScenarioDependencies(
+    harness,
+    durationsMs,
+    observations,
+  );
+
+  for (let call = 0; call < (scenario.replayLoads ?? 0); call += 1) {
+    await fake.getMessagesSince();
+  }
+  for (let call = 0; call < (scenario.threadMessageLoads ?? 0); call += 1) {
+    await fake.getThreadMessages(`${scenario.id}:thread`);
+  }
+  if (scenario.providerHistory) await fake.hydrateProviderHistory();
+  if (scenario.memory) await fake.hydrateMemory();
+  if (scenario.provisionalSessionContext) {
+    await fake.loadProvisionalSessionContext();
+  }
+  if (scenario.finalSessionContext) await fake.loadFinalSessionContext();
+  if (scenario.adapterPrepare) await fake.prepareAdapter();
+
+  if (scenario.inputMessageCount !== undefined) {
+    const messages = Array.from(
+      { length: scenario.inputMessageCount },
+      (_, id) => id,
+    );
+    fake.recordInputMessages(messages);
+  }
+
+  if (scenario.skills) {
+    const enabledSkills = await fake.listEnabledSkills(
+      scenario.skills.enabledCount,
+    );
+    const selectedSkills = enabledSkills.slice(
+      0,
+      scenario.skills.selectedCount,
+    );
+    harness.operations.increment('selected_skill_count', selectedSkills.length);
+
+    if (scenario.skills.store === 's3-like') {
+      await fake.listS3SkillObjects();
+    }
+    for (const skill of selectedSkills) {
+      await fake.getSkill(skill, scenario.skills.store);
+    }
+  }
+
+  if (scenario.mcpConnectDelaysMs) {
+    const bindings = await fake.listMcpBindings(
+      scenario.mcpConnectDelaysMs.length,
+    );
+    for (const [binding, delayMs] of scenario.mcpConnectDelaysMs.entries()) {
+      const server = await fake.getMcpServer(bindings[binding]!);
+      const connection = await fake.connectMcp(server, delayMs);
+      await fake.listMcpTools(connection);
+    }
+  }
+
+  const barrier = harness.createBarrier(scenario.routeCount);
+  const routes = Array.from({ length: scenario.routeCount }, (_, route) => ({
+    attemptId: `${scenario.id}:${route}`,
+    ...(scenario.conversationCount === undefined
+      ? {}
+      : { conversationId: `${scenario.id}:conversation:${route}` }),
+  }));
+  harness.operations.increment('agent_route_count', routes.length);
+
+  const request = new Uint8Array(scenario.modelRequestBytes ?? 0);
+  const routeResults = await Promise.all(
+    routes.map(async ({ attemptId, conversationId }) => {
+      harness.operations.increment('barrier_arrivals');
+      const participant = barrier.arrive();
+      await barrier.waitForAll();
+      const routeDurationsMs: Record<string, number> = {};
+      const routeHarness = createResponseLatencyHarness({
+        startMs: harness.clock.nowMs(),
+      });
+      const routeFake = createFakeScenarioDependencies(
+        routeHarness,
+        routeDurationsMs,
+        observations,
+      );
+      try {
+        if (conversationId) {
+          await routeFake.getThreadMessages(conversationId);
+        }
+        if (scenario.id === 'S8') await routeFake.notifyAdmission();
+        await routeFake.streamModel({ attemptId, request, conversationId });
+        return {
+          durationsMs: routeDurationsMs,
+          firstContentAtMs: routeHarness.channel.firstContentAtMs(),
+          completedAtMs: routeHarness.clock.nowMs(),
+          externalNetworkCalls: routeFake.externalNetworkCalls(),
+        };
+      } finally {
+        participant.release();
+      }
+    }),
+  );
+  const barrierSnapshot = barrier.snapshot();
+  harness.operations.increment(
+    'maximum_active_routes',
+    barrierSnapshot.maximumActive,
+  );
+  for (const route of routeResults) {
+    for (const [boundary, durationMs] of Object.entries(route.durationsMs)) {
+      durationsMs[boundary] = Math.max(durationsMs[boundary] ?? 0, durationMs);
+    }
+  }
+  const conversations = fake.conversationSnapshot();
+  if (scenario.conversationCount !== undefined) {
+    harness.operations.increment('conversation_count', conversations.count);
+  }
+
+  durationsMs.total = Math.max(
+    harness.clock.nowMs(),
+    ...routeResults.map(({ completedAtMs }) => completedAtMs),
+  );
+  const firstContentTimes = routeResults.flatMap(({ firstContentAtMs }) =>
+    firstContentAtMs === undefined ? [] : [firstContentAtMs],
+  );
+  const firstContentDurationMs = Math.min(...firstContentTimes);
+  if (!Number.isFinite(firstContentDurationMs)) {
+    throw new Error(`Scenario ${scenarioId} did not deliver first content`);
+  }
+
+  return {
+    scenarioId,
+    status: 'completed',
+    counts: harness.operations.snapshot(),
+    durationsMs: Object.freeze({ ...durationsMs }),
+    booleans: Object.freeze({
+      ...scenario.booleans,
+      allArrived: barrierSnapshot.allArrived,
+      noRealNetwork:
+        fake.externalNetworkCalls() === 0 &&
+        routeResults.every(
+          ({ externalNetworkCalls }) => externalNetworkCalls === 0,
+        ),
+      distinctRouteIds:
+        new Set(routes.map(({ attemptId }) => attemptId)).size ===
+        routes.length,
+      ...(scenario.conversationCount === undefined
+        ? {}
+        : {
+            independentConversations:
+              conversations.independent &&
+              conversations.count === scenario.conversationCount,
+          }),
+    }),
+    firstContentDurationMs,
+  };
+}

--- a/apps/core/test/integration/response-latency-postgres.postgres.integration.test.ts
+++ b/apps/core/test/integration/response-latency-postgres.postgres.integration.test.ts
@@ -1,0 +1,175 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+import {
+  classifyPostgresEvidenceAvailability,
+  measurePostgresOperations,
+} from '../harness/response-latency-postgres.js';
+
+describe('Postgres response-latency evidence gate', () => {
+  it('classifies missing database configuration as blocked evidence', () => {
+    expect(classifyPostgresEvidenceAvailability({})).toEqual({
+      status: 'blocked',
+      blocker: 'missing_gantry_test_database_url',
+    });
+    expect(
+      classifyPostgresEvidenceAvailability({
+        GANTRY_TEST_DATABASE_URL: '   ',
+      }),
+    ).toEqual({
+      status: 'blocked',
+      blocker: 'missing_gantry_test_database_url',
+    });
+  });
+});
+
+describe.runIf(hasPostgresIntegrationDatabase)(
+  'Postgres response-latency operation counting',
+  () => {
+    let runtime: PostgresIntegrationRuntime;
+
+    beforeAll(async () => {
+      runtime = await createPostgresIntegrationRuntime({
+        schemaPrefix: 'response_latency',
+      });
+    }, 60_000);
+
+    afterAll(async () => {
+      await runtime?.cleanup();
+    });
+
+    it('counts pool and checked-out-client statements plus outer transactions', async () => {
+      const measurement = await measurePostgresOperations(
+        runtime.service.pool,
+        async () => {
+          await runtime.service.pool.query('SELECT 1');
+          const client = await runtime.service.pool.connect();
+          try {
+            await client.query('BEGIN');
+            await client.query({ text: 'SELECT 2' });
+            await client.query('SAVEPOINT response_latency_probe');
+            await client.query('RELEASE SAVEPOINT response_latency_probe');
+            await client.query('COMMIT');
+          } finally {
+            client.release();
+          }
+          return { completed: true };
+        },
+      );
+
+      expect(measurement).toEqual({
+        counts: {
+          postgres_statements: 2,
+          postgres_transactions: 1,
+        },
+      });
+      expect(measurement).not.toHaveProperty('sql');
+    });
+
+    it('counts START TRANSACTION once and ignores its control statements', async () => {
+      const measurement = await measurePostgresOperations(
+        runtime.service.pool,
+        async () => {
+          const client = await runtime.service.pool.connect();
+          try {
+            await client.query(
+              '/* outer /* nested */ comment */ START TRANSACTION',
+            );
+            await client.query('SELECT 3');
+            await client.query('ROLLBACK');
+          } finally {
+            client.release();
+          }
+        },
+      );
+
+      expect(measurement.counts).toEqual({
+        postgres_statements: 1,
+        postgres_transactions: 1,
+      });
+    });
+
+    it('rejects overlapping measurements and restores patches after failure', async () => {
+      const originalConnect = runtime.service.pool.connect;
+      let releaseOperation: (() => void) | undefined;
+      let markStarted: (() => void) | undefined;
+      const operationStarted = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const operationReleased = new Promise<void>((resolve) => {
+        releaseOperation = resolve;
+      });
+
+      const firstMeasurement = measurePostgresOperations(
+        runtime.service.pool,
+        async () => {
+          markStarted?.();
+          await operationReleased;
+        },
+      );
+      await operationStarted;
+
+      await expect(
+        measurePostgresOperations(runtime.service.pool, async () => undefined),
+      ).rejects.toThrow('already being measured');
+      await runtime.service.pool.query('SELECT 4');
+      releaseOperation?.();
+      const firstResult = await firstMeasurement;
+      expect(firstResult.counts).toEqual({
+        postgres_statements: 0,
+        postgres_transactions: 0,
+      });
+      expect(runtime.service.pool.connect).toBe(originalConnect);
+
+      await expect(
+        measurePostgresOperations(runtime.service.pool, async () => {
+          throw new Error('measurement failed');
+        }),
+      ).rejects.toThrow('measurement failed');
+      expect(runtime.service.pool.connect).toBe(originalConnect);
+
+      const checkedOut = await runtime.service.pool.connect();
+      try {
+        await expect(
+          measurePostgresOperations(
+            runtime.service.pool,
+            async () => undefined,
+          ),
+        ).rejects.toThrow('must be idle');
+      } finally {
+        checkedOut.release();
+      }
+    });
+
+    it('removes the isolated schema during cleanup', async () => {
+      const isolated = await createPostgresIntegrationRuntime({
+        schemaPrefix: 'response_latency_cleanup',
+      });
+      const schemaName = isolated.schemaName;
+
+      try {
+        const beforeCleanup = await runtime.service.pool.query<{
+          present: boolean;
+        }>(
+          'SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = $1) AS present',
+          [schemaName],
+        );
+        expect(beforeCleanup.rows[0]?.present).toBe(true);
+      } finally {
+        await isolated.cleanup();
+      }
+
+      const afterCleanup = await runtime.service.pool.query<{
+        present: boolean;
+      }>(
+        'SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = $1) AS present',
+        [schemaName],
+      );
+      expect(afterCleanup.rows[0]?.present).toBe(false);
+    }, 60_000);
+  },
+);

--- a/apps/core/test/unit/runtime/response-latency-contract.test.ts
+++ b/apps/core/test/unit/runtime/response-latency-contract.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RESPONSE_LATENCY_BOUNDARIES,
+  RESPONSE_LATENCY_OPERATION_NAMES,
+  createBoundaryDelayInjector,
+  createDeterministicBarrier,
+  createManualClock,
+  createOperationCounter,
+  createResponseLatencyHarness,
+  createScriptedFakeStreamingModel,
+  isContentBearingFrame,
+  type ResponseLatencyFrame,
+} from '../../harness/response-latency-harness.js';
+
+describe('response latency harness contract', () => {
+  it('records deterministic clock markers and advances only under test control', () => {
+    const clock = createManualClock(100);
+
+    expect(clock.mark('ingress_received')).toEqual({
+      name: 'ingress_received',
+      atMs: 100,
+    });
+    expect(clock.advanceMs(25)).toBe(125);
+    expect(clock.mark('provider_first_byte')).toEqual({
+      name: 'provider_first_byte',
+      atMs: 125,
+    });
+    expect(clock.markers()).toEqual([
+      { name: 'ingress_received', atMs: 100 },
+      { name: 'provider_first_byte', atMs: 125 },
+    ]);
+    expect(() => clock.advanceMs(-1)).toThrow(/non-negative/);
+  });
+
+  it('counts every named operation plus phase-local additions', () => {
+    const operations = createOperationCounter();
+
+    RESPONSE_LATENCY_OPERATION_NAMES.forEach((name, index) => {
+      operations.increment(name, index + 1);
+    });
+    operations.increment('phase_local_calls', 2);
+    const snapshot = operations.snapshot();
+    operations.increment('phase_local_calls');
+
+    expect(snapshot).toEqual({
+      postgres_statements: 1,
+      postgres_transactions: 2,
+      get_messages_since_calls: 3,
+      provider_history_calls: 4,
+      memory_hydrate_calls: 5,
+      list_enabled_skills_calls: 6,
+      get_skill_calls: 7,
+      list_tool_bindings_calls: 8,
+      get_tool_calls: 9,
+      list_mcp_bindings_calls: 10,
+      get_mcp_server_calls: 11,
+      s3_list_calls: 12,
+      s3_get_calls: 13,
+      mcp_connect_calls: 14,
+      mcp_list_tools_calls: 15,
+      phase_local_calls: 2,
+    });
+    expect(operations.get('phase_local_calls')).toBe(3);
+    expect(operations.get('unobserved_calls')).toBe(0);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+
+  it('injects every named boundary delay under manual-clock control', async () => {
+    const clock = createManualClock(20);
+    const delays = createBoundaryDelayInjector({ clock });
+
+    RESPONSE_LATENCY_BOUNDARIES.forEach((boundary, index) => {
+      delays.setDelayMs(boundary, index);
+    });
+    for (const boundary of RESPONSE_LATENCY_BOUNDARIES) {
+      await delays.wait(boundary);
+    }
+
+    expect(clock.nowMs()).toBe(210);
+    expect(delays.snapshot()).toEqual(
+      Object.fromEntries(
+        RESPONSE_LATENCY_BOUNDARIES.map((boundary, index) => [boundary, index]),
+      ),
+    );
+  });
+
+  it('rejects invalid clock, counter, and delay values', () => {
+    const clock = createManualClock();
+    const operations = createOperationCounter();
+    const delays = createBoundaryDelayInjector({ clock });
+
+    for (const startMs of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      expect(() => createManualClock(startMs)).toThrow(/start must be finite/);
+    }
+    expect(() => clock.advanceMs(Number.POSITIVE_INFINITY)).toThrow(/finite/);
+    expect(() => operations.increment('memory_hydrate_calls', 0.5)).toThrow(
+      /integer/,
+    );
+    expect(() => delays.setDelayMs('provider_first_byte', Number.NaN)).toThrow(
+      /finite/,
+    );
+  });
+
+  it('rejects manual-clock overflow without mutating its timestamp', () => {
+    const clock = createManualClock(Number.MAX_VALUE);
+
+    expect(() => clock.advanceMs(Number.MAX_VALUE)).toThrow(
+      /result must be finite/,
+    );
+    expect(clock.nowMs()).toBe(Number.MAX_VALUE);
+  });
+
+  it('excludes init, control, terminal, empty, and whitespace frames from content', () => {
+    const nonContentFrames: ResponseLatencyFrame[] = [
+      { kind: 'session_init', sessionCreated: true },
+      { kind: 'runtime_event', eventType: 'run.startup_diagnostic' },
+      { kind: 'progress', status: 'working' },
+      { kind: 'typing', active: true },
+      { kind: 'usage', inputTokens: 10, outputTokens: 0 },
+      { kind: 'terminal', result: null },
+      { kind: 'terminal', result: 'completed' },
+      { kind: 'terminal', result: 'failed' },
+      { kind: 'content_part', text: '' },
+      { kind: 'content_chunk', text: '   ' },
+      { kind: 'content_part', text: '\u200b\u200d\u200f' },
+      { kind: 'content_chunk', text: '\0\ufe0f' },
+    ];
+
+    expect(
+      nonContentFrames.every((frame) => !isContentBearingFrame(frame)),
+    ).toBe(true);
+    expect(
+      isContentBearingFrame({ kind: 'content_part', text: ' answer ' }),
+    ).toBe(true);
+    expect(
+      isContentBearingFrame({ kind: 'content_chunk', text: '\nanswer\n' }),
+    ).toBe(true);
+    expect(isContentBearingFrame({ kind: 'content_chunk', text: '👩‍💻' })).toBe(
+      true,
+    );
+  });
+
+  it('emits scripted control frames before delayed fake-model content', async () => {
+    const clock = createManualClock(10);
+    const frames: ResponseLatencyFrame[] = [];
+    const model = createScriptedFakeStreamingModel({
+      preContentFrames: [
+        { kind: 'session_init', sessionCreated: true },
+        { kind: 'progress', status: 'thinking' },
+      ],
+      contentFrame: { kind: 'content_chunk', text: 'ready' },
+      delay: () => {
+        clock.advanceMs(40);
+      },
+    });
+
+    await model.stream((frame) => {
+      frames.push(frame);
+    });
+
+    expect(frames.map((frame) => frame.kind)).toEqual([
+      'session_init',
+      'progress',
+      'content_chunk',
+    ]);
+    expect(clock.nowMs()).toBe(50);
+  });
+
+  it('rejects fake-model scripts that blur the pre-content boundary', () => {
+    expect(() =>
+      createScriptedFakeStreamingModel({
+        preContentFrames: [{ kind: 'content_part', text: 'too early' }],
+        contentFrame: { kind: 'content_chunk', text: 'ready' },
+        delay: () => undefined,
+      }),
+    ).toThrow(/pre-content frames must be non-content/);
+    expect(() =>
+      createScriptedFakeStreamingModel({
+        contentFrame: { kind: 'terminal', result: null },
+        delay: () => undefined,
+      }),
+    ).toThrow(/requires one content-bearing frame/);
+  });
+
+  it('publishes a completed send from its original visibility candidate', () => {
+    const harness = createResponseLatencyHarness({ startMs: 100 });
+    const attempt = harness.channel.beginAttempt('completed');
+    attempt.observe(
+      { kind: 'progress', status: 'working' },
+      { delivered: true },
+    );
+    harness.clock.advanceMs(20);
+    attempt.observe(
+      { kind: 'content_chunk', text: 'first content' },
+      { delivered: true },
+    );
+    harness.clock.advanceMs(80);
+    attempt.settle('completed');
+
+    expect(harness.channel.firstContentAtMs()).toBe(120);
+    expect(attempt.snapshot()).toMatchObject({
+      settlement: 'completed',
+      candidateAtMs: 120,
+      publishedAtMs: 120,
+    });
+  });
+
+  it('publishes delivery_incomplete only with delivered content proof', () => {
+    const qualifying = createResponseLatencyHarness({ startMs: 200 });
+    const qualifyingAttempt =
+      qualifying.channel.beginAttempt('partial-content');
+    qualifyingAttempt.observe(
+      { kind: 'content_part', text: 'visible part' },
+      { delivered: true },
+    );
+    qualifyingAttempt.settle('delivery_incomplete');
+
+    const controlOnly = createResponseLatencyHarness({ startMs: 300 });
+    const controlAttempt = controlOnly.channel.beginAttempt('partial-control');
+    controlAttempt.observe(
+      { kind: 'progress', status: 'working' },
+      { delivered: true },
+    );
+    controlAttempt.observe(
+      { kind: 'content_part', text: 'failed part' },
+      { delivered: false },
+    );
+    controlAttempt.settle('delivery_incomplete');
+
+    expect(qualifying.channel.firstContentAtMs()).toBe(200);
+    expect(qualifyingAttempt.snapshot().publishedAtMs).toBe(200);
+    expect(controlOnly.channel.firstContentAtMs()).toBeUndefined();
+    expect(controlAttempt.snapshot()).not.toHaveProperty('publishedAtMs');
+  });
+
+  it('discards candidates for failed and rejected delivery attempts', () => {
+    const harness = createResponseLatencyHarness({ startMs: 400 });
+    const failed = harness.channel.beginAttempt('failed');
+    failed.observe(
+      { kind: 'content_chunk', text: 'candidate' },
+      { delivered: true },
+    );
+    failed.settle('not_delivered');
+
+    harness.clock.advanceMs(10);
+    const rejected = harness.channel.beginAttempt('rejected');
+    rejected.observe(
+      { kind: 'content_chunk', text: 'candidate' },
+      { delivered: true },
+    );
+    rejected.reject();
+
+    expect(harness.channel.firstContentAtMs()).toBeUndefined();
+    expect(failed.snapshot()).not.toHaveProperty('publishedAtMs');
+    expect(rejected.snapshot()).not.toHaveProperty('publishedAtMs');
+    expect(
+      harness.channel.attempts().map((attempt) => attempt.settlement),
+    ).toEqual(['not_delivered', 'rejected']);
+  });
+
+  it('keeps the earliest qualifying timestamp across retries and settlement order', () => {
+    const harness = createResponseLatencyHarness({ startMs: 100 });
+    const first = harness.channel.beginAttempt('first');
+    first.observe(
+      { kind: 'content_chunk', text: 'earliest candidate' },
+      { delivered: true },
+    );
+
+    harness.clock.advanceMs(100);
+    const retry = harness.channel.beginAttempt('retry');
+    retry.observe(
+      { kind: 'content_chunk', text: 'later candidate' },
+      { delivered: true },
+    );
+    retry.settle('completed');
+    expect(harness.channel.firstContentAtMs()).toBe(200);
+
+    first.settle('delivery_incomplete');
+    expect(harness.channel.firstContentAtMs()).toBe(100);
+
+    harness.clock.advanceMs(100);
+    const fallback = harness.channel.beginAttempt('fallback');
+    fallback.observe(
+      { kind: 'content_chunk', text: 'latest candidate' },
+      { delivered: true },
+    );
+    fallback.settle('completed');
+    expect(harness.channel.firstContentAtMs()).toBe(100);
+  });
+
+  it('records only sanitized delivery status, timing, and boolean evidence', () => {
+    const harness = createResponseLatencyHarness();
+    const attempt = harness.channel.beginAttempt('sanitized-attempt');
+    attempt.observe(
+      { kind: 'content_chunk', text: 'secret message content' },
+      { delivered: true },
+    );
+    attempt.settle('completed');
+
+    expect(attempt.snapshot()).toEqual({
+      id: 'sanitized-attempt',
+      settlement: 'completed',
+      frames: [
+        {
+          kind: 'content_chunk',
+          contentBearing: true,
+          delivered: true,
+        },
+      ],
+      candidateAtMs: 0,
+      publishedAtMs: 0,
+    });
+    expect(JSON.stringify(harness.channel.attempts())).not.toContain(
+      'secret message content',
+    );
+  });
+
+  it('refuses observations or repeated settlement after an attempt ends', () => {
+    const harness = createResponseLatencyHarness();
+    const attempt = harness.channel.beginAttempt('one-shot');
+    attempt.settle('not_delivered');
+
+    expect(() =>
+      attempt.observe(
+        { kind: 'content_chunk', text: 'too late' },
+        { delivered: true },
+      ),
+    ).toThrow(/already settled/);
+    expect(() => attempt.settle('completed')).toThrow(/already settled/);
+  });
+
+  it('proves five operations begin through a four-active bound', async () => {
+    const barrier = createDeterministicBarrier(5);
+    const pending = [0, 1, 2, 3, 4];
+    const participants: ReturnType<typeof barrier.arrive>[] = [];
+    let resolveDrained: (() => void) | undefined;
+    const drained = new Promise<void>((resolve) => {
+      resolveDrained = resolve;
+    });
+    const beginNext = () => {
+      if (pending.shift() === undefined) return;
+      const participant = barrier.arrive();
+      participants.push(participant);
+      void participant.completed.then(() => {
+        beginNext();
+        if (barrier.snapshot().completed === 5) resolveDrained?.();
+      });
+    };
+    Array.from({ length: 4 }).forEach(beginNext);
+
+    await barrier.waitForArrivals(4);
+    expect(barrier.snapshot()).toEqual({
+      arrivals: 4,
+      active: 4,
+      completed: 0,
+      maximumActive: 4,
+      allArrived: false,
+    });
+
+    participants[0]?.release();
+    await participants[0]?.completed;
+    await barrier.waitForAll();
+    expect(barrier.snapshot()).toEqual({
+      arrivals: 5,
+      active: 4,
+      completed: 1,
+      maximumActive: 4,
+      allArrived: true,
+    });
+
+    participants.slice(1).forEach((participant) => participant.release());
+    await drained;
+    expect(barrier.snapshot()).toEqual({
+      arrivals: 5,
+      active: 0,
+      completed: 5,
+      maximumActive: 4,
+      allArrived: true,
+    });
+  });
+
+  it('detects an unbounded caller exceeding a four-operation cap', async () => {
+    const barrier = createDeterministicBarrier(5);
+    const participants = Array.from({ length: 5 }, () => barrier.arrive());
+
+    await barrier.waitForAll();
+    expect(barrier.snapshot().maximumActive).toBe(5);
+    participants.forEach((participant) => participant.release());
+    await Promise.all(participants.map((participant) => participant.completed));
+    expect(barrier.snapshot().active).toBe(0);
+  });
+
+  it('rejects invalid barrier sizes, waits, and excess arrivals', () => {
+    expect(() => createDeterministicBarrier(0)).toThrow(/positive integer/);
+    const barrier = createDeterministicBarrier(1);
+    expect(() => barrier.waitForArrivals(2)).toThrow(/expected arrivals/);
+    const participant = barrier.arrive();
+    expect(() => barrier.arrive()).toThrow(/more arrivals/);
+    participant.release();
+    participant.release();
+    expect(barrier.snapshot().completed).toBe(1);
+  });
+
+  it('isolates all mutable primitive state across ten harness instances', async () => {
+    const harnesses = Array.from({ length: 10 }, (_, index) =>
+      createResponseLatencyHarness({ startMs: index * 100 }),
+    );
+    const barriers = harnesses.map((harness) => harness.createBarrier(1));
+    const participants = barriers.map((barrier) => barrier.arrive());
+    await Promise.all(barriers.map((barrier) => barrier.waitForAll()));
+
+    for (const [index, harness] of harnesses.entries()) {
+      harness.clock.advanceMs(index);
+      harness.clock.mark(`marker_${index}`);
+      harness.operations.increment(`operation_${index}`, index + 1);
+      harness.delays.setDelayMs('provider_first_byte', index);
+      await harness.delays.wait('provider_first_byte');
+      const attempt = harness.channel.beginAttempt(`attempt_${index}`);
+      attempt.observe(
+        { kind: 'content_part', text: `content ${index}` },
+        { delivered: true },
+      );
+      attempt.settle('completed');
+    }
+
+    participants[0]?.release();
+    await participants[0]?.completed;
+    expect(barriers[0]?.snapshot().active).toBe(0);
+    expect(
+      barriers.slice(1).every((barrier) => barrier.snapshot().active === 1),
+    ).toBe(true);
+    participants.slice(1).forEach((participant) => participant.release());
+    await Promise.all(
+      participants.slice(1).map((participant) => participant.completed),
+    );
+
+    harnesses.forEach((harness, index) => {
+      expect(harness.clock.nowMs()).toBe(index * 102);
+      expect(harness.clock.markers()).toEqual([
+        { name: `marker_${index}`, atMs: index * 101 },
+      ]);
+      expect(harness.operations.get(`operation_${index}`)).toBe(index + 1);
+      expect(
+        harnesses.every(
+          (other, otherIndex) =>
+            otherIndex === index ||
+            other.operations.get(`operation_${index}`) === 0,
+        ),
+      ).toBe(true);
+      expect(harness.delays.snapshot().provider_first_byte).toBe(index);
+      expect(harness.channel.attempts()).toHaveLength(1);
+      expect(harness.channel.firstContentAtMs()).toBe(index * 102);
+    });
+  });
+});

--- a/apps/core/test/unit/runtime/response-latency-scenarios.test.ts
+++ b/apps/core/test/unit/runtime/response-latency-scenarios.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RESPONSE_LATENCY_REGRESSION_ANCHORS,
+  RESPONSE_LATENCY_SCENARIOS,
+  runResponseLatencyScenario,
+  type ResponseLatencyScenarioId,
+} from '../../harness/response-latency-scenarios.js';
+
+const scenarioNames = {
+  S1: 'warm top/no thread/no skill/no MCP/new session',
+  S2: 'sparse top provider history',
+  S3: 'sparse thread root+tail',
+  S4: 'resumed provider session+memory',
+  S5: '10 enabled/3 selected/local store',
+  S6: '10 enabled/3 selected/delayed S3-like store',
+  S7: '3 MCP servers 100/200/300',
+  S8: 'one message to 3 agents',
+  S9: '10 conversations',
+  S10: 'direct LLM streaming 1MiB',
+  S11: '500 jobs',
+  S12: 'IPC 5000 markers',
+} as const satisfies Record<ResponseLatencyScenarioId, string>;
+
+describe('response latency scenario contracts', () => {
+  it('keeps the exact S1-S12 scenario IDs and names', () => {
+    expect(
+      Object.fromEntries(
+        RESPONSE_LATENCY_SCENARIOS.map(({ id, name }) => [id, name]),
+      ),
+    ).toEqual(scenarioNames);
+  });
+
+  it.each([
+    ['S1', { get_messages_since_calls: 1 }],
+    ['S2', { provider_history_calls: 1 }],
+    ['S3', { get_messages_since_calls: 2 }],
+    [
+      'S4',
+      {
+        provider_history_calls: 1,
+        memory_hydrate_calls: 1,
+      },
+    ],
+    [
+      'S5',
+      {
+        enabled_skill_count: 10,
+        selected_skill_count: 3,
+        list_enabled_skills_calls: 1,
+        get_skill_calls: 3,
+        s3_list_calls: 0,
+        s3_get_calls: 0,
+      },
+    ],
+    [
+      'S6',
+      {
+        enabled_skill_count: 10,
+        selected_skill_count: 3,
+        list_enabled_skills_calls: 1,
+        get_skill_calls: 3,
+        s3_list_calls: 1,
+        s3_get_calls: 3,
+      },
+    ],
+    [
+      'S7',
+      {
+        mcp_server_count: 3,
+        list_mcp_bindings_calls: 1,
+        get_mcp_server_calls: 3,
+        mcp_connect_calls: 3,
+        mcp_list_tools_calls: 3,
+      },
+    ],
+    [
+      'S8',
+      {
+        input_message_count: 1,
+        agent_route_count: 3,
+        model_stream_calls: 3,
+        channel_delivery_attempts: 3,
+      },
+    ],
+    [
+      'S9',
+      {
+        conversation_count: 10,
+        get_messages_since_calls: 10,
+        model_stream_calls: 10,
+        channel_delivery_attempts: 10,
+      },
+    ],
+    [
+      'S10',
+      {
+        model_request_bytes: 1_048_576,
+        model_stream_calls: 1,
+        channel_delivery_attempts: 1,
+      },
+    ],
+  ] as const)(
+    '%s invokes fake seams and emits first-content evidence',
+    async (scenarioId, expectedCounts) => {
+      const result = await runResponseLatencyScenario(scenarioId);
+
+      expect(result).toMatchObject({
+        scenarioId,
+        status: 'completed',
+        counts: expectedCounts,
+        booleans: {
+          allArrived: true,
+          noRealNetwork: true,
+        },
+      });
+      expect(result.counts.barrier_arrivals).toBe(
+        result.counts.model_stream_calls,
+      );
+      expect(result.counts.maximum_active_routes).toBe(
+        result.counts.model_stream_calls,
+      );
+      expect(result.firstContentDurationMs).toBeTypeOf('number');
+      expect(result.firstContentDurationMs).toBeGreaterThan(0);
+      expect(result.durationsMs.total).toBeGreaterThanOrEqual(
+        result.firstContentDurationMs!,
+      );
+    },
+  );
+
+  it('observes the controlled S3-like store and MCP boundary delays', async () => {
+    const s6 = await runResponseLatencyScenario('S6');
+    const s7 = await runResponseLatencyScenario('S7');
+
+    expect(s6.durationsMs.skill_artifact_projection).toBe(3);
+    expect(s7.durationsMs.mcp_connect).toBe(600);
+  });
+
+  it('binds S9 loads and model calls to ten distinct conversations', async () => {
+    const result = await runResponseLatencyScenario('S9');
+
+    expect(result.counts).toMatchObject({
+      conversation_count: 10,
+      get_messages_since_calls: 10,
+      model_stream_calls: 10,
+    });
+    expect(result.booleans.independentConversations).toBe(true);
+  });
+
+  it('overlaps S8 and S9 route timing instead of summing fan-out delays', async () => {
+    const s8 = await runResponseLatencyScenario('S8');
+    const s9 = await runResponseLatencyScenario('S9');
+
+    expect(s8.firstContentDurationMs).toBe(2);
+    expect(s8.durationsMs.total).toBe(2);
+    expect(s9.firstContentDurationMs).toBe(2);
+    expect(s9.durationsMs.total).toBe(2);
+  });
+
+  it('anchors S11 to the existing 500-job regression contract', async () => {
+    const result = await runResponseLatencyScenario('S11');
+
+    expect(RESPONSE_LATENCY_REGRESSION_ANCHORS.S11).toEqual({
+      sourceId:
+        'job-lifecycle.postgres.integration:projects-one-latest-non-session-run-for-500-jobs',
+      jobCount: 500,
+      queryCount: 2,
+      distinctOnQueryCount: 1,
+    });
+    expect(result).toEqual({
+      scenarioId: 'S11',
+      status: 'current_baseline',
+      counts: {
+        jobs: 500,
+        postgres_statements: 2,
+        distinct_on_queries: 1,
+      },
+      durationsMs: {},
+      booleans: {
+        regressionSourceReferenced: true,
+      },
+    });
+  });
+
+  it('anchors S12 to the existing 5,000-marker regression contract', async () => {
+    const result = await runResponseLatencyScenario('S12');
+
+    expect(RESPONSE_LATENCY_REGRESSION_ANCHORS.S12).toEqual({
+      sourceId:
+        'ipc-auth-boundary:performs-bounded-filesystem-work-with-5000-replay-markers',
+      markerCount: 5_000,
+      replayStoreOperationCount: 4,
+      scanCount: 0,
+      readCount: 0,
+      removeCount: 0,
+    });
+    expect(result).toEqual({
+      scenarioId: 'S12',
+      status: 'current_baseline',
+      counts: {
+        replay_markers: 5_000,
+        replay_store_operations: 4,
+        replay_scans: 0,
+        replay_reads: 0,
+        replay_removes: 0,
+      },
+      durationsMs: {},
+      booleans: {
+        regressionSourceReferenced: true,
+      },
+    });
+  });
+
+  it('keeps emitted evidence to IDs, counts, durations, statuses, and booleans', async () => {
+    for (const { id } of RESPONSE_LATENCY_SCENARIOS) {
+      const result = await runResponseLatencyScenario(id);
+      expect(Object.keys(result).sort()).toEqual(
+        [
+          'booleans',
+          'counts',
+          'durationsMs',
+          ...(id === 'S11' || id === 'S12' ? [] : ['firstContentDurationMs']),
+          'scenarioId',
+          'status',
+        ].sort(),
+      );
+      expect(
+        Object.values(result.counts).every(
+          (value) => typeof value === 'number',
+        ),
+      ).toBe(true);
+      expect(
+        Object.values(result.durationsMs).every(
+          (value) => typeof value === 'number',
+        ),
+      ).toBe(true);
+      expect(
+        Object.values(result.booleans).every(
+          (value) => typeof value === 'boolean',
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/docs/decisions/0069-client-signoff.md
+++ b/docs/decisions/0069-client-signoff.md
@@ -54,7 +54,7 @@ including:
 - `apps/core/test/harness/response-latency-scenarios.ts`
 - `apps/core/test/unit/runtime/response-latency-scenarios.test.ts`
 - `apps/core/test/harness/response-latency-postgres.ts`
-- `apps/core/test/integration/response-latency-postgres.integration.test.ts`
+- `apps/core/test/integration/response-latency-postgres.postgres.integration.test.ts`
 
 Every commit still needs local autoreview before commit. The task cannot be
 PR-ready until automated tests, deterministic verify, one three-lens autoreview

--- a/docs/decisions/0069-client-signoff.md
+++ b/docs/decisions/0069-client-signoff.md
@@ -1,0 +1,63 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-27
+---
+
+# LAT-0 Client Signoff
+
+## Context
+The user authorized the all-phase MyClaw response-latency program, requiring
+separate bounded Forge PRs, Node 25, Ponytail simplicity, reviewed-before-commit
+discipline, full integration/E2E/autoreview, checkout-bound KnackLabs runtime
+smoke for runtime PRs, and ignored `@session-state.md` coordination state.
+
+The archived Phase 0 branch proved only a narrow two-file shared harness port:
+generic primitives, warm/new-session fixture behavior, and ten-instance
+isolation. That was not enough for the user-supplied Phase 0 measurement
+contract. An earlier fresh-worktree draft incorrectly narrowed LAT-0 to that
+old 17-test primitive scope; this decision revises signoff upward before any
+commit.
+
+Current active Decision 0066 already accepts app/content-addressed skill
+artifact refs and read-time hash verification, so Phase 6 cannot replay that
+old roadmap scope as future work.
+
+## Decision
+Proceed with LAT-0 planning and later implementation as the full test-only
+Phase 0 response-latency measurement harness on branch
+`perf/response-latency-baseline` from
+`db41baa550a5779f119bf2cfa1b9890856afc69d`.
+
+LAT-0 authorizes deterministic support for the user's exact S1-S12 scenario
+contracts, all named operation counters and boundary delays, first-content
+metric support, bounded concurrency barriers, fake streaming model/channel
+support, and a separate explicitly Postgres-gated query-counting helper.
+
+S11 is the 500-job large-cardinality baseline and S12 is the IPC 5,000-marker
+baseline. Because their production fixes already exist, LAT-0 records their
+current deterministic baselines using existing behavior/tests rather than
+renaming or redefining those scenario IDs.
+
+LAT-0 does not authorize production behavior changes, real provider calls, real
+S3 network dependency, real remote MCP network dependency, or later phase
+optimizations. Later phases may add phase-specific before/after assertions
+using the LAT-0 fixtures.
+
+## Consequences
+Forge may record the LAT-0 plan and decomposition after the required plan grill.
+Implementation remains limited to test-only write scope under `apps/core/test/`,
+including:
+
+- `apps/core/test/harness/response-latency-harness.ts`
+- `apps/core/test/unit/runtime/response-latency-contract.test.ts`
+- `apps/core/test/harness/response-latency-scenarios.ts`
+- `apps/core/test/unit/runtime/response-latency-scenarios.test.ts`
+- `apps/core/test/harness/response-latency-postgres.ts`
+- `apps/core/test/integration/response-latency-postgres.integration.test.ts`
+
+Every commit still needs local autoreview before commit. The task cannot be
+PR-ready until automated tests, deterministic verify, one three-lens autoreview
+run, and CI pass. Runtime PRs must prove the installed KnackLabs local service
+points at the active checkout before running the lead-maintenance smoke; LAT-0
+is test-only, so that runtime smoke is not a LAT-0 gate.

--- a/plans/LAT-0-Response-Latency-Baseline-Plan.md
+++ b/plans/LAT-0-Response-Latency-Baseline-Plan.md
@@ -1,0 +1,328 @@
+# LAT-0 Response Latency Baseline Plan
+
+## Problem
+
+MyClaw has confirmed response-latency hotspots in the inbound-message to
+first-content-bearing-output path, but the program must not optimize or claim
+latency wins from source inspection alone. LAT-0 must provide the deterministic
+Phase 0 measurement contract the user requested: reusable test-only primitives,
+S1-S12 scenario harness support, named operation counters, boundary delay
+injection, bounded concurrency barriers, and a separate Postgres-gated
+query-counting helper.
+
+This revision corrects the earlier draft, which incorrectly narrowed LAT-0 to
+the archived 17-test primitive harness. That old port is useful evidence for
+the primitives stage, but it does not satisfy the full Phase 0 measurement
+contract.
+
+Assumptions:
+
+- Source roadmap: `plans/MyClaw-Response-Latency-Refactor-Plan.md`.
+- Worktree base: `db41baa550a5779f119bf2cfa1b9890856afc69d`.
+- Node 25 evidence: `v25.2.1`.
+- `@session-state.md` is ignored local coordination state.
+- Phase 0 is test-only and keeps production behavior unchanged.
+- Later phase PRs may add phase-specific before/after assertions using the
+  LAT-0 fixtures, but LAT-0 owns the reusable scenario matrix/counter support
+  and current deterministic baselines for S11/S12 using existing
+  large-cardinality behavior/tests.
+
+## Scope / Non-goals
+
+Scope:
+
+- Add reusable test-only helpers for deterministic manual time, first
+  content-bearing delivery, explicit boundary delays, operation counters, and
+  bounded concurrency barriers.
+- Add a provider-neutral scripted fake streaming model and fake channel probe
+  that distinguish control/progress/session frames from content-bearing output.
+- Add all named operation counters from the source contract:
+  `postgres_statements`, `postgres_transactions`, `get_messages_since_calls`,
+  `provider_history_calls`, `memory_hydrate_calls`,
+  `list_enabled_skills_calls`, `get_skill_calls`, `list_tool_bindings_calls`,
+  `get_tool_calls`, `list_mcp_bindings_calls`, `get_mcp_server_calls`,
+  `s3_list_calls`, `s3_get_calls`, `mcp_connect_calls`, and
+  `mcp_list_tools_calls`.
+- Add boundary delay injection points for ingress receipt, metadata
+  persistence, message commit, admission notification, replay load,
+  conversation local load, provider history hydration, provider-history
+  persistence, provisional/final session context, memory hydration, access row
+  load/projection, skill artifact projection, MCP materialization,
+  MCP connect/discovery, adapter prepare, provider first byte, and channel
+  first visible delivery.
+- Add deterministic S1-S12 scenario fixture contracts using the user's exact
+  scenario IDs:
+  - S1 warm top-level/no thread/no skill/no MCP/new session;
+  - S2 sparse top-level provider history;
+  - S3 sparse thread root plus tail;
+  - S4 resumed provider session plus memory;
+  - S5 ten enabled skills, three selected skills, local store;
+  - S6 same delayed S3-like store;
+  - S7 three MCP servers delayed 100/200/300 ms;
+  - S8 one message to three agents;
+  - S9 ten independent conversations;
+  - S10 direct LLM streaming with a 1 MiB request;
+  - S11 500 jobs;
+  - S12 IPC 5,000 markers.
+- Record S11/S12 current deterministic baselines using existing
+  large-cardinality behavior/tests because their production fixes already
+  exist.
+- Add explicitly Postgres-gated query counting/integration support as a
+  separate helper/gate, not as S12. It must run only in the disposable Postgres
+  lane and treat missing `GANTRY_TEST_DATABASE_URL` as blocked evidence, not a
+  pass.
+- Keep diagnostics and evidence payloads count/timing/status/boolean-only.
+
+Non-goals:
+
+- No production behavior change.
+- No production tracing framework, cache, prewarm, global singleton, or remote
+  service.
+- No real provider calls, real S3 network dependency, or real remote MCP
+  network dependency in deterministic unit scenarios.
+- No persistent developer data in LAT-0 tests.
+- No Phase 1+ optimization or before/after performance claim.
+- No changes to durable message, admission, cursor, session, memory, access,
+  audit, credential, replay/signature, authorization, cancellation, provider,
+  app, or skill-storage authority boundaries.
+
+## Acceptance Criteria
+
+- `LAT-0` provides deterministic reusable harness primitives and S1-S12
+  scenario fixture support for later baseline/after tests.
+- First-visible timing captures a pending candidate timestamp exactly when the
+  first content-bearing part or chunk reaches the fake channel.
+- Settlement publishes that candidate only when a completed send succeeds or
+  when a `delivery_incomplete` settlement proves at least one content-bearing
+  part or chunk reached the channel.
+- The harness trims whitespace and ignores session-init, runtime-event,
+  progress, terminal-null, typing, usage, empty, and whitespace-only frames.
+- It discards the candidate for `not_delivered`, rejected sends, or partial
+  attempts with no delivered content-bearing part.
+- Delay injection is explicit at the named boundaries in this plan and can be
+  advanced under test control.
+- Operation counters expose all named operation counters in this plan and allow
+  generic string counters for future phase-local additions without API changes.
+- Barrier helpers deterministically prove all expected work arrived and report
+  observed maximum active count without relying on elapsed time as the merge
+  gate.
+- The provider-neutral scripted fake streaming model emits configured
+  non-content frames and one content-bearing frame after a controlled delay and
+  never calls a real provider.
+- The fake channel delivery probe records attempted deliveries and settlements.
+- The S1-S10 fixture contracts emit first-content timing plus
+  operation-counter snapshots.
+- S11 records the current deterministic 500-job baseline using existing
+  large-cardinality behavior/tests.
+- S12 records the current deterministic IPC 5,000-marker baseline using
+  existing large-cardinality behavior/tests.
+- A separate disposable-Postgres integration helper records statement and
+  transaction counts. It is explicitly skipped only by the repository's
+  Postgres-lane gating rules and is blocked, not green, when a Postgres-backed
+  claim is required but `GANTRY_TEST_DATABASE_URL` is missing.
+- Ten independent harness instances do not share clock, counters, barriers,
+  deliveries, scenario state, or first-content observations.
+- Diagnostics and evidence payloads contain only identifiers, counts,
+  durations, statuses, and booleans. They do not contain prompts, message text,
+  schemas, credentials, secret-bearing URLs, or tool arguments.
+- Existing production and test behavior outside the new LAT-0 harness/tests
+  remains unchanged.
+- The decomposition records `user_facing: false`.
+
+## Technical Approach
+
+Recommendation: implement Phase 0 as three bounded test-only stages in one PR.
+This satisfies the user's full measurement contract without touching production
+runtime behavior.
+
+Expected test-only write scope:
+
+- `apps/core/test/harness/response-latency-harness.ts`
+- `apps/core/test/harness/response-latency-scenarios.ts`
+- `apps/core/test/harness/response-latency-postgres.ts`
+- `apps/core/test/unit/runtime/response-latency-contract.test.ts`
+- `apps/core/test/unit/runtime/response-latency-scenarios.test.ts`
+- `apps/core/test/integration/response-latency-postgres.integration.test.ts`
+
+Stage 1 primitives:
+
+- deterministic manual clock with `nowMs`, `advanceMs`, and marker recording;
+- named and generic operation counters with immutable snapshots;
+- boundary delay controls keyed by stable boundary names;
+- bounded concurrency barriers with all-arrived and max-active observations;
+- provider-neutral scripted fake streaming model;
+- settlement-aware first-content delivery probe;
+- small content predicate helpers.
+
+Stage 2 scenario fixtures:
+
+- S1-S10 scenario builders that share the same primitive harness and emit
+  first-content metrics plus counter snapshots;
+- deterministic fake dependencies for provider history, memory hydration,
+  access rows, selected-skill artifacts, remote MCP connect/list-tools,
+  inbound multi-route admission, and direct LLM streaming;
+- no real provider/S3/MCP network calls in unit scenarios.
+
+Stage 3 Postgres/query counting:
+
+- a Postgres-gated integration fixture that runs only through the disposable
+  Postgres lane;
+- query/transaction counting as a separate integration helper and reusable
+  support for later Postgres-backed phases;
+- explicit blocked reporting when Postgres-backed evidence is required but
+  `GANTRY_TEST_DATABASE_URL` is unavailable.
+
+Rejected narrower approach:
+
+- The archived 17-test primitive harness is not enough. It omits S1-S12 and
+  real Postgres query-counting support, so it would not satisfy the user's
+  Phase 0 measurement contract.
+
+Rejected broader approach:
+
+- Production tracing or optimization hooks are still too broad for LAT-0.
+  Phase 0 should provide deterministic test support; later phase PRs use that
+  support for before/after optimization evidence.
+
+## Decisions
+
+- `docs/decisions/0069-client-signoff.md` records the accepted LAT-0 client
+  signoff for the full Phase 0 measurement harness contract.
+- No new technical decisions. LAT-0 adds no durable data model, public API,
+  production setting, runtime authority boundary, library dependency, or
+  runtime behavior.
+- Later Phase 6 planning must reconcile accepted Decisions 0021 and 0066 before
+  changing skill artifact layout, cache, IAM, or readiness behavior.
+
+## Surface Impact
+
+| Surface | Classification | Reason |
+| --- | --- | --- |
+| Runtime behavior | Unchanged by design | LAT-0 is test-only and does not wire production timing, caching, prewarm, or optimization behavior. |
+| API | Unchanged by design | No public route, SDK, provider, or channel contract changes. |
+| Data/schema | Unchanged by design | No migrations, tables, repository writes, or durable state changes. |
+| CLI/ops | Read-only | Existing verification commands and Postgres lane are used; no CLI/settings change. |
+| UI | N-A | No user-facing UI or channel presentation change. |
+| Docs | Changed | Adds the program roadmap, LAT-0 plan draft, and signoff decision. |
+| Tests | Changed | Adds test-only harness, scenario contract tests, and a Postgres-gated query-counting integration scenario. |
+
+## Task Decomposition
+
+Stage `LAT-0-PRIMITIVES`
+
+- Objective: create the deterministic primitive harness used by every LAT-0
+  scenario.
+- Write scope:
+  - `apps/core/test/harness/response-latency-harness.ts`
+  - `apps/core/test/unit/runtime/response-latency-contract.test.ts`
+- Dependencies: none.
+- Required tests: manual clock, named/generic counters, boundary delays,
+  scripted fake streaming model, fake channel first-content semantics,
+  completed send, qualifying partial delivery, non-qualifying partial delivery,
+  not-delivered, rejected send, retry timestamp stability, barrier
+  all-arrived/max-active behavior, and ten-instance isolation.
+- Reviewer focus: false first-content positives, shared mutable state,
+  wall-clock-only assertions, and diagnostic content leaks.
+
+Stage `LAT-0-SCENARIOS`
+
+- Objective: add deterministic S1-S12 scenario fixture contracts on top of the
+  primitives.
+- Write scope:
+  - `apps/core/test/harness/response-latency-scenarios.ts`
+  - `apps/core/test/unit/runtime/response-latency-scenarios.test.ts`
+- Dependencies:
+  - `LAT-0-PRIMITIVES`
+- Required tests: S1-S10 fixture contracts emit first-content timing, named
+  operation-counter snapshots, and controlled boundary delays without real
+  provider/S3/MCP network calls. S11/S12 record current deterministic baselines
+  using existing large-cardinality behavior/tests for 500 jobs and IPC 5,000
+  markers.
+- Reviewer focus: scenario names matching the source contract, no hidden
+  production dependencies, no phase-specific optimization assertions, and no
+  omitted operation counters.
+
+Stage `LAT-0-POSTGRES`
+
+- Objective: add the disposable-Postgres query-counting integration support
+  for later Postgres-backed phase baselines as a separate helper/gate, not as
+  S12.
+- Write scope:
+  - `apps/core/test/harness/response-latency-postgres.ts`
+  - `apps/core/test/integration/response-latency-postgres.integration.test.ts`
+- Dependencies:
+  - `LAT-0-PRIMITIVES`
+  - `LAT-0-SCENARIOS`
+- Required tests: Postgres statement count, transaction count, cleanup between
+  runs, no persistent developer data, and explicit blocked handling when
+  Postgres evidence is required but `GANTRY_TEST_DATABASE_URL` is unavailable.
+- Reviewer focus: disposable database isolation, no durable schema changes,
+  accurate query/transaction counting, and blocked-versus-skipped reporting.
+
+## Risks
+
+- Phase 0 can bloat into production tracing. Mitigation: keep all writes under
+  `apps/core/test/` and leave production runtime unchanged.
+- Scenario fixtures can overfit future implementation choices. Mitigation:
+  model boundaries and counters, not optimized behavior.
+- A fake visibility predicate can count control frames. Mitigation: explicit
+  negative-frame unit tests.
+- Timing assertions can become flaky. Mitigation: barriers are the merge gate;
+  elapsed time is supplemental only.
+- Postgres query counting can be mistaken for a green default test run.
+  Mitigation: keep query counting in its separate disposable Postgres helper
+  and report missing `GANTRY_TEST_DATABASE_URL` as blocked when Postgres
+  evidence is required.
+- Runtime smoke can use another checkout if service installation is stale.
+  Mitigation: runtime-behavior PRs must prove the installed service points at
+  the active checkout before running smoke; LAT-0 itself is test-only.
+
+## Verify Plan
+
+Planning verification already run:
+
+```bash
+./forge next
+./forge decision list --active
+./forge findings patterns
+./forge context list --pending
+./forge defer list --open
+./forge lesson relevant --files apps/core/test/harness/response-latency-harness.ts apps/core/test/unit/runtime/response-latency-contract.test.ts plans/MyClaw-Response-Latency-Refactor-Plan.md
+node --version
+```
+
+Targeted implementation checks:
+
+```bash
+npm run test:unit -- apps/core/test/unit/runtime/response-latency-contract.test.ts
+npm run test:unit -- apps/core/test/unit/runtime/response-latency-scenarios.test.ts
+npm run test:integration:postgres -- apps/core/test/integration/response-latency-postgres.integration.test.ts
+```
+
+Before review:
+
+```bash
+npm run format:check
+npm run typecheck
+npm run lint
+npm run test:unit
+npm run test:integration
+npm run test:integration:postgres
+npm run test:e2e:agent:hermetic
+npm run check:architecture
+python3 .agents/scripts/verify.py
+```
+
+Closeout gates:
+
+- signoff grill refreshed after this scope correction;
+- plan grilled and saved after this scope correction;
+- decomposition recorded with three stages and `user_facing: false`;
+- automated tests recorded through the repository recorder;
+- deterministic verify passes;
+- one autoreview run records quality, performance, and security;
+- `python3 .agents/scripts/pr_ready.py` passes;
+- GitHub CI is green;
+- checkout-bound KnackLabs lead-maintenance smoke is not required for LAT-0
+  because it is test-only; runtime-behavior PRs in later phases must run it
+  before merge.

--- a/plans/LAT-0-Response-Latency-Baseline-Plan.md
+++ b/plans/LAT-0-Response-Latency-Baseline-Plan.md
@@ -142,7 +142,7 @@ Expected test-only write scope:
 - `apps/core/test/harness/response-latency-postgres.ts`
 - `apps/core/test/unit/runtime/response-latency-contract.test.ts`
 - `apps/core/test/unit/runtime/response-latency-scenarios.test.ts`
-- `apps/core/test/integration/response-latency-postgres.integration.test.ts`
+- `apps/core/test/integration/response-latency-postgres.postgres.integration.test.ts`
 
 Stage 1 primitives:
 
@@ -249,7 +249,7 @@ Stage `LAT-0-POSTGRES`
   S12.
 - Write scope:
   - `apps/core/test/harness/response-latency-postgres.ts`
-  - `apps/core/test/integration/response-latency-postgres.integration.test.ts`
+  - `apps/core/test/integration/response-latency-postgres.postgres.integration.test.ts`
 - Dependencies:
   - `LAT-0-PRIMITIVES`
   - `LAT-0-SCENARIOS`
@@ -296,7 +296,7 @@ Targeted implementation checks:
 ```bash
 npm run test:unit -- apps/core/test/unit/runtime/response-latency-contract.test.ts
 npm run test:unit -- apps/core/test/unit/runtime/response-latency-scenarios.test.ts
-npm run test:integration:postgres -- apps/core/test/integration/response-latency-postgres.integration.test.ts
+npm run test:integration:postgres -- apps/core/test/integration/response-latency-postgres.postgres.integration.test.ts
 ```
 
 Before review:

--- a/plans/MyClaw-Response-Latency-Refactor-Plan.md
+++ b/plans/MyClaw-Response-Latency-Refactor-Plan.md
@@ -1,0 +1,236 @@
+# MyClaw Response-Latency Program Roadmap
+
+Status: source roadmap for bounded Forge tasks; not a per-task implementation plan
+Validated against: `db41baa550a5779f119bf2cfa1b9890856afc69d` (`origin/main`, 2026-07-27)
+Node evidence: `v25.2.1`
+Primary metric: inbound message received to first content-bearing channel delivery
+
+This roadmap reconciles the archived latency branch with the current accepted
+decision corpus. Each optimization still needs its own worktree, Forge intake,
+signoff, grilled and approved plan, decomposition, implementation, tests,
+deterministic verify, one autoreview pass, and CI before merge. Runtime-behavior
+PRs also need the checkout-bound KnackLabs runtime smoke before merge.
+
+## Current-State Reconciliation
+
+- Both `docs/decisions/0021-capability-artifacts.md` and
+  `docs/decisions/0066-race-1-skill-artifact-app-isolation.md` are accepted,
+  so Phase 6 has a live decision-reconciliation requirement rather than a
+  simple "supersede 0021" prerequisite.
+- Current code reflects Decision 0066's main contract: app/content-addressed
+  skill artifact refs, length-prefixed bundle hashing, read-time hash
+  verification in selected-skill projection, and storage refs keyed as
+  `apps/<appId>/skills/<catalogId>/<contentHash>/`.
+- Therefore the old Phase 6 cannot be replayed as "build immutable
+  app-scoped refs and hash verification." That is delivered by the RACE-1 lane.
+- Remaining Phase 6 work is measurement-gated: selected-skill read-cache
+  behavior, single-object versus current per-asset layout decision
+  reconciliation, bounded selected-skill materialization concurrency,
+  fleet/IAM writer authority, side-effect-free readiness, and local-storage
+  fail-closed runtime behavior.
+- The archived two-file Phase 0 port proved only generic primitives,
+  warm/new-session first-visible fixture behavior, and ten-instance isolation.
+  That is insufficient for the user-supplied Phase 0 measurement contract.
+  The fresh LAT-0 plan therefore expands Phase 0 to deliver deterministic
+  the exact S1-S12 scenario harness support, named operation counters,
+  boundary delay injection, bounded concurrency barriers, and a separate
+  explicitly Postgres-gated query-counting helper while keeping production
+  behavior unchanged. S11/S12 are current deterministic baselines over existing
+  large-cardinality behavior/tests because their production fixes already
+  exist.
+- Job-list batching and IPC replay cleanup remain closed by shipped current
+  code and regression evidence. Do not recreate a stale hot-path phase for
+  them without a new measured contradiction.
+- Current validation keeps Phases 1, 2, 3B, 4A, 5, and 7 directionally valid
+  after rebaseline. Phase 3A needs a fence redesign before implementation.
+  Phase 6 is obsolete as written and must honor accepted Decision 0066. Phase
+  8 is closed, and Phase 9 remains measurement-gated.
+
+## Program Acceptance
+
+1. Every phase is a separate bounded Forge task, branch, reviewed commit set,
+   PR, and CI run. Runtime-behavior phases also include a runtime-smoke
+   package.
+2. Every Phase 1+ optimization reports parent-commit baseline and PR-commit
+   after evidence from the same scenario code.
+3. Baseline evidence includes operation counts and first-content-bearing
+   timing. Source inspection alone is not a performance claim.
+4. Durable message, admission, cursor, session, memory, access, audit,
+   credential, replay/signature, authorization, cancellation, provider-account,
+   and app/skill isolation boundaries are preserved.
+5. Replaced duplicate code is deleted in the same phase after parity proof.
+6. Postgres-backed changes run the disposable Postgres lane. Missing
+   `GANTRY_TEST_DATABASE_URL` is a blocker, not a pass.
+7. Runtime PRs run the checkout-bound KnackLabs lead-maintenance smoke before
+   merge.
+
+## Phase Roadmap
+
+### Phase 0 - Shared Response-Latency Harness Foundation
+
+Branch: `perf/response-latency-baseline`
+
+Add test-only primitives and scenario support for deterministic manual time,
+operation counters, boundary delay injection, bounded concurrency barriers, a
+provider-neutral scripted fake streaming model, a settlement-aware fake channel,
+the first-content metric, exact S1-S12 scenario fixtures/contracts, and a
+separate Postgres-gated query-counting helper.
+
+Phase 0 may split into bounded stages/commits inside one PR:
+
+1. primitives and first-content contract;
+2. S1-S12 scenario fixture contracts;
+3. Postgres-gated query counting and integration support.
+
+Non-goal: no production tracing, cache, prewarm, real provider calls, real S3
+network dependency, real remote MCP network dependency, or production runtime
+behavior change. Later phase PRs may add phase-specific before/after assertions
+using these fixtures.
+
+### Phase 1 - Bounded Concurrent Remote MCP Startup
+
+Branch: `perf/parallel-inline-mcp-startup`
+
+Connect and discover remote MCP servers with a small local concurrency limit,
+preserving deterministic server/tool order, guarded fetch, headers, abort
+handling, host denylist behavior, and exact cleanup of connected clients.
+
+### Phase 2 - One Immutable Per-Turn Access Snapshot
+
+Branch: `perf/agent-access-snapshot`
+
+Load active tool bindings, enabled skills, and materialized MCP server rows
+once per turn, then derive tool policy, selected-skill displays, skill actions,
+semantic capability context, capability catalog, and access fingerprint through
+pure value-equivalent projections.
+
+### Phase 3A - Single Memory Hydration
+
+Branch: `perf/single-memory-hydration`
+
+Needs fence redesign before implementation. Keep admission non-hydrating, but
+do not assume the old expected session/reset fence is sufficient. The phase plan
+must re-resolve the current runner/admission/session paths and design the exact
+final-turn context fence that permits one memory hydration without losing reset,
+promotion, compaction, or resumed-session correctness.
+
+### Phase 3B - Cursor-Fenced Pending Replay Reuse
+
+Branch: `perf/cursor-fenced-replay`
+
+Reuse a preloaded pending replay only when cursor, queue identity,
+conversation/thread/provider scope, replay ids, and replay cursor are
+internally consistent. Mismatch falls back to the authoritative load.
+
+### Phase 4A - One Inbound Envelope Transaction
+
+Branch: `perf/inbound-envelope-persistence`
+
+Persist normalized metadata, one message, and all eligible admissions in one
+serialized transaction, then notify new admissions after commit. Stable graph
+upsert deletion is out of scope unless after-measurement earns a separate
+decision and PR.
+
+### Phase 5 - Durable Provider-History Coverage
+
+Branch: `perf/provider-history-watermark`
+
+Requires a new accepted decision before implementation. Durable coverage must
+be scoped by app, provider account, conversation, exact thread scope, provider
+generation, coverage cursor, bounded-window completeness, thread-root coverage,
+and an expiring claim. Provider API coverage must be recorded as actual
+coverage, not inferred from local row count.
+
+### Phase 6 - Skill Artifact Read-Path And Fleet Readiness Remainder
+
+Branch: to be decided after measurement and decision reconciliation
+
+Delivered by Decision 0066/current code:
+
+- app/content-addressed immutable storage refs;
+- unambiguous length-prefixed hash framing;
+- read-time hash verification for selected-skill projection;
+- app-scoped install lock keys;
+- no generic new storage abstraction.
+
+Remaining candidate scope:
+
+- measure selected-skill S3/local-cache operation counts on current code;
+- reconcile accepted Decisions 0021 and 0066 before implementation;
+- decide whether a single-object bundle is still worth replacing the current
+  Decision 0066 per-asset content-addressed layout;
+- prove cache hit zero remote reads and miss behavior against exact
+  `appId/catalogId/contentHash` identity, or record why current behavior is
+  acceptable;
+- bound selected-skill materialization concurrency if measurement shows it is
+  material;
+- verify fleet IAM writer/read-only ownership and deployment canary behavior;
+- enforce or document fail-closed fleet startup for local skill storage and
+  side-effect-free exact-key readiness.
+
+Do not absorb general `FileArtifact` bytes into this phase; that remains ART-1
+or a separately approved storage task.
+
+### Phase 7 - Direct In-Process Model Forwarding
+
+Branch: `perf/direct-llm-forwarder`
+
+Requires the accepted SPS/direct-forwarding decision before implementation.
+Extract one forwarding application operation for route confinement, credential
+injection/revocation, approved headers, upstream timeout, cancellation,
+streaming, usage/audit, and error normalization. Preserve Decision 0046's
+process-local admission-before-body-read behavior unless superseded.
+
+### Closed/Measurement-Gated Items
+
+- Job latest-run batching: closed by shipped batch projection and regression
+  coverage.
+- IPC replay cleanup: closed by shipped bounded cleanup and regression
+  coverage.
+- Warm reusable resources: unscheduled. Reopen only if post-Phase-7 evidence
+  shows repeated deterministic local construction remains material and a new
+  accepted decision scopes the authority fences.
+
+## Decisions Required Later
+
+- Phase 5 durable provider-history coverage ownership, generation
+  invalidation, and claim semantics.
+- Phase 6 decision reconciliation if replacing the current Decision 0066
+  per-asset layout with a single-object bundle, adding migration readers, or
+  changing IAM/readiness authority.
+- Phase 7 direct model-forwarding boundary.
+- Any reusable warm-resource proposal after measurement.
+
+## Verification Doctrine
+
+Before each phase:
+
+```bash
+./forge next
+./forge decision list --active
+./forge findings patterns
+./forge context list --pending
+./forge lesson relevant --files <expected write scope>
+```
+
+Before review, select the smallest relevant gates plus the repository release
+gates:
+
+```bash
+npm run format:check
+npm run typecheck
+npm run lint
+npm run test:unit
+npm run test:integration
+npm run test:integration:postgres
+npm run test:e2e:agent:hermetic
+npm run check:architecture
+python3 .agents/scripts/verify.py
+```
+
+Every runtime PR additionally proves the active checkout is the installed
+runtime and then runs:
+
+```bash
+scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e --timeout-sec 900
+```


### PR DESCRIPTION
This PR establishes trustworthy response-latency evidence before any production hot-path change. It gives every later phase the same deterministic scenarios, operation counters, and first-content-bearing output definition so latency claims are measured instead of inferred.

## What changed

- Added deterministic timing, barrier, fake streaming model, fake channel, and count-only diagnostic primitives.
- Added exact S1-S12 response-path scenarios, including sparse history, memory, skills, S3-like artifacts, MCP startup, multi-route ingress, direct LLM payload size, jobs, and IPC anchors.
- Added a disposable-Postgres query/transaction counter with async-scope isolation and failure-safe cleanup.
- Recorded LAT-0 sign-off as decision 0069 and saved the validated all-phase roadmap against current main.
- Production runtime behavior is unchanged.

## Validation

- Canonical Forge verify: green at the exact reviewed tree.
- Unit: 586 files, 7,650 tests passed.
- Standard integration: 13 files, 87 tests passed.
- Postgres integration: 44 files, 269 passed, 1 skipped.
- Postgres hot path: 4 files, 5 tests passed.
- Build, format, typecheck, architecture, focused ESLint, and diff checks: green.
- Single branch autoreview covering quality, performance, and security: clean, no actionable findings, confidence 0.87.
- Exact-head key-gated agent E2E is not claimed; the client explicitly waived missing-key failures for this phase. LAT-0 is test-only, so no local KnackLabs lead-generation runtime smoke is required.

## Measured baseline behavior

The harness reproduces the planned deterministic anchors without contacting real providers, including serial MCP startup, repeated sparse-history hydration, duplicate replay loads, repeated access reads, S3 LIST plus per-object GET behavior, per-job latest-run fanout, and directory-wide IPC replay scans. Later phases remain separate branches/PRs.
