### PR TITLE
LAT-1: bound remote MCP startup concurrency

### DIFF
--- a/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts
@@ -58,6 +58,7 @@ import { createInlineSkillsMiddleware } from './skills.js';
 import { abortedOutput, structuredOutputError } from './inline-lane-output.js';
 
 const CHECKPOINT_POOL_MAX_CONNECTIONS = 1;
+const REMOTE_MCP_STARTUP_CONCURRENCY = 4;
 const DENY_ALL_FILESYSTEM: FilesystemPermission[] = [
   { operations: ['read', 'write'], paths: ['/**'], mode: 'deny' },
 ];
@@ -484,118 +485,175 @@ async function connectRemoteMcpTools(
     lookupHostname: input.lookupHostname,
   });
   const clients: Client[] = [];
-  const tools: StructuredToolInterface[] = [];
-  try {
-    for (const server of servers) {
-      if (server.config.type !== 'http' && server.config.type !== 'sse')
-        continue;
-      input.signal.throwIfAborted();
-      assertMcpNetworkHostAllowed({
-        serverName: server.name,
-        url: server.config.url,
-        denylist: input.egressDenylist,
-      });
-      const client = new Client({
-        name: `gantry-inline-${server.name}`,
-        version: '1.0.0',
-      });
-      const headers = server.config.headers;
-      const transport =
-        server.config.type === 'sse'
-          ? new SSEClientTransport(new URL(server.config.url), {
-              fetch: guardedFetch as never,
-              requestInit: headers ? { headers } : undefined,
-            })
-          : new StreamableHTTPClientTransport(new URL(server.config.url), {
-              fetch: guardedFetch as never,
-              requestInit: headers ? { headers } : undefined,
-            });
-      await client.connect(transport);
-      clients.push(client);
-      const loaded = await loadMcpTools(server.name, client, {
-        prefixToolNameWithServerName: false,
-      });
-      for (const remoteTool of loaded) {
-        if (
-          !server.allowedToolPatterns.some((pattern) =>
-            mcpToolPatternCovers(pattern, remoteTool.name),
-          )
-        ) {
-          continue;
-        }
-        const toolName = `mcp__${server.name}__${remoteTool.name}`;
-        tools.push(
-          createLangChainTool(
-            async (args, config) => {
-              const authorization = await input.authorizeThirdPartyMcpTool(
-                toolName,
-                args,
-                { signal: config?.signal ?? input.signal },
-              );
-              if (!authorization.allowed) {
-                return `Permission denied: ${authorization.reason ?? 'request denied'}`;
-              }
-              return input.toolActivity.run(toolName, async () => {
-                const startedAt = Date.now();
-                await input.recordThirdPartyMcpToolActivity({
-                  serverName: server.name,
-                  toolName: remoteTool.name,
-                  toolInput: args,
-                  outcome: 'attempt',
-                  latencyMs: 0,
-                });
-                try {
-                  const result = await remoteTool.invoke(
-                    args,
-                    config?.signal ? { signal: config.signal } : undefined,
-                  );
-                  const activity = {
-                    serverName: server.name,
-                    toolName: remoteTool.name,
-                    toolInput: args,
-                    outcome: 'success',
-                    latencyMs: Date.now() - startedAt,
-                    result,
-                  } as const;
-                  await input.recordThirdPartyMcpToolActivity(activity);
-                  return typeof result === 'string'
-                    ? result
-                    : JSON.stringify(result);
-                } catch (error) {
-                  await input.recordThirdPartyMcpToolActivity({
-                    serverName: server.name,
-                    toolName: remoteTool.name,
-                    toolInput: args,
-                    outcome: 'failure',
-                    latencyMs: Date.now() - startedAt,
-                    error,
-                  });
-                  throw error;
-                }
-              });
-            },
-            {
-              name: toolName,
-              description: remoteTool.description,
-              schema: remoteTool.schema as never,
-            },
-          ),
-        );
+  const results: Array<
+    | {
+        index: number;
+        client: Client;
+        tools: StructuredToolInterface[];
+      }
+    | undefined
+  > = [];
+  let nextIndex = 0;
+  let failure: { error: unknown } | undefined;
+  const workerCount = Math.min(REMOTE_MCP_STARTUP_CONCURRENCY, servers.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (!failure) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const server = servers[index];
+      if (!server) return;
+      try {
+        const result = await connectOneRemoteMcpServer({
+          index,
+          server,
+          input,
+          guardedFetch,
+          connectedClients: clients,
+        });
+        if (result) results[index] = result;
+      } catch (error) {
+        failure ??= { error };
+        return;
       }
     }
-  } catch (error) {
+  });
+  await Promise.all(workers);
+  if (failure) {
     await Promise.all(
       clients.map((client) => client.close().catch(() => undefined)),
     );
-    throw error;
+    throw failure.error;
   }
+  const tools = results.flatMap((result) => result?.tools ?? []);
+  let closed = false;
   return {
     tools,
-    close: () =>
-      Promise.all(clients.map((client) => client.close())).then(
-        () => undefined,
-      ),
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      await Promise.all(clients.map((client) => client.close()));
+    },
   };
+}
+
+async function connectOneRemoteMcpServer(input: {
+  index: number;
+  server: MaterializedMcpCapability;
+  input: {
+    authorizeThirdPartyMcpTool: Parameters<ProviderInlineAgentLoopLane>[0]['coreTools']['authorizeThirdPartyMcpTool'];
+    recordThirdPartyMcpToolActivity: Parameters<ProviderInlineAgentLoopLane>[0]['coreTools']['recordThirdPartyMcpToolActivity'];
+    egressDenylist: readonly string[];
+    signal: AbortSignal;
+    toolActivity: InlineToolActivity;
+  };
+  guardedFetch: ReturnType<typeof createGuardedMcpFetch>;
+  connectedClients: Client[];
+}): Promise<
+  | {
+      index: number;
+      client: Client;
+      tools: StructuredToolInterface[];
+    }
+  | undefined
+> {
+  const { server } = input;
+  if (server.config.type !== 'http' && server.config.type !== 'sse')
+    return undefined;
+  input.input.signal.throwIfAborted();
+  assertMcpNetworkHostAllowed({
+    serverName: server.name,
+    url: server.config.url,
+    denylist: input.input.egressDenylist,
+  });
+  const client = new Client({
+    name: `gantry-inline-${server.name}`,
+    version: '1.0.0',
+  });
+  const headers = server.config.headers;
+  const transport =
+    server.config.type === 'sse'
+      ? new SSEClientTransport(new URL(server.config.url), {
+          fetch: input.guardedFetch as never,
+          requestInit: headers ? { headers } : undefined,
+        })
+      : new StreamableHTTPClientTransport(new URL(server.config.url), {
+          fetch: input.guardedFetch as never,
+          requestInit: headers ? { headers } : undefined,
+        });
+  await client.connect(transport);
+  input.connectedClients.push(client);
+  const loaded = await loadMcpTools(server.name, client, {
+    prefixToolNameWithServerName: false,
+  });
+  const tools: StructuredToolInterface[] = [];
+  for (const remoteTool of loaded) {
+    if (
+      !server.allowedToolPatterns.some((pattern) =>
+        mcpToolPatternCovers(pattern, remoteTool.name),
+      )
+    ) {
+      continue;
+    }
+    const toolName = `mcp__${server.name}__${remoteTool.name}`;
+    tools.push(
+      createLangChainTool(
+        async (args, config) => {
+          const authorization = await input.input.authorizeThirdPartyMcpTool(
+            toolName,
+            args,
+            { signal: config?.signal ?? input.input.signal },
+          );
+          if (!authorization.allowed) {
+            return `Permission denied: ${authorization.reason ?? 'request denied'}`;
+          }
+          return input.input.toolActivity.run(toolName, async () => {
+            const startedAt = Date.now();
+            await input.input.recordThirdPartyMcpToolActivity({
+              serverName: server.name,
+              toolName: remoteTool.name,
+              toolInput: args,
+              outcome: 'attempt',
+              latencyMs: 0,
+            });
+            try {
+              const result = await remoteTool.invoke(
+                args,
+                config?.signal ? { signal: config.signal } : undefined,
+              );
+              const activity = {
+                serverName: server.name,
+                toolName: remoteTool.name,
+                toolInput: args,
+                outcome: 'success',
+                latencyMs: Date.now() - startedAt,
+                result,
+              } as const;
+              await input.input.recordThirdPartyMcpToolActivity(activity);
+              return typeof result === 'string'
+                ? result
+                : JSON.stringify(result);
+            } catch (error) {
+              await input.input.recordThirdPartyMcpToolActivity({
+                serverName: server.name,
+                toolName: remoteTool.name,
+                toolInput: args,
+                outcome: 'failure',
+                latencyMs: Date.now() - startedAt,
+                error,
+              });
+              throw error;
+            }
+          });
+        },
+        {
+          name: toolName,
+          description: remoteTool.description,
+          schema: remoteTool.schema as never,
+        },
+      ),
+    );
+  }
+  return { index: input.index, client, tools };
 }
 
 function inlineSystemPrompt(

--- a/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto';
 
-import { loadMcpTools } from '@langchain/mcp-adapters';
 import type { BaseMessage } from '@langchain/core/messages';
 import {
   tool as createLangChainTool,
@@ -8,20 +7,11 @@ import {
 } from '@langchain/core/tools';
 import type { BaseStore } from '@langchain/langgraph-checkpoint';
 import { PostgresSaver } from '@langchain/langgraph-checkpoint-postgres';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createDeepAgent, StateBackend } from 'deepagents';
 import type { FileData, FilesystemPermission } from 'deepagents';
 import { ProviderStrategy, ToolStrategy } from 'langchain';
 import pg from 'pg';
 
-import {
-  assertMcpNetworkHostAllowed,
-  createGuardedMcpFetch,
-} from '../../../../application/mcp/mcp-tool-proxy-network.js';
-import type { MaterializedMcpCapability } from '../../../../application/mcp/mcp-server-service.js';
-import { mcpToolPatternCovers } from '../../../../shared/mcp-tool-scope.js';
 import type { NormalizedCacheProvider } from '../../../../shared/model-catalog.js';
 import type { OpenRouterProviderRouting } from '../../../../shared/model-catalog-provider-metadata.js';
 import type { RunnerOutputFrame } from '../../../../runner/runner-frame.js';
@@ -56,9 +46,9 @@ import {
 import * as memory from './gantry-memory-middleware.js';
 import { createInlineSkillsMiddleware } from './skills.js';
 import { abortedOutput, structuredOutputError } from './inline-lane-output.js';
+import { connectRemoteMcpTools } from './remote-mcp-startup.js';
 
 const CHECKPOINT_POOL_MAX_CONNECTIONS = 1;
-const REMOTE_MCP_STARTUP_CONCURRENCY = 4;
 const DENY_ALL_FILESYSTEM: FilesystemPermission[] = [
   { operations: ['read', 'write'], paths: ['/**'], mode: 'deny' },
 ];
@@ -466,194 +456,6 @@ function buildCoreLangChainTools(
       },
     ),
   );
-}
-
-async function connectRemoteMcpTools(
-  servers: readonly MaterializedMcpCapability[],
-  input: {
-    authorizeThirdPartyMcpTool: Parameters<ProviderInlineAgentLoopLane>[0]['coreTools']['authorizeThirdPartyMcpTool'];
-    recordThirdPartyMcpToolActivity: Parameters<ProviderInlineAgentLoopLane>[0]['coreTools']['recordThirdPartyMcpToolActivity'];
-    egressDenylist: readonly string[];
-    lookupHostname?: Parameters<
-      typeof createGuardedMcpFetch
-    >[0]['lookupHostname'];
-    signal: AbortSignal;
-    toolActivity: InlineToolActivity;
-  },
-): Promise<{ tools: StructuredToolInterface[]; close(): Promise<void> }> {
-  const guardedFetch = createGuardedMcpFetch({
-    lookupHostname: input.lookupHostname,
-  });
-  const clients: Client[] = [];
-  const results: Array<
-    | {
-        index: number;
-        client: Client;
-        tools: StructuredToolInterface[];
-      }
-    | undefined
-  > = [];
-  let nextIndex = 0;
-  let failure: { error: unknown } | undefined;
-  const workerCount = Math.min(REMOTE_MCP_STARTUP_CONCURRENCY, servers.length);
-  const workers = Array.from({ length: workerCount }, async () => {
-    while (!failure) {
-      const index = nextIndex;
-      nextIndex += 1;
-      const server = servers[index];
-      if (!server) return;
-      try {
-        const result = await connectOneRemoteMcpServer({
-          index,
-          server,
-          input,
-          guardedFetch,
-          connectedClients: clients,
-        });
-        if (result) results[index] = result;
-      } catch (error) {
-        failure ??= { error };
-        return;
-      }
-    }
-  });
-  await Promise.all(workers);
-  if (failure) {
-    await Promise.all(
-      clients.map((client) => client.close().catch(() => undefined)),
-    );
-    throw failure.error;
-  }
-  const tools = results.flatMap((result) => result?.tools ?? []);
-  let closed = false;
-  return {
-    tools,
-    close: async () => {
-      if (closed) return;
-      closed = true;
-      await Promise.all(clients.map((client) => client.close()));
-    },
-  };
-}
-
-async function connectOneRemoteMcpServer(input: {
-  index: number;
-  server: MaterializedMcpCapability;
-  input: {
-    authorizeThirdPartyMcpTool: Parameters<ProviderInlineAgentLoopLane>[0]['coreTools']['authorizeThirdPartyMcpTool'];
-    recordThirdPartyMcpToolActivity: Parameters<ProviderInlineAgentLoopLane>[0]['coreTools']['recordThirdPartyMcpToolActivity'];
-    egressDenylist: readonly string[];
-    signal: AbortSignal;
-    toolActivity: InlineToolActivity;
-  };
-  guardedFetch: ReturnType<typeof createGuardedMcpFetch>;
-  connectedClients: Client[];
-}): Promise<
-  | {
-      index: number;
-      client: Client;
-      tools: StructuredToolInterface[];
-    }
-  | undefined
-> {
-  const { server } = input;
-  if (server.config.type !== 'http' && server.config.type !== 'sse')
-    return undefined;
-  input.input.signal.throwIfAborted();
-  assertMcpNetworkHostAllowed({
-    serverName: server.name,
-    url: server.config.url,
-    denylist: input.input.egressDenylist,
-  });
-  const client = new Client({
-    name: `gantry-inline-${server.name}`,
-    version: '1.0.0',
-  });
-  const headers = server.config.headers;
-  const transport =
-    server.config.type === 'sse'
-      ? new SSEClientTransport(new URL(server.config.url), {
-          fetch: input.guardedFetch as never,
-          requestInit: headers ? { headers } : undefined,
-        })
-      : new StreamableHTTPClientTransport(new URL(server.config.url), {
-          fetch: input.guardedFetch as never,
-          requestInit: headers ? { headers } : undefined,
-        });
-  await client.connect(transport);
-  input.connectedClients.push(client);
-  const loaded = await loadMcpTools(server.name, client, {
-    prefixToolNameWithServerName: false,
-  });
-  const tools: StructuredToolInterface[] = [];
-  for (const remoteTool of loaded) {
-    if (
-      !server.allowedToolPatterns.some((pattern) =>
-        mcpToolPatternCovers(pattern, remoteTool.name),
-      )
-    ) {
-      continue;
-    }
-    const toolName = `mcp__${server.name}__${remoteTool.name}`;
-    tools.push(
-      createLangChainTool(
-        async (args, config) => {
-          const authorization = await input.input.authorizeThirdPartyMcpTool(
-            toolName,
-            args,
-            { signal: config?.signal ?? input.input.signal },
-          );
-          if (!authorization.allowed) {
-            return `Permission denied: ${authorization.reason ?? 'request denied'}`;
-          }
-          return input.input.toolActivity.run(toolName, async () => {
-            const startedAt = Date.now();
-            await input.input.recordThirdPartyMcpToolActivity({
-              serverName: server.name,
-              toolName: remoteTool.name,
-              toolInput: args,
-              outcome: 'attempt',
-              latencyMs: 0,
-            });
-            try {
-              const result = await remoteTool.invoke(
-                args,
-                config?.signal ? { signal: config.signal } : undefined,
-              );
-              const activity = {
-                serverName: server.name,
-                toolName: remoteTool.name,
-                toolInput: args,
-                outcome: 'success',
-                latencyMs: Date.now() - startedAt,
-                result,
-              } as const;
-              await input.input.recordThirdPartyMcpToolActivity(activity);
-              return typeof result === 'string'
-                ? result
-                : JSON.stringify(result);
-            } catch (error) {
-              await input.input.recordThirdPartyMcpToolActivity({
-                serverName: server.name,
-                toolName: remoteTool.name,
-                toolInput: args,
-                outcome: 'failure',
-                latencyMs: Date.now() - startedAt,
-                error,
-              });
-              throw error;
-            }
-          });
-        },
-        {
-          name: toolName,
-          description: remoteTool.description,
-          schema: remoteTool.schema as never,
-        },
-      ),
-    );
-  }
-  return { index: input.index, client, tools };
 }
 
 function inlineSystemPrompt(

--- a/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
@@ -49,10 +49,36 @@ export async function connectRemoteMcpTools(
   const guardedFetch = createGuardedMcpFetch({
     lookupHostname: input.lookupHostname,
   });
+  const startupAbort = new AbortController();
   const clients: Client[] = [];
+  const failureClosedClients = new WeakSet<Client>();
+  const failureClosePromises: Promise<void>[] = [];
   const results: Array<ConnectedRemoteMcpServer | undefined> = [];
   let nextIndex = 0;
   let failure: { error: unknown } | undefined;
+  const closeClientAfterFailure = (client: Client) => {
+    if (failureClosedClients.has(client)) return;
+    failureClosedClients.add(client);
+    failureClosePromises.push(client.close().catch(() => undefined));
+  };
+  const stopStartup = (error: unknown) => {
+    failure ??= { error };
+    if (!startupAbort.signal.aborted) startupAbort.abort(error);
+    for (const client of clients) closeClientAfterFailure(client);
+  };
+  const registerClient = (client: Client) => {
+    clients.push(client);
+    if (failure) closeClientAfterFailure(client);
+  };
+  const throwIfStartupStopped = () => {
+    if (failure) throw failure.error;
+    input.signal.throwIfAborted();
+  };
+  const onInputAbort = () => {
+    stopStartup(input.signal.reason ?? new Error('Remote MCP startup aborted'));
+  };
+  if (input.signal.aborted) onInputAbort();
+  else input.signal.addEventListener('abort', onInputAbort, { once: true });
   const workerCount = Math.min(REMOTE_MCP_STARTUP_CONCURRENCY, servers.length);
   const workers = Array.from({ length: workerCount }, async () => {
     while (!failure) {
@@ -61,25 +87,30 @@ export async function connectRemoteMcpTools(
       const server = servers[index];
       if (!server) return;
       try {
+        throwIfStartupStopped();
         const result = await connectOneRemoteMcpServer({
           index,
           server,
           input,
           guardedFetch,
-          connectedClients: clients,
+          startupSignal: startupAbort.signal,
+          registerClient,
+          throwIfStartupStopped,
         });
         if (result) results[index] = result;
       } catch (error) {
-        failure ??= { error };
+        stopStartup(error);
         return;
       }
     }
   });
-  await Promise.all(workers);
+  try {
+    await Promise.all(workers);
+  } finally {
+    input.signal.removeEventListener('abort', onInputAbort);
+  }
   if (failure) {
-    await Promise.all(
-      clients.map((client) => client.close().catch(() => undefined)),
-    );
+    await Promise.all(failureClosePromises);
     throw failure.error;
   }
   const tools = results.flatMap((result) => result?.tools ?? []);
@@ -99,12 +130,14 @@ async function connectOneRemoteMcpServer(input: {
   server: MaterializedMcpCapability;
   input: RemoteMcpStartupInput;
   guardedFetch: ReturnType<typeof createGuardedMcpFetch>;
-  connectedClients: Client[];
+  startupSignal: AbortSignal;
+  registerClient(client: Client): void;
+  throwIfStartupStopped(): void;
 }): Promise<ConnectedRemoteMcpServer | undefined> {
   const { server } = input;
   if (server.config.type !== 'http' && server.config.type !== 'sse')
     return undefined;
-  input.input.signal.throwIfAborted();
+  input.throwIfStartupStopped();
   assertMcpNetworkHostAllowed({
     serverName: server.name,
     url: server.config.url,
@@ -114,22 +147,29 @@ async function connectOneRemoteMcpServer(input: {
     name: `gantry-inline-${server.name}`,
     version: '1.0.0',
   });
+  input.registerClient(client);
+  input.throwIfStartupStopped();
   const headers = server.config.headers;
+  const requestInit = {
+    ...(headers ? { headers } : {}),
+    signal: combineAbortSignals(input.input.signal, input.startupSignal),
+  };
   const transport =
     server.config.type === 'sse'
       ? new SSEClientTransport(new URL(server.config.url), {
           fetch: input.guardedFetch as never,
-          requestInit: headers ? { headers } : undefined,
+          requestInit,
         })
       : new StreamableHTTPClientTransport(new URL(server.config.url), {
           fetch: input.guardedFetch as never,
-          requestInit: headers ? { headers } : undefined,
+          requestInit,
         });
   await client.connect(transport);
-  input.connectedClients.push(client);
+  input.throwIfStartupStopped();
   const loaded = await loadMcpTools(server.name, client, {
     prefixToolNameWithServerName: false,
   });
+  input.throwIfStartupStopped();
   const tools: StructuredToolInterface[] = [];
   for (const remoteTool of loaded) {
     if (
@@ -199,4 +239,23 @@ async function connectOneRemoteMcpServer(input: {
     );
   }
   return { index: input.index, client, tools };
+}
+
+function combineAbortSignals(
+  signal: AbortSignal,
+  startupSignal: AbortSignal,
+): AbortSignal {
+  const controller = new AbortController();
+  const abort = (source: AbortSignal) => {
+    if (!controller.signal.aborted) controller.abort(source.reason);
+  };
+  if (signal.aborted) abort(signal);
+  if (startupSignal.aborted) abort(startupSignal);
+  if (!controller.signal.aborted) {
+    signal.addEventListener('abort', () => abort(signal), { once: true });
+    startupSignal.addEventListener('abort', () => abort(startupSignal), {
+      once: true,
+    });
+  }
+  return controller.signal;
 }

--- a/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
@@ -24,7 +24,9 @@ interface RemoteMcpStartupInput {
   authorizeThirdPartyMcpTool: LaneInput['coreTools']['authorizeThirdPartyMcpTool'];
   recordThirdPartyMcpToolActivity: LaneInput['coreTools']['recordThirdPartyMcpToolActivity'];
   egressDenylist: readonly string[];
-  lookupHostname?: Parameters<typeof createGuardedMcpFetch>[0]['lookupHostname'];
+  lookupHostname?: Parameters<
+    typeof createGuardedMcpFetch
+  >[0]['lookupHostname'];
   signal: AbortSignal;
   toolActivity: InlineToolActivity;
 }

--- a/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
@@ -46,6 +46,13 @@ export async function connectRemoteMcpTools(
   servers: readonly MaterializedMcpCapability[],
   input: RemoteMcpStartupInput,
 ): Promise<RemoteMcpStartupResult> {
+  if (
+    !servers.some(
+      (server) => server.config.type === 'http' || server.config.type === 'sse',
+    )
+  ) {
+    return { tools: [], close: () => Promise.resolve() };
+  }
   const guardedFetch = createGuardedMcpFetch({
     lookupHostname: input.lookupHostname,
   });
@@ -164,7 +171,7 @@ async function connectOneRemoteMcpServer(input: {
           fetch: input.guardedFetch as never,
           requestInit,
         });
-  await client.connect(transport);
+  await settleOnAbort(client.connect(transport), input.startupSignal);
   input.throwIfStartupStopped();
   const loaded = await loadMcpTools(server.name, client, {
     prefixToolNameWithServerName: false,
@@ -258,4 +265,25 @@ function combineAbortSignals(
     });
   }
   return controller.signal;
+}
+
+function settleOnAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
 }

--- a/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts
@@ -1,0 +1,200 @@
+import { loadMcpTools } from '@langchain/mcp-adapters';
+import {
+  tool as createLangChainTool,
+  type StructuredToolInterface,
+} from '@langchain/core/tools';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+import {
+  assertMcpNetworkHostAllowed,
+  createGuardedMcpFetch,
+} from '../../../../application/mcp/mcp-tool-proxy-network.js';
+import type { MaterializedMcpCapability } from '../../../../application/mcp/mcp-server-service.js';
+import { mcpToolPatternCovers } from '../../../../shared/mcp-tool-scope.js';
+import type { ProviderInlineAgentLoopLane } from '../../inline-lane-dispatcher.js';
+import type { InlineToolActivity } from '../../inline-lane-tool-activity.js';
+
+const REMOTE_MCP_STARTUP_CONCURRENCY = 4;
+
+type LaneInput = Parameters<ProviderInlineAgentLoopLane>[0];
+
+interface RemoteMcpStartupInput {
+  authorizeThirdPartyMcpTool: LaneInput['coreTools']['authorizeThirdPartyMcpTool'];
+  recordThirdPartyMcpToolActivity: LaneInput['coreTools']['recordThirdPartyMcpToolActivity'];
+  egressDenylist: readonly string[];
+  lookupHostname?: Parameters<typeof createGuardedMcpFetch>[0]['lookupHostname'];
+  signal: AbortSignal;
+  toolActivity: InlineToolActivity;
+}
+
+interface RemoteMcpStartupResult {
+  tools: StructuredToolInterface[];
+  close(): Promise<void>;
+}
+
+interface ConnectedRemoteMcpServer {
+  index: number;
+  client: Client;
+  tools: StructuredToolInterface[];
+}
+
+export async function connectRemoteMcpTools(
+  servers: readonly MaterializedMcpCapability[],
+  input: RemoteMcpStartupInput,
+): Promise<RemoteMcpStartupResult> {
+  const guardedFetch = createGuardedMcpFetch({
+    lookupHostname: input.lookupHostname,
+  });
+  const clients: Client[] = [];
+  const results: Array<ConnectedRemoteMcpServer | undefined> = [];
+  let nextIndex = 0;
+  let failure: { error: unknown } | undefined;
+  const workerCount = Math.min(REMOTE_MCP_STARTUP_CONCURRENCY, servers.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (!failure) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const server = servers[index];
+      if (!server) return;
+      try {
+        const result = await connectOneRemoteMcpServer({
+          index,
+          server,
+          input,
+          guardedFetch,
+          connectedClients: clients,
+        });
+        if (result) results[index] = result;
+      } catch (error) {
+        failure ??= { error };
+        return;
+      }
+    }
+  });
+  await Promise.all(workers);
+  if (failure) {
+    await Promise.all(
+      clients.map((client) => client.close().catch(() => undefined)),
+    );
+    throw failure.error;
+  }
+  const tools = results.flatMap((result) => result?.tools ?? []);
+  let closed = false;
+  return {
+    tools,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      await Promise.all(clients.map((client) => client.close()));
+    },
+  };
+}
+
+async function connectOneRemoteMcpServer(input: {
+  index: number;
+  server: MaterializedMcpCapability;
+  input: RemoteMcpStartupInput;
+  guardedFetch: ReturnType<typeof createGuardedMcpFetch>;
+  connectedClients: Client[];
+}): Promise<ConnectedRemoteMcpServer | undefined> {
+  const { server } = input;
+  if (server.config.type !== 'http' && server.config.type !== 'sse')
+    return undefined;
+  input.input.signal.throwIfAborted();
+  assertMcpNetworkHostAllowed({
+    serverName: server.name,
+    url: server.config.url,
+    denylist: input.input.egressDenylist,
+  });
+  const client = new Client({
+    name: `gantry-inline-${server.name}`,
+    version: '1.0.0',
+  });
+  const headers = server.config.headers;
+  const transport =
+    server.config.type === 'sse'
+      ? new SSEClientTransport(new URL(server.config.url), {
+          fetch: input.guardedFetch as never,
+          requestInit: headers ? { headers } : undefined,
+        })
+      : new StreamableHTTPClientTransport(new URL(server.config.url), {
+          fetch: input.guardedFetch as never,
+          requestInit: headers ? { headers } : undefined,
+        });
+  await client.connect(transport);
+  input.connectedClients.push(client);
+  const loaded = await loadMcpTools(server.name, client, {
+    prefixToolNameWithServerName: false,
+  });
+  const tools: StructuredToolInterface[] = [];
+  for (const remoteTool of loaded) {
+    if (
+      !server.allowedToolPatterns.some((pattern) =>
+        mcpToolPatternCovers(pattern, remoteTool.name),
+      )
+    ) {
+      continue;
+    }
+    const toolName = `mcp__${server.name}__${remoteTool.name}`;
+    tools.push(
+      createLangChainTool(
+        async (args, config) => {
+          const authorization = await input.input.authorizeThirdPartyMcpTool(
+            toolName,
+            args,
+            { signal: config?.signal ?? input.input.signal },
+          );
+          if (!authorization.allowed) {
+            return `Permission denied: ${authorization.reason ?? 'request denied'}`;
+          }
+          return input.input.toolActivity.run(toolName, async () => {
+            const startedAt = Date.now();
+            await input.input.recordThirdPartyMcpToolActivity({
+              serverName: server.name,
+              toolName: remoteTool.name,
+              toolInput: args,
+              outcome: 'attempt',
+              latencyMs: 0,
+            });
+            try {
+              const result = await remoteTool.invoke(
+                args,
+                config?.signal ? { signal: config.signal } : undefined,
+              );
+              const activity = {
+                serverName: server.name,
+                toolName: remoteTool.name,
+                toolInput: args,
+                outcome: 'success',
+                latencyMs: Date.now() - startedAt,
+                result,
+              } as const;
+              await input.input.recordThirdPartyMcpToolActivity(activity);
+              return typeof result === 'string'
+                ? result
+                : JSON.stringify(result);
+            } catch (error) {
+              await input.input.recordThirdPartyMcpToolActivity({
+                serverName: server.name,
+                toolName: remoteTool.name,
+                toolInput: args,
+                outcome: 'failure',
+                latencyMs: Date.now() - startedAt,
+                error,
+              });
+              throw error;
+            }
+          });
+        },
+        {
+          name: toolName,
+          description: remoteTool.description,
+          schema: remoteTool.schema as never,
+        },
+      ),
+    );
+  }
+  return { index: input.index, client, tools };
+}

--- a/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
@@ -1134,6 +1134,118 @@ Always mention the migration impact.
     }
   });
 
+  it('cancels already-started remote MCP startup peers before waiting for them after an initial-wave failure', async () => {
+    const serverNames = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
+    const startupError = new Error('alpha startup failed');
+    const discoveryBarrier = createDeterministicBarrier(4);
+    const participants: ReturnType<typeof discoveryBarrier.arrive>[] = [];
+    const connectOrder: string[] = [];
+    let releaseInitialWave: (() => void) | undefined;
+    const initialWaveGate = new Promise<void>((resolve) => {
+      releaseInitialWave = resolve;
+    });
+    let releaseBlockedPeer: (() => void) | undefined;
+    let blockedPeerClosed = false;
+    let blockedPeerRequestAborted = false;
+    let blockedPeerRequestSignal: AbortSignal | undefined;
+    remote.Client.connectImpl = async (client, transport) => {
+      const info = client.info as { name: string };
+      const serverName = info.name.replace('gantry-inline-', '');
+      connectOrder.push(serverName);
+      if (serverName !== 'bravo') return;
+      const transportOptions = (
+        transport as {
+          options?: { requestInit?: { signal?: AbortSignal } };
+        }
+      ).options;
+      blockedPeerRequestSignal = transportOptions?.requestInit?.signal;
+      if (blockedPeerRequestSignal) {
+        blockedPeerRequestSignal.addEventListener(
+          'abort',
+          () => {
+            blockedPeerRequestAborted = true;
+          },
+          { once: true },
+        );
+      }
+    };
+    remote.loadTools.mockImplementation(async (serverName: string, client) => {
+      const participant = discoveryBarrier.arrive();
+      participants.push(participant);
+      await initialWaveGate;
+      if (serverName === 'alpha') throw startupError;
+      if (serverName === 'bravo') {
+        await new Promise<void>((resolve) => {
+          releaseBlockedPeer = resolve;
+          client.close.mockImplementationOnce(async () => {
+            blockedPeerClosed = true;
+            resolve();
+          });
+        });
+      } else {
+        await participant.completed;
+      }
+      return [
+        {
+          name: 'read',
+          description: `${serverName} read tool.`,
+          schema: z.object({}),
+          invoke: remote.invoke,
+        },
+      ];
+    });
+    const input = laneInput({
+      mcpServers: serverNames.map((serverName) => ({
+        name: serverName,
+        config: {
+          type: 'http',
+          url: `https://mcp.example.test/${serverName}`,
+        },
+        allowedToolPatterns: ['*'],
+      })),
+    });
+    const lane = createDeepAgentsInlineAgentLoopLane({
+      databaseUrl: 'postgres://gantry:test@localhost:5432/gantry',
+      schema: 'gantry_deepagents',
+    });
+
+    const result = lane(input);
+    try {
+      await flushMicrotasks();
+
+      expect(discoveryBarrier.snapshot()).toMatchObject({ arrivals: 4 });
+      expect(connectOrder).toEqual(serverNames.slice(0, 4));
+      expect(connectOrder).not.toContain('echo');
+      expect(deep.createAgent).not.toHaveBeenCalled();
+      expect(remote.Client.instances).toHaveLength(4);
+
+      releaseInitialWave?.();
+      await flushMicrotasks();
+      expect(
+        blockedPeerClosed || blockedPeerRequestAborted,
+        'blocked peer should be cancelled before its discovery promise settles',
+      ).toBe(true);
+
+      participants
+        .filter((_, index) => serverNames[index] !== 'bravo')
+        .forEach((participant) => participant.release());
+
+      await expect(result).rejects.toBe(startupError);
+      expect(remote.Client.instances).toHaveLength(4);
+      expect(connectOrder).not.toContain('echo');
+      for (const client of remote.Client.instances) {
+        expect(client.close).toHaveBeenCalledOnce();
+      }
+      expect(checkpoint.Saver.instances[0]?.end).toHaveBeenCalledOnce();
+    } finally {
+      releaseInitialWave?.();
+      await flushMicrotasks();
+      releaseBlockedPeer?.();
+      participants.forEach((participant) => participant.release());
+      await releaseBarrierParticipantsUntilSettled(result, participants);
+    }
+  });
+
   it('aborts remote MCP startup without starting queued work and closes connected clients', async () => {
     const serverNames = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
     const controller = new AbortController();

--- a/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
@@ -1064,6 +1064,141 @@ Always mention the migration impact.
     }
   });
 
+  it('stops queued remote MCP startup after an initial-wave server failure and cleans up connected clients', async () => {
+    const serverNames = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
+    const startupError = new Error('bravo startup failed');
+    const discoveryBarrier = createDeterministicBarrier(4);
+    const participants: ReturnType<typeof discoveryBarrier.arrive>[] = [];
+    const connectOrder: string[] = [];
+    remote.Client.connectImpl = async (client) => {
+      const info = client.info as { name: string };
+      connectOrder.push(info.name.replace('gantry-inline-', ''));
+    };
+    remote.loadTools.mockImplementation(async (serverName: string) => {
+      const participant = discoveryBarrier.arrive();
+      participants.push(participant);
+      await discoveryBarrier.waitForArrivals(4);
+      if (serverName === 'bravo') throw startupError;
+      await participant.completed;
+      return [
+        {
+          name: 'read',
+          description: `${serverName} read tool.`,
+          schema: z.object({}),
+          invoke: remote.invoke,
+        },
+      ];
+    });
+    const input = laneInput({
+      mcpServers: serverNames.map((serverName) => ({
+        name: serverName,
+        config: {
+          type: 'http',
+          url: `https://mcp.example.test/${serverName}`,
+        },
+        allowedToolPatterns: ['*'],
+      })),
+    });
+    const lane = createDeepAgentsInlineAgentLoopLane({
+      databaseUrl: 'postgres://gantry:test@localhost:5432/gantry',
+      schema: 'gantry_deepagents',
+    });
+
+    const result = lane(input);
+    try {
+      await discoveryBarrier.waitForArrivals(4);
+      await flushMicrotasks();
+
+      expect(connectOrder).toEqual(serverNames.slice(0, 4));
+      expect(remote.Client.instances).toHaveLength(4);
+      for (const client of remote.Client.instances) {
+        client.close.mockRejectedValueOnce(new Error('cleanup close failed'));
+      }
+
+      expect(connectOrder).not.toContain('echo');
+      expect(deep.createAgent).not.toHaveBeenCalled();
+
+      participants
+        .filter((_, index) => serverNames[index] !== 'bravo')
+        .forEach((participant) => participant.release());
+
+      await expect(result).rejects.toBe(startupError);
+      expect(remote.Client.instances).toHaveLength(4);
+      expect(connectOrder).not.toContain('echo');
+      for (const client of remote.Client.instances) {
+        expect(client.close).toHaveBeenCalledOnce();
+      }
+      expect(checkpoint.Saver.instances[0]?.end).toHaveBeenCalledOnce();
+    } finally {
+      await releaseBarrierParticipantsUntilSettled(result, participants);
+    }
+  });
+
+  it('aborts remote MCP startup without starting queued work and closes connected clients', async () => {
+    const serverNames = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
+    const controller = new AbortController();
+    const connectBarrier = createDeterministicBarrier(4);
+    const participants: ReturnType<typeof connectBarrier.arrive>[] = [];
+    const connectOrder: string[] = [];
+    remote.Client.connectImpl = async (client) => {
+      const info = client.info as { name: string };
+      connectOrder.push(info.name.replace('gantry-inline-', ''));
+      const participant = connectBarrier.arrive();
+      participants.push(participant);
+      await participant.completed;
+    };
+    remote.loadTools.mockImplementation(async (serverName: string) => [
+      {
+        name: 'read',
+        description: `${serverName} read tool.`,
+        schema: z.object({}),
+        invoke: remote.invoke,
+      },
+    ]);
+    const input = laneInput({
+      signal: controller.signal,
+      mcpServers: serverNames.map((serverName) => ({
+        name: serverName,
+        config: {
+          type: 'http',
+          url: `https://mcp.example.test/${serverName}`,
+        },
+        allowedToolPatterns: ['*'],
+      })),
+    });
+    const lane = createDeepAgentsInlineAgentLoopLane({
+      databaseUrl: 'postgres://gantry:test@localhost:5432/gantry',
+      schema: 'gantry_deepagents',
+    });
+
+    const result = lane(input);
+    try {
+      await connectBarrier.waitForArrivals(4);
+      expect(connectOrder).toEqual(serverNames.slice(0, 4));
+
+      const abortError = new Error('startup aborted');
+      abortError.name = 'AbortError';
+      controller.abort(abortError);
+      await flushMicrotasks();
+
+      expect(remote.Client.instances).toHaveLength(4);
+      expect(connectOrder).not.toContain('echo');
+      expect(deep.createAgent).not.toHaveBeenCalled();
+
+      participants.forEach((participant) => participant.release());
+
+      await expect(result).rejects.toBe(abortError);
+      expect(remote.Client.instances).toHaveLength(4);
+      expect(connectOrder).not.toContain('echo');
+      for (const client of remote.Client.instances) {
+        expect(client.close).toHaveBeenCalledOnce();
+      }
+      expect(checkpoint.Saver.instances[0]?.end).toHaveBeenCalledOnce();
+    } finally {
+      await releaseBarrierParticipantsUntilSettled(result, participants);
+    }
+  });
+
   it('filters remote MCP tools with reviewed wildcard scopes', async () => {
     deep.streamEvents.mockImplementation(() => ({
       async *[Symbol.asyncIterator]() {

--- a/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
@@ -55,10 +55,14 @@ const remote = vi.hoisted(() => {
     static instances: Client[] = [];
     static connectImpl: (client: Client, transport: unknown) => Promise<void> =
       async () => undefined;
-    connect = vi.fn((transport: unknown) =>
-      Client.connectImpl(this, transport),
-    );
-    close = vi.fn(async () => undefined);
+    private transport?: { close?(): Promise<void> | void };
+    connect = vi.fn((transport: unknown) => {
+      this.transport = transport as { close?(): Promise<void> | void };
+      return Client.connectImpl(this, transport);
+    });
+    close = vi.fn(async () => {
+      await this.transport?.close?.();
+    });
     constructor(readonly info: unknown) {
       Client.instances.push(this);
     }
@@ -72,7 +76,9 @@ const remote = vi.hoisted(() => {
       HttpTransport.instances.push(this);
     }
   }
-  class SseTransport extends HttpTransport {}
+  class SseTransport extends HttpTransport {
+    close = vi.fn(async () => undefined);
+  }
   return {
     Client,
     HttpTransport,
@@ -1246,6 +1252,89 @@ Always mention the migration impact.
     }
   });
 
+  it('settles an in-flight SSE endpoint connection when a peer startup fails', async () => {
+    const startupError = new Error('alpha startup failed');
+    const connectBarrier = createDeterministicBarrier(2);
+    const participants: ReturnType<typeof connectBarrier.arrive>[] = [];
+    let releaseSseConnect: (() => void) | undefined;
+    const sseConnect = new Promise<void>((resolve) => {
+      releaseSseConnect = resolve;
+    });
+    remote.Client.connectImpl = async (client, transport) => {
+      const participant = connectBarrier.arrive();
+      participants.push(participant);
+      await connectBarrier.waitForArrivals(2);
+      const serverName = (client.info as { name: string }).name.replace(
+        'gantry-inline-',
+        '',
+      );
+      if (serverName === 'alpha') throw startupError;
+      expect(transport).toBeInstanceOf(remote.SseTransport);
+      // The MCP SDK's SSE start promise remains pending when close aborts the
+      // initial EventSource fetch, so only an explicit startup race can settle it.
+      await sseConnect;
+    };
+    const input = laneInput({
+      mcpServers: [
+        {
+          name: 'alpha',
+          config: {
+            type: 'http',
+            url: 'https://mcp.example.test/alpha',
+          },
+          allowedToolPatterns: ['*'],
+        },
+        {
+          name: 'bravo',
+          config: {
+            type: 'sse',
+            url: 'https://mcp.example.test/bravo',
+          },
+          allowedToolPatterns: ['*'],
+        },
+      ],
+    });
+    const lane = createDeepAgentsInlineAgentLoopLane({
+      databaseUrl: 'postgres://gantry:test@localhost:5432/gantry',
+      schema: 'gantry_deepagents',
+    });
+
+    const result = lane(input);
+    let outcome:
+      | { status: 'resolved' }
+      | { status: 'rejected'; error: unknown };
+    const observed = result.then(
+      () => {
+        outcome = { status: 'resolved' };
+      },
+      (error: unknown) => {
+        outcome = { status: 'rejected', error };
+      },
+    );
+    try {
+      await connectBarrier.waitForArrivals(2);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const sseTransport = remote.HttpTransport.instances.find(
+        (transport) => transport instanceof remote.SseTransport,
+      ) as InstanceType<typeof remote.SseTransport> | undefined;
+      expect(sseTransport?.options.fetch).toEqual(expect.any(Function));
+      expect(
+        (
+          sseTransport?.options.requestInit as
+            | { signal?: AbortSignal }
+            | undefined
+        )?.signal?.aborted,
+      ).toBe(true);
+      expect(sseTransport?.close).toHaveBeenCalledOnce();
+      expect(outcome).toEqual({ status: 'rejected', error: startupError });
+    } finally {
+      releaseSseConnect?.();
+      participants.forEach((participant) => participant.release());
+      await observed;
+    }
+  });
+
   it('aborts remote MCP startup without starting queued work and closes connected clients', async () => {
     const serverNames = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
     const controller = new AbortController();
@@ -1309,6 +1398,44 @@ Always mention the migration impact.
     } finally {
       await releaseBarrierParticipantsUntilSettled(result, participants);
     }
+  });
+
+  it('returns the graceful aborted result when cancellation reaches startup with no remote MCP work', async () => {
+    const controller = new AbortController();
+    model.build.mockImplementationOnce(async () => {
+      controller.abort(new Error('cancelled during model setup'));
+      return {
+        model: { profile: { maxInputTokens: 100 } },
+        endpointFamily: 'openai',
+        modelId: 'test-model',
+      };
+    });
+    deep.streamEvents.mockImplementation(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield streamEvent('ignored after cancellation');
+      },
+    }));
+    const input = laneInput({
+      signal: controller.signal,
+      mcpServers: [
+        {
+          name: 'local-only',
+          config: { command: 'ignored-stdio-command' },
+          allowedToolPatterns: ['*'],
+        },
+      ],
+    });
+    const lane = createDeepAgentsInlineAgentLoopLane({
+      databaseUrl: 'postgres://gantry:test@localhost:5432/gantry',
+      schema: 'gantry_deepagents',
+    });
+
+    await expect(lane(input)).resolves.toMatchObject({
+      status: 'error',
+      error: 'Inline DeepAgents lane aborted.',
+      newSessionId: expect.any(String),
+    });
+    expect(remote.Client.instances).toHaveLength(0);
   });
 
   it('filters remote MCP tools with reviewed wildcard scopes', async () => {

--- a/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
@@ -53,7 +53,11 @@ const model = vi.hoisted(() => ({
 const remote = vi.hoisted(() => {
   class Client {
     static instances: Client[] = [];
-    connect = vi.fn(async () => undefined);
+    static connectImpl: (client: Client, transport: unknown) => Promise<void> =
+      async () => undefined;
+    connect = vi.fn((transport: unknown) =>
+      Client.connectImpl(this, transport),
+    );
     close = vi.fn(async () => undefined);
     constructor(readonly info: unknown) {
       Client.instances.push(this);
@@ -129,6 +133,7 @@ vi.mock(mcpAdaptersPackage, () => ({
 import { createDeepAgentsInlineAgentLoopLane } from '@core/adapters/llm/deepagents-langchain/inline-lane/index.js';
 import { InMemoryInlineRunnerControlPort } from '@core/runtime/agent-inline.js';
 import { DEEPAGENTS_ENGINE } from '@core/shared/agent-engine.js';
+import { createDeterministicBarrier } from '../../harness/response-latency-harness.js';
 
 function laneInput(overrides: Record<string, unknown> = {}) {
   const coreTools = {
@@ -202,6 +207,7 @@ beforeEach(() => {
   checkpoint.Saver.tuple = { checkpoint: {} };
   checkpoint.Pool.instances = [];
   remote.Client.instances = [];
+  remote.Client.connectImpl = async () => undefined;
   remote.HttpTransport.instances = [];
   deep.createAgent.mockReturnValue({ streamEvents: deep.streamEvents });
   deep.createAgentMemory.mockReturnValue({
@@ -951,6 +957,113 @@ Always mention the migration impact.
     expect(remote.Client.instances[0]?.close).toHaveBeenCalledOnce();
   });
 
+  it('starts remote MCP servers with bounded concurrency and keeps configured tool order', async () => {
+    deep.streamEvents.mockImplementation(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield streamEvent('done');
+      },
+    }));
+    const serverNames = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
+    const barrier = createDeterministicBarrier(serverNames.length);
+    const participants: ReturnType<typeof barrier.arrive>[] = [];
+    const connectOrder: string[] = [];
+    const inventoryByServer = Object.fromEntries(
+      serverNames.map((serverName) => [
+        serverName,
+        [
+          {
+            name: 'first',
+            description: `${serverName} first tool.`,
+            schema: z.object({}),
+            invoke: remote.invoke,
+          },
+          {
+            name: 'second',
+            description: `${serverName} second tool.`,
+            schema: z.object({}),
+            invoke: remote.invoke,
+          },
+        ],
+      ]),
+    );
+    remote.Client.connectImpl = async (client) => {
+      const info = client.info as { name: string };
+      connectOrder.push(info.name.replace('gantry-inline-', ''));
+      const participant = barrier.arrive();
+      participants.push(participant);
+      await participant.completed;
+    };
+    remote.loadTools.mockImplementation(async (serverName: string) => {
+      const tools = inventoryByServer[serverName];
+      if (!tools) throw new Error(`unexpected server ${serverName}`);
+      return tools;
+    });
+    const input = laneInput({
+      mcpServers: serverNames.map((serverName, index) => ({
+        name: serverName,
+        config: {
+          type: index % 2 === 0 ? 'http' : 'sse',
+          url: `https://mcp.example.test/${serverName}`,
+        },
+        allowedToolPatterns: ['*'],
+      })),
+    });
+    const lane = createDeepAgentsInlineAgentLoopLane({
+      databaseUrl: 'postgres://gantry:test@localhost:5432/gantry',
+      schema: 'gantry_deepagents',
+    });
+
+    const result = lane(input);
+    try {
+      await flushMicrotasks();
+
+      expect(barrier.snapshot()).toMatchObject({
+        arrivals: 4,
+        active: 4,
+        completed: 0,
+        maximumActive: 4,
+        allArrived: false,
+      });
+      expect(connectOrder).toEqual(serverNames.slice(0, 4));
+
+      participants[0]?.release();
+      await barrier.waitForArrivals(5);
+
+      expect(connectOrder).toEqual(serverNames);
+      expect(barrier.snapshot()).toMatchObject({
+        arrivals: 5,
+        active: 4,
+        maximumActive: 4,
+        allArrived: true,
+      });
+
+      participants[4]?.release();
+      participants[3]?.release();
+      participants[2]?.release();
+      participants[1]?.release();
+
+      await expect(result).resolves.toMatchObject({ status: 'success' });
+      const toolNames = deep.createAgent.mock.calls[0]?.[0].tools.map(
+        (tool) => tool.name,
+      );
+      expect(toolNames).toEqual([
+        'send_message',
+        'mcp__alpha__first',
+        'mcp__alpha__second',
+        'mcp__bravo__first',
+        'mcp__bravo__second',
+        'mcp__charlie__first',
+        'mcp__charlie__second',
+        'mcp__delta__first',
+        'mcp__delta__second',
+        'mcp__echo__first',
+        'mcp__echo__second',
+      ]);
+    } finally {
+      await releaseBarrierParticipantsUntilSettled(result, participants);
+    }
+  });
+
   it('filters remote MCP tools with reviewed wildcard scopes', async () => {
     deep.streamEvents.mockImplementation(() => ({
       async *[Symbol.asyncIterator]() {
@@ -1168,4 +1281,38 @@ function streamEvent(text: string) {
       },
     },
   };
+}
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+async function releaseBarrierParticipantsUntilSettled(
+  result: Promise<unknown>,
+  participants: readonly ReturnType<
+    ReturnType<typeof createDeterministicBarrier>['arrive']
+  >[],
+) {
+  const released = new Set<
+    ReturnType<ReturnType<typeof createDeterministicBarrier>['arrive']>
+  >();
+  let settled = false;
+  const settledResult = result
+    .catch(() => undefined)
+    .finally(() => {
+      settled = true;
+    });
+
+  while (!settled) {
+    for (const participant of participants) {
+      if (!released.has(participant)) {
+        released.add(participant);
+        participant.release();
+      }
+    }
+    await Promise.race([settledResult, flushMicrotasks()]);
+  }
+  await settledResult;
 }

--- a/docs/decisions/0070-client-signoff.md
+++ b/docs/decisions/0070-client-signoff.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-27
+---
+
+# LAT-1 Client Signoff
+
+## Context
+The user explicitly signed off the full MyClaw response-latency program and
+specifically ordered Phase 1 planning on branch
+`perf/parallel-inline-mcp-startup`.
+
+The program roadmap names Phase 1 as bounded concurrent remote MCP startup:
+connect and discover remote MCP servers with a small local concurrency limit
+while preserving deterministic server/tool order, guarded fetch, headers, abort
+handling, host denylist behavior, and exact cleanup of connected clients.
+
+This branch is intentionally stacked on Phase 0. `main` now contains decision
+0068, while the stacked Phase 0 signoff currently also occupies 0068 on this
+branch. Phase 0 must be renumbered to 0069 during the post-merge rebase, so
+LAT-1 reserves 0070 for this signoff and must not use 0068 or 0069.
+
+## Decision
+Proceed with LAT-1 planning and later implementation as the bounded concurrent
+remote MCP startup phase for the DeepAgents inline lane.
+
+LAT-1 authorizes a red-first contract test for current serial remote MCP startup,
+the smallest production change needed to connect/list remote MCP servers with at
+most four concurrent starts, deterministic final tool order, fail-closed denylist
+and abort handling, header/guarded-fetch preservation, and cleanup of every
+client connected before any failure.
+
+LAT-1 does not authorize checkpoint pool reuse, reusable warm resource pools,
+long-lived MCP clients across turns, Anthropic SDK lane changes, provider
+gateway changes, permission policy changes, storage schema changes, real remote
+MCP network dependency in tests, or changes to Phase 0 measurement fixtures.
+
+## Consequences
+Forge may record the LAT-1 plan and decomposition after the required plan grill.
+Implementation remains limited to the inline DeepAgents remote MCP startup seam
+and focused tests around that seam.
+
+The branch must be rebased after Phase 0 merges so the stacked decision corpus
+contains `0069-client-signoff.md` for LAT-0 and this
+`0070-client-signoff.md` for LAT-1 without collisions.
+
+Every runtime-behavior commit still needs local autoreview before commit. The
+task cannot be PR-ready until automated tests, deterministic verify, one
+three-lens autoreview run, CI, and the checkout-bound KnackLabs runtime smoke
+required for runtime PRs have passed.

--- a/plans/LAT-1-Bounded-Concurrent-Remote-MCP-Startup-Plan.md
+++ b/plans/LAT-1-Bounded-Concurrent-Remote-MCP-Startup-Plan.md
@@ -42,7 +42,17 @@ Non-goals:
 Bounded write scope for implementation:
 
 - `apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts`
+- `apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts`
 - `apps/core/test/unit/adapters/deepagents-inline-lane.test.ts`
+
+Structural amendment after first verification: the initial in-file extraction
+proved `inline-lane/index.ts` at 761 lines against the 720-line architecture
+budget. The canonical architecture gate requires splitting the cohesive helper
+instead of adding a file-size allowlist. The sibling must stay adapter-local to
+the DeepAgents inline-lane directory, must be named only for remote MCP startup,
+and must not become a generic concurrency/config abstraction. In this plan,
+"local" means adapter-local, not physically inside `index.ts`. This amendment is
+behavior-neutral and retains the exact LAT-1 acceptance and security boundaries.
 
 ## Acceptance Criteria
 - With five remote MCP servers in a unit test, at most four `Client.connect`
@@ -66,18 +76,24 @@ Bounded write scope for implementation:
 - No new dependency is added for concurrency limiting.
 
 ## Technical Approach
-Recommendation: keep the limiter local to `inline-lane/index.ts` and run server
-startup tasks with a fixed limit of 4. This is the smallest shape that satisfies
-the approved Phase 1 contract without adding a shared utility for one call site.
+Recommendation: keep the limiter adapter-local to the DeepAgents inline lane and
+run server startup tasks with a fixed limit of 4. The implementation may use the
+small sibling module
+`apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts`
+because the first verification measured `inline-lane/index.ts` at 761 lines
+against the 720-line architecture budget. This is the smallest shape that
+satisfies the approved Phase 1 contract without adding a shared utility for one
+call site.
 
 Implementation outline:
 
-1. Extract the per-server serial body into a small local async helper that returns
-   `{ index, clients, tools }` or no tools for unsupported transports.
+1. Extract the per-server serial body into a small adapter-local async helper
+   that returns `{ index, clients, tools }` or no tools for unsupported
+   transports.
 2. Before each server task starts, preserve the existing checks:
    `signal.throwIfAborted()` and `assertMcpNetworkHostAllowed(...)`.
-3. Start tasks through a tiny local limit runner with concurrency 4. Do not add
-   `p-limit`; there is no existing dependency and this is a single use.
+3. Start tasks through a tiny adapter-local limit runner with concurrency 4. Do
+   not add `p-limit`; there is no existing dependency and this is a single use.
 4. Keep each server's connect and list-tools sequence ordered within that server.
    Concurrency is across servers only.
 5. Collect results by original input index and flatten tools in that order. This
@@ -97,9 +113,13 @@ there is no second production call site in scope.
 - `docs/decisions/0070-client-signoff.md` records accepted LAT-1 client signoff,
   the stacked rebase dependency, the limit-4 startup scope, and the explicit
   non-goals.
-- No new technical decisions beyond the LAT-1 signoff. The implementation uses
-  existing architecture: DeepAgents owns this adapter seam, Gantry owns remote
-  MCP guarded fetch and policy, and no public contract changes.
+- No new technical decisions beyond the LAT-1 signoff. The structural amendment
+  follows the canonical architecture gate's measured `index.ts` line-budget
+  failure and the repo policy to split cohesive helpers instead of adding a
+  file-size allowlist; it adds no generic concurrency/config decision. The
+  implementation uses existing architecture: DeepAgents owns this adapter seam,
+  Gantry owns remote MCP guarded fetch and policy, and no public contract
+  changes.
 
 ## Surface Impact
 | Surface | Status | Reason |
@@ -140,6 +160,7 @@ Stage `LAT-1-IMPLEMENT-CLEANUP`
   code left by the extraction.
 - Write scope:
   - `apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts`
+  - `apps/core/src/adapters/llm/deepagents-langchain/inline-lane/remote-mcp-startup.ts`
   - `apps/core/test/unit/adapters/deepagents-inline-lane.test.ts`
 - Dependencies:
   - `LAT-1-RED-CONTRACT`
@@ -151,7 +172,8 @@ Stage `LAT-1-IMPLEMENT-CLEANUP`
     and rethrows the original setup error.
   - Existing remote MCP tests for filtering, authorization, audit, and close pass.
 - Reviewer focus: no unbounded `Promise.all`, no new dependency, deterministic
-  flattening by input index, no late client leak on reject.
+  flattening by input index, no late client leak on reject, and no extraction
+  outside the adapter-local inline-lane directory.
 
 Stage `LAT-1-VALIDATION-CLOSEOUT`
 
@@ -177,6 +199,11 @@ Stage `LAT-1-VALIDATION-CLOSEOUT`
 - A rejected task can leave later-started clients open if cleanup runs before
   started tasks settle. Mitigation: wait for started work to settle before
   closing tracked clients.
+- If the helper is forced to live physically inside `index.ts`, architecture
+  file-size gates fail again. Mitigation: keep remote MCP startup in the small
+  adapter-local sibling required by the canonical architecture gate after the
+  measured `index.ts` 761-line result exceeded the 720-line budget, and keep
+  generic concurrency/config out of scope.
 - Unbounded concurrency would move latency but create resource and egress spikes.
   Mitigation: fixed limit 4 and a five-server test proving the fifth waits.
 - The branch is stacked on Phase 0. After Phase 0 merges, rebase must preserve

--- a/plans/LAT-1-Bounded-Concurrent-Remote-MCP-Startup-Plan.md
+++ b/plans/LAT-1-Bounded-Concurrent-Remote-MCP-Startup-Plan.md
@@ -1,0 +1,208 @@
+# LAT-1 Bounded Concurrent Remote MCP Startup Plan
+
+## Problem
+The DeepAgents inline lane currently connects and lists configured remote MCP
+servers one at a time in `connectRemoteMcpTools(...)`. For a turn with multiple
+approved remote MCP servers, first visible output waits on the sum of all MCP
+connect/list delays instead of the slowest bounded batch.
+
+The response-latency roadmap explicitly scopes Phase 1 to bounded concurrent
+remote MCP startup on branch `perf/parallel-inline-mcp-startup`. The task is
+runtime behavior, not a broad warm-resource cycle.
+
+Product model: a selected remote MCP source is reviewed per agent, materialized
+for the current turn, connected through Gantry's guarded transport, exposed as
+deterministically ordered LangChain tools, and closed before the turn exits or
+after setup failure.
+
+## Scope / Non-goals
+In scope:
+
+- DeepAgents inline lane remote MCP startup only.
+- A red-first unit contract proving five configured servers start with local
+  concurrency limit 4: the first four starts overlap, the fifth waits, and final
+  tool order still follows configured server/tool order.
+- Preserve guarded fetch, configured headers, SSE vs Streamable HTTP transport
+  selection, host denylist checks, abort checks, reviewed wildcard filtering,
+  authorization before tool invocation, tool activity audit, and close-on-success.
+- On setup failure, wait for already-started work to settle before cleanup, then
+  close every connected client exactly once.
+
+Non-goals:
+
+- Checkpoint pool reuse, reusable warm MCP clients, or any cross-turn resource
+  pool.
+- Anthropic SDK inline lane changes.
+- Spawned DeepAgents runner startup reuse.
+- Provider gateway, permission policy, storage schema, Control API, SDK, CLI, or
+  channel behavior changes.
+- Real remote MCP network dependency in tests.
+- Changes to Phase 0 harness files or optional checkpoint-pool experiments.
+
+Bounded write scope for implementation:
+
+- `apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts`
+- `apps/core/test/unit/adapters/deepagents-inline-lane.test.ts`
+
+## Acceptance Criteria
+- With five remote MCP servers in a unit test, at most four `Client.connect`
+  calls are active at once, and the fifth does not start until one of the first
+  four completes.
+- The concurrency contract fails against the current serial implementation before
+  the production change.
+- Final `createDeepAgent({ tools })` ordering remains deterministic: core tools
+  first, then remote MCP tools grouped by configured server order and per-server
+  `loadMcpTools(...)` order.
+- Guarded fetch and configured headers are still passed to both SSE and
+  Streamable HTTP transports.
+- Denylisted hosts fail before any client is created for that server.
+- Abort before a server starts prevents further startup.
+- If any connect/list/filter step fails, already-started server work settles and
+  every connected client is closed once; no late client leaks after the function
+  rejects.
+- Remote MCP tool execution semantics are unchanged: reviewed wildcard filtering,
+  per-call authorization, attempt/success/failure audit events, and string/JSON
+  result normalization continue to pass existing tests.
+- No new dependency is added for concurrency limiting.
+
+## Technical Approach
+Recommendation: keep the limiter local to `inline-lane/index.ts` and run server
+startup tasks with a fixed limit of 4. This is the smallest shape that satisfies
+the approved Phase 1 contract without adding a shared utility for one call site.
+
+Implementation outline:
+
+1. Extract the per-server serial body into a small local async helper that returns
+   `{ index, clients, tools }` or no tools for unsupported transports.
+2. Before each server task starts, preserve the existing checks:
+   `signal.throwIfAborted()` and `assertMcpNetworkHostAllowed(...)`.
+3. Start tasks through a tiny local limit runner with concurrency 4. Do not add
+   `p-limit`; there is no existing dependency and this is a single use.
+4. Keep each server's connect and list-tools sequence ordered within that server.
+   Concurrency is across servers only.
+5. Collect results by original input index and flatten tools in that order. This
+   preserves deterministic model-visible tool order even when faster servers
+   finish first.
+6. Track all clients created by started tasks. If any task rejects, wait for
+   started tasks to settle before closing connected clients, then rethrow the
+   original failure. This prevents late connections from escaping cleanup.
+7. Keep returned `close()` behavior as one close call per connected client.
+
+Rejected simpler shape: `Promise.all(servers.map(...))` is shorter but unbounded,
+which violates the Phase 1 limit and can create too many simultaneous outbound
+connections. A shared generic concurrency helper is also rejected for now because
+there is no second production call site in scope.
+
+## Decisions
+- `docs/decisions/0070-client-signoff.md` records accepted LAT-1 client signoff,
+  the stacked rebase dependency, the limit-4 startup scope, and the explicit
+  non-goals.
+- No new technical decisions beyond the LAT-1 signoff. The implementation uses
+  existing architecture: DeepAgents owns this adapter seam, Gantry owns remote
+  MCP guarded fetch and policy, and no public contract changes.
+
+## Surface Impact
+| Surface | Status | Reason |
+|---|---|---|
+| Runtime behavior | Changed | DeepAgents inline remote MCP server startup changes from serial to bounded concurrent setup with deterministic output order. |
+| `settings.yaml` | Unchanged by design | No settings keys or deployment knobs are introduced; limit 4 is phase-scoped runtime code. |
+| Postgres/runtime projection | Unchanged by design | Existing selected MCP materialization rows are read as before; no schema or repository behavior changes. |
+| Control API | Unchanged by design | MCP server catalog, selection, and admin APIs keep the same contract. |
+| SDK/contracts | Unchanged by design | No generated SDK or public contract fields change. |
+| CLI | Unchanged by design | No CLI commands or setup flows change. |
+| Gantry MCP tools/admin skill | Unchanged by design | Gantry MCP tool names, request flows, and permission semantics are unchanged. |
+| Channel/provider adapters | Changed | Only the DeepAgents inline provider adapter changes internal startup scheduling; Anthropic SDK and channels are unchanged. |
+| Docs/prompts | Changed | Adds LAT-1 signoff, plan, and decomposition artifacts; no product docs or prompt copy changes. |
+| Audit/events | Read-only/observable | Existing remote MCP tool activity audit remains; startup concurrency adds no new event type. |
+| Tests/verification | Changed | Adds focused unit contracts for concurrency, ordering, cleanup, abort, and existing behavior preservation. |
+
+## Task Decomposition
+Stage `LAT-1-RED-CONTRACT`
+
+- Objective: add the failing unit contract before production edits.
+- Write scope:
+  - `apps/core/test/unit/adapters/deepagents-inline-lane.test.ts`
+- Dependencies: none.
+- Acceptance criteria:
+  - The test configures five HTTP/SSE remote MCP servers.
+  - The mocked `Client.connect` barrier proves four starts are active before the
+    fifth starts and the fifth waits until one completes.
+  - The test asserts deterministic final remote tool ordering by configured
+    server order, not completion order.
+  - Run the focused unit test and record that it fails on the current serial
+    implementation for the concurrency expectation.
+- Reviewer focus: test proves the actual critical path and cannot pass on serial
+  startup by accident.
+
+Stage `LAT-1-IMPLEMENT-CLEANUP`
+
+- Objective: implement bounded concurrent startup and remove any duplicate serial
+  code left by the extraction.
+- Write scope:
+  - `apps/core/src/adapters/llm/deepagents-langchain/inline-lane/index.ts`
+  - `apps/core/test/unit/adapters/deepagents-inline-lane.test.ts`
+- Dependencies:
+  - `LAT-1-RED-CONTRACT`
+- Acceptance criteria:
+  - Limit is exactly 4.
+  - Unsupported transports are skipped without occupying final tool order.
+  - Denylist and abort remain fail-closed before connect.
+  - Failure path waits for started work to settle, closes all connected clients,
+    and rethrows the original setup error.
+  - Existing remote MCP tests for filtering, authorization, audit, and close pass.
+- Reviewer focus: no unbounded `Promise.all`, no new dependency, deterministic
+  flattening by input index, no late client leak on reject.
+
+Stage `LAT-1-VALIDATION-CLOSEOUT`
+
+- Objective: run and record the implementation proof required by the factory.
+- Write scope:
+  - `.factory/tests.json` via `record_test_from_json.py`
+  - no production or test source edits
+- Dependencies:
+  - `LAT-1-IMPLEMENT-CLEANUP`
+- Acceptance criteria:
+  - Focused unit proof passes.
+  - Typecheck/format/architecture checks are either passed or explicitly recorded
+    as blocked with exact command output.
+  - Runtime PR checkout-bound KnackLabs smoke is run before PR-ready, or the
+    blocker is recorded if the environment cannot run it.
+- Reviewer focus: evidence matches the runtime-behavior scope and does not claim
+  skipped heavy gates as passing.
+
+## Risks
+- A naive concurrent implementation can return tools in completion order, making
+  model-visible tool order nondeterministic. Mitigation: retain original index
+  and flatten sorted results.
+- A rejected task can leave later-started clients open if cleanup runs before
+  started tasks settle. Mitigation: wait for started work to settle before
+  closing tracked clients.
+- Unbounded concurrency would move latency but create resource and egress spikes.
+  Mitigation: fixed limit 4 and a five-server test proving the fifth waits.
+- The branch is stacked on Phase 0. After Phase 0 merges, rebase must preserve
+  `0069-client-signoff.md` for LAT-0 and `0070-client-signoff.md` for LAT-1.
+- Full deterministic verify may be heavy because `verify.py` runs structural,
+  typecheck, and `npm test`. Planning does not run it; implementation must record
+  exact blockers if environment limits appear.
+
+## Verify Plan
+During implementation:
+
+```bash
+npm run test:unit -- apps/core/test/unit/adapters/deepagents-inline-lane.test.ts
+npm run test:unit -- apps/core/test/unit/adapters/remote-mcp-provider-proxy.test.ts
+npm run format:check
+npm run typecheck
+npm run check:architecture
+```
+
+Before PR-ready:
+
+```bash
+/opt/homebrew/bin/python3 .agents/scripts/verify.py
+scripts/agent-job-smoke.sh job-knacklabs-lead-maintenance-43527c192a6e --timeout-sec 900
+```
+
+Implementation must record automated test evidence through
+`record_test_from_json.py`. Review remains one branch-wide autoreview pass with
+quality, performance, and security artifacts; no inline or nested review.


### PR DESCRIPTION
This reduces response startup time for agents with multiple remote MCP servers. Remote connections now begin with a fixed concurrency limit instead of serially, while tool order and all existing security checks remain unchanged.

## What changed

- start at most four remote MCP connections concurrently
- preserve configured server order and each server's discovered tool order
- cancel and close connected or in-flight peers when startup fails or the run is aborted
- explicitly settle pending SSE initial connections on cancellation
- preserve graceful cancellation when there is no HTTP/SSE startup work
- retain guarded DNS-pinned fetch, host restrictions, transport headers, authorization, audit, tool filtering, and idempotent shutdown

## Evidence

- deterministic concurrency barrier: first four servers start; the fifth waits
- focused DeepAgents inline-lane tests: 24/24
- canonical Forge verify: passed
- unit: 586 files, 7,656 tests passed
- integration: 13 files, 87 tests passed
- Postgres integration: 44 files, 269 passed, 1 skipped
- Postgres hot path: 4 files, 5 passed
- final three-lens autoreview: clean, confidence 0.88
- exact local and remote Git tree verified equal

The model-key E2E lane is explicitly waived for this PR because the shared key is rate-limited; it is not claimed as passing. The checkout-bound KnackLabs lead-generation smoke will run against this exact branch before merge.

## Performance claim

The deterministic gate proves bounded overlap and ordering rather than relying on flaky wall-clock timing. With three delayed servers, connection/discovery now tracks the slowest bounded batch instead of the sum of serial starts.
