### PR TITLE
fix(channels): prevent multi-agent credential overrides

### DIFF
--- a/apps/core/src/cli/discord.ts
+++ b/apps/core/src/cli/discord.ts
@@ -187,8 +187,7 @@ export async function runDiscordConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
-  const credentialOwnerName =
-    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
+  const credentialOwnerId = requestedAgentId?.trim() || DEFAULT_AGENT_FOLDER;
   p.note(
     [
       'Create or reuse a Discord application and bot.',
@@ -226,11 +225,7 @@ export async function runDiscordConnectCommand(
 
   const botSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: runtimeSecretNameForAgent(
-      'discord',
-      credentialOwnerName,
-      'BOT_TOKEN',
-    ),
+    name: runtimeSecretNameForAgent('discord', credentialOwnerId, 'BOT_TOKEN'),
     value: credentials.botToken,
     actor: 'cli:discord-connect',
     label: 'Discord bot token',
@@ -240,7 +235,7 @@ export async function runDiscordConnectCommand(
     runtimeHome,
     name: runtimeSecretNameForAgent(
       'discord',
-      credentialOwnerName,
+      credentialOwnerId,
       'APPLICATION_ID',
     ),
     value: credentials.applicationId,

--- a/apps/core/src/cli/discord.ts
+++ b/apps/core/src/cli/discord.ts
@@ -31,6 +31,7 @@ import {
 } from '../platform/profile-file-mirror.js';
 import { planRuntimeSecretInput } from './runtime-secret-ref-prompt.js';
 import { providerAccountIdForAgent } from './provider-utils.js';
+import { runtimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
 
 type DiscordChannelChoice =
   | { type: 'selected'; channel: DiscordDiscoveredChannel }
@@ -54,6 +55,7 @@ export async function registerDiscordMainGroup(options: {
   chatJid: string;
   displayName: string;
   agentId?: string;
+  runtimeSecretRefs?: Record<string, string>;
 }): Promise<{ folder: string; groupName: string }> {
   ensureRuntimeLayout(options.runtimeHome);
   const db = await openRuntimeGroupDb(options.runtimeHome);
@@ -86,10 +88,9 @@ export async function registerDiscordMainGroup(options: {
       requiresTrigger: false,
       agentConfig: existingGroup?.agentConfig,
     };
-    await db.setConversationRoute(options.chatJid, route);
     const settings = loadRuntimeSettings(options.runtimeHome);
     const previousSettings = structuredClone(settings);
-    ensureConfiguredConversationBinding(settings, {
+    const binding = ensureConfiguredConversationBinding(settings, {
       agentId: folder,
       agentName: groupName,
       agentFolder: folder,
@@ -98,11 +99,22 @@ export async function registerDiscordMainGroup(options: {
       trigger: route.trigger,
       requiresTrigger: false,
     });
+    if (options.runtimeSecretRefs) {
+      settings.providerAccounts[binding.providerConnectionId] = {
+        ...settings.providerAccounts[binding.providerConnectionId],
+        runtimeSecretRefs: {
+          ...settings.providerAccounts[binding.providerConnectionId]
+            ?.runtimeSecretRefs,
+          ...options.runtimeSecretRefs,
+        },
+      };
+    }
     await writeDesiredRuntimeSettings({
       runtimeHome: options.runtimeHome,
       settings,
       previousSettings,
     });
+    await db.setConversationRoute(options.chatJid, route);
     await new PromptProfileService({
       fileArtifactStore: () => db.getFileArtifactStore(),
       mirrorProfileFile: createProfileFileMirrorWriter(options.runtimeHome),
@@ -175,6 +187,8 @@ export async function runDiscordConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
+  const credentialOwnerName =
+    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
   p.note(
     [
       'Create or reuse a Discord application and bot.',
@@ -212,7 +226,11 @@ export async function runDiscordConnectCommand(
 
   const botSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'DISCORD_BOT_TOKEN',
+    name: runtimeSecretNameForAgent(
+      'discord',
+      credentialOwnerName,
+      'BOT_TOKEN',
+    ),
     value: credentials.botToken,
     actor: 'cli:discord-connect',
     label: 'Discord bot token',
@@ -220,7 +238,11 @@ export async function runDiscordConnectCommand(
   if (!botSecret) return 1;
   const applicationSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'DISCORD_APPLICATION_ID',
+    name: runtimeSecretNameForAgent(
+      'discord',
+      credentialOwnerName,
+      'APPLICATION_ID',
+    ),
     value: credentials.applicationId,
     actor: 'cli:discord-connect',
     label: 'Discord application ID',
@@ -271,6 +293,7 @@ export async function runDiscordConnectCommand(
       }
       return 1;
     }
+    await Promise.all([botSecret.persist(), applicationSecret.persist()]);
     const registered = await registerDiscordMainGroup({
       runtimeHome,
       chatJid: verified.chatJid,
@@ -279,6 +302,10 @@ export async function runDiscordConnectCommand(
         requestedAgentDisplayName ||
         currentSettings.agent.name,
       agentId: requestedAgentId,
+      runtimeSecretRefs: {
+        bot_token: botSecret.ref,
+        application_id: applicationSecret.ref,
+      },
     });
     registeredFolder = registered.folder;
     conversationRouteName = registered.groupName;
@@ -289,7 +316,9 @@ export async function runDiscordConnectCommand(
     );
   }
 
-  await Promise.all([botSecret.persist(), applicationSecret.persist()]);
+  if (channelChoice.type !== 'selected') {
+    await Promise.all([botSecret.persist(), applicationSecret.persist()]);
+  }
   const settings = loadRuntimeSettings(runtimeHome);
   const previousSettings = structuredClone(settings);
   const previousDiscordEnabled = settings.providers.discord?.enabled ?? false;

--- a/apps/core/src/cli/group-helpers.ts
+++ b/apps/core/src/cli/group-helpers.ts
@@ -377,10 +377,11 @@ export async function syncConfiguredConversationBinding(input: {
   displayName: string;
   trigger: string;
   requiresTrigger: boolean;
+  runtimeSecretRefs?: Record<string, string>;
 }): Promise<void> {
   const settings = loadRuntimeSettings(input.runtimeHome);
   const previousSettings = structuredClone(settings);
-  ensureConfiguredConversationBinding(settings, {
+  const binding = ensureConfiguredConversationBinding(settings, {
     agentId: input.agentId,
     agentName: input.agentName,
     agentFolder: input.agentFolder,
@@ -389,6 +390,16 @@ export async function syncConfiguredConversationBinding(input: {
     trigger: input.trigger,
     requiresTrigger: input.requiresTrigger,
   });
+  if (input.runtimeSecretRefs) {
+    settings.providerAccounts[binding.providerConnectionId] = {
+      ...settings.providerAccounts[binding.providerConnectionId],
+      runtimeSecretRefs: {
+        ...settings.providerAccounts[binding.providerConnectionId]
+          ?.runtimeSecretRefs,
+        ...input.runtimeSecretRefs,
+      },
+    };
+  }
   await writeDesiredRuntimeSettings({
     runtimeHome: input.runtimeHome,
     settings,

--- a/apps/core/src/cli/onboarding-config.ts
+++ b/apps/core/src/cli/onboarding-config.ts
@@ -27,7 +27,7 @@ import {
 import { runPostgresMigrations } from '../postgres-migrate.js';
 import { storeRuntimeSecretInput } from './credentials.js';
 import { DEFAULT_AGENT_FOLDER } from './main-agent.js';
-import { slackRuntimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
+import { runtimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
 import {
   readOnboardingState,
   writeOnboardingState,
@@ -306,7 +306,18 @@ function buildOnboardingSettings(input: {
       runtimeSecretRefs: {
         ...(settings.providerAccounts.telegram_default?.runtimeSecretRefs ||
           {}),
-        bot_token: gantryRuntimeSecretRef('TELEGRAM_BOT_TOKEN'),
+        ...(hasTelegramBotToken ||
+        !settings.providerAccounts.telegram_default?.runtimeSecretRefs.bot_token
+          ? {
+              bot_token: gantryRuntimeSecretRef(
+                runtimeSecretNameForAgent(
+                  'telegram',
+                  settings.agent.name,
+                  'BOT_TOKEN',
+                ),
+              ),
+            }
+          : {}),
       },
     };
   }
@@ -329,13 +340,15 @@ function buildOnboardingSettings(input: {
         ...(hasSlackTokens
           ? {
               bot_token: gantryRuntimeSecretRef(
-                slackRuntimeSecretNameForAgent(
+                runtimeSecretNameForAgent(
+                  'slack',
                   settings.agent.name,
                   'BOT_TOKEN',
                 ),
               ),
               app_token: gantryRuntimeSecretRef(
-                slackRuntimeSecretNameForAgent(
+                runtimeSecretNameForAgent(
+                  'slack',
                   settings.agent.name,
                   'APP_TOKEN',
                 ),
@@ -372,7 +385,11 @@ async function storeOnboardingRuntimeSecrets(
   if (input.telegramBotToken?.trim()) {
     await storeRuntimeSecretInput({
       runtimeHome: input.runtimeHome,
-      name: 'TELEGRAM_BOT_TOKEN',
+      name: runtimeSecretNameForAgent(
+        'telegram',
+        runtimeSettings.agent.name,
+        'BOT_TOKEN',
+      ),
       value: input.telegramBotToken.trim(),
       actor: 'cli:onboarding',
       runtimeSettings,
@@ -383,7 +400,8 @@ async function storeOnboardingRuntimeSecrets(
     await Promise.all([
       storeRuntimeSecretInput({
         runtimeHome: input.runtimeHome,
-        name: slackRuntimeSecretNameForAgent(
+        name: runtimeSecretNameForAgent(
+          'slack',
           runtimeSettings.agent.name,
           'BOT_TOKEN',
         ),
@@ -393,7 +411,8 @@ async function storeOnboardingRuntimeSecrets(
       }),
       storeRuntimeSecretInput({
         runtimeHome: input.runtimeHome,
-        name: slackRuntimeSecretNameForAgent(
+        name: runtimeSecretNameForAgent(
+          'slack',
           runtimeSettings.agent.name,
           'APP_TOKEN',
         ),

--- a/apps/core/src/cli/onboarding-config.ts
+++ b/apps/core/src/cli/onboarding-config.ts
@@ -27,6 +27,7 @@ import {
 import { runPostgresMigrations } from '../postgres-migrate.js';
 import { storeRuntimeSecretInput } from './credentials.js';
 import { DEFAULT_AGENT_FOLDER } from './main-agent.js';
+import { runtimeSecretNameForProviderAccount } from '../domain/provider/provider-runtime-secret-keys.js';
 import {
   readOnboardingState,
   writeOnboardingState,
@@ -325,8 +326,20 @@ function buildOnboardingSettings(input: {
       label: settings.providerAccounts.slack_default?.label || 'Slack Default',
       runtimeSecretRefs: {
         ...(settings.providerAccounts.slack_default?.runtimeSecretRefs || {}),
-        bot_token: gantryRuntimeSecretRef('SLACK_BOT_TOKEN'),
-        app_token: gantryRuntimeSecretRef('SLACK_APP_TOKEN'),
+        bot_token: gantryRuntimeSecretRef(
+          runtimeSecretNameForProviderAccount(
+            'slack',
+            'slack_default',
+            'BOT_TOKEN',
+          ),
+        ),
+        app_token: gantryRuntimeSecretRef(
+          runtimeSecretNameForProviderAccount(
+            'slack',
+            'slack_default',
+            'APP_TOKEN',
+          ),
+        ),
       },
     };
   }
@@ -368,14 +381,22 @@ async function storeOnboardingRuntimeSecrets(
     await Promise.all([
       storeRuntimeSecretInput({
         runtimeHome: input.runtimeHome,
-        name: 'SLACK_BOT_TOKEN',
+        name: runtimeSecretNameForProviderAccount(
+          'slack',
+          'slack_default',
+          'BOT_TOKEN',
+        ),
         value: input.slackBotToken.trim(),
         actor: 'cli:onboarding',
         runtimeSettings,
       }),
       storeRuntimeSecretInput({
         runtimeHome: input.runtimeHome,
-        name: 'SLACK_APP_TOKEN',
+        name: runtimeSecretNameForProviderAccount(
+          'slack',
+          'slack_default',
+          'APP_TOKEN',
+        ),
         value: input.slackAppToken.trim(),
         actor: 'cli:onboarding',
         runtimeSettings,

--- a/apps/core/src/cli/onboarding-config.ts
+++ b/apps/core/src/cli/onboarding-config.ts
@@ -326,12 +326,22 @@ function buildOnboardingSettings(input: {
       label: settings.providerAccounts.slack_default?.label || 'Slack Default',
       runtimeSecretRefs: {
         ...(settings.providerAccounts.slack_default?.runtimeSecretRefs || {}),
-        bot_token: gantryRuntimeSecretRef(
-          slackRuntimeSecretNameForAgent(settings.agent.name, 'BOT_TOKEN'),
-        ),
-        app_token: gantryRuntimeSecretRef(
-          slackRuntimeSecretNameForAgent(settings.agent.name, 'APP_TOKEN'),
-        ),
+        ...(hasSlackTokens
+          ? {
+              bot_token: gantryRuntimeSecretRef(
+                slackRuntimeSecretNameForAgent(
+                  settings.agent.name,
+                  'BOT_TOKEN',
+                ),
+              ),
+              app_token: gantryRuntimeSecretRef(
+                slackRuntimeSecretNameForAgent(
+                  settings.agent.name,
+                  'APP_TOKEN',
+                ),
+              ),
+            }
+          : {}),
       },
     };
   }

--- a/apps/core/src/cli/onboarding-config.ts
+++ b/apps/core/src/cli/onboarding-config.ts
@@ -312,7 +312,7 @@ function buildOnboardingSettings(input: {
               bot_token: gantryRuntimeSecretRef(
                 runtimeSecretNameForAgent(
                   'telegram',
-                  settings.agent.name,
+                  DEFAULT_AGENT_FOLDER,
                   'BOT_TOKEN',
                 ),
               ),
@@ -342,14 +342,14 @@ function buildOnboardingSettings(input: {
               bot_token: gantryRuntimeSecretRef(
                 runtimeSecretNameForAgent(
                   'slack',
-                  settings.agent.name,
+                  DEFAULT_AGENT_FOLDER,
                   'BOT_TOKEN',
                 ),
               ),
               app_token: gantryRuntimeSecretRef(
                 runtimeSecretNameForAgent(
                   'slack',
-                  settings.agent.name,
+                  DEFAULT_AGENT_FOLDER,
                   'APP_TOKEN',
                 ),
               ),
@@ -387,7 +387,7 @@ async function storeOnboardingRuntimeSecrets(
       runtimeHome: input.runtimeHome,
       name: runtimeSecretNameForAgent(
         'telegram',
-        runtimeSettings.agent.name,
+        DEFAULT_AGENT_FOLDER,
         'BOT_TOKEN',
       ),
       value: input.telegramBotToken.trim(),
@@ -402,7 +402,7 @@ async function storeOnboardingRuntimeSecrets(
         runtimeHome: input.runtimeHome,
         name: runtimeSecretNameForAgent(
           'slack',
-          runtimeSettings.agent.name,
+          DEFAULT_AGENT_FOLDER,
           'BOT_TOKEN',
         ),
         value: input.slackBotToken.trim(),
@@ -413,7 +413,7 @@ async function storeOnboardingRuntimeSecrets(
         runtimeHome: input.runtimeHome,
         name: runtimeSecretNameForAgent(
           'slack',
-          runtimeSettings.agent.name,
+          DEFAULT_AGENT_FOLDER,
           'APP_TOKEN',
         ),
         value: input.slackAppToken.trim(),

--- a/apps/core/src/cli/onboarding-config.ts
+++ b/apps/core/src/cli/onboarding-config.ts
@@ -27,7 +27,7 @@ import {
 import { runPostgresMigrations } from '../postgres-migrate.js';
 import { storeRuntimeSecretInput } from './credentials.js';
 import { DEFAULT_AGENT_FOLDER } from './main-agent.js';
-import { runtimeSecretNameForProviderAccount } from '../domain/provider/provider-runtime-secret-keys.js';
+import { slackRuntimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
 import {
   readOnboardingState,
   writeOnboardingState,
@@ -327,18 +327,10 @@ function buildOnboardingSettings(input: {
       runtimeSecretRefs: {
         ...(settings.providerAccounts.slack_default?.runtimeSecretRefs || {}),
         bot_token: gantryRuntimeSecretRef(
-          runtimeSecretNameForProviderAccount(
-            'slack',
-            'slack_default',
-            'BOT_TOKEN',
-          ),
+          slackRuntimeSecretNameForAgent(settings.agent.name, 'BOT_TOKEN'),
         ),
         app_token: gantryRuntimeSecretRef(
-          runtimeSecretNameForProviderAccount(
-            'slack',
-            'slack_default',
-            'APP_TOKEN',
-          ),
+          slackRuntimeSecretNameForAgent(settings.agent.name, 'APP_TOKEN'),
         ),
       },
     };
@@ -381,9 +373,8 @@ async function storeOnboardingRuntimeSecrets(
     await Promise.all([
       storeRuntimeSecretInput({
         runtimeHome: input.runtimeHome,
-        name: runtimeSecretNameForProviderAccount(
-          'slack',
-          'slack_default',
+        name: slackRuntimeSecretNameForAgent(
+          runtimeSettings.agent.name,
           'BOT_TOKEN',
         ),
         value: input.slackBotToken.trim(),
@@ -392,9 +383,8 @@ async function storeOnboardingRuntimeSecrets(
       }),
       storeRuntimeSecretInput({
         runtimeHome: input.runtimeHome,
-        name: runtimeSecretNameForProviderAccount(
-          'slack',
-          'slack_default',
+        name: slackRuntimeSecretNameForAgent(
+          runtimeSettings.agent.name,
           'APP_TOKEN',
         ),
         value: input.slackAppToken.trim(),

--- a/apps/core/src/cli/slack.ts
+++ b/apps/core/src/cli/slack.ts
@@ -480,8 +480,7 @@ export async function runSlackConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
-  const credentialOwnerName =
-    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
+  const credentialOwnerId = requestedAgentId?.trim() || DEFAULT_AGENT_FOLDER;
   const env = readEnvFile(envFilePath(runtimeHome));
   p.note(
     [
@@ -537,7 +536,7 @@ export async function runSlackConnectCommand(
 
   const botSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: runtimeSecretNameForAgent('slack', credentialOwnerName, 'BOT_TOKEN'),
+    name: runtimeSecretNameForAgent('slack', credentialOwnerId, 'BOT_TOKEN'),
     value: botTokenInput,
     actor: 'cli:slack-connect',
     label: 'Slack bot token',
@@ -548,7 +547,7 @@ export async function runSlackConnectCommand(
   }
   const appSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: runtimeSecretNameForAgent('slack', credentialOwnerName, 'APP_TOKEN'),
+    name: runtimeSecretNameForAgent('slack', credentialOwnerId, 'APP_TOKEN'),
     value: appTokenInput,
     actor: 'cli:slack-connect',
     label: 'Slack app token',

--- a/apps/core/src/cli/slack.ts
+++ b/apps/core/src/cli/slack.ts
@@ -34,6 +34,7 @@ import {
 } from '../platform/profile-file-mirror.js';
 import { planRuntimeSecretInput } from './runtime-secret-ref-prompt.js';
 import { providerAccountIdForAgent } from './provider-utils.js';
+import { slackRuntimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
 
 export interface SlackTokenValidation {
   ok: boolean;
@@ -375,6 +376,7 @@ export async function registerSlackMainGroup(options: {
   conversationDisplayName?: string;
   approverIds?: string[];
   agentId?: string;
+  runtimeSecretRefs?: Record<string, string>;
 }): Promise<{ folder: string; groupName: string }> {
   ensureRuntimeLayout(options.runtimeHome);
   const db = await openRuntimeGroupDb(options.runtimeHome);
@@ -409,11 +411,9 @@ export async function registerSlackMainGroup(options: {
       requiresTrigger: true,
       agentConfig: existingGroup?.agentConfig,
     };
-    await db.setConversationRoute(options.chatJid, route);
-
     const settings = loadRuntimeSettings(options.runtimeHome);
     const previousSettings = structuredClone(settings);
-    ensureConfiguredConversationBinding(settings, {
+    const binding = ensureConfiguredConversationBinding(settings, {
       agentId: folder,
       agentName: groupName,
       agentFolder: folder,
@@ -423,11 +423,22 @@ export async function registerSlackMainGroup(options: {
       requiresTrigger: true,
       approverIds: options.approverIds,
     });
+    if (options.runtimeSecretRefs) {
+      settings.providerAccounts[binding.providerConnectionId] = {
+        ...settings.providerAccounts[binding.providerConnectionId],
+        runtimeSecretRefs: {
+          ...settings.providerAccounts[binding.providerConnectionId]
+            .runtimeSecretRefs,
+          ...options.runtimeSecretRefs,
+        },
+      };
+    }
     await writeDesiredRuntimeSettings({
       runtimeHome: options.runtimeHome,
       settings,
       previousSettings,
     });
+    await db.setConversationRoute(options.chatJid, route);
 
     await new PromptProfileService({
       fileArtifactStore: () => db.getFileArtifactStore(),
@@ -469,6 +480,8 @@ export async function runSlackConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
+  const credentialOwnerName =
+    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
   const env = readEnvFile(envFilePath(runtimeHome));
   p.note(
     [
@@ -524,7 +537,7 @@ export async function runSlackConnectCommand(
 
   const botSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'SLACK_BOT_TOKEN',
+    name: slackRuntimeSecretNameForAgent(credentialOwnerName, 'BOT_TOKEN'),
     value: botTokenInput,
     actor: 'cli:slack-connect',
     label: 'Slack bot token',
@@ -535,7 +548,7 @@ export async function runSlackConnectCommand(
   }
   const appSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'SLACK_APP_TOKEN',
+    name: slackRuntimeSecretNameForAgent(credentialOwnerName, 'APP_TOKEN'),
     value: appTokenInput,
     actor: 'cli:slack-connect',
     label: 'Slack app token',
@@ -582,6 +595,11 @@ export async function runSlackConnectCommand(
     }
     conversationDisplayName = access.chatTitle || normalizedChatJid;
 
+    // Persist the operator-selected source before settings validation. The
+    // registration write below receives these final refs, so it never falls
+    // back to legacy global env:SLACK_* references.
+    await Promise.all([botSecret.persist(), appSecret.persist()]);
+
     const registered = await registerSlackMainGroup({
       runtimeHome,
       chatJid: normalizedChatJid,
@@ -592,6 +610,10 @@ export async function runSlackConnectCommand(
       conversationDisplayName,
       approverIds,
       agentId: requestedAgentId,
+      runtimeSecretRefs: {
+        bot_token: botSecret.ref,
+        app_token: appSecret.ref,
+      },
     });
     registeredFolder = registered.folder;
     conversationRouteName = registered.groupName;

--- a/apps/core/src/cli/slack.ts
+++ b/apps/core/src/cli/slack.ts
@@ -34,7 +34,7 @@ import {
 } from '../platform/profile-file-mirror.js';
 import { planRuntimeSecretInput } from './runtime-secret-ref-prompt.js';
 import { providerAccountIdForAgent } from './provider-utils.js';
-import { slackRuntimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
+import { runtimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
 
 export interface SlackTokenValidation {
   ok: boolean;
@@ -537,7 +537,7 @@ export async function runSlackConnectCommand(
 
   const botSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: slackRuntimeSecretNameForAgent(credentialOwnerName, 'BOT_TOKEN'),
+    name: runtimeSecretNameForAgent('slack', credentialOwnerName, 'BOT_TOKEN'),
     value: botTokenInput,
     actor: 'cli:slack-connect',
     label: 'Slack bot token',
@@ -548,7 +548,7 @@ export async function runSlackConnectCommand(
   }
   const appSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: slackRuntimeSecretNameForAgent(credentialOwnerName, 'APP_TOKEN'),
+    name: runtimeSecretNameForAgent('slack', credentialOwnerName, 'APP_TOKEN'),
     value: appTokenInput,
     actor: 'cli:slack-connect',
     label: 'Slack app token',

--- a/apps/core/src/cli/slack.ts
+++ b/apps/core/src/cli/slack.ts
@@ -623,7 +623,9 @@ export async function runSlackConnectCommand(
     );
   }
 
-  await Promise.all([botSecret.persist(), appSecret.persist()]);
+  if (!normalizedChatJid) {
+    await Promise.all([botSecret.persist(), appSecret.persist()]);
+  }
   const settings = loadRuntimeSettings(runtimeHome);
   const previousSettings = structuredClone(settings);
   settings.providers.slack.enabled = true;

--- a/apps/core/src/cli/teams.ts
+++ b/apps/core/src/cli/teams.ts
@@ -31,6 +31,7 @@ import {
 } from '../platform/profile-file-mirror.js';
 import { planRuntimeSecretInput } from './runtime-secret-ref-prompt.js';
 import { providerAccountIdForAgent } from './provider-utils.js';
+import { runtimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
 
 type TeamsChannelChoice =
   | { type: 'selected'; channel: TeamsDiscoveredChannel }
@@ -54,6 +55,7 @@ export async function registerTeamsMainGroup(options: {
   chatJid: string;
   displayName: string;
   agentId?: string;
+  runtimeSecretRefs?: Record<string, string>;
 }): Promise<{ folder: string; groupName: string }> {
   ensureRuntimeLayout(options.runtimeHome);
   const db = await openRuntimeGroupDb(options.runtimeHome);
@@ -87,10 +89,9 @@ export async function registerTeamsMainGroup(options: {
       requiresTrigger: false,
       agentConfig: existingGroup?.agentConfig,
     };
-    await db.setConversationRoute(options.chatJid, route);
     const settings = loadRuntimeSettings(options.runtimeHome);
     const previousSettings = structuredClone(settings);
-    ensureConfiguredConversationBinding(settings, {
+    const binding = ensureConfiguredConversationBinding(settings, {
       agentId: folder,
       agentName: groupName,
       agentFolder: folder,
@@ -99,11 +100,22 @@ export async function registerTeamsMainGroup(options: {
       trigger: route.trigger,
       requiresTrigger: false,
     });
+    if (options.runtimeSecretRefs) {
+      settings.providerAccounts[binding.providerConnectionId] = {
+        ...settings.providerAccounts[binding.providerConnectionId],
+        runtimeSecretRefs: {
+          ...settings.providerAccounts[binding.providerConnectionId]
+            ?.runtimeSecretRefs,
+          ...options.runtimeSecretRefs,
+        },
+      };
+    }
     await writeDesiredRuntimeSettings({
       runtimeHome: options.runtimeHome,
       settings,
       previousSettings,
     });
+    await db.setConversationRoute(options.chatJid, route);
 
     await new PromptProfileService({
       fileArtifactStore: () => db.getFileArtifactStore(),
@@ -234,6 +246,8 @@ export async function runTeamsConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
+  const credentialOwnerName =
+    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
   p.note(
     [
       'Create or reuse a Microsoft Entra app for Teams Graph discovery.',
@@ -288,7 +302,7 @@ export async function runTeamsConnectCommand(
 
   const clientIdSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'TEAMS_CLIENT_ID',
+    name: runtimeSecretNameForAgent('teams', credentialOwnerName, 'CLIENT_ID'),
     value: credentials.clientId,
     actor: 'cli:teams-connect',
     label: 'Teams client ID',
@@ -299,7 +313,11 @@ export async function runTeamsConnectCommand(
   }
   const clientSecretRef = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'TEAMS_CLIENT_SECRET',
+    name: runtimeSecretNameForAgent(
+      'teams',
+      credentialOwnerName,
+      'CLIENT_SECRET',
+    ),
     value: credentials.clientSecret,
     actor: 'cli:teams-connect',
     label: 'Teams client secret',
@@ -310,7 +328,7 @@ export async function runTeamsConnectCommand(
   }
   const tenantIdSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'TEAMS_TENANT_ID',
+    name: runtimeSecretNameForAgent('teams', credentialOwnerName, 'TENANT_ID'),
     value: credentials.tenantId,
     actor: 'cli:teams-connect',
     label: 'Teams tenant ID',
@@ -359,6 +377,11 @@ export async function runTeamsConnectCommand(
       if (verified.nextAction) p.log.info(verified.nextAction);
       return 1;
     }
+    await Promise.all([
+      clientIdSecret.persist(),
+      clientSecretRef.persist(),
+      tenantIdSecret.persist(),
+    ]);
     const registered = await registerTeamsMainGroup({
       runtimeHome,
       chatJid: verified.chatJid,
@@ -367,6 +390,11 @@ export async function runTeamsConnectCommand(
         requestedAgentDisplayName ||
         currentSettings.agent.name,
       agentId: requestedAgentId,
+      runtimeSecretRefs: {
+        client_id: clientIdSecret.ref,
+        client_secret: clientSecretRef.ref,
+        tenant_id: tenantIdSecret.ref,
+      },
     });
     registeredFolder = registered.folder;
     conversationRouteName = registered.groupName;
@@ -377,11 +405,13 @@ export async function runTeamsConnectCommand(
     );
   }
 
-  await Promise.all([
-    clientIdSecret.persist(),
-    clientSecretRef.persist(),
-    tenantIdSecret.persist(),
-  ]);
+  if (channelChoice.type !== 'selected') {
+    await Promise.all([
+      clientIdSecret.persist(),
+      clientSecretRef.persist(),
+      tenantIdSecret.persist(),
+    ]);
+  }
   const settings = loadRuntimeSettings(runtimeHome);
   const previousSettings = structuredClone(settings);
   settings.providers.teams.enabled = true;

--- a/apps/core/src/cli/teams.ts
+++ b/apps/core/src/cli/teams.ts
@@ -246,8 +246,7 @@ export async function runTeamsConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
-  const credentialOwnerName =
-    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
+  const credentialOwnerId = requestedAgentId?.trim() || DEFAULT_AGENT_FOLDER;
   p.note(
     [
       'Create or reuse a Microsoft Entra app for Teams Graph discovery.',
@@ -302,7 +301,7 @@ export async function runTeamsConnectCommand(
 
   const clientIdSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: runtimeSecretNameForAgent('teams', credentialOwnerName, 'CLIENT_ID'),
+    name: runtimeSecretNameForAgent('teams', credentialOwnerId, 'CLIENT_ID'),
     value: credentials.clientId,
     actor: 'cli:teams-connect',
     label: 'Teams client ID',
@@ -315,7 +314,7 @@ export async function runTeamsConnectCommand(
     runtimeHome,
     name: runtimeSecretNameForAgent(
       'teams',
-      credentialOwnerName,
+      credentialOwnerId,
       'CLIENT_SECRET',
     ),
     value: credentials.clientSecret,
@@ -328,7 +327,7 @@ export async function runTeamsConnectCommand(
   }
   const tenantIdSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: runtimeSecretNameForAgent('teams', credentialOwnerName, 'TENANT_ID'),
+    name: runtimeSecretNameForAgent('teams', credentialOwnerId, 'TENANT_ID'),
     value: credentials.tenantId,
     actor: 'cli:teams-connect',
     label: 'Teams tenant ID',

--- a/apps/core/src/cli/telegram-connect.ts
+++ b/apps/core/src/cli/telegram-connect.ts
@@ -19,6 +19,7 @@ import {
 } from './telegram.js';
 import { planRuntimeSecretInput } from './runtime-secret-ref-prompt.js';
 import { providerAccountIdForAgent } from './provider-utils.js';
+import { runtimeSecretNameForAgent } from '../domain/provider/provider-runtime-secret-keys.js';
 
 type TelegramChatChoice =
   | {
@@ -194,6 +195,8 @@ export async function runTelegramConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
+  const credentialOwnerName =
+    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
   const env = readTelegramFromRuntimeEnv(runtimeHome);
   p.note(
     [
@@ -221,7 +224,11 @@ export async function runTelegramConnectCommand(
 
   const tokenSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: 'TELEGRAM_BOT_TOKEN',
+    name: runtimeSecretNameForAgent(
+      'telegram',
+      credentialOwnerName,
+      'BOT_TOKEN',
+    ),
     value: tokenInput,
     actor: 'cli:telegram-connect',
     label: 'Telegram bot token',
@@ -267,6 +274,7 @@ export async function runTelegramConnectCommand(
       if (access.nextAction) p.log.info(access.nextAction);
       return 1;
     }
+    await tokenSecret.persist();
 
     const registered = await registerTelegramMainGroup({
       runtimeHome,
@@ -276,6 +284,9 @@ export async function runTelegramConnectCommand(
         requestedAgentDisplayName ||
         currentSettings.agent.name,
       agentId: requestedAgentId,
+      runtimeSecretRefs: {
+        bot_token: tokenSecret.ref,
+      },
     });
     registeredFolder = registered.folder;
     conversationRouteName = registered.groupName;
@@ -285,7 +296,9 @@ export async function runTelegramConnectCommand(
     );
   }
 
-  await tokenSecret.persist();
+  if (!normalizedChatJid) {
+    await tokenSecret.persist();
+  }
   const settings = loadRuntimeSettings(runtimeHome);
   const previousSettings = structuredClone(settings);
   settings.providers.telegram.enabled = true;

--- a/apps/core/src/cli/telegram-connect.ts
+++ b/apps/core/src/cli/telegram-connect.ts
@@ -195,8 +195,7 @@ export async function runTelegramConnectCommand(
 ): Promise<number> {
   ensureRuntimeLayout(runtimeHome);
   const requestedAgentDisplayName = requestedAgentName?.trim();
-  const credentialOwnerName =
-    requestedAgentDisplayName || loadRuntimeSettings(runtimeHome).agent.name;
+  const credentialOwnerId = requestedAgentId?.trim() || DEFAULT_AGENT_FOLDER;
   const env = readTelegramFromRuntimeEnv(runtimeHome);
   p.note(
     [
@@ -224,11 +223,7 @@ export async function runTelegramConnectCommand(
 
   const tokenSecret = await planRuntimeSecretInput({
     runtimeHome,
-    name: runtimeSecretNameForAgent(
-      'telegram',
-      credentialOwnerName,
-      'BOT_TOKEN',
-    ),
+    name: runtimeSecretNameForAgent('telegram', credentialOwnerId, 'BOT_TOKEN'),
     value: tokenInput,
     actor: 'cli:telegram-connect',
     label: 'Telegram bot token',

--- a/apps/core/src/cli/telegram.ts
+++ b/apps/core/src/cli/telegram.ts
@@ -317,6 +317,7 @@ export async function registerTelegramMainGroup(options: {
   chatJid: string;
   displayName: string;
   agentId?: string;
+  runtimeSecretRefs?: Record<string, string>;
 }): Promise<{ folder: string; groupName: string }> {
   ensureRuntimeLayout(options.runtimeHome);
   const db = await openRuntimeGroupDb(options.runtimeHome);
@@ -350,7 +351,6 @@ export async function registerTelegramMainGroup(options: {
       requiresTrigger: false,
       agentConfig: existingGroup?.agentConfig,
     };
-    await db.setConversationRoute(options.chatJid, route);
     await syncConfiguredConversationBinding({
       runtimeHome: options.runtimeHome,
       agentId: folder,
@@ -360,7 +360,9 @@ export async function registerTelegramMainGroup(options: {
       displayName: options.displayName,
       trigger: route.trigger,
       requiresTrigger: false,
+      runtimeSecretRefs: options.runtimeSecretRefs,
     });
+    await db.setConversationRoute(options.chatJid, route);
 
     await new PromptProfileService({
       fileArtifactStore: () => db.getFileArtifactStore(),

--- a/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
+++ b/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
@@ -35,6 +35,21 @@ export function runtimeSecretNameForProviderAccount(
   return `${provider}_${account}_${digest}_${suffix}`.slice(0, 128);
 }
 
+export function slackRuntimeSecretNameForAgent(
+  agentName: string,
+  key: 'BOT_TOKEN' | 'APP_TOKEN',
+): string {
+  const normalized = agentName
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!normalized) {
+    throw new Error('A non-empty Slack agent name is required for credential naming.');
+  }
+  return `${normalized}_SLACK_${key}`;
+}
+
 export function runtimeSecretKeyForEnv(
   providerId: string,
   envKey: string,

--- a/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
+++ b/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
@@ -45,7 +45,9 @@ export function slackRuntimeSecretNameForAgent(
     .replace(/[^A-Z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
   if (!normalized) {
-    throw new Error('A non-empty Slack agent name is required for credential naming.');
+    throw new Error(
+      'A non-empty Slack agent name is required for credential naming.',
+    );
   }
   return `${normalized}_SLACK_${key}`;
 }

--- a/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
+++ b/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
@@ -37,17 +37,17 @@ export function runtimeSecretNameForProviderAccount(
 
 export function runtimeSecretNameForAgent(
   providerId: string,
-  agentName: string,
+  agentId: string,
   key: string,
 ): string {
-  const normalized = agentName
+  const normalized = agentId
     .trim()
     .toUpperCase()
     .replace(/[^A-Z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
   if (!normalized) {
     throw new Error(
-      `A non-empty ${providerId.trim() || 'provider'} agent name is required for credential naming.`,
+      `A non-empty ${providerId.trim() || 'provider'} agent id is required for credential naming.`,
     );
   }
   const provider = providerEnvPrefix(providerId);
@@ -61,7 +61,18 @@ export function runtimeSecretNameForAgent(
       'A non-empty provider and credential key are required for credential naming.',
     );
   }
-  return `${normalized}_${provider}_${suffix}`.slice(0, 128);
+  const digest = sha256Hex(`${providerId}\u0000${agentId}\u0000${key}`)
+    .slice(0, 10)
+    .toUpperCase();
+  const tail = `_${provider}_${digest}_${suffix}`;
+  if (tail.length >= 128) {
+    throw new Error(
+      'Provider and credential key are too long for a runtime secret name.',
+    );
+  }
+  const owner =
+    normalized.slice(0, 128 - tail.length).replace(/_+$/g, '') || 'AGENT';
+  return `${owner}${tail}`;
 }
 
 export function runtimeSecretKeyForEnv(

--- a/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
+++ b/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
@@ -2,7 +2,7 @@ import {
   normalizeRuntimeSecretRefString,
   parseRuntimeSecretRefString,
 } from '../ports/runtime-secret-provider.js';
-import { createHash } from 'node:crypto';
+import { sha256Hex } from '../../shared/stable-hash.js';
 
 /**
  * Produces a stable, provider-account-scoped name for a runtime credential.
@@ -27,17 +27,18 @@ export function runtimeSecretNameForProviderAccount(
     .toUpperCase()
     .replace(/[^A-Z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
-  const digest = createHash('sha256')
-    .update(`${providerId}\u0000${providerAccountId}\u0000${key}`)
-    .digest('hex')
+  const digest = sha256Hex(
+    `${providerId}\u0000${providerAccountId}\u0000${key}`,
+  )
     .slice(0, 10)
     .toUpperCase();
   return `${provider}_${account}_${digest}_${suffix}`.slice(0, 128);
 }
 
-export function slackRuntimeSecretNameForAgent(
+export function runtimeSecretNameForAgent(
+  providerId: string,
   agentName: string,
-  key: 'BOT_TOKEN' | 'APP_TOKEN',
+  key: string,
 ): string {
   const normalized = agentName
     .trim()
@@ -46,10 +47,21 @@ export function slackRuntimeSecretNameForAgent(
     .replace(/^_+|_+$/g, '');
   if (!normalized) {
     throw new Error(
-      'A non-empty Slack agent name is required for credential naming.',
+      `A non-empty ${providerId.trim() || 'provider'} agent name is required for credential naming.`,
     );
   }
-  return `${normalized}_SLACK_${key}`;
+  const provider = providerEnvPrefix(providerId);
+  const suffix = key
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!provider || !suffix) {
+    throw new Error(
+      'A non-empty provider and credential key are required for credential naming.',
+    );
+  }
+  return `${normalized}_${provider}_${suffix}`.slice(0, 128);
 }
 
 export function runtimeSecretKeyForEnv(

--- a/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
+++ b/apps/core/src/domain/provider/provider-runtime-secret-keys.ts
@@ -2,6 +2,38 @@ import {
   normalizeRuntimeSecretRefString,
   parseRuntimeSecretRefString,
 } from '../ports/runtime-secret-provider.js';
+import { createHash } from 'node:crypto';
+
+/**
+ * Produces a stable, provider-account-scoped name for a runtime credential.
+ * The digest prevents two account ids that normalize to the same readable
+ * component from silently sharing a secret.
+ */
+export function runtimeSecretNameForProviderAccount(
+  providerId: string,
+  providerAccountId: string,
+  key: string,
+): string {
+  const provider = providerEnvPrefix(providerId);
+  const account =
+    providerAccountId
+      .trim()
+      .toUpperCase()
+      .replace(/[^A-Z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 72) || 'DEFAULT';
+  const suffix = key
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  const digest = createHash('sha256')
+    .update(`${providerId}\u0000${providerAccountId}\u0000${key}`)
+    .digest('hex')
+    .slice(0, 10)
+    .toUpperCase();
+  return `${provider}_${account}_${digest}_${suffix}`.slice(0, 128);
+}
 
 export function runtimeSecretKeyForEnv(
   providerId: string,

--- a/apps/core/test/unit/cli/discord.test.ts
+++ b/apps/core/test/unit/cli/discord.test.ts
@@ -10,8 +10,29 @@ import {
   loadRuntimeSettings,
   saveRuntimeSettings,
 } from '@core/config/settings/runtime-settings.js';
+import { runtimeSecretNameForAgent } from '@core/domain/provider/provider-runtime-secret-keys.js';
 
 const groupsStore = vi.hoisted(() => new Map<string, any>());
+const defaultDiscordBotSecretName = runtimeSecretNameForAgent(
+  'discord',
+  'main_agent',
+  'BOT_TOKEN',
+);
+const defaultDiscordApplicationSecretName = runtimeSecretNameForAgent(
+  'discord',
+  'main_agent',
+  'APPLICATION_ID',
+);
+const test2DiscordBotSecretName = runtimeSecretNameForAgent(
+  'discord',
+  'test2',
+  'BOT_TOKEN',
+);
+const test2DiscordApplicationSecretName = runtimeSecretNameForAgent(
+  'discord',
+  'test2',
+  'APPLICATION_ID',
+);
 
 vi.mock('@core/cli/runtime-group-db.js', () => ({
   openRuntimeGroupDb: async () => ({
@@ -119,13 +140,13 @@ describe('cli discord helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DEFAULT_AGENT_DISCORD_BOT_TOKEN',
+      name: defaultDiscordBotSecretName,
       value: 'discord-token',
       actor: 'cli:discord-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DEFAULT_AGENT_DISCORD_APPLICATION_ID',
+      name: defaultDiscordApplicationSecretName,
       value: '123456789',
       actor: 'cli:discord-connect',
     });
@@ -137,8 +158,8 @@ describe('cli discord helpers', () => {
     expect(settings.providerAccounts.discord_default).toMatchObject({
       provider: 'discord',
       runtimeSecretRefs: {
-        bot_token: 'gantry-secret:DEFAULT_AGENT_DISCORD_BOT_TOKEN',
-        application_id: 'gantry-secret:DEFAULT_AGENT_DISCORD_APPLICATION_ID',
+        bot_token: `gantry-secret:${defaultDiscordBotSecretName}`,
+        application_id: `gantry-secret:${defaultDiscordApplicationSecretName}`,
       },
     });
   });
@@ -210,8 +231,8 @@ describe('cli discord helpers', () => {
       provider: 'discord',
       label: 'Discord Default',
       runtimeSecretRefs: {
-        bot_token: 'gantry-secret:DEFAULT_AGENT_DISCORD_BOT_TOKEN',
-        application_id: 'gantry-secret:DEFAULT_AGENT_DISCORD_APPLICATION_ID',
+        bot_token: `gantry-secret:${defaultDiscordBotSecretName}`,
+        application_id: `gantry-secret:${defaultDiscordApplicationSecretName}`,
       },
     };
     saveRuntimeSettings(runtimeHome, existingSettings);
@@ -233,7 +254,7 @@ describe('cli discord helpers', () => {
     );
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEST_2_DISCORD_BOT_TOKEN',
+      name: test2DiscordBotSecretName,
       value: 'discord-token',
       actor: 'cli:discord-connect',
     });
@@ -244,8 +265,8 @@ describe('cli discord helpers', () => {
       loadRuntimeSettings(runtimeHome).providerAccounts.discord_test2
         .runtimeSecretRefs,
     ).toEqual({
-      bot_token: 'gantry-secret:TEST_2_DISCORD_BOT_TOKEN',
-      application_id: 'gantry-secret:TEST_2_DISCORD_APPLICATION_ID',
+      bot_token: `gantry-secret:${test2DiscordBotSecretName}`,
+      application_id: `gantry-secret:${test2DiscordApplicationSecretName}`,
     });
   });
 });

--- a/apps/core/test/unit/cli/discord.test.ts
+++ b/apps/core/test/unit/cli/discord.test.ts
@@ -119,13 +119,13 @@ describe('cli discord helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DISCORD_BOT_TOKEN',
+      name: 'DEFAULT_AGENT_DISCORD_BOT_TOKEN',
       value: 'discord-token',
       actor: 'cli:discord-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DISCORD_APPLICATION_ID',
+      name: 'DEFAULT_AGENT_DISCORD_APPLICATION_ID',
       value: '123456789',
       actor: 'cli:discord-connect',
     });
@@ -137,8 +137,8 @@ describe('cli discord helpers', () => {
     expect(settings.providerAccounts.discord_default).toMatchObject({
       provider: 'discord',
       runtimeSecretRefs: {
-        bot_token: 'gantry-secret:DISCORD_BOT_TOKEN',
-        application_id: 'gantry-secret:DISCORD_APPLICATION_ID',
+        bot_token: 'gantry-secret:DEFAULT_AGENT_DISCORD_BOT_TOKEN',
+        application_id: 'gantry-secret:DEFAULT_AGENT_DISCORD_APPLICATION_ID',
       },
     });
   });
@@ -196,12 +196,36 @@ describe('cli discord helpers', () => {
   it('registers a selected Discord channel and enables runtime transport', async () => {
     vi.resetModules();
     const runtimeHome = makeRuntimeHome();
+    const existingSettings = loadRuntimeSettings(runtimeHome);
+    existingSettings.agents.main_agent = {
+      name: 'Default Agent',
+      folder: 'main_agent',
+      bindings: {},
+      sources: { skills: [], mcpServers: [], tools: [] },
+      capabilities: [],
+      accessPreset: 'full',
+    };
+    existingSettings.providerAccounts.discord_default = {
+      agentId: 'main_agent',
+      provider: 'discord',
+      label: 'Discord Default',
+      runtimeSecretRefs: {
+        bot_token: 'gantry-secret:DEFAULT_AGENT_DISCORD_BOT_TOKEN',
+        application_id: 'gantry-secret:DEFAULT_AGENT_DISCORD_APPLICATION_ID',
+      },
+    };
+    saveRuntimeSettings(runtimeHome, existingSettings);
     mockPrompts('dc:1234567890');
     const discovery = fakeDiscordDiscovery();
     const storeRuntimeSecretInput = mockRuntimeSecretStorage();
 
     const { runDiscordConnectCommand } = await import('@core/cli/discord.js');
-    const code = await runDiscordConnectCommand(runtimeHome, discovery);
+    const code = await runDiscordConnectCommand(
+      runtimeHome,
+      discovery,
+      'test2',
+      'Test 2',
+    );
 
     expect(code).toBe(0);
     expect(loadRuntimeSettings(runtimeHome).providers.discord.enabled).toBe(
@@ -209,12 +233,19 @@ describe('cli discord helpers', () => {
     );
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DISCORD_BOT_TOKEN',
+      name: 'TEST_2_DISCORD_BOT_TOKEN',
       value: 'discord-token',
       actor: 'cli:discord-connect',
     });
     expect(groupsStore.get('dc:1234567890')).toEqual(
-      expect.objectContaining({ folder: 'main_agent' }),
+      expect.objectContaining({ folder: 'test2' }),
     );
+    expect(
+      loadRuntimeSettings(runtimeHome).providerAccounts.discord_test2
+        .runtimeSecretRefs,
+    ).toEqual({
+      bot_token: 'gantry-secret:TEST_2_DISCORD_BOT_TOKEN',
+      application_id: 'gantry-secret:TEST_2_DISCORD_APPLICATION_ID',
+    });
   });
 });

--- a/apps/core/test/unit/cli/onboarding-config.test.ts
+++ b/apps/core/test/unit/cli/onboarding-config.test.ts
@@ -151,13 +151,13 @@ describe('persistOnboardingConfig', () => {
     expect(events).toEqual([
       'migrate:custom_schema',
       'loadDesired:custom_schema',
-      'secret:TELEGRAM_BOT_TOKEN:custom_schema',
+      'secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN:custom_schema',
       'write:custom_schema',
     ]);
     expect(settingsWrites).toHaveLength(1);
     expect(settingsWrites[0]?.telegramEnabled).toBe(true);
     expect(settingsWrites[0]?.telegramBotRef).toBe(
-      'gantry-secret:TELEGRAM_BOT_TOKEN',
+      'gantry-secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
     );
     expect(settingsWrites[0]?.previousSchema).toBe('gantry');
     expect(settingsWrites[0]?.agentHarness).toBe('deepagents');
@@ -419,7 +419,7 @@ describe('persistOnboardingConfig', () => {
     expect(events).toEqual(['loadDesired:gantry', 'write:gantry']);
     expect(settingsWrites.at(-1)).toMatchObject({
       telegramEnabled: true,
-      telegramBotRef: 'gantry-secret:TELEGRAM_BOT_TOKEN',
+      telegramBotRef: 'gantry-secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
     });
   });
 

--- a/apps/core/test/unit/cli/onboarding-config.test.ts
+++ b/apps/core/test/unit/cli/onboarding-config.test.ts
@@ -368,15 +368,15 @@ describe('persistOnboardingConfig', () => {
     expect(stableJson(parsedDocument)).toBe(stableJson(storedDocument));
   });
 
-  it('preserves an enabled provider with stored refs when no new token is supplied', async () => {
+  it('preserves the exact stored Slack refs when no new token is supplied', async () => {
     desiredSettings.providers.slack.enabled = true;
     desiredSettings.providerAccounts.slack_default = {
       agentId: 'main_agent',
       provider: 'slack',
       label: 'Slack Default',
       runtimeSecretRefs: {
-        bot_token: 'gantry-secret:SLACK_BOT_TOKEN',
-        app_token: 'gantry-secret:SLACK_APP_TOKEN',
+        bot_token: 'gantry-secret:SLACK_SLACK_DEFAULT_EXISTING_BOT_TOKEN',
+        app_token: 'gantry-secret:SLACK_SLACK_DEFAULT_EXISTING_APP_TOKEN',
       },
     };
     const { persistOnboardingConfig } =
@@ -385,6 +385,7 @@ describe('persistOnboardingConfig', () => {
     await persistOnboardingConfig({
       runtimeHome: '/tmp/gantry',
       primaryProvider: 'slack',
+      hasStoredSlackSecretRefs: true,
       agentHarness: 'auto',
       credentialMode: 'gantry',
       memoryEnabled: true,
@@ -395,8 +396,8 @@ describe('persistOnboardingConfig', () => {
     expect(events).toEqual(['loadDesired:gantry', 'write:gantry']);
     expect(settingsWrites.at(-1)).toMatchObject({
       slackEnabled: true,
-      slackBotRef: 'gantry-secret:SLACK_BOT_TOKEN',
-      slackAppRef: 'gantry-secret:SLACK_APP_TOKEN',
+      slackBotRef: 'gantry-secret:SLACK_SLACK_DEFAULT_EXISTING_BOT_TOKEN',
+      slackAppRef: 'gantry-secret:SLACK_SLACK_DEFAULT_EXISTING_APP_TOKEN',
     });
   });
 

--- a/apps/core/test/unit/cli/onboarding-config.test.ts
+++ b/apps/core/test/unit/cli/onboarding-config.test.ts
@@ -6,8 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createDefaultRuntimeSettings } from '@core/config/settings/runtime-settings-defaults.js';
 import type { RuntimeSettings } from '@core/config/settings/runtime-settings-types.js';
+import { runtimeSecretNameForAgent } from '@core/domain/provider/provider-runtime-secret-keys.js';
 
 const events: string[] = [];
+const defaultTelegramBotSecretName = runtimeSecretNameForAgent(
+  'telegram',
+  'main_agent',
+  'BOT_TOKEN',
+);
 const STALE_SETTINGS_MESSAGE =
   'Settings mutation is based on stale settings; reload latest desired state and retry.';
 const settingsWrites: Array<{
@@ -151,13 +157,13 @@ describe('persistOnboardingConfig', () => {
     expect(events).toEqual([
       'migrate:custom_schema',
       'loadDesired:custom_schema',
-      'secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN:custom_schema',
+      `secret:${defaultTelegramBotSecretName}:custom_schema`,
       'write:custom_schema',
     ]);
     expect(settingsWrites).toHaveLength(1);
     expect(settingsWrites[0]?.telegramEnabled).toBe(true);
     expect(settingsWrites[0]?.telegramBotRef).toBe(
-      'gantry-secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
+      `gantry-secret:${defaultTelegramBotSecretName}`,
     );
     expect(settingsWrites[0]?.previousSchema).toBe('gantry');
     expect(settingsWrites[0]?.agentHarness).toBe('deepagents');
@@ -419,7 +425,7 @@ describe('persistOnboardingConfig', () => {
     expect(events).toEqual(['loadDesired:gantry', 'write:gantry']);
     expect(settingsWrites.at(-1)).toMatchObject({
       telegramEnabled: true,
-      telegramBotRef: 'gantry-secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
+      telegramBotRef: `gantry-secret:${defaultTelegramBotSecretName}`,
     });
   });
 

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -27,8 +27,29 @@ import {
   resolveGroupSelector,
 } from '@core/cli/group-helpers.js';
 import { agentIdForFolder } from '@core/domain/agent/agent-folder-id.js';
+import { runtimeSecretNameForAgent } from '@core/domain/provider/provider-runtime-secret-keys.js';
 
 const groupsStore = vi.hoisted(() => new Map<string, any>());
+const defaultSlackBotSecretName = runtimeSecretNameForAgent(
+  'slack',
+  'main_agent',
+  'BOT_TOKEN',
+);
+const defaultSlackAppSecretName = runtimeSecretNameForAgent(
+  'slack',
+  'main_agent',
+  'APP_TOKEN',
+);
+const recruitingSlackBotSecretName = runtimeSecretNameForAgent(
+  'slack',
+  'recruiting_agent',
+  'BOT_TOKEN',
+);
+const recruitingSlackAppSecretName = runtimeSecretNameForAgent(
+  'slack',
+  'recruiting_agent',
+  'APP_TOKEN',
+);
 const fileArtifacts = vi.hoisted(() => new Map<string, string>());
 const fileArtifactState = vi.hoisted(() => ({ failWrites: false }));
 const fileArtifactStore = vi.hoisted(() => ({
@@ -688,13 +709,13 @@ describe('cli slack helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DEFAULT_AGENT_SLACK_BOT_TOKEN',
+      name: defaultSlackBotSecretName,
       value: 'xoxb-valid-token',
       actor: 'cli:slack-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DEFAULT_AGENT_SLACK_APP_TOKEN',
+      name: defaultSlackAppSecretName,
       value: 'xapp-valid-token',
       actor: 'cli:slack-connect',
     });
@@ -816,8 +837,8 @@ describe('cli slack helpers', () => {
     expect(
       settings.providerAccounts.slack_recruiting_agent.runtimeSecretRefs,
     ).toEqual({
-      bot_token: 'gantry-secret:TEST_SLACK_BOT_TOKEN',
-      app_token: 'gantry-secret:TEST_SLACK_APP_TOKEN',
+      bot_token: `gantry-secret:${recruitingSlackBotSecretName}`,
+      app_token: `gantry-secret:${recruitingSlackAppSecretName}`,
     });
     expect(
       settings.conversations.slack_recruiting_agent_c0123456789.providerAccount,

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -688,13 +688,13 @@ describe('cli slack helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'SLACK_BOT_TOKEN',
+      name: 'DEFAULT_AGENT_SLACK_BOT_TOKEN',
       value: 'xoxb-valid-token',
       actor: 'cli:slack-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'SLACK_APP_TOKEN',
+      name: 'DEFAULT_AGENT_SLACK_APP_TOKEN',
       value: 'xapp-valid-token',
       actor: 'cli:slack-connect',
     });
@@ -812,8 +812,8 @@ describe('cli slack helpers', () => {
     expect(
       settings.providerAccounts.slack_recruiting_agent.runtimeSecretRefs,
     ).toEqual({
-      bot_token: 'gantry-secret:SLACK_BOT_TOKEN',
-      app_token: 'gantry-secret:SLACK_APP_TOKEN',
+      bot_token: 'gantry-secret:DEFAULT_AGENT_SLACK_BOT_TOKEN',
+      app_token: 'gantry-secret:DEFAULT_AGENT_SLACK_APP_TOKEN',
     });
     expect(
       settings.conversations.slack_recruiting_agent_c0123456789.providerAccount,

--- a/apps/core/test/unit/cli/slack.test.ts
+++ b/apps/core/test/unit/cli/slack.test.ts
@@ -802,7 +802,11 @@ describe('cli slack helpers', () => {
     mockRuntimeSecretStorage(runtimeHome);
 
     const { runSlackConnectCommand } = await import('@core/cli/slack.js');
-    const code = await runSlackConnectCommand(runtimeHome);
+    const code = await runSlackConnectCommand(
+      runtimeHome,
+      'recruiting_agent',
+      'Test',
+    );
 
     expect(code).toBe(0);
     const settings = loadRuntimeSettings(runtimeHome);
@@ -812,8 +816,8 @@ describe('cli slack helpers', () => {
     expect(
       settings.providerAccounts.slack_recruiting_agent.runtimeSecretRefs,
     ).toEqual({
-      bot_token: 'gantry-secret:DEFAULT_AGENT_SLACK_BOT_TOKEN',
-      app_token: 'gantry-secret:DEFAULT_AGENT_SLACK_APP_TOKEN',
+      bot_token: 'gantry-secret:TEST_SLACK_BOT_TOKEN',
+      app_token: 'gantry-secret:TEST_SLACK_APP_TOKEN',
     });
     expect(
       settings.conversations.slack_recruiting_agent_c0123456789.providerAccount,

--- a/apps/core/test/unit/cli/teams.test.ts
+++ b/apps/core/test/unit/cli/teams.test.ts
@@ -334,26 +334,51 @@ describe('cli teams helpers', () => {
       })),
     }));
     const storeRuntimeSecretInput = mockRuntimeSecretStorage();
+    const existingSettings = loadRuntimeSettings(runtimeHome);
+    existingSettings.agents.main_agent = {
+      name: 'Default Agent',
+      folder: 'main_agent',
+      bindings: {},
+      sources: { skills: [], mcpServers: [], tools: [] },
+      capabilities: [],
+      accessPreset: 'full',
+    };
+    existingSettings.providerAccounts.teams_default = {
+      agentId: 'main_agent',
+      provider: 'teams',
+      label: 'Teams Default',
+      runtimeSecretRefs: {
+        client_id: 'gantry-secret:DEFAULT_AGENT_TEAMS_CLIENT_ID',
+        client_secret: 'gantry-secret:DEFAULT_AGENT_TEAMS_CLIENT_SECRET',
+        tenant_id: 'gantry-secret:DEFAULT_AGENT_TEAMS_TENANT_ID',
+      },
+    };
+    saveRuntimeSettings(runtimeHome, existingSettings);
 
     const { runTeamsConnectCommand } = await import('@core/cli/teams.js');
-    const code = await runTeamsConnectCommand(runtimeHome);
+    const code = await runTeamsConnectCommand(
+      runtimeHome,
+      undefined,
+      'test2',
+      'Test 2',
+    );
 
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEAMS_CLIENT_ID',
+      name: 'TEST_2_TEAMS_CLIENT_ID',
       value: 'client-id',
       actor: 'cli:teams-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEAMS_CLIENT_SECRET',
+      name: 'TEST_2_TEAMS_CLIENT_SECRET',
       value: 'client-secret',
       actor: 'cli:teams-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEAMS_TENANT_ID',
+      name: 'TEST_2_TEAMS_TENANT_ID',
       value: 'tenant-id',
       actor: 'cli:teams-connect',
     });
@@ -362,14 +387,14 @@ describe('cli teams helpers', () => {
     );
     const settings = loadRuntimeSettings(runtimeHome);
     expect(settings.providers.teams.enabled).toBe(true);
-    expect(settings.providerAccounts.teams_default.runtimeSecretRefs).toEqual({
-      client_id: 'gantry-secret:TEAMS_CLIENT_ID',
-      client_secret: 'gantry-secret:TEAMS_CLIENT_SECRET',
-      tenant_id: 'gantry-secret:TEAMS_TENANT_ID',
+    expect(settings.providerAccounts.teams_test2.runtimeSecretRefs).toEqual({
+      client_id: 'gantry-secret:TEST_2_TEAMS_CLIENT_ID',
+      client_secret: 'gantry-secret:TEST_2_TEAMS_CLIENT_SECRET',
+      tenant_id: 'gantry-secret:TEST_2_TEAMS_TENANT_ID',
     });
     expect(groupsStore.get('teams:19:general@thread.tacv2')).toEqual(
       expect.objectContaining({
-        folder: 'main_agent',
+        folder: 'test2',
       }),
     );
     expect(outro).toHaveBeenCalledWith(

--- a/apps/core/test/unit/cli/teams.test.ts
+++ b/apps/core/test/unit/cli/teams.test.ts
@@ -10,8 +10,24 @@ import {
   loadRuntimeSettings,
   saveRuntimeSettings,
 } from '@core/config/settings/runtime-settings.js';
+import { runtimeSecretNameForAgent } from '@core/domain/provider/provider-runtime-secret-keys.js';
 
 const groupsStore = vi.hoisted(() => new Map<string, any>());
+const test2TeamsClientIdSecretName = runtimeSecretNameForAgent(
+  'teams',
+  'test2',
+  'CLIENT_ID',
+);
+const test2TeamsClientSecretName = runtimeSecretNameForAgent(
+  'teams',
+  'test2',
+  'CLIENT_SECRET',
+);
+const test2TeamsTenantIdSecretName = runtimeSecretNameForAgent(
+  'teams',
+  'test2',
+  'TENANT_ID',
+);
 
 vi.mock('@core/cli/runtime-group-db.js', () => ({
   openRuntimeGroupDb: async () => ({
@@ -366,19 +382,19 @@ describe('cli teams helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEST_2_TEAMS_CLIENT_ID',
+      name: test2TeamsClientIdSecretName,
       value: 'client-id',
       actor: 'cli:teams-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEST_2_TEAMS_CLIENT_SECRET',
+      name: test2TeamsClientSecretName,
       value: 'client-secret',
       actor: 'cli:teams-connect',
     });
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEST_2_TEAMS_TENANT_ID',
+      name: test2TeamsTenantIdSecretName,
       value: 'tenant-id',
       actor: 'cli:teams-connect',
     });
@@ -388,9 +404,9 @@ describe('cli teams helpers', () => {
     const settings = loadRuntimeSettings(runtimeHome);
     expect(settings.providers.teams.enabled).toBe(true);
     expect(settings.providerAccounts.teams_test2.runtimeSecretRefs).toEqual({
-      client_id: 'gantry-secret:TEST_2_TEAMS_CLIENT_ID',
-      client_secret: 'gantry-secret:TEST_2_TEAMS_CLIENT_SECRET',
-      tenant_id: 'gantry-secret:TEST_2_TEAMS_TENANT_ID',
+      client_id: `gantry-secret:${test2TeamsClientIdSecretName}`,
+      client_secret: `gantry-secret:${test2TeamsClientSecretName}`,
+      tenant_id: `gantry-secret:${test2TeamsTenantIdSecretName}`,
     });
     expect(groupsStore.get('teams:19:general@thread.tacv2')).toEqual(
       expect.objectContaining({

--- a/apps/core/test/unit/cli/telegram.test.ts
+++ b/apps/core/test/unit/cli/telegram.test.ts
@@ -543,7 +543,7 @@ describe('cli telegram helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TELEGRAM_BOT_TOKEN',
+      name: 'DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
       value: 'telegram-token',
       actor: 'cli:telegram-connect',
     });
@@ -628,7 +628,7 @@ describe('cli telegram helpers', () => {
     );
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TELEGRAM_BOT_TOKEN',
+      name: 'DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
       value: 'telegram-token',
       actor: 'cli:telegram-connect',
     });
@@ -637,9 +637,31 @@ describe('cli telegram helpers', () => {
   it('telegram connect enables session admin commands for an explicitly entered sender', async () => {
     vi.resetModules();
     const runtimeHome = makeRuntimeHome();
+    const existingSettings = loadRuntimeSettings(runtimeHome);
+    existingSettings.agents.main_agent = {
+      name: 'Default Agent',
+      folder: 'main_agent',
+      bindings: {},
+      sources: { skills: [], mcpServers: [], tools: [] },
+      capabilities: [],
+      accessPreset: 'full',
+    };
+    existingSettings.providerAccounts.telegram_default = {
+      agentId: 'main_agent',
+      provider: 'telegram',
+      label: 'Telegram Default',
+      runtimeSecretRefs: {
+        bot_token: 'gantry-secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
+      },
+    };
+    saveRuntimeSettings(runtimeHome, existingSettings);
     const select = vi.fn(async () => 'tg:-100123');
     const text = vi.fn(async () => '5759865942');
-    mockRuntimeSecretStorage(runtimeHome);
+    const storeRuntimeSecretInput = mockRuntimeSecretStorage(runtimeHome);
+    const registerTelegramMainGroup = vi.fn(async () => ({
+      groupName: 'Test 2',
+      folder: 'test2',
+    }));
 
     vi.doMock('@clack/prompts', () => ({
       isCancel: () => false,
@@ -678,10 +700,7 @@ describe('cli telegram helpers', () => {
         return trimmed.startsWith('tg:') ? trimmed : `tg:${trimmed}`;
       }),
       readTelegramFromRuntimeEnv: vi.fn(() => ({ token: '' })),
-      registerTelegramMainGroup: vi.fn(async () => ({
-        groupName: 'Default Agent',
-        folder: 'main_agent',
-      })),
+      registerTelegramMainGroup,
       validateTelegramBotToken: vi.fn(async () => ({
         ok: true,
         message: 'ok',
@@ -696,13 +715,31 @@ describe('cli telegram helpers', () => {
 
     const { runTelegramConnectCommand } =
       await import('@core/cli/telegram-connect.js');
-    const code = await runTelegramConnectCommand(runtimeHome);
+    const code = await runTelegramConnectCommand(
+      runtimeHome,
+      'test2',
+      'Test 2',
+    );
 
     expect(code).toBe(0);
+    expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
+      runtimeHome,
+      name: 'TEST_2_TELEGRAM_BOT_TOKEN',
+      value: 'telegram-token',
+      actor: 'cli:telegram-connect',
+    });
+    expect(registerTelegramMainGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'test2',
+        runtimeSecretRefs: {
+          bot_token: 'gantry-secret:TEST_2_TELEGRAM_BOT_TOKEN',
+        },
+      }),
+    );
     const settings = loadRuntimeSettings(runtimeHome);
     expect(settings.providers.telegram.enabled).toBe(true);
     const conversation = Object.values(settings.conversations).find(
-      (entry) => entry.providerConnection === 'telegram_default',
+      (entry) => entry.providerConnection === 'telegram_test2',
     );
     expect(conversation?.senderPolicy.allow).toBe('*');
     expect(conversation?.controlApprovers).toEqual(['5759865942']);

--- a/apps/core/test/unit/cli/telegram.test.ts
+++ b/apps/core/test/unit/cli/telegram.test.ts
@@ -19,8 +19,19 @@ import {
 import { listTelegramRecentChats } from '@core/cli/telegram-chat-discovery.js';
 import { makeAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
 import { resolveGroupSelector } from '@core/cli/group-helpers.js';
+import { runtimeSecretNameForAgent } from '@core/domain/provider/provider-runtime-secret-keys.js';
 
 const groupsStore = vi.hoisted(() => new Map<string, any>());
+const defaultTelegramBotSecretName = runtimeSecretNameForAgent(
+  'telegram',
+  'main_agent',
+  'BOT_TOKEN',
+);
+const test2TelegramBotSecretName = runtimeSecretNameForAgent(
+  'telegram',
+  'test2',
+  'BOT_TOKEN',
+);
 const fileArtifacts = vi.hoisted(() => new Map<string, string>());
 const fileArtifactStore = vi.hoisted(() => ({
   async listFileArtifacts(input: any) {
@@ -543,7 +554,7 @@ describe('cli telegram helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
+      name: defaultTelegramBotSecretName,
       value: 'telegram-token',
       actor: 'cli:telegram-connect',
     });
@@ -628,7 +639,7 @@ describe('cli telegram helpers', () => {
     );
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
+      name: defaultTelegramBotSecretName,
       value: 'telegram-token',
       actor: 'cli:telegram-connect',
     });
@@ -651,7 +662,7 @@ describe('cli telegram helpers', () => {
       provider: 'telegram',
       label: 'Telegram Default',
       runtimeSecretRefs: {
-        bot_token: 'gantry-secret:DEFAULT_AGENT_TELEGRAM_BOT_TOKEN',
+        bot_token: `gantry-secret:${defaultTelegramBotSecretName}`,
       },
     };
     saveRuntimeSettings(runtimeHome, existingSettings);
@@ -724,7 +735,7 @@ describe('cli telegram helpers', () => {
     expect(code).toBe(0);
     expect(storeRuntimeSecretInput).toHaveBeenCalledWith({
       runtimeHome,
-      name: 'TEST_2_TELEGRAM_BOT_TOKEN',
+      name: test2TelegramBotSecretName,
       value: 'telegram-token',
       actor: 'cli:telegram-connect',
     });
@@ -732,7 +743,7 @@ describe('cli telegram helpers', () => {
       expect.objectContaining({
         agentId: 'test2',
         runtimeSecretRefs: {
-          bot_token: 'gantry-secret:TEST_2_TELEGRAM_BOT_TOKEN',
+          bot_token: `gantry-secret:${test2TelegramBotSecretName}`,
         },
       }),
     );

--- a/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
+++ b/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { runtimeSecretNameForProviderAccount } from '@core/domain/provider/provider-runtime-secret-keys.js';
+
+describe('runtimeSecretNameForProviderAccount', () => {
+  it('is stable, readable, and account-scoped', () => {
+    expect(
+      runtimeSecretNameForProviderAccount(
+        'slack',
+        'slack_default',
+        'BOT_TOKEN',
+      ),
+    ).toMatch(/^SLACK_SLACK_DEFAULT_[A-F0-9]{10}_BOT_TOKEN$/);
+    expect(
+      runtimeSecretNameForProviderAccount(
+        'slack',
+        'slack_default',
+        'BOT_TOKEN',
+      ),
+    ).toBe(
+      runtimeSecretNameForProviderAccount(
+        'slack',
+        'slack_default',
+        'BOT_TOKEN',
+      ),
+    );
+  });
+
+  it('does not collide when account ids normalize to the same readable form', () => {
+    expect(
+      runtimeSecretNameForProviderAccount('slack', 'team/a', 'BOT_TOKEN'),
+    ).not.toBe(
+      runtimeSecretNameForProviderAccount('slack', 'team_a', 'BOT_TOKEN'),
+    );
+  });
+});

--- a/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
+++ b/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
@@ -38,24 +38,36 @@ describe('runtimeSecretNameForProviderAccount', () => {
     );
   });
 
-  it('uses the agent display name for Slack credential names', () => {
-    expect(runtimeSecretNameForAgent('slack', 'Test', 'BOT_TOKEN')).toBe(
-      'TEST_SLACK_BOT_TOKEN',
-    );
-    expect(runtimeSecretNameForAgent('slack', 'Test', 'APP_TOKEN')).toBe(
-      'TEST_SLACK_APP_TOKEN',
-    );
+  it('uses the stable agent id for readable Slack credential names', () => {
+    expect(
+      runtimeSecretNameForAgent('slack', 'recruiting_agent', 'BOT_TOKEN'),
+    ).toMatch(/^RECRUITING_AGENT_SLACK_[A-F0-9]{10}_BOT_TOKEN$/);
+    expect(
+      runtimeSecretNameForAgent('slack', 'recruiting_agent', 'APP_TOKEN'),
+    ).toMatch(/^RECRUITING_AGENT_SLACK_[A-F0-9]{10}_APP_TOKEN$/);
   });
 
   it('creates isolated credential names for every channel provider', () => {
-    expect(runtimeSecretNameForAgent('telegram', 'Test 2', 'BOT_TOKEN')).toBe(
-      'TEST_2_TELEGRAM_BOT_TOKEN',
+    expect(runtimeSecretNameForAgent('telegram', 'test2', 'BOT_TOKEN')).toMatch(
+      /^TEST2_TELEGRAM_[A-F0-9]{10}_BOT_TOKEN$/,
     );
     expect(
-      runtimeSecretNameForAgent('discord', 'Test 2', 'APPLICATION_ID'),
-    ).toBe('TEST_2_DISCORD_APPLICATION_ID');
-    expect(runtimeSecretNameForAgent('teams', 'Test 2', 'CLIENT_SECRET')).toBe(
-      'TEST_2_TEAMS_CLIENT_SECRET',
+      runtimeSecretNameForAgent('discord', 'test2', 'APPLICATION_ID'),
+    ).toMatch(/^TEST2_DISCORD_[A-F0-9]{10}_APPLICATION_ID$/);
+    expect(
+      runtimeSecretNameForAgent('teams', 'test2', 'CLIENT_SECRET'),
+    ).toMatch(/^TEST2_TEAMS_[A-F0-9]{10}_CLIENT_SECRET$/);
+  });
+
+  it('does not collide for distinct agent ids with the same readable form', () => {
+    expect(runtimeSecretNameForAgent('slack', 'ops-a', 'BOT_TOKEN')).not.toBe(
+      runtimeSecretNameForAgent('slack', 'ops_a', 'BOT_TOKEN'),
+    );
+  });
+
+  it('does not collide when duplicate display names receive suffixed ids', () => {
+    expect(runtimeSecretNameForAgent('slack', 'test', 'BOT_TOKEN')).not.toBe(
+      runtimeSecretNameForAgent('slack', 'test_2', 'BOT_TOKEN'),
     );
   });
 

--- a/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
+++ b/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  isProviderRuntimeSecretRefTarget,
+  runtimeSecretNameForAgent,
   runtimeSecretNameForProviderAccount,
-  slackRuntimeSecretNameForAgent,
 } from '@core/domain/provider/provider-runtime-secret-keys.js';
 
 describe('runtimeSecretNameForProviderAccount', () => {
@@ -38,11 +39,47 @@ describe('runtimeSecretNameForProviderAccount', () => {
   });
 
   it('uses the agent display name for Slack credential names', () => {
-    expect(slackRuntimeSecretNameForAgent('Test', 'BOT_TOKEN')).toBe(
+    expect(runtimeSecretNameForAgent('slack', 'Test', 'BOT_TOKEN')).toBe(
       'TEST_SLACK_BOT_TOKEN',
     );
-    expect(slackRuntimeSecretNameForAgent('Test', 'APP_TOKEN')).toBe(
+    expect(runtimeSecretNameForAgent('slack', 'Test', 'APP_TOKEN')).toBe(
       'TEST_SLACK_APP_TOKEN',
     );
+  });
+
+  it('creates isolated credential names for every channel provider', () => {
+    expect(runtimeSecretNameForAgent('telegram', 'Test 2', 'BOT_TOKEN')).toBe(
+      'TEST_2_TELEGRAM_BOT_TOKEN',
+    );
+    expect(
+      runtimeSecretNameForAgent('discord', 'Test 2', 'APPLICATION_ID'),
+    ).toBe('TEST_2_DISCORD_APPLICATION_ID');
+    expect(runtimeSecretNameForAgent('teams', 'Test 2', 'CLIENT_SECRET')).toBe(
+      'TEST_2_TEAMS_CLIENT_SECRET',
+    );
+  });
+
+  it('accepts agent-scoped Gantry, env, and AWS secret references', () => {
+    expect(
+      isProviderRuntimeSecretRefTarget(
+        'telegram',
+        'bot_token',
+        'gantry-secret:TEST2_TELEGRAM_BOT_TOKEN',
+      ),
+    ).toBe(true);
+    expect(
+      isProviderRuntimeSecretRefTarget(
+        'discord',
+        'bot_token',
+        'env:TEST2_DISCORD_BOT_TOKEN',
+      ),
+    ).toBe(true);
+    expect(
+      isProviderRuntimeSecretRefTarget(
+        'teams',
+        'client_secret',
+        'aws-sm:production/gantry/test2/teams-client-secret',
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
+++ b/apps/core/test/unit/domain/provider-runtime-secret-keys.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { runtimeSecretNameForProviderAccount } from '@core/domain/provider/provider-runtime-secret-keys.js';
+import {
+  runtimeSecretNameForProviderAccount,
+  slackRuntimeSecretNameForAgent,
+} from '@core/domain/provider/provider-runtime-secret-keys.js';
 
 describe('runtimeSecretNameForProviderAccount', () => {
   it('is stable, readable, and account-scoped', () => {
@@ -31,6 +34,15 @@ describe('runtimeSecretNameForProviderAccount', () => {
       runtimeSecretNameForProviderAccount('slack', 'team/a', 'BOT_TOKEN'),
     ).not.toBe(
       runtimeSecretNameForProviderAccount('slack', 'team_a', 'BOT_TOKEN'),
+    );
+  });
+
+  it('uses the agent display name for Slack credential names', () => {
+    expect(slackRuntimeSecretNameForAgent('Test', 'BOT_TOKEN')).toBe(
+      'TEST_SLACK_BOT_TOKEN',
+    );
+    expect(slackRuntimeSecretNameForAgent('Test', 'APP_TOKEN')).toBe(
+      'TEST_SLACK_APP_TOKEN',
     );
   });
 });


### PR DESCRIPTION
## Goal

Allow multiple Gantry agents to connect separate Slack, Telegram, Discord, or Teams apps without one agent overwriting another agent's credentials.

## Why

Channel onboarding reused provider-global secret names, and some registration paths validated settings before binding the newly selected secret references. As a result, adding a second agent could overwrite the first agent's stored tokens or incorrectly demand global `.env` values even after **Store in Gantry** was selected.

## What changed

- Derive stable, agent-scoped credential names such as `TEST2_SLACK_BOT_TOKEN` and `TEST2_SLACK_APP_TOKEN`.
- Bind final runtime secret references before settings validation and conversation registration.
- Preserve existing stored references during maintenance setup.
- Avoid duplicate credential persistence.
- Keep `gantry-secret:`, `env:`, and `aws-sm:` references supported.
- Apply the credential-isolation behavior consistently to Slack, Telegram, Discord, and Teams.
- Add regression coverage for multi-agent credential naming and channel setup.

## Impact

Each agent/provider account can own independent channel credentials. Connecting a second bot no longer replaces the first bot's credentials or incorrectly falls back to provider-global environment variables.

## Verification

Passed locally:

- `npm ci`
- `npm run format:check`
- `npm run check:architecture`
- `npm run typecheck`
- `npm run build`
- `npm run security:package`
- `npm run --silent security:sbom`
- Unit suite: 7,722 tests passed
- Non-Postgres integration suite: 87 passed, 362 skipped by suite design
- End-to-end suite: 5 passed
- Postgres E2E: 26 passed
- Postgres integration: 272 passed, 1 skipped
- Postgres chaos: 1 passed
- Docker runtime image build
- Runtime image security gate
- Trivy HIGH/CRITICAL image scan: 0 findings

Local macOS hermetic agent E2E reached the job-lifecycle scenario but its fake Anthropic SDK returned no messages; the same result reproduced twice and does not touch the files changed here. The draft remains gated on the repository's Linux GitHub Actions result.
