### PR TITLE
feat(setup): add conversations to an existing agent

### DIFF
--- a/apps/core/src/cli/index.ts
+++ b/apps/core/src/cli/index.ts
@@ -362,6 +362,10 @@ async function runSetupCommand(
           label: 'Add another agent',
         },
         {
+          value: 'add_conversation',
+          label: 'Add conversation to existing agent',
+        },
+        {
           value: 'channel',
           label: 'Chat channel',
         },
@@ -399,6 +403,11 @@ async function runSetupCommand(
       const { runAddAgentSetupSlice } =
         await import('./setup-flow-core-steps.js');
       return runAddAgentSetupSlice(runtimeHome);
+    }
+    if (choice === 'add_conversation') {
+      const { runAddConversationSetupSlice } =
+        await import('./setup-add-conversation.js');
+      return runAddConversationSetupSlice(runtimeHome);
     }
     startStep = choice as OnboardingStep;
     const nextState = createInitialState(runtimeHome);

--- a/apps/core/src/cli/index.ts
+++ b/apps/core/src/cli/index.ts
@@ -406,7 +406,7 @@ async function runSetupCommand(
     }
     if (choice === 'add_conversation') {
       const { runAddConversationSetupSlice } =
-        await import('./setup-add-conversation.js');
+        await import('./setup-flow-core-steps.js');
       return runAddConversationSetupSlice(runtimeHome);
     }
     startStep = choice as OnboardingStep;

--- a/apps/core/src/cli/setup-add-conversation.ts
+++ b/apps/core/src/cli/setup-add-conversation.ts
@@ -1,0 +1,460 @@
+import * as p from '@clack/prompts';
+
+import { RuntimeSecretConversationDiscovery } from '../channels/control-provider-catalog.js';
+import { RuntimeSecretConversationMembershipValidator } from '../channels/conversation-membership-validation.js';
+import {
+  getProvider,
+  listConnectableChannelProviders,
+  providerJidPrefix,
+} from '../channels/provider-registry.js';
+import {
+  applyConversationInstallToSettings,
+  hasConversationInstallInSettings,
+} from '../config/settings/conversation-install-settings.js';
+import {
+  loadDesiredRuntimeSettingsForWrite,
+  noteRestartRequired,
+  writeDesiredRuntimeSettings,
+} from '../config/settings/runtime-settings.js';
+import type {
+  RuntimeProviderAccountSettings,
+  RuntimeSettings,
+} from '../config/settings/runtime-settings-types.js';
+import type { Conversation } from '../domain/conversation/conversation.js';
+import type { ProviderAccount } from '../domain/provider/provider.js';
+import type { ChatAllowlistEntry } from '../config/settings/sender-allowlist.js';
+import { openRuntimeGroupDb } from './runtime-group-db.js';
+
+type MemoryScope = 'conversation' | 'user' | 'agent' | 'app';
+
+interface ConversationChoice {
+  externalId: string;
+  title: string;
+  kind: Conversation['kind'];
+}
+
+function normalizeConversationExternalId(
+  providerId: string,
+  raw: string,
+): string {
+  const value = raw.trim();
+  const prefix = providerJidPrefix(providerId);
+  return prefix && value.startsWith(prefix)
+    ? value.slice(prefix.length)
+    : value;
+}
+
+function conversationKindForManualId(
+  providerId: string,
+  externalId: string,
+): Conversation['kind'] {
+  if (providerId === 'slack' && externalId.toUpperCase().startsWith('D')) {
+    return 'direct';
+  }
+  if (providerId === 'telegram' && !externalId.startsWith('-')) {
+    return 'direct';
+  }
+  return 'channel';
+}
+
+function configuredProviderAccount(input: {
+  id: string;
+  settings: RuntimeProviderAccountSettings;
+  now: string;
+}): ProviderAccount {
+  return {
+    id: input.id as never,
+    appId: 'default' as never,
+    agentId: input.settings.agentId as never,
+    providerId: input.settings.provider as never,
+    label: input.settings.label,
+    status: input.settings.status ?? 'active',
+    config: input.settings.config ?? {},
+    runtimeSecretRefs: input.settings.runtimeSecretRefs,
+    ...(input.settings.externalIdentityRef
+      ? {
+          externalIdentityRef: input.settings.externalIdentityRef as never,
+        }
+      : {}),
+    createdAt: input.now as never,
+    updatedAt: input.now as never,
+  };
+}
+
+function transientConversation(input: {
+  providerAccountId: string;
+  choice: ConversationChoice;
+  now: string;
+}): Conversation {
+  return {
+    id: `conversation:${input.providerAccountId}:${input.choice.externalId}` as never,
+    appId: 'default' as never,
+    providerAccountId: input.providerAccountId as never,
+    externalRef: {
+      kind: 'conversation',
+      value: input.choice.externalId,
+    } as never,
+    kind: input.choice.kind,
+    title: input.choice.title,
+    status: 'active',
+    createdAt: input.now as never,
+    updatedAt: input.now as never,
+  };
+}
+
+function parseCsv(value: unknown): string[] {
+  return [
+    ...new Set(
+      String(value ?? '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+async function chooseAgent(settings: RuntimeSettings): Promise<string | null> {
+  const agentIds = Object.keys(settings.agents).sort();
+  if (agentIds.length === 0) {
+    p.log.error('No existing agents are configured.');
+    return null;
+  }
+  const selected = await p.select({
+    message: 'Choose an existing agent',
+    options: [
+      ...agentIds.map((agentId) => ({
+        value: agentId,
+        label: `${settings.agents[agentId]!.name} (${agentId})`,
+      })),
+      { value: '__manual', label: 'Enter agent ID manually' },
+      { value: '__cancel', label: 'Cancel' },
+    ],
+  });
+  if (p.isCancel(selected) || selected === '__cancel') return null;
+  if (selected !== '__manual') return String(selected);
+  const manual = await p.text({
+    message: 'Existing agent ID',
+    validate: (value) =>
+      settings.agents[String(value ?? '').trim()]
+        ? undefined
+        : 'Agent not found. Choose an agent that already exists; this flow does not create agents.',
+  });
+  if (p.isCancel(manual)) return null;
+  return String(manual).trim();
+}
+
+function providerAccountOptions(settings: RuntimeSettings, agentId: string) {
+  const connectable = new Set(
+    listConnectableChannelProviders().map((provider) => provider.id),
+  );
+  return Object.entries(settings.providerAccounts)
+    .filter(
+      ([, account]) =>
+        account.agentId === agentId &&
+        account.status !== 'disabled' &&
+        settings.providers[account.provider]?.enabled === true &&
+        connectable.has(account.provider) &&
+        Object.keys(account.runtimeSecretRefs).length > 0,
+    )
+    .sort(([left], [right]) => left.localeCompare(right));
+}
+
+async function chooseProviderAccount(
+  settings: RuntimeSettings,
+  agentId: string,
+): Promise<[string, RuntimeProviderAccountSettings] | null> {
+  const accounts = providerAccountOptions(settings, agentId);
+  if (accounts.length === 0) {
+    p.log.error(
+      `No provider accounts are installed for this agent. Run gantry provider connect <provider> --agent ${agentId} first.`,
+    );
+    return null;
+  }
+  const selected = await p.select({
+    message: 'Choose the Provider Account to reuse',
+    options: [
+      ...accounts.map(([id, account]) => ({
+        value: id,
+        label: `${account.label} (${account.provider}, ${id})`,
+      })),
+      { value: '__cancel', label: 'Cancel' },
+    ],
+  });
+  if (p.isCancel(selected) || selected === '__cancel') return null;
+  const id = String(selected);
+  return [id, settings.providerAccounts[id]!];
+}
+
+async function chooseConversation(input: {
+  providerAccount: ProviderAccount;
+  discovery: RuntimeSecretConversationDiscovery;
+}): Promise<ConversationChoice | null> {
+  const spinner = p.spinner();
+  spinner.start(
+    'Looking for conversations this provider account can access...',
+  );
+  let discovered: Awaited<
+    ReturnType<RuntimeSecretConversationDiscovery['discover']>
+  > = [];
+  try {
+    discovered = await input.discovery.discover({
+      providerAccount: input.providerAccount,
+      limit: 100,
+    });
+    spinner.stop(`Found ${discovered.length} conversation(s).`);
+  } catch (error) {
+    spinner.stop('Conversation discovery was unavailable.');
+    p.log.warn(error instanceof Error ? error.message : String(error));
+  }
+
+  const selected = await p.select({
+    message: 'Choose a conversation to install',
+    options: [
+      ...discovered.slice(0, 100).map((conversation) => ({
+        value: conversation.externalId,
+        label: `${conversation.title || conversation.externalId} (${conversation.externalId})`,
+        hint: conversation.kind,
+      })),
+      { value: '__manual', label: 'Enter conversation ID manually' },
+      { value: '__cancel', label: 'Cancel' },
+    ],
+  });
+  if (p.isCancel(selected) || selected === '__cancel') return null;
+  if (selected !== '__manual') {
+    const match = discovered.find(
+      (conversation) => conversation.externalId === selected,
+    )!;
+    return {
+      externalId: match.externalId,
+      title: match.title || match.externalId,
+      kind: match.kind,
+    };
+  }
+
+  const providerId = String(input.providerAccount.providerId);
+  const provider = getProvider(providerId);
+  const manual = await p.text({
+    message: `${provider?.label || providerId} conversation ID`,
+    validate: (value) =>
+      String(value ?? '').trim() ? undefined : 'Conversation ID is required.',
+  });
+  if (p.isCancel(manual)) return null;
+  const externalId = normalizeConversationExternalId(
+    providerId,
+    String(manual),
+  );
+  return {
+    externalId,
+    title: externalId,
+    kind: conversationKindForManualId(providerId, externalId),
+  };
+}
+
+async function promptSenderPolicy(): Promise<ChatAllowlistEntry | null> {
+  const selected = await p.select({
+    message: 'Sender policy',
+    options: [
+      {
+        value: 'all',
+        label: 'Allow all senders (Recommended)',
+      },
+      {
+        value: 'listed',
+        label: 'Only listed senders',
+      },
+      { value: '__cancel', label: 'Cancel' },
+    ],
+  });
+  if (p.isCancel(selected) || selected === '__cancel') return null;
+  if (selected === 'all') return { allow: '*', mode: 'trigger' };
+  const allow = await p.text({
+    message: 'Allowed sender user IDs (comma-separated)',
+    validate: (value) =>
+      parseCsv(value).length > 0 ? undefined : 'Enter at least one sender ID.',
+  });
+  if (p.isCancel(allow)) return null;
+  return { allow: parseCsv(allow), mode: 'drop' };
+}
+
+export async function runAddConversationSetupSlice(
+  runtimeHome: string,
+): Promise<number> {
+  p.note(
+    'Reuse an existing agent and Provider Account. This flow will not ask for or overwrite credentials.',
+    'Add conversation to existing agent',
+  );
+  const settings = await loadDesiredRuntimeSettingsForWrite({ runtimeHome });
+  const agentId = await chooseAgent(settings);
+  if (!agentId) return 1;
+  const accountChoice = await chooseProviderAccount(settings, agentId);
+  if (!accountChoice) return 1;
+  const [providerAccountId, accountSettings] = accountChoice;
+  p.log.info(
+    'Credentials: reused from this Provider Account; no secret will be changed.',
+  );
+
+  const now = new Date().toISOString();
+  const providerAccount = configuredProviderAccount({
+    id: providerAccountId,
+    settings: accountSettings,
+    now,
+  });
+  const db = await openRuntimeGroupDb(runtimeHome);
+  try {
+    const secrets = db.getRuntimeSecrets?.();
+    if (!secrets) {
+      p.log.error('Runtime secret storage is unavailable.');
+      return 1;
+    }
+    const choice = await chooseConversation({
+      providerAccount,
+      discovery: new RuntimeSecretConversationDiscovery(secrets),
+    });
+    if (!choice) return 1;
+    const conversation = transientConversation({
+      providerAccountId,
+      choice,
+      now,
+    });
+    if (
+      hasConversationInstallInSettings({
+        settings,
+        conversation,
+        providerAccountId,
+        agentFolder: agentId,
+      })
+    ) {
+      p.log.error(
+        'This conversation is already installed for this agent and Provider Account. No changes were saved.',
+      );
+      return 1;
+    }
+
+    const displayName = await p.text({
+      message: 'Conversation display name',
+      defaultValue: choice.title,
+      validate: (value) =>
+        String(value ?? '').trim()
+          ? undefined
+          : 'Conversation display name is required.',
+    });
+    if (p.isCancel(displayName)) return 1;
+    const approverInput = await p.text({
+      message:
+        'Conversation approver user IDs (comma-separated; must be members of this conversation)',
+      validate: (value) =>
+        parseCsv(value).length > 0
+          ? undefined
+          : 'Enter at least one conversation approver.',
+    });
+    if (p.isCancel(approverInput)) return 1;
+    const controlApprovers = parseCsv(approverInput);
+    const membership = await new RuntimeSecretConversationMembershipValidator(
+      secrets,
+    ).validateControlApprovers({
+      providerId: providerAccount.providerId,
+      providerAccount,
+      conversation,
+      userIds: controlApprovers,
+    });
+    if (membership.invalidUserIds.length > 0) {
+      p.log.error(
+        [
+          'Conversation access or approver membership could not be verified.',
+          `Invalid approvers: ${membership.invalidUserIds.join(', ')}`,
+          membership.reason,
+          'Invite the Provider Account and approvers to the conversation, check provider permissions, then retry.',
+        ]
+          .filter(Boolean)
+          .join(' '),
+      );
+      return 1;
+    }
+
+    const senderPolicy = await promptSenderPolicy();
+    if (!senderPolicy) return 1;
+    const defaultTrigger = `@${settings.agents[agentId]!.name}`;
+    const trigger = await p.text({
+      message: 'Trigger phrase',
+      defaultValue: defaultTrigger,
+      validate: (value) =>
+        String(value ?? '').trim() ? undefined : 'Trigger phrase is required.',
+    });
+    if (p.isCancel(trigger)) return 1;
+    const requiresTrigger = await p.confirm({
+      message: 'Require trigger before this agent responds?',
+      initialValue: choice.kind !== 'direct',
+    });
+    if (p.isCancel(requiresTrigger)) return 1;
+    const memoryScope = await p.select({
+      message: 'Memory scope',
+      options: [
+        {
+          value: 'conversation',
+          label: 'Conversation (Recommended)',
+        },
+        { value: 'user', label: 'User' },
+        { value: 'agent', label: 'Agent' },
+        { value: 'app', label: 'App' },
+        { value: '__cancel', label: 'Cancel' },
+      ],
+    });
+    if (p.isCancel(memoryScope) || memoryScope === '__cancel') return 1;
+
+    p.note(
+      [
+        `Agent: ${settings.agents[agentId]!.name} (${agentId})`,
+        `Provider Account: ${accountSettings.label} (${providerAccountId})`,
+        `Conversation: ${String(displayName).trim()} (${choice.externalId})`,
+        `Approvers: ${controlApprovers.join(', ')}`,
+        `Sender policy: ${senderPolicy.allow === '*' ? 'all senders' : senderPolicy.allow.join(', ')}`,
+        `Trigger: ${String(trigger).trim()}`,
+        `Requires trigger: ${requiresTrigger ? 'yes' : 'no'}`,
+        `Memory scope: ${String(memoryScope)}`,
+        'Credentials: reused; no secret will be changed.',
+      ].join('\n'),
+      'Review conversation install',
+    );
+    const save = await p.confirm({
+      message: 'Save this conversation install?',
+      initialValue: true,
+    });
+    if (p.isCancel(save) || !save) return 1;
+
+    const nextSettings = structuredClone(settings);
+    applyConversationInstallToSettings({
+      settings: nextSettings,
+      conversation,
+      providerAccountId,
+      agentFolder: agentId,
+      controlApprovers,
+      now,
+      displayName: String(displayName),
+      senderPolicy,
+      memoryScope: String(memoryScope) as MemoryScope,
+      trigger: String(trigger),
+      requiresTrigger: Boolean(requiresTrigger),
+    });
+    const result = await writeDesiredRuntimeSettings({
+      runtimeHome,
+      settings: nextSettings,
+      previousSettings: settings,
+      createdBy: 'cli:setup-add-conversation',
+    });
+    noteRestartRequired(result);
+    p.note(
+      [
+        `${String(displayName).trim()} is now installed for ${settings.agents[agentId]!.name}.`,
+        'Existing credentials and conversations were not changed.',
+        'Next: run gantry restart for this conversation topology change to take effect.',
+      ].join('\n'),
+      'Conversation installed',
+    );
+    return 0;
+  } catch (error) {
+    p.log.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  } finally {
+    await db.close();
+  }
+}

--- a/apps/core/src/cli/setup-add-conversation.ts
+++ b/apps/core/src/cli/setup-add-conversation.ts
@@ -7,25 +7,63 @@ import {
   listConnectableChannelProviders,
   providerJidPrefix,
 } from '../channels/provider-registry.js';
-import {
-  applyConversationInstallToSettings,
-  hasConversationInstallInSettings,
-} from '../config/settings/conversation-install-settings.js';
-import {
-  loadDesiredRuntimeSettingsForWrite,
-  noteRestartRequired,
-  writeDesiredRuntimeSettings,
-} from '../config/settings/runtime-settings.js';
-import type {
-  RuntimeProviderAccountSettings,
-  RuntimeSettings,
-} from '../config/settings/runtime-settings-types.js';
-import type { Conversation } from '../domain/conversation/conversation.js';
+import { type Conversation } from '../domain/conversation/conversation.js';
 import type { ProviderAccount } from '../domain/provider/provider.js';
-import type { ChatAllowlistEntry } from '../config/settings/sender-allowlist.js';
 import { openRuntimeGroupDb } from './runtime-group-db.js';
 
 type MemoryScope = 'conversation' | 'user' | 'agent' | 'app';
+type SenderPolicy = {
+  allow: '*' | string[];
+  mode: 'trigger' | 'drop';
+};
+
+interface SetupProviderAccount {
+  agentId: string;
+  provider: string;
+  label: string;
+  status?: 'active' | 'disabled';
+  runtimeSecretRefs: Record<string, string>;
+  externalIdentityRef?: Record<string, string>;
+  config?: Record<string, string>;
+}
+
+interface SetupSettings {
+  providers: Record<string, { enabled: boolean }>;
+  providerAccounts: Record<string, SetupProviderAccount>;
+  agents: Record<string, { name: string }>;
+  conversations: Record<string, unknown>;
+}
+
+export interface AddConversationSetupDependencies<
+  TSettings extends SetupSettings,
+> {
+  loadSettings(): Promise<TSettings>;
+  writeSettings(input: {
+    settings: TSettings;
+    previousSettings: TSettings;
+    createdBy: string;
+  }): Promise<unknown>;
+  noteRestartRequired(result: unknown): void;
+  hasConversationInstallInSettings(input: {
+    settings: TSettings;
+    conversation: Pick<Conversation, 'id' | 'externalRef' | 'kind' | 'title'>;
+    providerAccountId: string;
+    agentFolder: string;
+  }): boolean;
+  applyConversationInstallToSettings(input: {
+    settings: TSettings;
+    conversation: Pick<Conversation, 'id' | 'externalRef' | 'kind' | 'title'>;
+    providerAccountId: string;
+    agentFolder: string;
+    controlApprovers: readonly string[];
+    now: string;
+    displayName?: string;
+    senderPolicy?: SenderPolicy;
+    memoryScope?: MemoryScope;
+    trigger?: string;
+    requiresTrigger?: boolean;
+  }): string;
+}
 
 interface ConversationChoice {
   externalId: string;
@@ -59,7 +97,7 @@ function conversationKindForManualId(
 
 function configuredProviderAccount(input: {
   id: string;
-  settings: RuntimeProviderAccountSettings;
+  settings: SetupProviderAccount;
   now: string;
 }): ProviderAccount {
   return {
@@ -113,7 +151,7 @@ function parseCsv(value: unknown): string[] {
   ];
 }
 
-async function chooseAgent(settings: RuntimeSettings): Promise<string | null> {
+async function chooseAgent(settings: SetupSettings): Promise<string | null> {
   const agentIds = Object.keys(settings.agents).sort();
   if (agentIds.length === 0) {
     p.log.error('No existing agents are configured.');
@@ -143,7 +181,7 @@ async function chooseAgent(settings: RuntimeSettings): Promise<string | null> {
   return String(manual).trim();
 }
 
-function providerAccountOptions(settings: RuntimeSettings, agentId: string) {
+function providerAccountOptions(settings: SetupSettings, agentId: string) {
   const connectable = new Set(
     listConnectableChannelProviders().map((provider) => provider.id),
   );
@@ -160,9 +198,9 @@ function providerAccountOptions(settings: RuntimeSettings, agentId: string) {
 }
 
 async function chooseProviderAccount(
-  settings: RuntimeSettings,
+  settings: SetupSettings,
   agentId: string,
-): Promise<[string, RuntimeProviderAccountSettings] | null> {
+): Promise<[string, SetupProviderAccount] | null> {
   const accounts = providerAccountOptions(settings, agentId);
   if (accounts.length === 0) {
     p.log.error(
@@ -250,7 +288,7 @@ async function chooseConversation(input: {
   };
 }
 
-async function promptSenderPolicy(): Promise<ChatAllowlistEntry | null> {
+async function promptSenderPolicy(): Promise<SenderPolicy | null> {
   const selected = await p.select({
     message: 'Sender policy',
     options: [
@@ -276,14 +314,17 @@ async function promptSenderPolicy(): Promise<ChatAllowlistEntry | null> {
   return { allow: parseCsv(allow), mode: 'drop' };
 }
 
-export async function runAddConversationSetupSlice(
+export async function runAddConversationSetupSlice<
+  TSettings extends SetupSettings,
+>(
   runtimeHome: string,
+  dependencies: AddConversationSetupDependencies<TSettings>,
 ): Promise<number> {
   p.note(
     'Reuse an existing agent and Provider Account. This flow will not ask for or overwrite credentials.',
     'Add conversation to existing agent',
   );
-  const settings = await loadDesiredRuntimeSettingsForWrite({ runtimeHome });
+  const settings = await dependencies.loadSettings();
   const agentId = await chooseAgent(settings);
   if (!agentId) return 1;
   const accountChoice = await chooseProviderAccount(settings, agentId);
@@ -317,7 +358,7 @@ export async function runAddConversationSetupSlice(
       now,
     });
     if (
-      hasConversationInstallInSettings({
+      dependencies.hasConversationInstallInSettings({
         settings,
         conversation,
         providerAccountId,
@@ -422,7 +463,7 @@ export async function runAddConversationSetupSlice(
     if (p.isCancel(save) || !save) return 1;
 
     const nextSettings = structuredClone(settings);
-    applyConversationInstallToSettings({
+    dependencies.applyConversationInstallToSettings({
       settings: nextSettings,
       conversation,
       providerAccountId,
@@ -435,13 +476,12 @@ export async function runAddConversationSetupSlice(
       trigger: String(trigger),
       requiresTrigger: Boolean(requiresTrigger),
     });
-    const result = await writeDesiredRuntimeSettings({
-      runtimeHome,
+    const result = await dependencies.writeSettings({
       settings: nextSettings,
       previousSettings: settings,
       createdBy: 'cli:setup-add-conversation',
     });
-    noteRestartRequired(result);
+    dependencies.noteRestartRequired(result);
     p.note(
       [
         `${String(displayName).trim()} is now installed for ${settings.agents[agentId]!.name}.`,

--- a/apps/core/src/cli/setup-flow-core-steps.ts
+++ b/apps/core/src/cli/setup-flow-core-steps.ts
@@ -6,7 +6,9 @@ import {
   resolveRuntimeHome,
 } from '../config/settings/runtime-home.js';
 import {
+  applyConversationInstallToSettings,
   ensureConfiguredAgent,
+  hasConversationInstallInSettings,
   loadDesiredRuntimeSettingsForWrite,
   noteRestartRequired,
   writeDesiredRuntimeSettings,
@@ -228,6 +230,27 @@ export async function runAddAgentSetupSlice(
   });
   noteRestartRequired(writeResult);
   return 0;
+}
+
+export async function runAddConversationSetupSlice(
+  runtimeHome: string,
+): Promise<number> {
+  const { runAddConversationSetupSlice: runSlice } =
+    await import('./setup-add-conversation.js');
+  return runSlice(runtimeHome, {
+    loadSettings: () =>
+      loadDesiredRuntimeSettingsForWrite({
+        runtimeHome,
+      }),
+    writeSettings: (input) =>
+      writeDesiredRuntimeSettings({
+        runtimeHome,
+        ...input,
+      }),
+    noteRestartRequired,
+    hasConversationInstallInSettings,
+    applyConversationInstallToSettings,
+  });
 }
 
 export async function runWelcomeStep(): Promise<FlowAction> {

--- a/apps/core/src/config/settings/conversation-install-settings.ts
+++ b/apps/core/src/config/settings/conversation-install-settings.ts
@@ -1,7 +1,40 @@
 import { createHash } from 'node:crypto';
 
 import type { Conversation } from '../../domain/conversation/conversation.js';
+import type { ChatAllowlistEntry } from './sender-allowlist.js';
 import type { RuntimeSettings } from './runtime-settings-types.js';
+
+export interface ConversationInstallSettingsInput {
+  settings: RuntimeSettings;
+  conversation: Pick<Conversation, 'id' | 'externalRef' | 'kind' | 'title'>;
+  providerAccountId: string;
+  agentFolder: string;
+  controlApprovers: readonly string[];
+  now: string;
+  displayName?: string;
+  senderPolicy?: ChatAllowlistEntry;
+  memoryScope?: 'conversation' | 'user' | 'agent' | 'app';
+  trigger?: string;
+  requiresTrigger?: boolean;
+}
+
+export function hasConversationInstallInSettings(
+  input: Pick<
+    ConversationInstallSettingsInput,
+    'settings' | 'conversation' | 'providerAccountId' | 'agentFolder'
+  >,
+): boolean {
+  const conversationKey = configuredConversationKey(
+    input.settings,
+    input.conversation,
+    input.providerAccountId,
+  );
+  return Boolean(
+    input.settings.conversations[conversationKey]?.installedAgents[
+      input.agentFolder
+    ],
+  );
+}
 
 export function applyConversationInstallToSettings(input: {
   settings: RuntimeSettings;
@@ -10,6 +43,11 @@ export function applyConversationInstallToSettings(input: {
   agentFolder: string;
   controlApprovers: readonly string[];
   now: string;
+  displayName?: string;
+  senderPolicy?: ChatAllowlistEntry;
+  memoryScope?: 'conversation' | 'user' | 'agent' | 'app';
+  trigger?: string;
+  requiresTrigger?: boolean;
 }): string {
   const { settings, conversation, providerAccountId, agentFolder } = input;
   const conversationKey = configuredConversationKey(
@@ -30,9 +68,15 @@ export function applyConversationInstallToSettings(input: {
     providerAccount: providerAccountId,
     externalId,
     kind: conversation.kind === 'direct' ? 'dm' : conversation.kind,
-    displayName: conversation.title || existing?.displayName || conversationKey,
+    displayName:
+      input.displayName?.trim() ||
+      conversation.title ||
+      existing?.displayName ||
+      conversationKey,
     senderPolicy:
-      existing?.senderPolicy ?? ({ allow: '*', mode: 'trigger' } as never),
+      input.senderPolicy ??
+      existing?.senderPolicy ??
+      ({ allow: '*', mode: 'trigger' } as never),
     controlApprovers,
     installedAgents: {
       ...(existing?.installedAgents ?? {}),
@@ -41,9 +85,12 @@ export function applyConversationInstallToSettings(input: {
         providerAccountId,
         status: 'active',
         addedAt: input.now,
-        memoryScope: 'conversation',
-        trigger: `@${settings.agents[agentFolder]?.name || agentFolder}`,
-        requiresTrigger: conversation.kind !== 'direct',
+        memoryScope: input.memoryScope ?? 'conversation',
+        trigger:
+          input.trigger?.trim() ||
+          `@${settings.agents[agentFolder]?.name || agentFolder}`,
+        requiresTrigger:
+          input.requiresTrigger ?? conversation.kind !== 'direct',
       },
     },
   };

--- a/apps/core/src/config/settings/desired-state-service-helpers.ts
+++ b/apps/core/src/config/settings/desired-state-service-helpers.ts
@@ -349,7 +349,7 @@ export function normalizeRuntimeSecretRefs(input: {
 
 function conversationTopology(settings: RuntimeSettings): unknown {
   return Object.fromEntries(
-    Object.entries(settings.conversations)
+    Object.entries(settings.conversations ?? {})
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([conversationKey, conversation]) => [
         conversationKey,
@@ -359,7 +359,7 @@ function conversationTopology(settings: RuntimeSettings): unknown {
           externalId: conversation.externalId,
           kind: conversation.kind,
           installedAgents: Object.fromEntries(
-            Object.entries(conversation.installedAgents)
+            Object.entries(conversation.installedAgents ?? {})
               .sort(([left], [right]) => left.localeCompare(right))
               .map(([agentKey, install]) => [
                 agentKey,

--- a/apps/core/src/config/settings/desired-state-service-helpers.ts
+++ b/apps/core/src/config/settings/desired-state-service-helpers.ts
@@ -347,6 +347,35 @@ export function normalizeRuntimeSecretRefs(input: {
   );
 }
 
+function conversationTopology(settings: RuntimeSettings): unknown {
+  return Object.fromEntries(
+    Object.entries(settings.conversations)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([conversationKey, conversation]) => [
+        conversationKey,
+        {
+          providerAccount:
+            conversation.providerAccount ?? conversation.providerConnection,
+          externalId: conversation.externalId,
+          kind: conversation.kind,
+          installedAgents: Object.fromEntries(
+            Object.entries(conversation.installedAgents)
+              .sort(([left], [right]) => left.localeCompare(right))
+              .map(([agentKey, install]) => [
+                agentKey,
+                {
+                  agentId: install.agentId,
+                  providerAccountId: install.providerAccountId,
+                  threadId: install.threadId,
+                  status: install.status,
+                },
+              ]),
+          ),
+        },
+      ]),
+  );
+}
+
 export function classifySettingsChanges(
   before: RuntimeSettings,
   after: RuntimeSettings,
@@ -367,12 +396,19 @@ export function classifySettingsChanges(
   if (providerTopologyChanged) {
     restartRequired.push('providers');
   }
-  if (
-    !providerTopologyChanged &&
-    (!jsonEqual(before.conversations, after.conversations) ||
-      !jsonEqual(before.bindings, after.bindings))
-  ) {
-    liveApplied.push('conversation_policies');
+  if (!providerTopologyChanged) {
+    const conversationTopologyChanged = !jsonEqual(
+      conversationTopology(before),
+      conversationTopology(after),
+    );
+    if (conversationTopologyChanged) {
+      restartRequired.push('conversations');
+    } else if (
+      !jsonEqual(before.conversations, after.conversations) ||
+      !jsonEqual(before.bindings, after.bindings)
+    ) {
+      liveApplied.push('conversation_policies');
+    }
   }
   if (!jsonEqual(before.agent, after.agent)) {
     liveApplied.push('agent_defaults');

--- a/apps/core/src/config/settings/runtime-settings.ts
+++ b/apps/core/src/config/settings/runtime-settings.ts
@@ -56,6 +56,10 @@ export {
   noteRestartRequired,
   writeDesiredRuntimeSettings,
 } from './desired-settings-writer.js';
+export {
+  applyConversationInstallToSettings,
+  hasConversationInstallInSettings,
+} from './conversation-install-settings.js';
 
 const DEFAULT_PROVIDER_ACCOUNT_IDS: Record<string, string> = {
   app: 'app_default',

--- a/apps/core/test/integration/conversation-install-settings.postgres.integration.test.ts
+++ b/apps/core/test/integration/conversation-install-settings.postgres.integration.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SettingsDesiredStateService } from '@core/config/settings/desired-state-service.js';
+import { applyConversationInstallToSettings } from '@core/config/settings/conversation-install-settings.js';
+import {
+  createDefaultRuntimeSettings,
+  ensureConfiguredAgent,
+  parseRuntimeSettings,
+} from '@core/config/settings/runtime-settings.js';
+import { renderRuntimeSettingsYaml } from '@core/config/settings/runtime-settings-renderer.js';
+import type { AppId } from '@core/domain/app/app.js';
+
+import {
+  createPostgresIntegrationRuntime,
+  hasPostgresIntegrationDatabase,
+  type PostgresIntegrationRuntime,
+} from '../harness/postgres-integration-runtime.js';
+
+const maybeDescribe = hasPostgresIntegrationDatabase ? describe : describe.skip;
+const APP_ID = 'default' as AppId;
+const AGENT_FOLDER = 'conversation_agent';
+const PROVIDER_ACCOUNT_ID = 'slack_conversation_agent';
+const EXTERNAL_ID = 'C12345678';
+const NOW = '2026-07-29T00:00:00.000Z';
+
+maybeDescribe(
+  'conversation install desired-state projection (Postgres)',
+  () => {
+    let runtime: PostgresIntegrationRuntime;
+
+    beforeAll(async () => {
+      runtime = await createPostgresIntegrationRuntime({
+        schemaPrefix: 'conversation_install_settings',
+      });
+    }, 60_000);
+
+    afterAll(async () => {
+      if (runtime) await runtime.cleanup();
+    });
+
+    it('projects a generated conversation install without changing provider credentials', async () => {
+      const authoredSettings = createDefaultRuntimeSettings();
+      authoredSettings.desiredState.authoritative = true;
+      ensureConfiguredAgent(authoredSettings, {
+        agentId: AGENT_FOLDER,
+        agentName: 'Conversation Agent',
+        agentFolder: AGENT_FOLDER,
+      });
+      authoredSettings.providers.slack.enabled = true;
+      authoredSettings.providerAccounts[PROVIDER_ACCOUNT_ID] = {
+        agentId: AGENT_FOLDER,
+        provider: 'slack',
+        label: 'Conversation Slack',
+        runtimeSecretRefs: {
+          bot_token: 'gantry-secret:CONVERSATION_SLACK_BOT_TOKEN',
+          app_token: 'gantry-secret:CONVERSATION_SLACK_APP_TOKEN',
+        },
+      };
+
+      applyConversationInstallToSettings({
+        settings: authoredSettings,
+        conversation: {
+          id: `conversation:${PROVIDER_ACCOUNT_ID}:${EXTERNAL_ID}` as never,
+          externalRef: { kind: 'conversation', value: EXTERNAL_ID } as never,
+          kind: 'channel',
+          title: 'incident-room',
+        },
+        providerAccountId: PROVIDER_ACCOUNT_ID,
+        agentFolder: AGENT_FOLDER,
+        controlApprovers: ['U12345678'],
+        now: NOW,
+        displayName: 'Incident Room',
+        senderPolicy: { allow: ['U12345678'], mode: 'drop' },
+        memoryScope: 'conversation',
+        trigger: '@Incident',
+        requiresTrigger: true,
+      });
+
+      const settings = parseRuntimeSettings(
+        renderRuntimeSettingsYaml(authoredSettings),
+      );
+      const result = await new SettingsDesiredStateService({
+        ops: runtime.ops,
+        repositories: runtime.repositories,
+        clock: { now: () => NOW },
+      }).reconcile(settings);
+
+      expect(result.invalidReferences).toEqual([]);
+      await expect(
+        runtime.repositories.providerAccounts.getProviderAccount(
+          PROVIDER_ACCOUNT_ID as never,
+        ),
+      ).resolves.toMatchObject({
+        agentId: `agent:${AGENT_FOLDER}`,
+        runtimeSecretRefs: {
+          bot_token: 'gantry-secret:CONVERSATION_SLACK_BOT_TOKEN',
+          app_token: 'gantry-secret:CONVERSATION_SLACK_APP_TOKEN',
+        },
+      });
+
+      const conversation =
+        await runtime.repositories.conversations.getConversationByExternalRef({
+          appId: APP_ID,
+          providerId: 'slack' as never,
+          providerAccountId: PROVIDER_ACCOUNT_ID as never,
+          externalConversationId: EXTERNAL_ID,
+        });
+      expect(conversation).toMatchObject({
+        providerAccountId: PROVIDER_ACCOUNT_ID,
+        externalRef: { kind: 'conversation', value: EXTERNAL_ID },
+        kind: 'channel',
+        title: 'Incident Room',
+      });
+
+      await expect(
+        runtime.repositories.providerAccounts.getConversationInstall({
+          appId: APP_ID,
+          agentId: `agent:${AGENT_FOLDER}` as never,
+          conversationId: conversation!.id,
+        }),
+      ).resolves.toMatchObject({
+        providerAccountId: PROVIDER_ACCOUNT_ID,
+        status: 'active',
+        memoryScope: 'conversation',
+      });
+
+      const routes = await runtime.ops.getAllConversationRoutes();
+      expect(Object.values(routes)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            folder: AGENT_FOLDER,
+            conversationId: conversation!.id,
+            providerAccountId: PROVIDER_ACCOUNT_ID,
+            trigger: '@Incident',
+            requiresTrigger: true,
+          }),
+        ]),
+      );
+    });
+  },
+);

--- a/apps/core/test/unit/cli/index-local-routing.test.ts
+++ b/apps/core/test/unit/cli/index-local-routing.test.ts
@@ -360,7 +360,7 @@ describe('CLI local routing', () => {
       select,
       log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), success: vi.fn() },
     }));
-    vi.doMock('@core/cli/setup-add-conversation.js', () => ({
+    vi.doMock('@core/cli/setup-flow-core-steps.js', () => ({
       runAddConversationSetupSlice,
     }));
 

--- a/apps/core/test/unit/cli/index-local-routing.test.ts
+++ b/apps/core/test/unit/cli/index-local-routing.test.ts
@@ -25,6 +25,7 @@ afterEach(() => {
   vi.doUnmock('@core/cli/onboarding-state.js');
   vi.doUnmock('@core/cli/setup-flow.js');
   vi.doUnmock('@core/cli/setup-flow-core-steps.js');
+  vi.doUnmock('@core/cli/setup-add-conversation.js');
   vi.doUnmock('@core/cli/setup-credentials.js');
   vi.doUnmock('@core/cli/setup-flow-provider-steps.js');
   vi.doUnmock('@core/cli/setup-flow-final-steps.js');
@@ -342,6 +343,43 @@ describe('CLI local routing', () => {
       'research_bot',
       'Research Bot',
     );
+  });
+
+  it('runs the completed setup add-conversation mini-flow', async () => {
+    const runtimeHome = makeRuntimeHome();
+    const onboarding = await import('@core/cli/onboarding-state.js');
+    const state = onboarding.createInitialState(runtimeHome);
+    state.status = 'completed';
+    state.currentStep = 'ready';
+    onboarding.writeOnboardingState(runtimeHome, state);
+    const select = vi.fn(async () => 'add_conversation');
+    const runAddConversationSetupSlice = vi.fn(async () => 0);
+    vi.doMock('@clack/prompts', () => ({
+      isCancel: () => false,
+      outro: vi.fn(),
+      select,
+      log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), success: vi.fn() },
+    }));
+    vi.doMock('@core/cli/setup-add-conversation.js', () => ({
+      runAddConversationSetupSlice,
+    }));
+
+    const { main } = await import('@core/cli/index.js');
+    const code = await main(['--runtime-home', runtimeHome, 'setup']);
+
+    expect(code).toBe(0);
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'What do you want to change?',
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            value: 'add_conversation',
+            label: 'Add conversation to existing agent',
+          }),
+        ]),
+      }),
+    );
+    expect(runAddConversationSetupSlice).toHaveBeenCalledWith(runtimeHome);
   });
 
   it('does not persist an add-agent when the conversation kept its existing owner', async () => {

--- a/apps/core/test/unit/cli/setup-add-conversation.test.ts
+++ b/apps/core/test/unit/cli/setup-add-conversation.test.ts
@@ -119,6 +119,23 @@ function mockProviderValidation() {
   }));
 }
 
+async function setupDependencies(
+  settings: ReturnType<typeof createSettings>,
+  writeSettings: ReturnType<typeof vi.fn>,
+  noteRestartRequired = vi.fn(),
+) {
+  const helpers =
+    await import('@core/config/settings/conversation-install-settings.js');
+  return {
+    loadSettings: vi.fn(async () => settings),
+    writeSettings,
+    noteRestartRequired,
+    hasConversationInstallInSettings: helpers.hasConversationInstallInSettings,
+    applyConversationInstallToSettings:
+      helpers.applyConversationInstallToSettings,
+  };
+}
+
 describe('add conversation to existing agent setup slice', () => {
   it('writes one additive install and preserves provider secret refs', async () => {
     const settings = createSettings();
@@ -146,7 +163,14 @@ describe('add conversation to existing agent setup slice', () => {
 
     const { runAddConversationSetupSlice } =
       await import('@core/cli/setup-add-conversation.js');
-    const code = await runAddConversationSetupSlice('/tmp/gantry');
+    const code = await runAddConversationSetupSlice(
+      '/tmp/gantry',
+      await setupDependencies(
+        settings,
+        writeDesiredRuntimeSettings,
+        noteRestartRequired,
+      ),
+    );
 
     expect(code).toBe(0);
     expect(writeDesiredRuntimeSettings).toHaveBeenCalledTimes(1);
@@ -194,7 +218,10 @@ describe('add conversation to existing agent setup slice', () => {
 
     const { runAddConversationSetupSlice } =
       await import('@core/cli/setup-add-conversation.js');
-    const code = await runAddConversationSetupSlice('/tmp/gantry');
+    const code = await runAddConversationSetupSlice(
+      '/tmp/gantry',
+      await setupDependencies(settings, writeDesiredRuntimeSettings),
+    );
 
     expect(code).toBe(1);
     expect(writeDesiredRuntimeSettings).not.toHaveBeenCalled();
@@ -237,7 +264,10 @@ describe('add conversation to existing agent setup slice', () => {
 
     const { runAddConversationSetupSlice } =
       await import('@core/cli/setup-add-conversation.js');
-    const code = await runAddConversationSetupSlice('/tmp/gantry');
+    const code = await runAddConversationSetupSlice(
+      '/tmp/gantry',
+      await setupDependencies(settings, writeDesiredRuntimeSettings),
+    );
 
     expect(code).toBe(1);
     expect(writeDesiredRuntimeSettings).not.toHaveBeenCalled();

--- a/apps/core/test/unit/cli/setup-add-conversation.test.ts
+++ b/apps/core/test/unit/cli/setup-add-conversation.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+function createSettings() {
+  return {
+    providers: { slack: { enabled: true } },
+    providerAccounts: {
+      slack_ops: {
+        agentId: 'main_agent',
+        provider: 'slack',
+        label: 'Slack Ops',
+        runtimeSecretRefs: {
+          bot_token: 'gantry-secret:MAIN_SLACK_BOT_TOKEN',
+          app_token: 'gantry-secret:MAIN_SLACK_APP_TOKEN',
+        },
+      },
+    },
+    agents: {
+      main_agent: {
+        name: 'Ops',
+        folder: 'main_agent',
+      },
+    },
+    conversations: {},
+  } as any;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock('@clack/prompts');
+  vi.doUnmock('@core/channels/control-provider-catalog.js');
+  vi.doUnmock('@core/channels/conversation-membership-validation.js');
+  vi.doUnmock('@core/channels/provider-registry.js');
+  vi.doUnmock('@core/config/settings/runtime-settings.js');
+  vi.doUnmock('@core/cli/runtime-group-db.js');
+});
+
+function mockPrompts(options: { confirmSave?: boolean } = {}) {
+  const select = vi.fn(async ({ message }: { message: string }) => {
+    if (message === 'Choose an existing agent') return 'main_agent';
+    if (message === 'Choose the Provider Account to reuse') return 'slack_ops';
+    if (message === 'Choose a conversation to install') return 'C12345678';
+    if (message === 'Sender policy') return 'all';
+    if (message === 'Memory scope') return 'conversation';
+    return '__cancel';
+  });
+  const text = vi.fn(async ({ message }: { message: string }) => {
+    if (message === 'Conversation display name') return 'incident-room';
+    if (message.startsWith('Conversation approver')) return 'U12345678';
+    if (message === 'Trigger phrase') return '@Ops';
+    return '';
+  });
+  const confirm = vi.fn(async ({ message }: { message: string }) => {
+    if (message === 'Save this conversation install?') {
+      return options.confirmSave ?? true;
+    }
+    return true;
+  });
+  const note = vi.fn();
+  const log = {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  };
+  vi.doMock('@clack/prompts', () => ({
+    isCancel: () => false,
+    select,
+    text,
+    confirm,
+    note,
+    log,
+    spinner: vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+    })),
+  }));
+  return { select, text, confirm, note, log };
+}
+
+function mockProviderValidation() {
+  vi.doMock('@core/channels/provider-registry.js', () => ({
+    getProvider: () => ({
+      id: 'slack',
+      label: 'Slack',
+      jidPrefix: 'sl:',
+    }),
+    listConnectableChannelProviders: () => [
+      {
+        id: 'slack',
+        label: 'Slack',
+        jidPrefix: 'sl:',
+      },
+    ],
+    providerJidPrefix: () => 'sl:',
+  }));
+  vi.doMock('@core/channels/control-provider-catalog.js', () => ({
+    RuntimeSecretConversationDiscovery: class {
+      async discover() {
+        return [
+          {
+            externalId: 'C12345678',
+            title: 'incident-room',
+            kind: 'channel',
+          },
+        ];
+      }
+    },
+  }));
+  vi.doMock('@core/channels/conversation-membership-validation.js', () => ({
+    RuntimeSecretConversationMembershipValidator: class {
+      async validateControlApprovers(input: { userIds: string[] }) {
+        return {
+          validUserIds: input.userIds,
+          invalidUserIds: [],
+        };
+      }
+    },
+  }));
+}
+
+describe('add conversation to existing agent setup slice', () => {
+  it('writes one additive install and preserves provider secret refs', async () => {
+    const settings = createSettings();
+    const refsBefore = structuredClone(
+      settings.providerAccounts.slack_ops.runtimeSecretRefs,
+    );
+    const writeDesiredRuntimeSettings = vi.fn(async () => ({
+      reconciled: true,
+      restartRequired: ['conversations'],
+    }));
+    const noteRestartRequired = vi.fn();
+    mockPrompts();
+    mockProviderValidation();
+    vi.doMock('@core/config/settings/runtime-settings.js', () => ({
+      loadDesiredRuntimeSettingsForWrite: vi.fn(async () => settings),
+      writeDesiredRuntimeSettings,
+      noteRestartRequired,
+    }));
+    vi.doMock('@core/cli/runtime-group-db.js', () => ({
+      openRuntimeGroupDb: vi.fn(async () => ({
+        getRuntimeSecrets: () => ({ get: vi.fn() }),
+        close: vi.fn(async () => undefined),
+      })),
+    }));
+
+    const { runAddConversationSetupSlice } =
+      await import('@core/cli/setup-add-conversation.js');
+    const code = await runAddConversationSetupSlice('/tmp/gantry');
+
+    expect(code).toBe(0);
+    expect(writeDesiredRuntimeSettings).toHaveBeenCalledTimes(1);
+    const write = writeDesiredRuntimeSettings.mock.calls[0]![0];
+    expect(write.settings.providerAccounts.slack_ops.runtimeSecretRefs).toEqual(
+      refsBefore,
+    );
+    expect(write.previousSettings).toBe(settings);
+    const conversation = Object.values(write.settings.conversations)[0] as any;
+    expect(conversation).toMatchObject({
+      providerAccount: 'slack_ops',
+      externalId: 'C12345678',
+      controlApprovers: ['U12345678'],
+      installedAgents: {
+        main_agent: {
+          agentId: 'main_agent',
+          providerAccountId: 'slack_ops',
+          trigger: '@Ops',
+          requiresTrigger: true,
+          memoryScope: 'conversation',
+        },
+      },
+    });
+    expect(noteRestartRequired).toHaveBeenCalledWith(
+      expect.objectContaining({ restartRequired: ['conversations'] }),
+    );
+  });
+
+  it('does not write when final confirmation is declined', async () => {
+    const settings = createSettings();
+    const writeDesiredRuntimeSettings = vi.fn();
+    mockPrompts({ confirmSave: false });
+    mockProviderValidation();
+    vi.doMock('@core/config/settings/runtime-settings.js', () => ({
+      loadDesiredRuntimeSettingsForWrite: vi.fn(async () => settings),
+      writeDesiredRuntimeSettings,
+      noteRestartRequired: vi.fn(),
+    }));
+    vi.doMock('@core/cli/runtime-group-db.js', () => ({
+      openRuntimeGroupDb: vi.fn(async () => ({
+        getRuntimeSecrets: () => ({ get: vi.fn() }),
+        close: vi.fn(async () => undefined),
+      })),
+    }));
+
+    const { runAddConversationSetupSlice } =
+      await import('@core/cli/setup-add-conversation.js');
+    const code = await runAddConversationSetupSlice('/tmp/gantry');
+
+    expect(code).toBe(1);
+    expect(writeDesiredRuntimeSettings).not.toHaveBeenCalled();
+    expect(settings.conversations).toEqual({});
+  });
+
+  it('rejects an existing exact install before collecting route policy', async () => {
+    const settings = createSettings();
+    settings.conversations.slack_ops_c12345678 = {
+      providerAccount: 'slack_ops',
+      externalId: 'C12345678',
+      kind: 'channel',
+      displayName: 'incident-room',
+      senderPolicy: { allow: '*', mode: 'trigger' },
+      controlApprovers: ['U12345678'],
+      installedAgents: {
+        main_agent: {
+          agentId: 'main_agent',
+          providerAccountId: 'slack_ops',
+          status: 'active',
+          addedAt: '2026-07-28T00:00:00.000Z',
+          memoryScope: 'conversation',
+        },
+      },
+    };
+    const writeDesiredRuntimeSettings = vi.fn();
+    const prompts = mockPrompts();
+    mockProviderValidation();
+    vi.doMock('@core/config/settings/runtime-settings.js', () => ({
+      loadDesiredRuntimeSettingsForWrite: vi.fn(async () => settings),
+      writeDesiredRuntimeSettings,
+      noteRestartRequired: vi.fn(),
+    }));
+    vi.doMock('@core/cli/runtime-group-db.js', () => ({
+      openRuntimeGroupDb: vi.fn(async () => ({
+        getRuntimeSecrets: () => ({ get: vi.fn() }),
+        close: vi.fn(async () => undefined),
+      })),
+    }));
+
+    const { runAddConversationSetupSlice } =
+      await import('@core/cli/setup-add-conversation.js');
+    const code = await runAddConversationSetupSlice('/tmp/gantry');
+
+    expect(code).toBe(1);
+    expect(writeDesiredRuntimeSettings).not.toHaveBeenCalled();
+    expect(prompts.log.error).toHaveBeenCalledWith(
+      expect.stringContaining('already installed'),
+    );
+    expect(prompts.text).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/test/unit/config/settings-desired-state-service.test.ts
+++ b/apps/core/test/unit/config/settings-desired-state-service.test.ts
@@ -3826,6 +3826,78 @@ conversations:
       restartRequired: ['observer'],
     });
   });
+
+  it('classifies conversation install topology additions as restart-required', () => {
+    const before = createDefaultRuntimeSettings();
+    const after = structuredClone(before);
+    after.providerAccounts.slack_ops = {
+      agentId: 'main_agent',
+      provider: 'slack',
+      label: 'Slack Ops',
+      runtimeSecretRefs: {
+        bot_token: 'gantry-secret:MAIN_SLACK_BOT_TOKEN',
+        app_token: 'gantry-secret:MAIN_SLACK_APP_TOKEN',
+      },
+    };
+    before.providerAccounts = structuredClone(after.providerAccounts);
+    after.conversations.slack_ops_incidents = {
+      providerAccount: 'slack_ops',
+      externalId: 'C12345678',
+      kind: 'channel',
+      displayName: 'incidents',
+      senderPolicy: { allow: '*', mode: 'trigger' },
+      controlApprovers: ['U12345678'],
+      installedAgents: {
+        main_agent: {
+          agentId: 'main_agent',
+          providerAccountId: 'slack_ops',
+          status: 'active',
+          addedAt: '2026-07-28T00:00:00.000Z',
+          memoryScope: 'conversation',
+          trigger: '@Main',
+          requiresTrigger: true,
+        },
+      },
+    };
+
+    expect(classifySettingsChanges(before, after)).toEqual({
+      liveApplied: [],
+      restartRequired: ['conversations'],
+    });
+  });
+
+  it('keeps conversation policy-only changes live-applied', () => {
+    const before = createDefaultRuntimeSettings();
+    before.conversations.slack_ops_incidents = {
+      providerAccount: 'slack_ops',
+      externalId: 'C12345678',
+      kind: 'channel',
+      displayName: 'incidents',
+      senderPolicy: { allow: '*', mode: 'trigger' },
+      controlApprovers: ['U12345678'],
+      installedAgents: {
+        main_agent: {
+          agentId: 'main_agent',
+          providerAccountId: 'slack_ops',
+          status: 'active',
+          addedAt: '2026-07-28T00:00:00.000Z',
+          memoryScope: 'conversation',
+          trigger: '@Main',
+          requiresTrigger: true,
+        },
+      },
+    };
+    const after = structuredClone(before);
+    after.conversations.slack_ops_incidents.controlApprovers = ['U87654321'];
+    after.conversations.slack_ops_incidents.installedAgents[
+      'main_agent'
+    ]!.requiresTrigger = false;
+
+    expect(classifySettingsChanges(before, after)).toEqual({
+      liveApplied: ['conversation_policies'],
+      restartRequired: [],
+    });
+  });
 });
 
 describe('reconcile preserves agent-installed bindings', () => {

--- a/docs/architecture/multi-agent-provider-configuration.md
+++ b/docs/architecture/multi-agent-provider-configuration.md
@@ -144,6 +144,34 @@ conversation's approvers unless a future product flow explicitly narrows them.
 Runtime queue keys may include agent and Provider Account ids, but those keys
 are not provider addresses and must not appear in public setup UX.
 
+### Guided setup for another conversation
+
+After the first setup is complete, run:
+
+```bash
+gantry setup
+```
+
+Choose **Add conversation to existing agent**. The flow:
+
+1. selects an existing agent;
+2. selects one active Provider Account already owned by that agent;
+3. discovers a conversation, with a manual conversation-ID fallback;
+4. validates the conversation approvers as members;
+5. reviews sender policy, trigger behavior, and memory scope; and
+6. saves one additional canonical conversation install.
+
+The flow reuses the Provider Account's existing `runtime_secret_refs`. It does
+not ask for provider tokens, rename secret references, or overwrite another
+agent or conversation. Canceling before the final confirmation writes nothing.
+After a successful install, run `gantry restart` so the new conversation
+topology is active.
+
+Use this flow repeatedly when the same agent should respond in several Slack,
+Teams, Telegram, or Discord conversations. Each conversation keeps its own
+approvers and sender policy, while the Provider Account and its credentials are
+shared by reference.
+
 ## CLI, API, And Agent Tool Usage
 
 All admin surfaces should converge on the same desired-state services:

--- a/docs/decisions/0076-conv-001-client-signoff.md
+++ b/docs/decisions/0076-conv-001-client-signoff.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+confirmed_by: "Yash"
+date: 2026-07-28
+---
+
+# Conv 001 Client Signoff
+
+## Context
+
+Gantry supports installing one existing agent into multiple channel
+conversations, but the completed-setup CLI does not expose a guided operation
+for it. Operators currently edit `settings.yaml` or use lower-level Control API
+operations and must know internal identifiers. Yash confirmed the desired flow
+after reviewing representative Slack conversation entries.
+
+## Decision
+
+Implement a guided **Add conversation to existing agent** flow that reuses an
+existing agent and provider account, supports discovered or validated manual
+conversation selection, collects conversation-specific approvers and route
+behavior, presents a review, and writes through the canonical desired-state
+service.
+
+The flow is additive: it does not create agents, replace credentials, rewrite
+existing conversation installs, or persist anything before confirmation.
+
+## Consequences
+
+- Existing provider credentials are reused by reference and are never requested
+  or overwritten by this flow.
+- Conversation ownership, provider-account ownership, membership, duplicate,
+  and settings revision checks fail closed.
+- The readable settings copy and Postgres/runtime projection remain aligned.
+- Existing setup and provider-connect flows keep their current behavior.
+- User-facing CLI, settings round-trip, discovery, cancellation, and projection
+  behavior require focused automated and functional verification.

--- a/docs/decisions/0077-client-signoff.md
+++ b/docs/decisions/0077-client-signoff.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+confirmed_by: "Yash"
+date: 2026-07-28
+---
+
+# CONV-001 Client Signoff
+
+## Context
+Gantry already supports installing one agent into multiple conversations, but operators lack a guided setup flow and currently edit `settings.yaml` or use low-level commands.
+
+## Decision
+Yash approved CONV-001: add a guided **Add conversation to existing agent** setup flow that reuses the agent's existing Provider Account and credentials, validates the target conversation and approvers, and writes one additive canonical conversation install.
+
+## Consequences
+The implementation must not create an agent, reconnect or overwrite credentials, or modify unrelated conversations. Cancellation before confirmation writes nothing, and the resulting topology change preserves the existing restart-required contract.

--- a/docs/product/BRIEF.md
+++ b/docs/product/BRIEF.md
@@ -16,6 +16,9 @@ need AI agents to run safely inside product and operations workflows.
 - Slack, Telegram, Teams, Discord, and web or SDK-facing runtime concepts.
 - Postgres-backed settings, credential references, memory, jobs, events, and audit state.
 - Provider-neutral model routing through catalog aliases and gateway-owned credentials.
+- Guided conversation installation for adding one existing agent and provider
+  account to additional channel conversations without re-entering credentials
+  or editing `settings.yaml`.
 
 ## Non-Goals
 

--- a/docs/product/DISCOVERY.md
+++ b/docs/product/DISCOVERY.md
@@ -41,3 +41,55 @@ this repo (see `goals-index.md` Shipped section). Phase 0 here covers the
 harness migration itself: legacy `.codex` factory rehomed 2026-07-22
 (`check_dual_runtime.py` clean), at-risk lane work rescued to branches, and
 scratchpad designs promoted into `docs/architecture/`.
+
+## CONV-001 — Add conversations to an existing agent
+
+### Confirmed problem
+
+An operator can already represent one agent in multiple channel conversations
+by editing `settings.yaml`, and the canonical backend supports provider-account
+conversation discovery and agent conversation installs. The guided workstation
+setup does not expose that capability. Operators must know internal settings
+keys or Control API calls to add another Slack channel to an existing agent.
+
+### Confirmed user outcome
+
+From completed setup, an operator can choose **Add conversation to existing
+agent**, select or enter an existing agent, reuse that agent's existing provider
+account and credentials, select a discovered conversation or enter its provider
+conversation ID, set conversation approvers and route behavior, review the
+result, and save it without editing YAML.
+
+### Constraints
+
+- The operation is additive. Existing agents, provider accounts, credentials,
+  and conversation installs are not replaced or removed.
+- Manual agent entry must resolve to an existing agent; this flow never creates
+  an agent.
+- Manual conversation entry must pass provider-specific validation and access
+  verification.
+- A conversation already installed for the selected agent/provider account is
+  rejected as a duplicate rather than silently rewritten.
+- Approvers must pass the provider's conversation-membership validation.
+- The desired-state service remains the durable write authority; the canonical
+  readable `settings.yaml` copy and Postgres/runtime projection stay aligned.
+- Conversation topology changes retain the existing restart-required contract.
+- The first implementation uses the existing connectable channel-provider
+  catalog rather than adding provider-specific behavior to the application
+  layer.
+
+### Acceptance checks
+
+- The completed-setup menu exposes **Add conversation to existing agent**.
+- The flow supports discovered selection and validated manual entry for agent
+  and conversation.
+- The review names the agent, provider account, conversation, approvers,
+  sender policy, trigger, trigger requirement, and memory scope.
+- Saving produces a separate canonical conversation entry with an
+  `installed_agents` binding to the existing agent.
+- Existing sibling conversation entries and provider secret references remain
+  byte-for-byte equivalent after the write.
+- Canceling before confirmation writes no desired-state revision.
+- Focused unit and integration coverage proves duplicate, ownership,
+  membership, cancellation, settings round-trip, and runtime projection
+  behavior.


### PR DESCRIPTION
## Goal

Make it easy and safe to use one existing Gantry agent in multiple Slack, Telegram, Discord, or Teams conversations.

Operators can now add another conversation through guided setup instead of manually editing `settings.yaml`. Gantry reuses the selected Provider Account credentials without requesting or overwriting tokens.

## What changed

- Added **Add conversation to existing agent** to the completed `gantry setup` menu.
- Added selection for an existing agent and its Provider Account.
- Added discovered and manually entered conversation selection.
- Added configuration for:
  - Conversation display name
  - Approvers
  - Sender policy
  - Trigger behavior
  - Memory scope
- Validated Provider Account ownership, conversation access, approver membership, and duplicate installations before saving.
- Preserved existing agents, Provider Accounts, encrypted secret references, conversations, and installed agents.
- Marked conversation topology changes as restart-required.
- Updated multi-agent provider configuration documentation.

## Why

Gantry already supports installing one agent into multiple conversations, but users previously had to edit `settings.yaml` manually.

The new guided flow makes this functionality discoverable and prevents accidental credential replacement or invalid conversation configuration.

## Safety

- Provider credentials are reused by reference.
- Tokens are never displayed or requested again.
- Existing Provider Accounts are not overwritten.
- Duplicate conversation installations are rejected.
- Cancellation before confirmation writes no settings changes.
- The change is additive and preserves unrelated configuration.

## Validation

- Build passed.
- TypeScript checks passed.
- Formatting and architecture checks passed.
- 589 test files passed.
- 7,723 automated tests passed.
- Focused functional tests passed.
- Quality, performance, and security review passed.
- Live setup was tested successfully with multiple conversations.

## Agent E2E delta

No new real-model agent E2E scenario was required because this change affects setup and desired-state projection rather than the agent response loop.

The behavior is covered by focused CLI/configuration tests, the complete repository test suite, and successful live setup testing.

## After setup

The operator must run:

```bash
gantry restart