### PR TITLE
fix(ci): green the brain/observer Postgres integration suites

### DIFF
--- a/apps/core/src/adapters/storage/postgres/runtime-store.ts
+++ b/apps/core/src/adapters/storage/postgres/runtime-store.ts
@@ -417,10 +417,22 @@ export async function closeRuntimeStorage(): Promise<void> {
   if (existing) await closeStorageRuntimeResources(existing);
 }
 
-/** @internal test hook */
-export function _setRuntimeStorageForTest(nextRuntime: StorageRuntime): void {
+/**
+ * @internal test hook
+ *
+ * Pass `scope` to install the storage AS the storage for a specific runtime
+ * home, so a home-scoped caller (a CLI command) reuses it instead of opening a
+ * second runtime against a schema it has not migrated. Without `scope` the
+ * scope stays unknown and any explicit home is rejected — the invariant
+ * asserted by 'rejects an explicit runtime home when service-owned storage
+ * scope is unknown'.
+ */
+export function _setRuntimeStorageForTest(
+  nextRuntime: StorageRuntime,
+  scope?: StorageRuntimeOptions,
+): void {
   runtime = nextRuntime;
-  runtimeScopeKey = 'process-runtime';
+  runtimeScopeKey = scope ? runtimeStorageScopeKey(scope) : 'process-runtime';
   const workerCoordination = nextRuntime.repositories?.workerCoordination;
   configurePendingInteractionDurability(
     workerCoordination

--- a/apps/core/test/integration/brain-core.postgres.integration.test.ts
+++ b/apps/core/test/integration/brain-core.postgres.integration.test.ts
@@ -15,6 +15,8 @@ import { BrainService } from '@core/brain/brain-service.js';
 import { runBrainEmbeddingBackfill } from '@core/brain/brain-embedding-backfill.js';
 import { processMemoryRequest } from '@core/memory/memory-ipc.js';
 import { runBrainCommand } from '@core/cli/brain.js';
+import { storageRuntimeOptionsForRuntimeHome } from '@core/adapters/storage/postgres/factory.js';
+import { loadRuntimeSettings } from '@core/config/settings/runtime-settings.js';
 import type { EmbeddingProvider } from '@core/memory/memory-embeddings.js';
 
 import {
@@ -62,8 +64,10 @@ maybeDescribe('company brain postgres core', () => {
   }, 60_000);
 
   afterAll(async () => {
-    await closeRuntimeStorage().catch(() => undefined);
+    // Drop the schema while the pool is still alive: closeRuntimeStorage ends
+    // the pool this harness owns, so cleanup() must run first.
     await runtime.cleanup();
+    await closeRuntimeStorage().catch(() => undefined);
   });
 
   it('creates pages, entities, edges, and the vector index', async () => {
@@ -209,6 +213,18 @@ Dana works at Knacklabs.`,
       process.env.GANTRY_BOOTSTRAP_SETTINGS_IF_MISSING = '1';
 
       const before = await brain.status('default');
+      // Claim the CLI's home scope so runBrainCommand reuses this already
+      // migrated storage. Built with the same helper the CLI uses, so the scope
+      // keys match by construction — the bootstrapped settings resolve schema
+      // 'gantry', not the harness schema, so a second runtime would open an
+      // unmigrated schema.
+      _setRuntimeStorageForTest(
+        runtime.storageRuntime,
+        storageRuntimeOptionsForRuntimeHome(
+          runtimeHome,
+          loadRuntimeSettings(runtimeHome),
+        ),
+      );
       expect(await runBrainCommand(runtimeHome, ['import', fixtureDir])).toBe(
         0,
       );
@@ -278,6 +294,14 @@ Dana works at Knacklabs.`,
       process.env.GANTRY_HOME = runtimeHome;
       process.env.GANTRY_BOOTSTRAP_SETTINGS_IF_MISSING = '1';
 
+      // Claim the CLI's home scope (see the import test above).
+      _setRuntimeStorageForTest(
+        runtime.storageRuntime,
+        storageRuntimeOptionsForRuntimeHome(
+          runtimeHome,
+          loadRuntimeSettings(runtimeHome),
+        ),
+      );
       // Bootstrapped settings have no verified owner → the notifier reports
       // delivered:false → the CLI must exit NON-zero, not print a false success.
       const code = await runBrainCommand(runtimeHome, [

--- a/apps/core/test/integration/brain-core.postgres.integration.test.ts
+++ b/apps/core/test/integration/brain-core.postgres.integration.test.ts
@@ -65,9 +65,13 @@ maybeDescribe('company brain postgres core', () => {
 
   afterAll(async () => {
     // Drop the schema while the pool is still alive: closeRuntimeStorage ends
-    // the pool this harness owns, so cleanup() must run first.
-    await runtime.cleanup();
-    await closeRuntimeStorage().catch(() => undefined);
+    // the pool this harness owns, so cleanup() must run first. The finally
+    // still resets module state if the schema drop throws.
+    try {
+      await runtime.cleanup();
+    } finally {
+      await closeRuntimeStorage().catch(() => undefined);
+    }
   });
 
   it('creates pages, entities, edges, and the vector index', async () => {

--- a/apps/core/test/integration/brain-harvest-dreaming.postgres.integration.test.ts
+++ b/apps/core/test/integration/brain-harvest-dreaming.postgres.integration.test.ts
@@ -59,9 +59,13 @@ maybeDescribe('brain harvest and dreaming postgres integration', () => {
 
   afterAll(async () => {
     // Drop the schema while the pool is still alive: closeRuntimeStorage ends
-    // the pool this harness owns, so cleanup() must run first.
-    await runtime.cleanup();
-    await closeRuntimeStorage().catch(() => undefined);
+    // the pool this harness owns, so cleanup() must run first. The finally
+    // still resets module state if the schema drop throws.
+    try {
+      await runtime.cleanup();
+    } finally {
+      await closeRuntimeStorage().catch(() => undefined);
+    }
   });
 
   it('harvests opted-in channel pages and dreams grounded additive facts', async () => {

--- a/apps/core/test/integration/brain-harvest-dreaming.postgres.integration.test.ts
+++ b/apps/core/test/integration/brain-harvest-dreaming.postgres.integration.test.ts
@@ -58,8 +58,10 @@ maybeDescribe('brain harvest and dreaming postgres integration', () => {
   }, 60_000);
 
   afterAll(async () => {
-    await closeRuntimeStorage().catch(() => undefined);
+    // Drop the schema while the pool is still alive: closeRuntimeStorage ends
+    // the pool this harness owns, so cleanup() must run first.
     await runtime.cleanup();
+    await closeRuntimeStorage().catch(() => undefined);
   });
 
   it('harvests opted-in channel pages and dreams grounded additive facts', async () => {

--- a/apps/core/test/integration/observer-insight-emission.postgres.integration.test.ts
+++ b/apps/core/test/integration/observer-insight-emission.postgres.integration.test.ts
@@ -97,9 +97,13 @@ maybeDescribe('observer insight emission postgres integration', () => {
 
   afterAll(async () => {
     // Drop the schema while the pool is still alive: closeRuntimeStorage ends
-    // the pool this harness owns, so cleanup() must run first.
-    await runtime.cleanup();
-    await closeRuntimeStorage().catch(() => undefined);
+    // the pool this harness owns, so cleanup() must run first. The finally
+    // still resets module state if the schema drop throws.
+    try {
+      await runtime.cleanup();
+    } finally {
+      await closeRuntimeStorage().catch(() => undefined);
+    }
   });
 
   it('applies floors and semantic dedup, persists structured evidence, and keeps unavailable retries cursor-safe', async () => {

--- a/apps/core/test/integration/observer-insight-emission.postgres.integration.test.ts
+++ b/apps/core/test/integration/observer-insight-emission.postgres.integration.test.ts
@@ -96,8 +96,10 @@ maybeDescribe('observer insight emission postgres integration', () => {
   }, 60_000);
 
   afterAll(async () => {
-    await closeRuntimeStorage().catch(() => undefined);
+    // Drop the schema while the pool is still alive: closeRuntimeStorage ends
+    // the pool this harness owns, so cleanup() must run first.
     await runtime.cleanup();
+    await closeRuntimeStorage().catch(() => undefined);
   });
 
   it('applies floors and semantic dedup, persists structured evidence, and keeps unavailable retries cursor-safe', async () => {


### PR DESCRIPTION
## What this is for

The `ci` lane has been red across branches. Three Postgres integration files fail on
`main` — `brain-core`, `brain-harvest-dreaming` and `observer-insight-emission` — so every
PR inherits a red lane and nobody can tell a real break from the standing noise. This
makes the lane green again.

Worth stating plainly: these failures are **not** a rate-limited API key and would not
have cleared on their own. They are ordinary assertion/teardown failures.

## Two independent causes

**1. Teardown order (all three files).** `afterAll` called `closeRuntimeStorage()` before
`runtime.cleanup()`. `closeRuntimeStorage()` ends the pool the *harness* owns, so
`cleanup()`'s `DROP SCHEMA` then ran against an ended pool → `Called end on pool more than
once`, and after that `Cannot use a pool after calling end on the pool`. Fixed by dropping
the schema first, with `closeRuntimeStorage()` in a `finally` so module state still resets
if the drop throws.

**2. Scope mismatch (brain-core's two CLI tests).** The cross-home guard added with the
runtime-home scoping work correctly rejects an explicit runtime home while unknown-scope
test storage is installed — so `runBrainCommand` could not open storage at all.

The tests need the CLI to **reuse** the already-migrated harness storage. Letting it open
its own is not an option: the bootstrapped settings resolve schema `gantry`, not the
harness's per-run schema (`GANTRY_SETTINGS_POSTGRES_SCHEMA` does not reach them), so a
second runtime targets an unmigrated schema and fails `assertMigrationsCurrent`.

So `_setRuntimeStorageForTest` takes an **optional scope**, and the tests build it with
`storageRuntimeOptionsForRuntimeHome` — the same helper the CLI uses — so the scope keys
match by construction rather than by a hand-copied guess.

## What is deliberately unchanged

Injection *without* a scope behaves exactly as before and still rejects an explicit runtime
home. That keeps the invariant asserted by `rejects an explicit runtime home when
service-owned storage scope is unknown`, which is a deliberate guard — an earlier attempt
here relaxed it and was reverted for that reason. No production call site changes behavior;
the only production edit is one additive optional parameter on an `@internal` test hook.

## Verification

- `test:integration:postgres` — **45 files / 272 passed**, exit 0 (was 3 files / 2 tests failed)
- `runtime-store` unit — 18/18, including the invariant above
- `test:integration:postgres:chaos` 1/1, `test:e2e:postgres` 5 files / 26 tests, `test:e2e` 2 files / 5 tests
- unit lane 7814/7814; `typecheck`, `format:check`, `check:architecture` clean; autoreview clean

**Negative-checked** — both fixes proven load-bearing:
- dropping the scope argument restores `Runtime storage is already initialized for a different runtime home`
- reverting the teardown order restores `Called end on pool more than once`

Not exercised locally: `test:e2e:agent:hermetic` and the supplementary real-model
`test:e2e:agent:turn`.
