### PR TITLE
Add direct LLM and agent task controls

### DIFF
--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/deep-agent-runner.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/deep-agent-runner.ts
@@ -3,10 +3,12 @@ import type { FileData, FilesystemPermission } from 'deepagents';
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
+import { ProviderStrategy, ToolStrategy } from 'langchain';
 
 import {
   buildRunnerModel,
   type OpenRouterProviderPreferences,
+  type ResolvedRunnerModel,
 } from './model-factory.js';
 import {
   applyCachePromptControl,
@@ -235,6 +237,14 @@ export async function runDeepAgentTurn(input: {
       () =>
         createDeepAgent({
           model: resolved.model,
+          ...(input.agentInput.responseSchema
+            ? {
+                responseFormat: responseFormatForSchema(
+                  input.agentInput.responseSchema,
+                  resolved.model,
+                ),
+              }
+            : {}),
           backend: (config) => new StateBackend(config),
           ...(input.checkpointer ? { checkpointer: input.checkpointer } : {}),
           permissions: hasProjectedSkills
@@ -276,6 +286,7 @@ export async function runDeepAgentTurn(input: {
       threadId: input.threadId,
       currentFiles: hasProjectedSkills ? skillProjection?.files : undefined,
     });
+    let structuredResponse: unknown;
     const events = startupTiming.measure('streamIteratorMs', () =>
       agent.streamEvents(
         {
@@ -296,7 +307,9 @@ export async function runDeepAgentTurn(input: {
       'streamNormalizeMs',
       () =>
         normalizeDeepAgentStream({
-          events,
+          events: captureStructuredResponse(events, (value) => {
+            structuredResponse = value;
+          }),
           newSessionId: input.newSessionId,
           modelId: resolved.modelId,
           modelProfile: { maxInputTokens: profile.maxInputTokens },
@@ -310,7 +323,12 @@ export async function runDeepAgentTurn(input: {
             threadId: input.agentInput.threadId,
             actor: 'deepagents',
           },
-          emit: input.emit,
+          emit: (frame) => {
+            if (input.agentInput.responseSchema && !frame.runtimeEventOnly) {
+              return;
+            }
+            input.emit(frame);
+          },
           onFirstEvent: (eventName) => {
             startupTiming.markFirstLangGraphEvent(eventName);
             logElapsed(`First LangGraph event (${eventName})`);
@@ -326,7 +344,12 @@ export async function runDeepAgentTurn(input: {
         }),
     );
     logElapsed('Stream normalized');
-    const text = normalized.text;
+    const terminalResult = input.agentInput.responseSchema
+      ? serializeStructuredResponse(structuredResponse)
+      : normalized.terminalResult;
+    const text = input.agentInput.responseSchema
+      ? (terminalResult ?? '')
+      : normalized.text;
     const startupRuntimeEvents = [
       buildDeepAgentStartupDiagnosticEvent({
         agentInput: input.agentInput,
@@ -354,13 +377,57 @@ export async function runDeepAgentTurn(input: {
 
     return {
       text,
-      terminalResult: normalized.terminalResult,
+      terminalResult,
       terminalUsage: normalized.terminalUsage,
       terminalContextUsage: normalized.terminalContextUsage,
       startupRuntimeEvents,
     };
   } finally {
     await connected.close().catch(() => {});
+  }
+}
+
+async function* captureStructuredResponse(
+  events: AsyncIterable<LangGraphStreamEvent>,
+  capture: (value: unknown) => void,
+): AsyncIterable<LangGraphStreamEvent> {
+  for await (const event of events) {
+    const output = event.data?.output;
+    if (
+      output &&
+      typeof output === 'object' &&
+      'structuredResponse' in output &&
+      output.structuredResponse !== undefined
+    ) {
+      capture(output.structuredResponse);
+    }
+    yield event;
+  }
+}
+
+function responseFormatForSchema(
+  schema: Record<string, unknown>,
+  { profile: { structuredOutput } }: ResolvedRunnerModel['model'],
+) {
+  const name = 'gantry_structured_output';
+  const normalized = { ...schema, name, title: name };
+  return structuredOutput === true
+    ? ProviderStrategy.fromSchema(normalized)
+    : ToolStrategy.fromSchema(normalized);
+}
+
+function serializeStructuredResponse(value: unknown): string {
+  if (value === undefined) {
+    throw new Error('DeepAgents structured output did not return a response.');
+  }
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    const detail = error instanceof Error ? ` ${error.message}` : '';
+    throw new Error(
+      `DeepAgents structured output could not be serialized.${detail}`,
+      { cause: error },
+    );
   }
 }
 

--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/types.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/types.ts
@@ -47,6 +47,7 @@ export interface DeepAgentRunnerInput {
     maxNoProgressContinuations: number;
     interactionTimeoutMs: number;
   };
+  responseSchema?: Record<string, unknown>;
   deepAgentCheckpointer?: DeepAgentCheckpointerConfig;
   deepAgentSkills?: DeepAgentSkillProjection;
   modelCredentialEnv?: Record<string, string>;

--- a/apps/core/src/app/bootstrap/AGENTS.md
+++ b/apps/core/src/app/bootstrap/AGENTS.md
@@ -3,3 +3,9 @@
 - `sendStreamingChunk` is a transport handoff for incremental provider text.
   Preserve leading, trailing, and whitespace-only chunks; channel-specific
   stream sinks own buffering and final formatting.
+- Startup must activate model aliases from the authoritative runtime settings
+  after either file or revision loading; parsing a revision document alone does
+  not update the process model catalog.
+- Re-activate those authoritative aliases after local preflight and watcher
+  initialization, before runtime services start, because loading a different
+  local mirror also updates the process-wide catalog.

--- a/apps/core/src/app/bootstrap/startup.ts
+++ b/apps/core/src/app/bootstrap/startup.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import {
   RuntimeSettings,
+  activateRuntimeModelAliases,
   loadRuntimeSettings,
 } from '../../config/settings/runtime-settings.js';
 import {
@@ -121,6 +122,9 @@ export async function runStartup(
     );
     return revisionSettings;
   })();
+  if (runtimeSettings.modelAliases) {
+    activateRuntimeModelAliases(runtimeSettings);
+  }
   if (
     resolved.settingsAuthority === 'file' &&
     runtimeSettings.desiredState &&

--- a/apps/core/src/app/index.ts
+++ b/apps/core/src/app/index.ts
@@ -36,6 +36,7 @@ import {
 } from '../config/index.js';
 import { getBrowserStatus } from '../runtime/browser-capability.js';
 import { startSettingsReloadWatcher } from '../runtime/settings-reload-watcher.js';
+import { activateRuntimeModelAliases } from '../config/settings/runtime-settings.js';
 import {
   prepareFleetSettings,
   startFleetSubsystems,
@@ -232,6 +233,7 @@ export async function startGantryRuntime(
         settingsRevisions: storage.repositories.settingsRevisions,
         settingsRevisionPool: storage.service.pool,
       });
+  activateRuntimeModelAliases(runtimeSettings);
   let fleetSubsystems: FleetSubsystems | undefined;
   const browserToolModulePath = [
     '..',

--- a/apps/core/src/control/server/http.ts
+++ b/apps/core/src/control/server/http.ts
@@ -12,6 +12,8 @@ export type ControlRequestLogEntry = {
   appId?: string;
   modelAlias?: string;
   modelRouteId?: string;
+  correlationId?: string;
+  taskType?: string;
   requestBodyBytes?: number;
   responseBodyBytes?: number;
   clientDisconnected?: boolean;

--- a/apps/core/src/control/server/routes/llm.ts
+++ b/apps/core/src/control/server/routes/llm.ts
@@ -44,6 +44,10 @@ const BLOCKED_LOOPBACK_RESPONSE_HEADERS = new Set([
   'connection',
   'set-cookie',
   'transfer-encoding',
+  'x-gantry-model-alias',
+  'x-gantry-model-route',
+  'x-gantry-provider',
+  'x-gantry-request-id',
 ]);
 
 type ResolvedLlmRequest = {
@@ -53,6 +57,8 @@ type ResolvedLlmRequest = {
   alias: string;
   provider: ModelProviderDefinition;
   tail: string;
+  correlationId?: string;
+  taskType?: string;
 };
 
 export async function handleLlmRoutes(
@@ -84,6 +90,10 @@ export async function handleLlmRoutes(
   if (!resolved) return true;
 
   const apiRequestId = randomUUID();
+  res.setHeader('x-gantry-request-id', apiRequestId);
+  res.setHeader('x-gantry-model-alias', resolved.alias);
+  res.setHeader('x-gantry-model-route', resolved.entry.modelRoute.id);
+  res.setHeader('x-gantry-provider', resolved.provider.id);
   let broker: AgentCredentialBroker | undefined;
   let injectionIssued = false;
   let statusCode = 502;
@@ -173,6 +183,10 @@ export async function handleLlmRoutes(
       appId: auth.appId,
       modelAlias: resolved.alias,
       modelRouteId: resolved.entry.modelRoute.id,
+      ...(resolved.correlationId
+        ? { correlationId: resolved.correlationId }
+        : {}),
+      ...(resolved.taskType ? { taskType: resolved.taskType } : {}),
       requestBodyBytes: resolved.body.byteLength,
       ...(responseBodyBytes !== undefined ? { responseBodyBytes } : {}),
       ...(clientDisconnected ? { clientDisconnected: true } : {}),
@@ -235,6 +249,15 @@ function resolveLlmRequest(
     sendError(res, 400, 'INVALID_MODEL', resolution.message);
     return null;
   }
+  if (resolution.alias === resolution.entry.modelRoute.providerModelId) {
+    sendError(
+      res,
+      400,
+      'INVALID_MODEL',
+      'Direct LLM callers must use an application-facing model alias',
+    );
+    return null;
+  }
   const provider = getModelProviderDefinition(resolution.entry.modelRoute.id);
   if (!provider) {
     sendError(res, 400, 'INVALID_MODEL', 'Model provider is not registered');
@@ -245,6 +268,9 @@ function resolveLlmRequest(
     sendError(res, 400, 'INVALID_MODEL', compatibilityError);
     return null;
   }
+  const metadata =
+    endpoint === 'chat_completions' ? stringMetadata(body.metadata) : {};
+  if (endpoint === 'chat_completions') delete body.metadata;
   body.model = resolution.entry.modelRoute.providerModelId;
   return {
     endpoint,
@@ -252,6 +278,10 @@ function resolveLlmRequest(
     entry: resolution.entry,
     alias: resolution.alias,
     provider,
+    ...(metadata.correlation_id
+      ? { correlationId: metadata.correlation_id }
+      : {}),
+    ...(metadata.task_type ? { taskType: metadata.task_type } : {}),
     tail:
       endpoint === 'messages'
         ? '/v1/messages'
@@ -259,6 +289,15 @@ function resolveLlmRequest(
           ? '/v1/messages/count_tokens'
           : chatCompletionsTail(provider),
   };
+}
+
+function stringMetadata(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
 }
 
 function parseBody(

--- a/apps/core/src/domain/job-types.ts
+++ b/apps/core/src/domain/job-types.ts
@@ -24,6 +24,7 @@ export interface JobNotificationRoute {
 }
 
 export interface JobAgentTask {
+  observability?: { traceparent: string };
   responseSchema?: Record<string, unknown>;
   callerResolvedTools?: {
     tools: Array<{

--- a/apps/core/src/jobs/execution.ts
+++ b/apps/core/src/jobs/execution.ts
@@ -472,6 +472,7 @@ export async function runJob(
                 jobId: currentJob.id,
                 jobName: currentJob.name,
                 runId,
+                ...(currentJob.agent_task?.observability ?? {}),
                 runLeaseToken: leaseContext.lease.leaseToken,
                 runLeaseFencingVersion: leaseContext.lease.fencingVersion,
                 jobModelUseKind,

--- a/apps/core/src/runtime/agent-spawn-admission.ts
+++ b/apps/core/src/runtime/agent-spawn-admission.ts
@@ -105,13 +105,6 @@ function inlineRuntimePreSpawnAdmissionError(input: {
   stdioMcpSourceIds?: readonly string[];
 }): string | null {
   const runtime = input.agentRuntime ?? input.agentInput.runtime ?? 'worker';
-  if (
-    input.agentInput.responseSchema &&
-    runtime === 'worker' &&
-    input.agentEngine === DEEPAGENTS_ENGINE
-  ) {
-    return 'response_schema is not supported by the selected worker agent harness';
-  }
   if (runtime !== 'inline') return null;
   const labels = new Set<string>();
   for (const rule of inlineWorkerOnlyToolRuleLabels(

--- a/apps/core/src/runtime/agent-spawn-types.ts
+++ b/apps/core/src/runtime/agent-spawn-types.ts
@@ -79,6 +79,7 @@ export interface AgentInput {
   jobName?: string;
   runId?: string;
   correlationId?: string | null;
+  traceparent?: string;
   parentTaskId?: string;
   runLeaseToken?: string;
   runLeaseFencingVersion?: number;

--- a/apps/core/test/unit/adapters/deep-agent-runner-startup-diagnostic.test.ts
+++ b/apps/core/test/unit/adapters/deep-agent-runner-startup-diagnostic.test.ts
@@ -79,6 +79,22 @@ async function* fakeLangGraphEvents(): AsyncIterable<LangGraphStreamEvent> {
   };
 }
 
+async function* fakeStructuredLangGraphEvents(): AsyncIterable<LangGraphStreamEvent> {
+  yield {
+    event: 'on_chat_model_stream',
+    data: {
+      chunk: {
+        content: 'intermediate text',
+        usage_metadata: { input_tokens: 11, output_tokens: 3 },
+      },
+    },
+  };
+  yield {
+    event: 'on_chain_end',
+    data: { output: { structuredResponse: { answer: 'verified' } } },
+  };
+}
+
 async function* fakeTaskLifecycleEvents(): AsyncIterable<LangGraphStreamEvent> {
   yield buildGantryTaskLifecycleStreamEvent({
     kind: 'progress',
@@ -225,6 +241,48 @@ describe('runDeepAgentTurn startup diagnostics', () => {
     expect(serialized).not.toContain('secret memory text');
     expect(serialized).not.toContain('http://127.0.0.1:4545/openai');
     expect(serialized).not.toContain('gtw_secret_token');
+  });
+
+  it('returns structured output from the DeepAgents worker without streaming partial text', async () => {
+    mocks.buildRunnerModel.mockResolvedValueOnce({
+      model: {
+        profile: { maxInputTokens: 8192, structuredOutput: true },
+      },
+      endpointFamily: 'openai',
+      modelId: 'gpt-test',
+    });
+    mocks.createDeepAgent.mockReturnValueOnce({
+      streamEvents: vi.fn(() => fakeStructuredLangGraphEvents()),
+    });
+    const { runDeepAgentTurn } =
+      await import('@core/adapters/llm/deepagents-langchain/runner/deep-agent-runner.js');
+    const frames: unknown[] = [];
+
+    const turn = await runDeepAgentTurn({
+      agentInput: input({
+        responseSchema: {
+          type: 'object',
+          properties: { answer: { type: 'string' } },
+          required: ['answer'],
+        },
+      }),
+      provider: 'openai',
+      modelId: 'gpt-test',
+      newSessionId: 'session-one',
+      includeMemoryContext: false,
+      emit: (frame) => frames.push(frame),
+    });
+
+    expect(mocks.createDeepAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ responseFormat: expect.anything() }),
+    );
+    expect(frames).toEqual([]);
+    expect(turn.terminalResult).toBe('{"answer":"verified"}');
+    expect(turn.text).toBe('{"answer":"verified"}');
+    expect(turn.terminalUsage).toMatchObject({
+      inputTokens: 11,
+      outputTokens: 3,
+    });
   });
 
   it('passes Gantry lifecycle context into DeepAgents stream normalization', async () => {

--- a/apps/core/test/unit/control/llm-routes.test.ts
+++ b/apps/core/test/unit/control/llm-routes.test.ts
@@ -214,6 +214,10 @@ describe('direct LLM control routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['content-type']).toBe('application/json');
     expect(res.headers['x-request-id']).toBe('req_1');
+    expect(res.headers['x-gantry-request-id']).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(res.headers['x-gantry-model-alias']).toBe('sonnet');
+    expect(res.headers['x-gantry-model-route']).toBe('anthropic');
+    expect(res.headers['x-gantry-provider']).toBe('anthropic');
     expect(res.headers.authorization).toBeUndefined();
     expect(res.body()).toBe('{"id":"msg_1"}');
 
@@ -302,6 +306,23 @@ describe('direct LLM control routes', () => {
         statusCode: 200,
       }),
     );
+  });
+
+  it('rejects provider model identifiers even when cataloged as aliases', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const res = new TestResponse();
+    await handleLlmRoutes(
+      request({ body: { model: 'gpt-5.5', messages: [] } }),
+      res as unknown as ServerResponse,
+      context({}),
+      '/llm/v1/chat/completions',
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body())).toMatchObject({
+      error: { code: 'INVALID_MODEL' },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -418,6 +439,10 @@ describe('direct LLM control routes', () => {
         ],
         response_format: { type: 'json_object' },
         reasoning_effort: 'medium',
+        metadata: {
+          correlation_id: 'scrape:run-1:task-1',
+          task_type: 'manipal.scrape.normalization.full',
+        },
       },
     });
     const res = new TestResponse();
@@ -446,6 +471,13 @@ describe('direct LLM control routes', () => {
     expect(upstreamBody.tools[0].type).toBe('function');
     expect(upstreamBody.response_format).toEqual({ type: 'json_object' });
     expect(upstreamBody.reasoning_effort).toBe('medium');
+    expect(upstreamBody.metadata).toBeUndefined();
+    expect(requestLogs).toContainEqual(
+      expect.objectContaining({
+        correlationId: 'scrape:run-1:task-1',
+        taskType: 'manipal.scrape.normalization.full',
+      }),
+    );
   });
 
   it.each([

--- a/apps/core/test/unit/control/sdk-transport.test.ts
+++ b/apps/core/test/unit/control/sdk-transport.test.ts
@@ -195,6 +195,80 @@ describe('@gantry/sdk transport', () => {
     ).resolves.toEqual({ sessionId: 'session-1' });
   });
 
+  it('invokes chat completions and preserves Gantry routing metadata', async () => {
+    const port = await listen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/llm/v1/chat/completions');
+        expect(req.headers.traceparent).toBe(
+          '00-0123456789abcdef0123456789abcdef-0123456789abcdef-01',
+        );
+        expect(
+          JSON.parse(Buffer.concat(chunks).toString('utf8')),
+        ).toMatchObject({
+          model: 'configured-alias',
+          messages: [{ role: 'user', content: 'return json' }],
+        });
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'x-gantry-request-id': 'gantry-request-1',
+          'x-gantry-model-alias': 'configured-alias',
+          'x-gantry-model-route': 'provider-route',
+          'x-gantry-provider': 'provider',
+        });
+        res.end(
+          JSON.stringify({
+            id: 'response-1',
+            object: 'chat.completion',
+            created: 1,
+            model: 'provider-model',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: '{"ok":true}' },
+                finish_reason: 'stop',
+              },
+            ],
+            usage: {
+              prompt_tokens: 3,
+              completion_tokens: 2,
+              total_tokens: 5,
+            },
+          }),
+        );
+      });
+    });
+    const client = new GantryClient({
+      apiKey: 'test-key',
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+
+    await expect(
+      client.llm.chatCompletions(
+        {
+          model: 'configured-alias',
+          messages: [{ role: 'user', content: 'return json' }],
+        },
+        {
+          traceparent:
+            '00-0123456789abcdef0123456789abcdef-0123456789abcdef-01',
+        },
+      ),
+    ).resolves.toMatchObject({
+      gantryRequestId: 'gantry-request-1',
+      modelAlias: 'configured-alias',
+      modelRoute: 'provider-route',
+      provider: 'provider',
+      response: {
+        id: 'response-1',
+        model: 'provider-model',
+        usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+      },
+    });
+  });
+
   it('sends idempotency and bounded queue policy for a session message', async () => {
     const port = await listen((req, res) => {
       const chunks: Buffer[] = [];

--- a/apps/core/test/unit/runtime/agent-spawn-admission.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-admission.test.ts
@@ -95,6 +95,21 @@ describe('agent spawn admission', () => {
     ).toBeNull();
   });
 
+  it('allows response schemas for the DeepAgents worker runtime', () => {
+    expect(
+      validateAgentPreSpawnAdmission({
+        agentRuntime: 'worker',
+        agentEngine: DEEPAGENTS_ENGINE,
+        sandboxProvider: 'direct',
+        securityEnv: {},
+        agentInput: {
+          ...baseInput,
+          responseSchema: { type: 'object' },
+        },
+      }),
+    ).toBeNull();
+  });
+
   it('names unsupported control fields and models before provider invocation', () => {
     expect(
       validateAgentPreSpawnAdmission({

--- a/ops/AGENTS.md
+++ b/ops/AGENTS.md
@@ -14,3 +14,6 @@
 - ECS task definitions must inject secret environment variables with `secrets` entries backed by Secrets Manager ARNs; keep plaintext `environment` entries to non-secret deployment knobs such as `GANTRY_PROCESS_ROLE`.
 - ECS deployment role layouts are `api-only`, `chat-only`, `jobs-only`, and `all`; the control service may attach the control/API target group, and the live-worker service may attach the webhook ingress target group.
 - Normalize executable shell scripts copied into Linux images during the image build; Windows worktrees may present tracked LF files as CRLF and make their shebang unexecutable.
+- Container settings importers must write the revision for `GANTRY_APP_ID` and
+  use the same settings import service as the runtime; do not populate an
+  application-scoped deployment through the default app revision.

--- a/ops/docker/Dockerfile
+++ b/ops/docker/Dockerfile
@@ -108,8 +108,9 @@ COPY --from=build /app/packages/contracts/package.json ./packages/contracts/pack
 COPY --from=build /app/packages/sdk/dist ./packages/sdk/dist
 COPY --from=build /app/packages/sdk/package.json ./packages/sdk/package.json
 
-# Ops scripts: fleet settings seed + entrypoint.
+# Ops scripts: settings revision seed/import + entrypoint.
 COPY ops/docker/fleet-settings-seed.mjs ./ops/docker/fleet-settings-seed.mjs
+COPY ops/docker/workstation-settings-import.mjs ./ops/docker/workstation-settings-import.mjs
 COPY ops/docker/entrypoint.sh /usr/local/bin/gantry-entrypoint
 RUN sed -i 's/\r$//' /usr/local/bin/gantry-entrypoint \
     && chmod +x /usr/local/bin/gantry-entrypoint

--- a/ops/docker/workstation-settings-import.mjs
+++ b/ops/docker/workstation-settings-import.mjs
@@ -1,0 +1,59 @@
+import {
+  closeRuntimeStorage,
+  getRuntimeStorage,
+  initializeRuntimeStorage,
+} from '../../dist/adapters/storage/postgres/runtime-store.js';
+import { loadRuntimeSettingsFromPath } from '../../dist/config/index.js';
+import {
+  importWorkstationSettings,
+  settingsFromRevisionDocument,
+} from '../../dist/config/settings/settings-import-service.js';
+
+const settingsPath = process.argv[2];
+if (!settingsPath) {
+  console.error(
+    'usage: node /app/ops/docker/workstation-settings-import.mjs <settings.yaml>',
+  );
+  process.exit(1);
+}
+
+const appId = process.env.GANTRY_APP_ID?.trim() || 'default';
+const runtimeHome = process.env.GANTRY_HOME || '/var/lib/gantry';
+const settings = loadRuntimeSettingsFromPath(settingsPath);
+
+await initializeRuntimeStorage({ runtimeSettings: settings });
+try {
+  const storage = getRuntimeStorage();
+  const latest =
+    await storage.repositories.settingsRevisions.getLatestSettingsRevision(
+      appId,
+    );
+  const previousSettings = latest
+    ? settingsFromRevisionDocument(latest.settingsDocument)
+    : settings;
+  const outcome = await importWorkstationSettings(
+    {
+      runtimeHome,
+      ops: storage.ops,
+      repositories: storage.repositories,
+      appId,
+      previousSettings,
+      revisionMirror: {
+        settingsRevisions: storage.repositories.settingsRevisions,
+        pool: storage.service.pool,
+        createdBy: 'docker:workstation-settings-import',
+        note: process.env.GANTRY_SETTINGS_IMPORT_NOTE?.trim() || null,
+      },
+      revisionMirrorRequired: true,
+      expectedRevision: latest?.revision ?? 0,
+    },
+    settings,
+  );
+  console.log(
+    outcome.revision
+      ? `workstation settings revision ${outcome.revision} imported for ${appId}`
+      : `workstation settings already current for ${appId}`,
+  );
+} finally {
+  await closeRuntimeStorage();
+}

--- a/packages/contracts/src/jobs/agent-task.ts
+++ b/packages/contracts/src/jobs/agent-task.ts
@@ -2,6 +2,14 @@ import { z } from 'zod';
 
 export const JobAgentTaskSchema = z
   .object({
+    observability: z
+      .object({
+        traceparent: z
+          .string()
+          .regex(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/iu),
+      })
+      .strict()
+      .optional(),
     responseSchema: z
       .record(z.string(), z.unknown())
       .refine((schema) => schema.type === 'object', {

--- a/packages/contracts/test/unit/index.test.ts
+++ b/packages/contracts/test/unit/index.test.ts
@@ -993,12 +993,23 @@ describe('contracts package', () => {
       ],
     });
     const agentTask = {
+      observability: {
+        traceparent:
+          '00-0123456789abcdef0123456789abcdef-0123456789abcdef-01',
+      },
       responseSchema: { type: 'object' as const, properties: {} },
       executionPolicy: { totalTimeoutMs: 30_000 },
     };
     expect(
       CreateJobRequestSchema.parse({ ...sdkCreatePayload, agentTask }),
     ).toMatchObject({ agentTask });
+    expectInvalid(CreateJobRequestSchema, {
+      ...sdkCreatePayload,
+      agentTask: {
+        ...agentTask,
+        observability: { traceparent: 'not-a-traceparent' },
+      },
+    });
     expectInvalid(CreateJobRequestSchema, {
       ...sdkCreatePayload,
       agentTask: {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gantry/sdk
 
+## Unreleased
+
+- Added typed `client.llm.chatCompletions()` support with safe request, model
+  alias, route, and provider correlation metadata.
+- Added HTTP status codes to `GantryError` for reliable retry classification.
+
 ## 0.5.0
 
 - Added app-owned agent selection and canonical `executionContext` to session

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -63,6 +63,10 @@ endpoints on the running runtime:
 - `client.usage` — `query`
 - `client.models` — `list`, `defaults.get`, `defaults.update`, `preview`, and
   scoped-admin `credentials.list`, `credentials.set`, `credentials.disable`
+- `client.llm.chatCompletions` — provider-neutral text/image structured
+  generation through a registered model alias. Requires `llm:invoke` and
+  returns safe Gantry request, alias, route, and provider correlation metadata
+  alongside the typed upstream response.
 - `client.agents` — admin read and profile-file read/write plus `skills`, `mcpServers`, `conversationInstalls`
 - `client.skills` — install and list skills
 - `client.mcpServers` — catalog of MCP servers

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,3 @@
-import http from 'node:http';
-import https from 'node:https';
-import { URL } from 'node:url';
 import type {
   ConversationDiscoveryInput,
   ConversationInstallInput,
@@ -20,17 +17,19 @@ import type {
   RuntimeEventListResponse,
   RuntimeEventQuery,
   RuntimeEventStreamOptions,
-  SseEvent,
+  TraceRequestOptions,
 } from './types.js';
 import { runtimeEventQuery } from './runtime-event-query.js';
 import type * as OpenApi from './openapi-types.js';
-import { parseSessionSseEvent } from './session-events.js';
 import { createIngressesClient } from './ingresses.js';
 import { querySuffix } from './query-string.js';
 export type { RuntimeSettingsResponse } from './settings.js';
 import * as mcpServerClients from './mcp-servers.js';
 import { jobListQuery } from './job-list-query.js';
 import { createModelsClient } from './models.js';
+import { createLlmClient } from './llm.js';
+import { Transport } from './transport.js';
+export type { GantryError } from './transport.js';
 import type {
   CreateJobInput,
   CreateJobResponse,
@@ -69,213 +68,18 @@ export type {
 } from './job-model-types.js';
 export type * from './openapi-types.js';
 
-export interface GantryError extends Error {
-  code: string;
-  details?: Record<string, unknown> | null;
-  requestId?: string;
-  retryable?: boolean;
-  restartRequired?: boolean;
-  nextAction?: string;
-}
-function toError(input: unknown): GantryError {
-  const fallback = new Error('Gantry request failed') as GantryError;
-  fallback.code = 'UNKNOWN_ERROR';
-  if (
-    input &&
-    typeof input === 'object' &&
-    'error' in input &&
-    input.error &&
-    typeof input.error === 'object'
-  ) {
-    const error = input.error as Record<string, unknown>;
-    const next = new Error(
-      String(error.message || 'Gantry request failed'),
-    ) as GantryError;
-    next.code = String(error.code || 'UNKNOWN_ERROR');
-    next.details =
-      error.details && typeof error.details === 'object'
-        ? (error.details as Record<string, unknown>)
-        : null;
-    next.requestId =
-      typeof error.requestId === 'string' ? error.requestId : undefined;
-    next.retryable =
-      typeof error.retryable === 'boolean' ? error.retryable : undefined;
-    next.restartRequired =
-      typeof error.restartRequired === 'boolean'
-        ? error.restartRequired
-        : undefined;
-    next.nextAction =
-      typeof error.nextAction === 'string' ? error.nextAction : undefined;
-    return next;
-  }
-  return fallback;
-}
-
-function parseJsonBody(raw: string): unknown {
-  if (!raw.trim()) return {};
-  try {
-    return JSON.parse(raw);
-  } catch {
-    const error = new Error(
-      'Gantry returned a non-JSON response',
-    ) as GantryError;
-    error.code = 'INVALID_RESPONSE';
-    throw error;
-  }
-}
-
-class Transport {
-  private readonly apiKey: string;
-  private readonly baseUrl: URL;
-  private readonly socketPath?: string;
-  private readonly timeoutMs: number;
-
-  constructor(options: ClientOptions) {
-    this.apiKey = options.apiKey;
-    this.baseUrl = new URL(options.baseUrl || 'http://127.0.0.1:3939');
-    this.socketPath = options.socketPath;
-    this.timeoutMs = options.timeoutMs ?? 60_000;
-  }
-
-  request<T>(options: RequestOptions): Promise<T> {
-    const url = new URL(options.path, this.baseUrl);
-    const mod = url.protocol === 'https:' ? https : http;
-    const body =
-      options.body === undefined
-        ? undefined
-        : options.body instanceof Uint8Array
-          ? options.body
-          : JSON.stringify(options.body);
-    const headers: Record<string, string> = {
-      authorization: `Bearer ${this.apiKey}`,
-      accept: options.accept || 'application/json',
-    };
-    if (body) {
-      headers['content-type'] =
-        options.contentType ||
-        (options.body instanceof Uint8Array
-          ? 'application/octet-stream'
-          : 'application/json');
-    }
-    return new Promise<T>((resolve, reject) => {
-      const req = mod.request(
-        {
-          protocol: url.protocol,
-          hostname: this.socketPath ? undefined : url.hostname,
-          port: this.socketPath ? undefined : url.port,
-          path: `${url.pathname}${url.search}`,
-          socketPath: this.socketPath,
-          method: options.method,
-          headers,
-        },
-        (res) => {
-          const chunks: Buffer[] = [];
-          res.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
-          res.on('end', () => {
-            const raw = Buffer.concat(chunks).toString('utf8');
-            let parsed: unknown = {};
-            try {
-              parsed = parseJsonBody(raw);
-            } catch (error) {
-              reject(error);
-              return;
-            }
-            if ((res.statusCode || 500) >= 400) {
-              reject(toError(parsed));
-              return;
-            }
-            resolve(parsed as T);
-          });
-        },
-      );
-      req.setTimeout(this.timeoutMs, () => {
-        req.destroy(new Error('Gantry request timed out'));
-      });
-      req.on('error', reject);
-      if (options.signal) {
-        options.signal.addEventListener(
-          'abort',
-          () => req.destroy(new Error('Gantry request aborted')),
-          { once: true },
-        );
-      }
-      if (body) req.write(body);
-      req.end();
-    });
-  }
-
-  async *stream(
-    pathname: string,
-    signal?: AbortSignal,
-  ): AsyncIterable<SseEvent> {
-    const url = new URL(pathname, this.baseUrl);
-    const mod = url.protocol === 'https:' ? https : http;
-    const req = mod.request({
-      protocol: url.protocol,
-      hostname: this.socketPath ? undefined : url.hostname,
-      port: this.socketPath ? undefined : url.port,
-      path: `${url.pathname}${url.search}`,
-      socketPath: this.socketPath,
-      method: 'GET',
-      headers: {
-        authorization: `Bearer ${this.apiKey}`,
-        accept: 'text/event-stream',
-      },
-    });
-    if (signal) {
-      signal.addEventListener(
-        'abort',
-        () => req.destroy(new Error('Gantry stream aborted')),
-        { once: true },
-      );
-    }
-    const response = await new Promise<http.IncomingMessage>(
-      (resolve, reject) => {
-        req.on('response', resolve);
-        req.on('error', reject);
-        req.end();
-      },
-    );
-    if ((response.statusCode || 500) >= 400) {
-      const chunks: Buffer[] = [];
-      for await (const chunk of response) {
-        chunks.push(Buffer.from(chunk));
-      }
-      throw toError(parseJsonBody(Buffer.concat(chunks).toString('utf8')));
-    }
-    let buffer = '';
-    for await (const chunk of response) {
-      buffer += chunk.toString();
-      while (true) {
-        const delimiter = buffer.indexOf('\n\n');
-        if (delimiter < 0) break;
-        const block = buffer.slice(0, delimiter);
-        buffer = buffer.slice(delimiter + 2);
-        const lines = block.split('\n');
-        const idLine = lines.find((line) => line.startsWith('id: '));
-        const eventLine = lines.find((line) => line.startsWith('event: '));
-        const dataLine = lines.find((line) => line.startsWith('data: '));
-        if (!idLine || !eventLine || !dataLine) continue;
-        yield parseSessionSseEvent({
-          eventId: Number(idLine.slice(4).trim()),
-          eventType: eventLine.slice(7).trim(),
-          data: JSON.parse(dataLine.slice(6)),
-        });
-      }
-    }
-  }
-}
-
 export class GantryClient {
   private readonly transport: Transport;
   private readonly request = <T>(options: RequestOptions) =>
     this.transport.request<T>(options);
   readonly ingresses: ReturnType<typeof createIngressesClient>;
+  readonly llm: ReturnType<typeof createLlmClient>;
   readonly models: ReturnType<typeof createModelsClient>;
 
   constructor(options: ClientOptions) {
     this.transport = new Transport(options);
     this.ingresses = createIngressesClient(this.transport);
+    this.llm = createLlmClient(this.transport);
     this.models = createModelsClient(this.transport);
   }
 
@@ -379,11 +183,12 @@ export class GantryClient {
   };
 
   readonly jobs = {
-    create: (input: CreateJobInput) =>
+    create: (input: CreateJobInput, options?: TraceRequestOptions) =>
       this.transport.request<CreateJobResponse>({
         method: 'POST',
         path: '/v1/jobs',
         body: input,
+        ...(options?.traceparent ? { traceparent: options.traceparent } : {}),
       }),
     list: (input?: ListJobsInput) =>
       this.transport.request<OpenApi.ListJobsResponse>({

--- a/packages/sdk/src/job-model-types.ts
+++ b/packages/sdk/src/job-model-types.ts
@@ -398,6 +398,7 @@ export interface CreateJobInput {
 }
 
 export interface JobAgentTask {
+  observability?: { traceparent: string };
   responseSchema?: { type: 'object' } & Record<string, unknown>;
   callerResolvedTools?: {
     tools: Array<{

--- a/packages/sdk/src/llm.ts
+++ b/packages/sdk/src/llm.ts
@@ -1,0 +1,47 @@
+import type * as OpenApi from './openapi-types.js';
+import type {
+  LlmRequestOptions,
+  RequestOptions,
+  TransportResponse,
+} from './types.js';
+import type { GantryError } from './transport.js';
+
+type LlmTransport = {
+  requestWithMetadata<T>(
+    options: RequestOptions,
+  ): Promise<TransportResponse<T>>;
+};
+
+export function createLlmClient(transport: LlmTransport) {
+  return {
+    chatCompletions: (
+      input: OpenApi.LlmChatCompletionsRequest,
+      options?: LlmRequestOptions,
+    ) =>
+      transport
+        .requestWithMetadata<OpenApi.LlmChatCompletionsResponse>({
+          method: 'POST',
+          path: '/llm/v1/chat/completions',
+          body: input,
+          traceparent: options?.traceparent,
+        })
+        .then(({ body, headers }) => ({
+          response: body,
+          gantryRequestId: requiredHeader(headers, 'x-gantry-request-id'),
+          modelAlias: requiredHeader(headers, 'x-gantry-model-alias'),
+          modelRoute: requiredHeader(headers, 'x-gantry-model-route'),
+          provider: requiredHeader(headers, 'x-gantry-provider'),
+        })),
+  };
+}
+
+function requiredHeader(
+  headers: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string {
+  const value = headers[name]?.trim();
+  if (value) return value;
+  const error = new Error(`Gantry response is missing ${name}`) as GantryError;
+  error.code = 'INVALID_RESPONSE';
+  throw error;
+}

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -1,0 +1,220 @@
+import http from 'node:http';
+import https from 'node:https';
+import { URL } from 'node:url';
+import { parseSessionSseEvent } from './session-events.js';
+import type {
+  ClientOptions,
+  RequestOptions,
+  SseEvent,
+  TransportResponse,
+} from './types.js';
+
+export interface GantryError extends Error {
+  code: string;
+  statusCode?: number;
+  details?: Record<string, unknown> | null;
+  requestId?: string;
+  retryable?: boolean;
+  restartRequired?: boolean;
+  nextAction?: string;
+}
+
+export class Transport {
+  private readonly apiKey: string;
+  private readonly baseUrl: URL;
+  private readonly socketPath?: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: ClientOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = new URL(options.baseUrl || 'http://127.0.0.1:3939');
+    this.socketPath = options.socketPath;
+    this.timeoutMs = options.timeoutMs ?? 60_000;
+  }
+
+  request<T>(options: RequestOptions): Promise<T> {
+    return this.requestWithMetadata<T>(options).then(
+      (response) => response.body,
+    );
+  }
+
+  requestWithMetadata<T>(
+    options: RequestOptions,
+  ): Promise<TransportResponse<T>> {
+    const url = new URL(options.path, this.baseUrl);
+    const mod = url.protocol === 'https:' ? https : http;
+    const body =
+      options.body === undefined
+        ? undefined
+        : options.body instanceof Uint8Array
+          ? options.body
+          : JSON.stringify(options.body);
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${this.apiKey}`,
+      accept: options.accept || 'application/json',
+    };
+    if (body) {
+      headers['content-type'] =
+        options.contentType ||
+        (options.body instanceof Uint8Array
+          ? 'application/octet-stream'
+          : 'application/json');
+    }
+    if (options.traceparent) headers.traceparent = options.traceparent;
+    return new Promise<TransportResponse<T>>((resolve, reject) => {
+      const req = mod.request(
+        {
+          protocol: url.protocol,
+          hostname: this.socketPath ? undefined : url.hostname,
+          port: this.socketPath ? undefined : url.port,
+          path: `${url.pathname}${url.search}`,
+          socketPath: this.socketPath,
+          method: options.method,
+          headers,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+          res.on('end', () => {
+            const raw = Buffer.concat(chunks).toString('utf8');
+            let parsed: unknown = {};
+            try {
+              parsed = parseJsonBody(raw);
+            } catch (error) {
+              reject(error);
+              return;
+            }
+            if ((res.statusCode || 500) >= 400) {
+              const error = toError(parsed);
+              error.statusCode = res.statusCode;
+              reject(error);
+              return;
+            }
+            const responseHeaders: Record<string, string | undefined> = {};
+            for (const [name, value] of Object.entries(res.headers)) {
+              responseHeaders[name] = Array.isArray(value)
+                ? value.join(', ')
+                : value;
+            }
+            resolve({ body: parsed as T, headers: responseHeaders });
+          });
+        },
+      );
+      req.setTimeout(this.timeoutMs, () =>
+        req.destroy(new Error('Gantry request timed out')),
+      );
+      req.on('error', reject);
+      options.signal?.addEventListener(
+        'abort',
+        () => req.destroy(new Error('Gantry request aborted')),
+        { once: true },
+      );
+      if (body) req.write(body);
+      req.end();
+    });
+  }
+
+  async *stream(
+    pathname: string,
+    signal?: AbortSignal,
+  ): AsyncIterable<SseEvent> {
+    const url = new URL(pathname, this.baseUrl);
+    const mod = url.protocol === 'https:' ? https : http;
+    const req = mod.request({
+      protocol: url.protocol,
+      hostname: this.socketPath ? undefined : url.hostname,
+      port: this.socketPath ? undefined : url.port,
+      path: `${url.pathname}${url.search}`,
+      socketPath: this.socketPath,
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        accept: 'text/event-stream',
+      },
+    });
+    signal?.addEventListener(
+      'abort',
+      () => req.destroy(new Error('Gantry stream aborted')),
+      { once: true },
+    );
+    const response = await new Promise<http.IncomingMessage>(
+      (resolve, reject) => {
+        req.on('response', resolve);
+        req.on('error', reject);
+        req.end();
+      },
+    );
+    if ((response.statusCode || 500) >= 400) {
+      const chunks: Buffer[] = [];
+      for await (const chunk of response) chunks.push(Buffer.from(chunk));
+      throw toError(parseJsonBody(Buffer.concat(chunks).toString('utf8')));
+    }
+    let buffer = '';
+    for await (const chunk of response) {
+      buffer += chunk.toString();
+      while (true) {
+        const delimiter = buffer.indexOf('\n\n');
+        if (delimiter < 0) break;
+        const block = buffer.slice(0, delimiter);
+        buffer = buffer.slice(delimiter + 2);
+        const lines = block.split('\n');
+        const idLine = lines.find((line) => line.startsWith('id: '));
+        const eventLine = lines.find((line) => line.startsWith('event: '));
+        const dataLine = lines.find((line) => line.startsWith('data: '));
+        if (!idLine || !eventLine || !dataLine) continue;
+        yield parseSessionSseEvent({
+          eventId: Number(idLine.slice(4).trim()),
+          eventType: eventLine.slice(7).trim(),
+          data: JSON.parse(dataLine.slice(6)),
+        });
+      }
+    }
+  }
+}
+
+function parseJsonBody(raw: string): unknown {
+  if (!raw.trim()) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const error = new Error(
+      'Gantry returned a non-JSON response',
+    ) as GantryError;
+    error.code = 'INVALID_RESPONSE';
+    throw error;
+  }
+}
+
+function toError(input: unknown): GantryError {
+  const fallback = new Error('Gantry request failed') as GantryError;
+  fallback.code = 'UNKNOWN_ERROR';
+  if (
+    !input ||
+    typeof input !== 'object' ||
+    !('error' in input) ||
+    !input.error ||
+    typeof input.error !== 'object'
+  ) {
+    return fallback;
+  }
+  const value = input.error as Record<string, unknown>;
+  const error = new Error(
+    String(value.message || 'Gantry request failed'),
+  ) as GantryError;
+  error.code = String(value.code || 'UNKNOWN_ERROR');
+  error.details =
+    value.details && typeof value.details === 'object'
+      ? (value.details as Record<string, unknown>)
+      : null;
+  error.requestId =
+    typeof value.requestId === 'string' ? value.requestId : undefined;
+  error.retryable =
+    typeof value.retryable === 'boolean' ? value.retryable : undefined;
+  error.restartRequired =
+    typeof value.restartRequired === 'boolean'
+      ? value.restartRequired
+      : undefined;
+  error.nextAction =
+    typeof value.nextAction === 'string' ? value.nextAction : undefined;
+  return error;
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -12,6 +12,20 @@ export type RequestOptions = {
   contentType?: string;
   accept?: string;
   signal?: AbortSignal;
+  traceparent?: string;
+};
+
+export type LlmRequestOptions = {
+  traceparent?: string;
+};
+
+export type TraceRequestOptions = {
+  traceparent?: string;
+};
+
+export type TransportResponse<T> = {
+  body: T;
+  headers: Readonly<Record<string, string | undefined>>;
 };
 
 export type RuntimeEventEnvelope = {


### PR DESCRIPTION
## What changed
- adds the direct LLM SDK transport used by Agent.Tender scrape operations
- adds model-alias request handling without moving application routing policy into Gantry defaults
- extends agent-task contracts and admission controls needed by Manipal deeper analysis
- adds startup settings import support for the Gantry container
- adds focused route, transport, startup, and admission regression coverage

## Validation
- npm run typecheck
- changed Gantry unit tests: 56 passed
- npm run build
- npm run check:architecture

## Full-suite note
The repository-wide unit sweep still contains unrelated legacy failures; the modified test files and production build pass.