### PR TITLE
perf(runtime): close Phase 3B by measurement — keep the authoritative second fetch (LAT-3B)

### DIFF
--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -5351,6 +5351,26 @@ describe('createGroupProcessor', () => {
   // =======================================================================
 
   describe('decision 0080 authoritative second pending-message fetch', () => {
+    // This suite mocks @core/config, so the behavioural test below runs against
+    // mocked limits. That alone would leave decision 0080's premise pinned to a
+    // fixture rather than to production. This check closes that gap by reading
+    // the REAL module: the shipped cap must stay below the shipped page size,
+    // which is the property that makes the second fetch a single statement.
+    //
+    // If someone raises MAX_MESSAGES_PER_PROMPT to or past
+    // MESSAGE_FETCH_PAGE_SIZE, the replay starts paging, the "one repository
+    // call" premise expires, and decision 0080 must be revisited. This fails
+    // then — against shipped values, not mocked ones.
+    it('keeps the shipped prompt cap below the shipped page size', async () => {
+      const realConfig = await vi.importActual<
+        typeof import('@core/config/index.js')
+      >('@core/config/index.js');
+
+      expect(realConfig.MAX_MESSAGES_PER_PROMPT).toBeLessThan(
+        realConfig.MESSAGE_FETCH_PAGE_SIZE,
+      );
+    });
+
     // If you are here to "optimise away the double fetch", read
     // docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md first
     // and satisfy its three reopen conditions; do not delete this test.

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -5355,25 +5355,58 @@ describe('createGroupProcessor', () => {
     // docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md first
     // and satisfy its three reopen conditions; do not delete this test.
     it('costs exactly one repository call for an ordinary queued turn', async () => {
+      // The backlog must EXCEED the prompt cap, and the fake must honour the
+      // `limit` argument. Otherwise the replay loop stops on "batch smaller
+      // than the page" for trivial reasons and the assertion below would hold
+      // under ANY configuration — pinning nothing.
+      //
+      // This suite's config mock (top of file) uses MAX_MESSAGES_PER_PROMPT 10
+      // and MESSAGE_FETCH_PAGE_SIZE 50 — the same cap-below-page relationship
+      // as the shipped 10/200, which is the property that matters.
+      //
+      // With 11 messages available, collectPendingMessagesSince asks for a
+      // page, gets 11, accepts 10, and returns immediately because the
+      // accepted slice is shorter than the batch
+      // (pending-message-replay.ts:66-68). One call.
+      //
+      // Verified sensitive: inverting the mock to cap 50 / page 5 makes this
+      // assertion fail with 3 calls instead of 1. That is the intended loud
+      // signal if decision 0080's one-statement premise ever expires, and it
+      // only works because the backlog is deep enough to page.
+      const backlog = Array.from({ length: 11 }, (_, index) =>
+        makeMessage({
+          id: `backlog-${index}`,
+          content: `backlog message ${index}`,
+          timestamp: `${1700000000 + index}`,
+        }),
+      );
       const group = makeGroup({ requiresTrigger: false });
-      const { deps } = setupHappyPath({
-        group,
-        messages: [
-          makeMessage({
-            id: 'execution-message',
-            content: 'ordinary queued turn',
-          }),
-        ],
-      });
+      const { deps } = setupHappyPath({ group });
+      let served = 0;
+      mockGetMessagesSince.mockImplementation(
+        async (
+          _jid: string,
+          _cursor: string,
+          limit?: number,
+        ): Promise<NewMessage[]> => {
+          const page = backlog.slice(
+            served,
+            served + (limit ?? backlog.length),
+          );
+          served += page.length;
+          return page;
+        },
+      );
 
       const { processGroupMessages } = createGroupProcessor(deps);
       await processGroupMessages('group1@g.us', { queued: true });
 
-      // One call is expected because MAX_MESSAGES_PER_PROMPT (10) is far
-      // below the shipped MESSAGE_FETCH_PAGE_SIZE (200), so replay returns
-      // after its first page. If that ratio ever inverts, this failing loudly
-      // is the intended signal, not test brittleness.
       expect(mockGetMessagesSince).toHaveBeenCalledTimes(1);
+      // Proves the fake actually honoured a page size big enough to expose
+      // paging, rather than accidentally returning a short batch.
+      expect(mockGetMessagesSince.mock.calls[0]?.[2]).toBeGreaterThan(
+        backlog.length,
+      );
       expect(mockSpawnAgent).toHaveBeenCalledOnce();
     });
 

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -5347,6 +5347,78 @@ describe('createGroupProcessor', () => {
   });
 
   // =======================================================================
+  // Decision 0080: authoritative second pending-message fetch
+  // =======================================================================
+
+  describe('decision 0080 authoritative second pending-message fetch', () => {
+    // If you are here to "optimise away the double fetch", read
+    // docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md first
+    // and satisfy its three reopen conditions; do not delete this test.
+    it('costs exactly one repository call for an ordinary queued turn', async () => {
+      const group = makeGroup({ requiresTrigger: false });
+      const { deps } = setupHappyPath({
+        group,
+        messages: [
+          makeMessage({
+            id: 'execution-message',
+            content: 'ordinary queued turn',
+          }),
+        ],
+      });
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await processGroupMessages('group1@g.us', { queued: true });
+
+      // One call is expected because MAX_MESSAGES_PER_PROMPT (10) is far
+      // below the shipped MESSAGE_FETCH_PAGE_SIZE (200), so replay returns
+      // after its first page. If that ratio ever inverts, this failing loudly
+      // is the intended signal, not test brittleness.
+      expect(mockGetMessagesSince).toHaveBeenCalledTimes(1);
+      expect(mockSpawnAgent).toHaveBeenCalledOnce();
+    });
+
+    // If you are here to "optimise away the double fetch", read
+    // docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md first
+    // and satisfy its three reopen conditions; do not delete this test.
+    // SCOPE NOTE: this suite can only observe the GROUP PROCESSOR's fetch.
+    // Admission's earlier fetch lives in message-loop.ts:505-518 and is covered
+    // by message-loop.test.ts. Asserting "two fetches happened" from here would
+    // require the test to call the repository itself and then count its own
+    // call — arithmetic on the fixture, not evidence about production. So this
+    // suite proves the half it can actually see: the processor reads
+    // independently, at execution time.
+    it('issues its own read at execution time using the queue cursor', async () => {
+      const executionMessage = makeMessage({
+        id: 'execution-only',
+        content: 'group processor authoritative body',
+        timestamp: '1700000002',
+      });
+      const group = makeGroup({ requiresTrigger: false });
+      const { deps } = setupHappyPath({ group });
+      deps.getCursor = vi.fn().mockReturnValue('cursor-before');
+      mockGetMessagesSince.mockResolvedValue([executionMessage]);
+      mockFormatConversationContextMessages.mockImplementation(
+        ({ currentMessages }: { currentMessages: NewMessage[] }) =>
+          currentMessages.map((message) => message.content).join(' | '),
+      );
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await processGroupMessages('group1@g.us', { queued: true });
+
+      // It reads the cursor itself and fetches from it, rather than consuming a
+      // snapshot handed to it. That independence is what decision 0080 keeps.
+      expect(deps.getCursor).toHaveBeenCalled();
+      expect(mockGetMessagesSince.mock.calls[0]?.[1]).toBe('cursor-before');
+      expect(mockSpawnAgent.mock.calls[0][1]).toMatchObject({
+        prompt: 'group processor authoritative body',
+      });
+    });
+
+    // The real unchanged-cursor mid-turn tripwire lives in message-loop.test.ts,
+    // where admission and the queued group run both execute their production reads.
+  });
+
+  // =======================================================================
   // Integration: cursor management end-to-end
   // =======================================================================
 

--- a/apps/core/test/unit/runtime/message-loop.test.ts
+++ b/apps/core/test/unit/runtime/message-loop.test.ts
@@ -10,10 +10,29 @@ const mockIsSenderControlAllowed = vi.fn();
 const mockIsTriggerAllowed = vi.fn();
 const mockExtractSessionCommand = vi.fn();
 const mockIsSessionCommandAllowed = vi.fn();
+const mockHandleSessionCommand = vi.fn();
 const mockFormatMessages = vi.fn();
+const mockFormatConversationContextMessages = vi.fn();
+const mockFormatOutboundForChannel = vi.fn();
+const mockIsSenderAllowed = vi.fn();
+const mockShouldDropMessage = vi.fn();
+const mockShouldLogDenied = vi.fn();
+const mockRunGroupAgent = vi.fn();
 
 vi.mock('@core/config/index.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+  IDLE_TIMEOUT: 1_800_000,
+  MEMORY_MAINTENANCE_MAX_PENDING: 5_000,
   getTriggerPattern: (...args: unknown[]) => mockGetTriggerPattern(...args),
+  getRuntimeSettingsForConfig: () => ({
+    memory: {
+      enabled: true,
+      embeddings: { enabled: false, provider: 'disabled' },
+    },
+  }),
+  getDefaultModelConfig: () => ({ model: undefined }),
+  getSelectedAgentHarness: () => 'auto',
+  getSelectedAgentPermissionMode: () => 'ask',
   MAX_MESSAGES_PER_PROMPT: 10,
   MESSAGE_FETCH_PAGE_SIZE: 50,
   TIMEZONE: 'UTC',
@@ -27,22 +46,39 @@ vi.mock('@core/platform/sender-allowlist.js', () => ({
   isSenderControlAllowed: (...args: unknown[]) =>
     mockIsSenderControlAllowed(...args),
   isTriggerAllowed: (...args: unknown[]) => mockIsTriggerAllowed(...args),
+  isSenderAllowed: (...args: unknown[]) => mockIsSenderAllowed(...args),
+  shouldDropMessage: (...args: unknown[]) => mockShouldDropMessage(...args),
+  shouldLogDenied: (...args: unknown[]) => mockShouldLogDenied(...args),
 }));
 vi.mock('@core/session/session-commands.js', () => ({
   extractSessionCommand: (...args: unknown[]) =>
     mockExtractSessionCommand(...args),
   isSessionCommandAllowed: (...args: unknown[]) =>
     mockIsSessionCommandAllowed(...args),
+  handleSessionCommand: (...args: unknown[]) =>
+    mockHandleSessionCommand(...args),
 }));
 vi.mock('@core/messaging/router.js', () => ({
   formatMessages: (...args: unknown[]) => mockFormatMessages(...args),
+  formatConversationContextMessages: (...args: unknown[]) =>
+    mockFormatConversationContextMessages(...args),
+  formatOutboundForChannel: (...args: unknown[]) =>
+    mockFormatOutboundForChannel(...args),
 }));
 vi.mock('@core/infrastructure/logging/logger.js', () => ({
   logger: {
     debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
+    error: vi.fn(),
+    updateLogContext: vi.fn(),
   },
+  redactString: (value: string) => value,
+  withLogContext: (_context: unknown, callback: () => unknown) => callback(),
+  updateLogContext: vi.fn(),
+}));
+vi.mock('@core/runtime/group-agent-runner.js', () => ({
+  createGroupAgentRunner: () => mockRunGroupAgent,
 }));
 
 import {
@@ -50,6 +86,7 @@ import {
   processLiveAdmissionWorkItem,
   recoverPendingMessages,
 } from '@core/runtime/message-loop.js';
+import type { GroupProcessingDeps } from '@core/runtime/group-processing-types.js';
 import { logger } from '@core/infrastructure/logging/logger.js';
 import {
   decodeGroupMessageCursor,
@@ -59,6 +96,9 @@ import {
 import { makeAgentThreadQueueKey } from '@core/shared/thread-queue-key.js';
 import { ConversationRoute } from '@core/domain/types.js';
 import type { LiveAdmissionWorkItem } from '@core/domain/ports/live-turns.js';
+
+const { createGroupProcessor } =
+  await import('@core/runtime/group-processing.js');
 
 function makeDeps(overrides: Partial<MessageLoopDeps> = {}): MessageLoopDeps & {
   enqueued: string[];
@@ -198,9 +238,16 @@ beforeEach(() => {
   mockIsSenderExplicitlyAllowed.mockReturnValue(false);
   mockIsSenderControlAllowed.mockReturnValue(false);
   mockIsTriggerAllowed.mockReturnValue(true);
+  mockIsSenderAllowed.mockReturnValue(true);
+  mockShouldDropMessage.mockReturnValue(false);
+  mockShouldLogDenied.mockReturnValue(true);
   mockExtractSessionCommand.mockReturnValue(null);
   mockIsSessionCommandAllowed.mockReturnValue(false);
+  mockHandleSessionCommand.mockResolvedValue({ handled: false });
   mockFormatMessages.mockReturnValue('formatted messages');
+  mockFormatConversationContextMessages.mockReturnValue('formatted messages');
+  mockFormatOutboundForChannel.mockImplementation((raw: string) => raw);
+  mockRunGroupAgent.mockResolvedValue('success');
 });
 
 afterEach(() => {
@@ -601,6 +648,131 @@ describe('recoverPendingMessages', () => {
 
     expect(mockGetMessagesSince).toHaveBeenCalledOnce();
     expect(deps.enqueued).toEqual([threadRouteKey]);
+  });
+});
+
+// =======================================================================
+// Decision 0080: authoritative second pending-message fetch
+// =======================================================================
+
+describe('decision 0080 authoritative second pending-message fetch', () => {
+  // If you are here to "optimise away the double fetch", read
+  // docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md first
+  // and satisfy its three reopen conditions; do not delete this test.
+  //
+  // Under replay reuse the queued run would skip its production fetch, so
+  // midTurn would be silently dropped even though the cursor stayed unchanged.
+  it('admission and the queued run each fetch, and the later read is what feeds the turn', async () => {
+    const sinceCursor = 'unchanged-cursor';
+    const earlier = {
+      ...makePendingMessage(1),
+      content: 'present at admission',
+    };
+    const midTurn = {
+      ...makePendingMessage(2),
+      content: 'distinctive mid-turn arrival',
+    };
+    mockGetMessagesSince
+      .mockResolvedValueOnce([earlier])
+      .mockResolvedValueOnce([earlier, midTurn]);
+
+    const group = {
+      name: 'Team',
+      folder: 'team',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+      requiresTrigger: false,
+    };
+    const groupDeps = {
+      channelRuntime: {
+        hasChannel: vi.fn().mockReturnValue(true),
+        supportsStreaming: vi.fn().mockReturnValue(false),
+        supportsProgress: vi.fn().mockReturnValue(false),
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+        sendStreamingChunk: vi.fn().mockResolvedValue(false),
+        resetStreaming: vi.fn(),
+        setTyping: vi.fn().mockResolvedValue(undefined),
+        sendProgressUpdate: vi.fn().mockResolvedValue(undefined),
+      },
+      getConversationRoutes: vi.fn().mockReturnValue({
+        'group@g.us': group,
+      }),
+      getGroup: vi.fn().mockReturnValue(group),
+      clearSession: vi.fn(),
+      getCursor: vi.fn().mockReturnValue(sinceCursor),
+      setCursor: vi.fn(),
+      saveState: vi.fn(),
+      setGroupModelOverride: vi.fn(),
+      setGroupThinkingOverride: vi.fn(),
+      setGroupPermissionModeOverride: vi.fn(),
+      getAvailableGroups: vi.fn().mockReturnValue([]),
+      getRegisteredJids: vi.fn().mockReturnValue(new Set<string>()),
+      opsRepository: {
+        getAllJobs: vi.fn().mockReturnValue([]),
+        getMessagesSince: (...args: unknown[]) => mockGetMessagesSince(...args),
+        getRecentJobRuns: vi.fn().mockReturnValue([]),
+        listRecentJobEvents: vi.fn().mockReturnValue([]),
+        getAllChats: vi.fn().mockResolvedValue([]),
+        storeMessage: vi.fn().mockResolvedValue(undefined),
+        getRecentTopLevelMessagesBefore: vi.fn().mockResolvedValue([]),
+        getFirstThreadMessages: vi.fn().mockResolvedValue([]),
+        getLatestThreadMessages: vi.fn().mockResolvedValue([]),
+        expireProviderSession: vi.fn(),
+        setSession: vi.fn(),
+        updateAgentRunProviderMetadata: vi.fn().mockResolvedValue(undefined),
+      },
+      queue: {
+        enqueueMessageCheck: vi.fn(),
+        closeStdin: vi.fn(),
+        notifyIdle: vi.fn(),
+        registerProcess: vi.fn(),
+      },
+      runnerSandboxProvider: {
+        id: 'direct' as const,
+        enforcing: false,
+        start: vi.fn(),
+      },
+      getSelectedAgentHarness: vi.fn(() => 'auto' as const),
+    } as unknown as GroupProcessingDeps;
+    mockFormatConversationContextMessages.mockImplementation(
+      ({ currentMessages }) =>
+        (currentMessages as Array<{ content: string }>)
+          .map((message) => message.content)
+          .join(' | '),
+    );
+
+    const { processGroupMessages } = createGroupProcessor(groupDeps);
+    let queuedRun: Promise<boolean> | undefined;
+    const enqueueMessageCheck = vi.fn((queueJid: string) => {
+      queuedRun = processGroupMessages(queueJid, { queued: true });
+      return true;
+    });
+    const admissionDeps = makeDeps({
+      getOrRecoverCursor: () => sinceCursor,
+      queue: {
+        sendMessage: vi.fn(() => false),
+        enqueueMessageCheck,
+        closeStdin: vi.fn(),
+      },
+    });
+
+    await expect(
+      processLiveAdmissionWorkItem(admissionDeps, makeAdmissionItem()),
+    ).resolves.toBe('completed');
+    expect(enqueueMessageCheck).toHaveBeenCalledOnce();
+    expect(enqueueMessageCheck).toHaveBeenCalledWith('group@g.us');
+    expect(queuedRun).toBeDefined();
+    await queuedRun;
+
+    expect(mockGetMessagesSince).toHaveBeenCalledTimes(2);
+    expect(mockGetMessagesSince.mock.calls.map((call) => call[1])).toEqual([
+      sinceCursor,
+      sinceCursor,
+    ]);
+    expect(mockRunGroupAgent).toHaveBeenCalledOnce();
+    expect(mockRunGroupAgent.mock.calls[0]?.[1]).toBe(
+      'present at admission | distinctive mid-turn arrival',
+    );
   });
 });
 

--- a/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
+++ b/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
@@ -309,6 +309,23 @@ unchanged; otherwise it must fetch the tail/current window. If the queue cannot
 provide that fence cheaply, retain the authoritative second fetch. A3 should be
 split from this cycle unless that cursor contract is designed and tested.
 
+**SETTLED 2026-07-29 by decision
+`0080-lat-3b-retain-authoritative-second-fetch` — the conditional above resolved
+to "retain the authoritative second fetch". Do not implement A3.**
+
+Two measurements closed it. First, the prize is one SQL statement: the replay
+returns after its first page at the shipped defaults (`MAX_MESSAGES_PER_PROMPT`
+10 vs `MESSAGE_FETCH_PAGE_SIZE` 200) and `getMessagesSince` issues a single
+`listMessages`. Second, and decisively, the fence cannot be built cheaply at
+all — **the queue cursor advances on consumption, not on arrival**, so a message
+landing between admission and execution does not move it. "Cursor unchanged"
+therefore does not imply "no new messages", and detecting new arrivals requires
+the very query the reuse removes. Reuse would silently drop mid-turn messages,
+and would also break the group processor's `hasMore` requeue and its use of
+`responseSchema` / `agentControls`.
+
+Decision 0080 carries the numbers and the exact conditions that would reopen it.
+
 ### 4. A4 context/memory hydration — PARTIAL; ADMISSION CALL MUST STAY
 
 The admission-side `hydrateMemory:false` call is load-bearing: it resolves the

--- a/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
+++ b/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
@@ -309,9 +309,11 @@ unchanged; otherwise it must fetch the tail/current window. If the queue cannot
 provide that fence cheaply, retain the authoritative second fetch. A3 should be
 split from this cycle unless that cursor contract is designed and tested.
 
-**SETTLED 2026-07-29 by decision
-`0080-lat-3b-retain-authoritative-second-fetch` — the conditional above resolved
-to "retain the authoritative second fetch". Do not implement A3.**
+**RESOLVED 2026-07-29 by decision
+`0080-lat-3b-retain-authoritative-second-fetch` (`status: proposed` — acceptance
+is a human gate, so this resolution is provisional until accepted). The
+conditional above resolves to "retain the authoritative second fetch". Do not
+implement A3.**
 
 Two measurements closed it. First, the prize is one SQL statement: the replay
 returns after its first page at the shipped defaults (`MAX_MESSAGES_PER_PROMPT`

--- a/docs/context/ledger.json
+++ b/docs/context/ledger.json
@@ -3,14 +3,14 @@
     "migrated-AGENTS.md": {
       "sha256": "e5a6ea2645b5f9e255aa7a85d4a3b8086c28b9ceb5ec2e1d4a68946f7eda10c7",
       "added": "2026-07-22T11:07:16+00:00",
-      "status": "pending",
+      "status": "harvested",
       "outputs": [
+        "docs/decisions/0002-symphony-forge-adoption.md",
         "docs/decisions/0003-early-stage-no-backcompat.md",
-        "docs/decisions/0004-gantry-naming-and-public-repo.md",
-        "docs/decisions/0002-symphony-forge-adoption.md"
+        "docs/decisions/0004-gantry-naming-and-public-repo.md"
       ],
-      "notes": "Product facts already canonical in docs/product/BRIEF.md; architecture rules canonical across docs/architecture/ (capability-management, current-verification-commands, codebase-refactor-principles, components) and 31 existing docs/decisions/ records; execution/orchestration standards superseded per 0002. Two previously unrecorded choices extracted as 0003 and 0004.",
-      "marked_at": "2026-07-22T11:10:14+00:00",
+      "notes": "Re-staled by PR #338, which added only an archival banner marking this file as a superseded migration snapshot and pointing at docs/architecture/capability-management.md, runtime-components.md, and the accepted permission decisions. Its substance was already harvested into decisions 0002/0003/0004; the banner is itself the resolution, so there is no new decision to extract. Marked during LAT-3B because pending context blocks plan save; unrelated to that phase's scope.",
+      "marked_at": "2026-07-29T03:56:07+00:00",
       "updated": "2026-07-28T19:09:02+00:00"
     },
     "migrated-CLAUDE.md": {

--- a/docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md
+++ b/docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md
@@ -1,0 +1,131 @@
+---
+status: proposed
+confirmed_by: ""
+date: 2026-07-29
+---
+
+# LAT-3B: Retain The Authoritative Second Message Fetch; Reject Cursor-Fenced Replay Reuse
+
+## Context
+
+The response-latency roadmap names Phase 3B "Cursor-Fenced Pending Replay
+Reuse": reuse a preloaded pending replay when cursor, queue identity,
+conversation/thread/provider scope, replay ids, and replay cursor are all
+internally consistent, falling back to the authoritative load on mismatch
+(`plans/MyClaw-Response-Latency-Refactor-Plan.md`, Phase 3B).
+
+The underlying observation is real. Admission fetches pending messages
+(`apps/core/src/runtime/message-loop.ts:505-518`) and the group processor
+independently fetches the same window later
+(`apps/core/src/runtime/group-processing.ts:87-103`), both through
+`collectPendingMessagesSince`
+(`apps/core/src/runtime/pending-message-replay.ts:24-75`). Admission's replay is
+reused only inside `processQueueMessages` via `preloadedInitialReplay`
+(`message-loop.ts:291-302,370-385`); it never reaches the group processor.
+
+The goal prompt already flagged the reuse claim as unproven
+(`docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md`,
+plan-validation §3, "A3 double fetch — OBSERVATION TRUE, REUSE CLAIM FALSE AS
+WRITTEN"), and instructed: "If the queue cannot provide that fence cheaply,
+retain the authoritative second fetch. A3 should be split from this cycle
+unless that cursor contract is designed and tested."
+
+Read-only measurement at `106f7d72b` settles both halves of that instruction.
+
+**The prize is one SQL statement.** `collectPendingMessagesSince` returns after
+its first page whenever it accepts fewer messages than the page size, which is
+necessarily true at the shipped defaults — `MAX_MESSAGES_PER_PROMPT` is 10 and
+`MESSAGE_FETCH_PAGE_SIZE` is 200 (`apps/core/src/config/index.ts:485-492`,
+`pending-message-replay.ts:40-74`). `getMessagesSince` makes one
+`listInboundMessages` call
+(`apps/core/src/adapters/storage/postgres/services/canonical-message-ops-service.ts:177-202`),
+which delegates to a single `listMessages` query
+(`canonical-message-repository.postgres.ts:392-407`). So the entire second
+fetch is **one repository call and one SQL statement per turn**, not a fan-out.
+
+**The fence cannot be built cheaply, and reuse is not merely risky — it drops
+messages.** The two fetches are deliberately at different times. The queue
+cursor advances after a successful active-run pipe
+(`message-loop.ts:437-466`), and new inbound messages are persisted
+concurrently by the channel persistence handler
+(`apps/core/src/app/bootstrap/channel-persistence-handlers.ts:172-199`) and by
+external ingress
+(`apps/core/src/application/external-ingress/conversation-message-ingress.ts:225-258`).
+
+The decisive point: **the cursor advances on consumption, not on arrival.** A
+message that lands between admission's fetch and the group processor's fetch
+does not move the cursor. So "cursor unchanged" does **not** imply "no new
+messages", and there is no cheap signal that does — detecting new arrivals
+requires exactly the query the reuse is trying to remove. The second fetch is
+not redundant work; it is an authoritative later read whose whole job is to see
+messages admission could not.
+
+Reuse would also break machinery that depends on the later read: the group
+processor requeues on `replay.hasMore`
+(`group-processing.ts:202-204,219-220,751`) and consumes `responseSchema` and
+`agentControls` from the replay, none of which survive passing a bare
+`NewMessage[]` (`pending-message-replay.ts:16-22`). `GroupProcessOptions` does
+not carry a replay payload today
+(`apps/core/src/runtime/group-processing-types.ts:51-70`), and
+`LiveTurn.pendingMessage` currently stores only
+`{ kind: 'message_cursor', queueJid, cursorBefore }`
+(`apps/core/src/domain/ports/live-turns.ts:58-80`,
+`apps/core/src/app/bootstrap/live-execution.ts:263-273`).
+
+## Decision
+
+**Do not implement replay reuse. Retain the authoritative second fetch.**
+
+The trade is a correctness regression — silently dropping inbound messages that
+arrive mid-turn — bought for one SQL statement on the hot path. That is the
+wrong side of the trade at any latency budget this program cares about, and the
+program's own primary metric (inbound message to first content-bearing
+delivery) would move by an amount indistinguishable from noise.
+
+This is a REVISION of the phase, not an abandonment of it. LAT-3B delivers:
+
+1. this decision record, carrying the measured numbers and the reason;
+2. a durable regression test that pins the contract — both fetches exist, the
+   second costs exactly one repository call, and the group processor's read is
+   the one that feeds the turn — so a future cycle cannot reintroduce reuse on
+   vibes without new evidence;
+3. no production behaviour change.
+
+**What would reopen this.** Reuse becomes worth revisiting only if ALL of the
+following hold, and the burden is on the proposal to show them:
+
+- a durable signal exists that distinguishes "cursor unchanged" from "no new
+  inbound messages in scope" without issuing the fetch (for example, a
+  per-conversation arrival watermark maintained by the write path);
+- `GroupProcessOptions` or the live-turn payload carries a full
+  `PendingMessageReplay` including `cursorAfter`, `hasMore`, `responseSchema`,
+  and `agentControls`, not a message array;
+- measurement shows the second fetch is material against the primary metric —
+  which at one statement per turn requires either a much larger configured
+  `MAX_MESSAGES_PER_PROMPT` relative to page size, or evidence that this query
+  is contended in production.
+
+## Consequences
+
+The double fetch stays. Anyone reading the roadmap's Phase 3B entry, or the
+goal prompt's A3, must read this record instead: the observation there is
+correct and the remedy there is wrong.
+
+The roadmap and the goal prompt are edited in this task to point here, so the
+instruction is corrected at source rather than left to be rediscovered by the
+next person who reads "double fetch" and assumes it is free money.
+
+`plans/MyClaw-Response-Latency-Refactor-Plan.md` Phase 3B moves from
+"directionally valid after rebaseline" to closed-by-measurement, joining job
+latest-run batching and IPC replay cleanup in the Closed/Measurement-Gated
+section.
+
+Accepted cost: the ~14 LOC the goal prompt hoped to delete stay. That was
+always the honest size of this item — the goal prompt itself scored A3 as a
+code-cleanliness win, not a latency win, and the cleanliness is not worth the
+message-loss risk.
+
+Risk that this decision is wrong: if production later shows this query
+contended, or configuration changes so the replay pages more than once, the
+measured premise here expires. The regression test pins the operation count
+precisely so that change is loud rather than silent.

--- a/docs/decisions/0081-client-signoff.md
+++ b/docs/decisions/0081-client-signoff.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-07-29
+---
+
+# LAT-3B Client Signoff
+
+## Context
+
+The client authorized the complete remaining MyClaw response-latency program in
+chat on 2026-07-28, and on 2026-07-29 asked for all remaining tasks to be
+completed with autoreview clean. LAT-3B is the roadmap's Phase 3B,
+"Cursor-Fenced Pending Replay Reuse", on branch
+`perf/phase3b-cursor-fenced-replay`.
+
+The client also required that each phase reproduce its baseline before changing
+production behavior, and that a Forge signal be raised and the plan revised —
+rather than the implementation forced — if the stated problem does not hold up.
+
+That is exactly what happened. Signal `S-0001-8b22` (contradiction) was raised
+and resolved before planning. The double fetch reproduces, but its premise does
+not: the second fetch costs one repository call and one SQL statement per turn,
+and reusing the admission snapshot would drop inbound messages arriving mid-turn
+because the queue cursor advances on consumption rather than arrival. The
+evidence and reasoning are recorded in
+`docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md`.
+
+## Decision
+
+Proceed with LAT-3B as a REVISED, measurement-closing phase rather than an
+optimization phase.
+
+LAT-3B authorizes: the decision record rejecting replay reuse; corrections to
+the roadmap's Phase 3B entry and the goal prompt's A3 section so the wrong
+remedy is not rediscovered; and a durable regression test that pins the
+two-fetch contract and the second fetch's operation count so the idea cannot
+return without new evidence.
+
+LAT-3B does NOT authorize any production behavior change. No reuse, no new
+payload field, no cursor-fence machinery, no cache.
+
+## Consequences
+
+Phase 3B is closed by measurement and joins job latest-run batching and IPC
+replay cleanup in the roadmap's Closed/Measurement-Gated section.
+
+The task is not PR-ready until the regression test passes, deterministic verify
+passes, one branch-closeout three-lens autoreview is clean, and CI is green.
+Merging remains human-gated. Phase 4A does not start until LAT-3B is merged.

--- a/plans/LAT-3B-Cursor-Fenced-Replay-Plan.md
+++ b/plans/LAT-3B-Cursor-Fenced-Replay-Plan.md
@@ -1,0 +1,169 @@
+# LAT-3B — Settle The Pending-Replay Reuse Contract With Evidence
+
+Issue: `LAT-3B`
+Branch: `perf/phase3b-cursor-fenced-replay`
+Base: `origin/main` @ `106f7d72b`
+Program: MyClaw Response-Latency Refactor, Phase 3B
+Governing decision: `docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md`
+Sign-off: `docs/decisions/0081-client-signoff.md`
+Signal: `S-0001-8b22` (contradiction) — raised and resolved before planning
+
+## Problem
+
+The roadmap's Phase 3B asks for cursor-fenced reuse of the admission replay so
+the group processor's second fetch can be deleted. The observation behind it is
+true: admission fetches pending messages
+(`apps/core/src/runtime/message-loop.ts:505-518`) and the group processor
+fetches the same window again (`apps/core/src/runtime/group-processing.ts:87-103`).
+
+The premise is false, in two independent ways, and this task's job is to prove
+that and pin it rather than to build the fence.
+
+**The prize is one SQL statement.** `collectPendingMessagesSince` returns after
+its first page whenever it accepts fewer messages than the page size, which is
+always true at shipped defaults — `MAX_MESSAGES_PER_PROMPT` 10 against
+`MESSAGE_FETCH_PAGE_SIZE` 200 (`apps/core/src/config/index.ts:485-492`,
+`apps/core/src/runtime/pending-message-replay.ts:40-74`). `getMessagesSince`
+makes one `listInboundMessages` call
+(`canonical-message-ops-service.ts:177-202`) delegating to one `listMessages`
+query (`canonical-message-repository.postgres.ts:392-407`).
+
+**The fence cannot be built, and reuse loses messages.** The queue cursor
+advances on *consumption*, not arrival (`message-loop.ts:437-466`). Messages
+persisted between admission and execution
+(`channel-persistence-handlers.ts:172-199`,
+`conversation-message-ingress.ts:225-258`) do not move it. So "cursor
+unchanged" cannot mean "no new messages", and the only way to learn about new
+arrivals is the query being removed. The second fetch is an authoritative later
+read by design; the group processor requeues on its `hasMore`
+(`group-processing.ts:202-204,219-220,751`) and reads `responseSchema` and
+`agentControls` that a bare `NewMessage[]` loses
+(`pending-message-replay.ts:16-22`).
+
+Baseline reproduced before any decision: the double fetch exists on
+`106f7d72b`. Signal `S-0001-8b22` was raised on the premise, not the
+observation, and resolved by revising the phase.
+
+## Scope / Non-goals
+
+### In scope
+
+- `docs/decisions/0080-…` — the governing record (already committed).
+- `docs/decisions/0081-client-signoff.md` (already committed).
+- Corrections at source: the roadmap's Phase 3B entry and the goal prompt's A3
+  section (already committed).
+- **One durable regression test** pinning the contract so reuse cannot return
+  without new evidence.
+
+### Non-goals
+
+- Any production behaviour change. No reuse, no replay payload on
+  `GroupProcessOptions` or `LiveTurn.pendingMessage`, no cursor-fence
+  machinery, no cache, no config change.
+- Deleting the ~14 LOC the goal prompt hoped to remove. Accepted cost, recorded
+  in 0080.
+- Touching admission, the queue, the cursor contract, or
+  `collectPendingMessagesSince` itself.
+
+## Acceptance Criteria
+
+- **AC1** — A test asserts that one ordinary queued turn performs **two**
+  separate pending-message fetches — admission's and the group processor's —
+  and that the group processor's is the one whose result feeds the turn.
+- **AC2** — A test asserts the group processor's fetch costs exactly **one**
+  `getMessagesSince` call at shipped defaults, pinning the one-statement
+  measurement that decision 0080 rests on.
+- **AC3** — A test asserts the message-loss hazard directly: with the cursor
+  **unchanged** between the two fetches, a message inserted in between is still
+  seen by the second fetch. This is the falsifiable core of the decision — if
+  reuse were adopted, that message would be dropped.
+- **AC4** — Each test names decision 0080 in a comment, so a future reader who
+  wants to "optimise away the double fetch" is routed to the evidence rather
+  than deleting the test.
+- **AC5** — No production file under `apps/core/src/` is modified. Verified by
+  the diff.
+- **AC6** — Release gates green: `format:check`, `typecheck`, `lint`,
+  `test:unit`, `test:integration`, `check:architecture`, `verify.py`.
+
+## Technical Approach
+
+Tests only, in `apps/core/test/unit/runtime/group-processing.test.ts`, reusing
+that file's existing scaffolding.
+
+Instrument the repository's `getMessagesSince` with a counting spy and drive one
+queued turn through `processGroupMessages`. Assert the call count and, for AC3,
+have the spy return an extra message on the second invocation while leaving the
+cursor argument identical — proving the later read is what surfaces it.
+
+AC3 is the important one and it is written to fail loudly if someone later
+implements reuse: under reuse the second fetch never happens, so the inserted
+message never reaches the turn and the assertion breaks. That is the intended
+tripwire.
+
+No new harness primitive is needed; the existing counting approach used for
+LAT-3A's `memory_hydrate_calls` is enough, and this phase does not warrant a new
+operation-name constant for a contract that is deliberately not changing.
+
+## Decisions
+
+- `docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md` — reject
+  replay reuse, retain the authoritative second fetch, with the measured numbers
+  and the three conditions that would reopen it.
+- `docs/decisions/0081-client-signoff.md` — sign-off for the revised scope.
+
+No further new decisions. The revision itself was routed through signal
+`S-0001-8b22` rather than taken silently.
+
+## Surface Impact
+
+| Surface | Classification | Reason |
+| --- | --- | --- |
+| Runtime behavior | **Unchanged by design** | This phase deliberately changes no production code; its output is evidence plus a decision. AC5 enforces it. |
+| API | **Unchanged by design** | No handler, contract, or port touched. |
+| Data / schema | **Unchanged by design** | No migration, no query change. The measurement is *of* an existing query. |
+| CLI / ops | **Unchanged by design** | No command, setting, or config key. |
+| UI | **N-A** | No user-visible surface. |
+| Docs | **Changed** | Decisions 0080 and 0081 added; the roadmap's Phase 3B entry and the goal prompt's A3 section corrected at source so the rejected remedy is not rediscovered. |
+| Tests | **Changed** | Three assertions pinning the two-fetch contract, the one-call cost, and the message-loss hazard. |
+| Deferred | **N-A** | Nothing parked. Reuse is rejected with reopen conditions, not deferred — 0080 names what new evidence would be required. |
+
+## Task Decomposition
+
+One bounded stage; the decision and doc corrections are already committed.
+
+**Stage LAT-3B-1 — pin the contract.**
+Write scope: `apps/core/test/unit/runtime/group-processing.test.ts`.
+Add the three assertions (AC1, AC2, AC3) with decision-0080 comments.
+Verify: `npm run test:unit`, `npm run typecheck`, `npm run lint`.
+
+## Risks
+
+- **The tests could ossify the wrong thing.** If a future cycle legitimately
+  earns reuse (per 0080's three reopen conditions), these tests must be deleted
+  as part of that work, not worked around. The comments say so explicitly.
+- **A one-call assertion is configuration-dependent.** It holds because
+  `MAX_MESSAGES_PER_PROMPT` (10) is far below `MESSAGE_FETCH_PAGE_SIZE` (200).
+  If that ratio ever inverts the replay pages and the count changes — which is
+  exactly the signal 0080 wants to be loud, so the test failing there is
+  correct behaviour, not brittleness. The test comment records this.
+- **Reviewer may read "no production change" as "no work done."** The PR body
+  leads with the measurement and the message-loss reasoning so the value is the
+  evidence, not the diff size.
+
+## Verify Plan
+
+1. **AC3 must be able to fail.** Confirm the inserted-message assertion fails if
+   the test is rewritten to consume the first fetch's result — i.e. simulate
+   reuse and watch the message disappear. That is the whole decision in one
+   check.
+2. **AC5 by inspection**: `git diff origin/main --stat -- apps/core/src` must be
+   empty.
+3. Smallest relevant suite, then local autoreview on the uncommitted diff until
+   clean, then commit.
+4. Branch closeout: `npm run format:check`, `npm run typecheck`, `npm run lint`,
+   `npm run test:unit`, `npm run test:integration`, `npm run check:architecture`,
+   `verify.py` (with the `.envrc` vars exported and WITHOUT
+   `GANTRY_TEST_DATABASE_URL`, under `caffeinate`).
+5. Postgres lanes are not required: this phase touches no persistence path and
+   changes no query. Stated here rather than silently skipped.
+6. ONE branch-wide autoreview, three lenses, then record the three artifacts.

--- a/plans/MyClaw-Response-Latency-Refactor-Plan.md
+++ b/plans/MyClaw-Response-Latency-Refactor-Plan.md
@@ -114,13 +114,29 @@ must re-resolve the current runner/admission/session paths and design the exact
 final-turn context fence that permits one memory hydration without losing reset,
 promotion, compaction, or resumed-session correctness.
 
-### Phase 3B - Cursor-Fenced Pending Replay Reuse
+### Phase 3B - Cursor-Fenced Pending Replay Reuse — CLOSED BY MEASUREMENT
 
-Branch: `perf/cursor-fenced-replay`
+Branch: `perf/phase3b-cursor-fenced-replay`
 
-Reuse a preloaded pending replay only when cursor, queue identity,
-conversation/thread/provider scope, replay ids, and replay cursor are
-internally consistent. Mismatch falls back to the authoritative load.
+**Do not implement. Read
+`docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md` before
+reopening this.**
+
+Original scope: reuse a preloaded pending replay only when cursor, queue
+identity, conversation/thread/provider scope, replay ids, and replay cursor are
+internally consistent, falling back to the authoritative load on mismatch.
+
+Measured at `106f7d72b` and rejected. The double fetch is real, but the second
+fetch costs exactly ONE repository call and ONE SQL statement per turn (the
+replay returns after its first page at the shipped defaults), and reusing the
+admission snapshot would DROP inbound messages arriving between admission and
+execution — the cursor advances on consumption, not arrival, so cursor equality
+cannot prove no-new-messages, and no cheap signal can. The second fetch is an
+authoritative later read by design, and the group processor depends on its
+`hasMore` to requeue.
+
+Decision 0080 records the numbers, the reasoning, and the exact conditions that
+would reopen it.
 
 ### Phase 4A - One Inbound Envelope Transaction
 

--- a/plans/MyClaw-Response-Latency-Refactor-Plan.md
+++ b/plans/MyClaw-Response-Latency-Refactor-Plan.md
@@ -114,13 +114,14 @@ must re-resolve the current runner/admission/session paths and design the exact
 final-turn context fence that permits one memory hydration without losing reset,
 promotion, compaction, or resumed-session correctness.
 
-### Phase 3B - Cursor-Fenced Pending Replay Reuse — CLOSED BY MEASUREMENT
+### Phase 3B - Cursor-Fenced Pending Replay Reuse — CLOSED BY MEASUREMENT (pending acceptance of decision 0080)
 
 Branch: `perf/phase3b-cursor-fenced-replay`
 
 **Do not implement. Read
 `docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md` before
-reopening this.**
+reopening this. That record is `status: proposed` — acceptance is a human
+gate, and this entry is provisional until it is accepted.**
 
 Original scope: reuse a preloaded pending replay only when cursor, queue
 identity, conversation/thread/provider scope, replay ids, and replay cursor are


### PR DESCRIPTION
## What this is for

Phase 3B was scoped to delete a redundant database read: admission fetches the
pending messages, then the group processor fetches the same window again. Two
reads, one turn — obvious waste.

**It isn't waste, and this PR is the evidence.** No production code changes.
What ships is the measurement, the reasoning, and three tests that make the
conclusion falsifiable instead of just stated.

## Why the optimization is wrong

**The prize is one SQL statement.** `collectPendingMessagesSince` returns on its
first batch whenever the prompt cap sits below the page size — shipped values are
10 and 200 — and `getMessagesSince` delegates to a single `listMessages`. The
whole second fetch is one repository call per turn.

**And reuse would lose messages.** This is the part the original scope missed:

> The queue cursor advances on **consumption**, not on **arrival**.

A message that lands between admission and execution does not move the cursor.
So "cursor unchanged" cannot mean "no new messages" — and the only way to learn
about new arrivals is the very query the optimization deletes. There is no cheap
fence, not because we couldn't find one, but because the signal doesn't exist.

The second fetch isn't redundant work. Its job is to see what admission couldn't.

Reuse would also break the group processor's `hasMore` requeue and its use of
`responseSchema` / `agentControls`, none of which survive passing a bare message
array.

## This was the documented plan

The goal prompt's A3 section already made this conditional:

> "If the queue cannot provide that fence cheaply, retain the authoritative
> second fetch. A3 should be split from this cycle unless that cursor contract
> is designed and tested."

This PR resolves that conditional with numbers. Forge signal `S-0001-8b22`
(contradiction) was raised and resolved **before** planning, rather than forcing
an implementation the evidence didn't support.

## The tests

Three assertions, each one falsified by hand rather than assumed:

| Test | Proves | Falsified by |
| --- | --- | --- |
| mid-turn arrival (`message-loop.test.ts`) | admission and the queued run both fetch, with an **identical cursor**, and a message arriving between them still reaches the turn | short-circuiting the second fetch → `expected 2 times, got 1` |
| one repository call | the second fetch costs exactly one call, with a backlog deep enough to expose paging | inverting the config mock to cap 50 / page 5 → 3 calls |
| shipped-config guard | the **real** `MAX_MESSAGES_PER_PROMPT` stays below the **real** `MESSAGE_FETCH_PAGE_SIZE` | `MAX_MESSAGES_PER_PROMPT=500` → `expected 500 to be less than 200` |

The first is the tripwire: if anyone implements reuse, that test fails. The third
matters because the behavioural test runs against mocked limits — without it, a
production configuration change would have expired the premise silently.

## Review found three real problems

Branch autoreview ran four times. Three rounds each caught the same *kind* of
flaw — a test claiming more than it proved — and all three were correct:

1. The original tests hand-called the repository to fake admission's fetch, then
   counted their own call. Arithmetic on the fixture, not evidence. Moved to
   `message-loop.test.ts` where both fetches are real.
2. A one-message fixture stopped replay after one page under *any* config, so the
   one-call test pinned nothing.
3. It still ran against mocked limits, so production changes wouldn't fail it.

Rounds 2–3 were judged a **converging tail**, not a recurring class — each
strictly strengthened one assertion, and tying it to shipped config leaves
nothing further to tighten. Recorded in the commits.

## Verification

| Gate | Result |
| --- | --- |
| `verify.py` | passed at `df029ab07` — structural / typecheck / tests all 0 |
| unit (message-loop + group-processing) | 220/220 |
| `typecheck` / `format:check` | clean |
| production diff | **empty** — `git diff origin/main -- apps/core/src` |

Postgres lanes were not run and are not required: this phase touches no
persistence path and changes no query. Stated rather than silently skipped.

## Needs your call

**`docs/decisions/0080-…` is `status: proposed`.** Autoreview flagged that the
roadmap and goal prompt were presenting it as settled while the record itself was
unaccepted; I corrected the *documents* to say "provisional pending acceptance"
rather than self-accept a human gate. Please accept or push back on 0080.

The same wording slip exists in **Phase 3A's already-merged** goal-prompt edit,
which says "accepted decision 0078" while 0078 is also proposed. Worth a one-line
follow-up alongside accepting both.

## Also in this PR

`docs/context/migrated-AGENTS.md` was marked harvested. PR #338 added only an
archival banner to a file already harvested into decisions 0002–0004, and pending
context blocks `plan save`. Unrelated to this phase; flagged so it doesn't read
as an unexplained ledger edit.
