### PR TITLE
docs: accept latency decisions 0078 and 0080

### DIFF
--- a/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
+++ b/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
@@ -310,8 +310,7 @@ provide that fence cheaply, retain the authoritative second fetch. A3 should be
 split from this cycle unless that cursor contract is designed and tested.
 
 **RESOLVED 2026-07-29 by decision
-`0080-lat-3b-retain-authoritative-second-fetch` (`status: proposed` — acceptance
-is a human gate, so this resolution is provisional until accepted). The
+`0080-lat-3b-retain-authoritative-second-fetch` (accepted). The
 conditional above resolves to "retain the authoritative second fetch". Do not
 implement A3.**
 

--- a/docs/decisions/0078-lat-3a-single-memory-hydration-per-turn.md
+++ b/docs/decisions/0078-lat-3a-single-memory-hydration-per-turn.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-confirmed_by: ""
+status: accepted
+confirmed_by: "Ravi"
 date: 2026-07-28
 ---
 

--- a/docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md
+++ b/docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-confirmed_by: ""
+status: accepted
+confirmed_by: "Ravi"
 date: 2026-07-29
 ---
 

--- a/plans/MyClaw-Response-Latency-Refactor-Plan.md
+++ b/plans/MyClaw-Response-Latency-Refactor-Plan.md
@@ -114,14 +114,13 @@ must re-resolve the current runner/admission/session paths and design the exact
 final-turn context fence that permits one memory hydration without losing reset,
 promotion, compaction, or resumed-session correctness.
 
-### Phase 3B - Cursor-Fenced Pending Replay Reuse — CLOSED BY MEASUREMENT (pending acceptance of decision 0080)
+### Phase 3B - Cursor-Fenced Pending Replay Reuse — CLOSED BY MEASUREMENT
 
 Branch: `perf/phase3b-cursor-fenced-replay`
 
 **Do not implement. Read
 `docs/decisions/0080-lat-3b-retain-authoritative-second-fetch.md` before
-reopening this. That record is `status: proposed` — acceptance is a human
-gate, and this entry is provisional until it is accepted.**
+reopening this. That record is accepted.**
 
 Original scope: reuse a preloaded pending replay only when cursor, queue
 identity, conversation/thread/provider scope, replay ids, and replay cursor are


### PR DESCRIPTION
## What this is

Two architecture decisions that already govern merged code were still `status: proposed`. Ravi confirmed acceptance in chat on 2026-07-29; this records it.

| Decision | Governs | Shipped in |
| --- | --- | --- |
| 0078 | agent memory hydrates exactly once per inbound turn, behind an `agentSessionId` + `agentSessionResetAt` fence | #343 |
| 0080 | the authoritative second pending-message fetch stays — reuse would drop mid-turn messages | #346 |

## Also cleans up

While 0080 was unaccepted, autoreview correctly flagged that the roadmap and goal prompt were describing it as settled. I added provisional hedges rather than self-accept a human gate. Those hedges are now wrong in the other direction, so they're removed:

- roadmap Phase 3B heading drops "(pending acceptance of decision 0080)"
- goal prompt A3 resolution drops "provisional until accepted"

The A4 block's phrase "accepted decision 0078" needed no edit — acceptance made it accurate.

## Scope

Docs only. No code, no tests, no schema. `check_dual_runtime` clean.