### PR TITLE
fix(mcp): defer proxy dispatcher authorization to host

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/runner/tool-permission-gate.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/runner/tool-permission-gate.ts
@@ -44,6 +44,7 @@ import { forceBackgroundNativeAgentInput } from './native-agent-tool-input.js';
 import { denyNonPromptableAutonomousRecovery } from './autonomous-permission-recovery.js';
 import { evaluateYoloModeDenylist } from '../../../../shared/yolo-mode-policy.js';
 import { formatPermissionDeniedMessage } from '../../../../shared/permission-decision-message.js';
+import { isHostAuthorizedMcpProxyDispatcherFullName } from '../../../../shared/admin-mcp-tools.js';
 type ApprovalInput = Parameters<typeof requestPermissionApproval>[0];
 const WORKSPACE_FOLDER_KEY = WORKSPACE_FOLDER_OPTION_KEY as keyof ApprovalInput;
 const RAW_REQ = /^(Agent|AskUserQuestion|TodoWrite)$/;
@@ -371,6 +372,14 @@ export function createCanUseToolCallback(
         principal: sdkApprovalPrincipal,
         reason: yoloDenylistReason,
       });
+    }
+
+    // The host resolves and authorizes the exact MCP target.
+    if (
+      !yoloDenylistMatch &&
+      isHostAuthorizedMcpProxyDispatcherFullName(toolName)
+    ) {
+      return allowToolUse('host resolves and authorizes the MCP target');
     }
 
     const toolExecutionRequest = buildAgentToolExecutionRequest(

--- a/apps/core/src/shared/admin-mcp-tools.ts
+++ b/apps/core/src/shared/admin-mcp-tools.ts
@@ -129,6 +129,16 @@ export const DURABLE_GRANT_EXCLUDED_DISPATCHERS = [
   'async_run_command',
 ] as const;
 
+// These dispatchers are intentionally never durable grants: their concrete
+// target determines the authority required. The MCP variants are safe to pass
+// through a runner-side permission gate because the host resolves and checks
+// their exact target before executing it. async_run_command has no equivalent
+// host-side target authorization, so it is deliberately excluded.
+export const HOST_AUTHORIZED_MCP_PROXY_DISPATCHERS = [
+  'mcp_call_tool',
+  'async_mcp_call',
+] as const;
+
 // Delegation dispatchers start or steer another agent's work. An exact grant
 // cannot bound the tools or commands that delegated agent may use.
 export const DELEGATION_DISPATCHERS = [
@@ -209,6 +219,9 @@ const DECISION_ACTOR_GANTRY_MCP_TOOL_NAME_SET = new Set<string>(
 const DURABLE_GRANT_EXCLUDED_DISPATCHER_SET = new Set<string>(
   DURABLE_GRANT_EXCLUDED_DISPATCHERS,
 );
+const HOST_AUTHORIZED_MCP_PROXY_DISPATCHER_SET = new Set<string>(
+  HOST_AUTHORIZED_MCP_PROXY_DISPATCHERS,
+);
 const DELEGATION_DISPATCHER_SET = new Set<string>(DELEGATION_DISPATCHERS);
 const ALL_GANTRY_MCP_TOOL_NAME_SET = new Set<string>(ALL_GANTRY_MCP_TOOL_NAMES);
 const GANTRY_MCP_TOOL_FULL_NAME_PATTERN = /^mcp__gantry__([a-z][a-z0-9_]*)$/;
@@ -274,6 +287,15 @@ export function isDurableGrantExcludedDispatcherFullName(
   const toolName = parseExactGantryMcpToolName(value);
   return (
     toolName !== null && DURABLE_GRANT_EXCLUDED_DISPATCHER_SET.has(toolName)
+  );
+}
+
+export function isHostAuthorizedMcpProxyDispatcherFullName(
+  value: string,
+): boolean {
+  const toolName = parseExactGantryMcpToolName(value);
+  return (
+    toolName !== null && HOST_AUTHORIZED_MCP_PROXY_DISPATCHER_SET.has(toolName)
   );
 }
 

--- a/apps/core/test/unit/runner/tool-permission-gate.test.ts
+++ b/apps/core/test/unit/runner/tool-permission-gate.test.ts
@@ -683,6 +683,46 @@ describe('createCanUseToolCallback', () => {
     expect(permissionMock.requestPermissionApproval).toHaveBeenCalledTimes(1);
   });
 
+  it.each(['mcp__gantry__mcp_call_tool', 'mcp__gantry__async_mcp_call'])(
+    'passes %s to host-side target authorization without requesting wrapper approval',
+    async (toolName) => {
+      const decision = await makeCallback()(
+        toolName,
+        {
+          serverName: 'ats-mcp-bearer',
+          toolName: 'ats_list_positions',
+          arguments: {},
+        },
+        makePermissionOptions({ displayName: toolName }) as never,
+      );
+
+      expect(decision).toEqual({
+        behavior: 'allow',
+        updatedInput: {
+          serverName: 'ats-mcp-bearer',
+          toolName: 'ats_list_positions',
+          arguments: {},
+        },
+      });
+      expect(permissionMock.requestPermissionApproval).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not treat a non-Gantry MCP tool as a host-authorized dispatcher', async () => {
+    permissionMock.requestPermissionApproval.mockResolvedValueOnce({
+      approved: false,
+      reason: 'Denied by operator',
+    });
+    const decision = await makeCallback()(
+      'mcp__third_party__mcp_call_tool',
+      { serverName: 'ats-mcp-bearer', toolName: 'ats_list_positions' },
+      makePermissionOptions({ displayName: 'mcp_call_tool' }) as never,
+    );
+
+    expect(decision).toEqual(expect.objectContaining({ behavior: 'deny' }));
+    expect(permissionMock.requestPermissionApproval).toHaveBeenCalledTimes(1);
+  });
+
   it('denies wait-only Bash monitoring instead of asking for permission', async () => {
     const canUseTool = makeCallback();
     const result = await canUseTool(


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
