### PR TITLE
fix(slack): preserve channel context for mentions

### DIFF
--- a/apps/core/src/channels/slack/channel-interactions.ts
+++ b/apps/core/src/channels/slack/channel-interactions.ts
@@ -78,13 +78,9 @@ export abstract class SlackChannelInteractions extends SlackChannelState {
         this.isLikelyGroupConversation(channelId),
     });
   }
-  protected async ingestSlackMessage(
-    event: SlackMessageLike,
-    options: { forceOwnedTopLevel?: boolean } = {},
-  ): Promise<void> {
+  protected async ingestSlackMessage(event: SlackMessageLike): Promise<void> {
     await ingestSlackMessageEvent({
       event,
-      options,
       opts: this.opts,
       botUserId: this.botUserId,
       resolveChannelName: (channelId) => this.resolveChannelName(channelId),
@@ -273,9 +269,7 @@ export abstract class SlackChannelInteractions extends SlackChannelState {
         await this.ingestSlackMessage(args.event as SlackMessageLike);
       });
       this.app.event('app_mention', async (args: any) => {
-        await this.ingestSlackMessage(args.event as SlackMessageLike, {
-          forceOwnedTopLevel: true,
-        });
+        await this.ingestSlackMessage(args.event as SlackMessageLike);
       });
       this.app.command('/gantry', async (args: any) => {
         await args.ack();

--- a/apps/core/src/channels/slack/channel-message-ingest.ts
+++ b/apps/core/src/channels/slack/channel-message-ingest.ts
@@ -91,7 +91,6 @@ export async function ingestSlackSlashCommand(input: {
 
 export async function ingestSlackMessage(input: {
   event: SlackMessageLike;
-  options?: { forceOwnedTopLevel?: boolean };
   opts: SlackIngestOpts;
   botUserId: string | null;
   resolveChannelName: (channelId: string) => Promise<string>;
@@ -201,15 +200,7 @@ export async function ingestSlackMessage(input: {
       : enriched.attachments;
   const sender = event.user || 'unknown';
   const senderName = await input.resolveUserName(event.user);
-  const ownsTopLevelMessage =
-    input.options?.forceOwnedTopLevel ||
-    (group
-      ? group.requiresTrigger === false ||
-        buildTriggerPattern(triggerForRoute(group)).test(content.trim())
-      : false);
-  const threadId =
-    event.thread_ts ||
-    (isGroupConversation && ownsTopLevelMessage ? event.ts : undefined);
+  const threadId = event.thread_ts;
   await input.opts.onMessage(jid, {
     id: event.ts,
     chat_jid: jid,

--- a/apps/core/src/channels/slack/conversation-context.ts
+++ b/apps/core/src/channels/slack/conversation-context.ts
@@ -22,7 +22,7 @@ type SlackHydratedFile = NonNullable<SlackMessageLike['files']>[number] & {
   size?: number;
 };
 
-const THREAD_LONG_FIRST_REPLIES = 10;
+const THREAD_LONG_FIRST_REPLIES = 0;
 const THREAD_TAIL_INITIAL_LOOKBACK_SECONDS = 60 * 60;
 const THREAD_TAIL_MAX_LOOKBACK_SECONDS = 7 * 24 * 60 * 60;
 const THREAD_TAIL_MIN_LOOKBACK_SECONDS = 1;
@@ -272,10 +272,7 @@ function slackTailWindowIsDense(
 }
 
 function slackThreadTailFetchLimit(limit: number): number {
-  return Math.max(
-    0,
-    limit - 1 - Math.min(THREAD_LONG_FIRST_REPLIES, Math.max(0, limit - 1)),
-  );
+  return Math.max(0, limit - 1);
 }
 
 function slackTailWindowOldest(

--- a/apps/core/src/runtime/conversation-context.ts
+++ b/apps/core/src/runtime/conversation-context.ts
@@ -2,9 +2,9 @@ import type { NewMessage } from '../domain/types.js';
 import type { RuntimeMessageRepository } from '../domain/repositories/ops-repo.js';
 
 const CHANNEL_CONTEXT_LIMIT = 30;
-const THREAD_CONTEXT_LIMIT = 50;
-const THREAD_LONG_FIRST_REPLIES = 10;
-const THREAD_LONG_LATEST_REPLIES = 39;
+const THREAD_CONTEXT_LIMIT = 10;
+const THREAD_LONG_FIRST_REPLIES = 0;
+const THREAD_LONG_LATEST_REPLIES = 9;
 
 export const CONVERSATION_CONTEXT_LIMITS = {
   channelMessages: CHANNEL_CONTEXT_LIMIT,

--- a/apps/core/test/unit/channels/slack.test.ts
+++ b/apps/core/test/unit/channels/slack.test.ts
@@ -947,7 +947,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         chat_jid: 'sl:C123',
         content: '@Ops list projects',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1023,7 +1023,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         content: '@Ops list projects',
         providerAccountId: 'slack_default',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1280,7 +1280,7 @@ describe('Slack channel', () => {
     );
   });
 
-  it('starts a Slack thread for top-level multi-agent messages with one trigger', async () => {
+  it('keeps top-level multi-agent mentions in channel scope', async () => {
     const opts = createOpts();
     opts.conversationRoutes.mockReturnValue({
       [makeAgentThreadQueueKey('sl:C123', 'agent:ops', null, 'slack_default')]:
@@ -1317,7 +1317,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         chat_jid: 'sl:C123',
         content: '@Ops status',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1400,7 +1400,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         chat_jid: 'sl:C123',
         content: '@Ops status',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1643,7 +1643,7 @@ describe('Slack channel', () => {
     expect(opts.onMessage).not.toHaveBeenCalled();
   });
 
-  it('normalizes top-level Slack channel messages as their own thread root', async () => {
+  it('normalizes top-level Slack channel messages without a thread id', async () => {
     const opts = createOpts();
     opts.conversationRoutes.mockReturnValue({
       [makeAgentThreadQueueKey('sl:C123', null, null, 'slack_default')]: {
@@ -1668,7 +1668,7 @@ describe('Slack channel', () => {
       'sl:C123',
       expect.objectContaining({
         external_message_id: '1710000000.000100',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
         content: '@Ops list projects',
         reply_to_message_id: undefined,
       }),
@@ -2288,7 +2288,7 @@ describe('Slack channel', () => {
         external_message_id: '1710000091.000100',
         thread_id: '1710000000.000100',
       },
-      limits: { channelMessages: 30, threadMessages: 50 },
+      limits: { channelMessages: 30, threadMessages: 10 },
     });
 
     expect(appRef.current.client.conversations.replies).toHaveBeenCalledTimes(
@@ -2301,7 +2301,7 @@ describe('Slack channel', () => {
         ts: '1710000000.000100',
         latest: '1710000091.000100',
         inclusive: false,
-        limit: 50,
+        limit: 10,
       },
     );
     expect(appRef.current.client.conversations.replies).toHaveBeenNthCalledWith(
@@ -2312,30 +2312,26 @@ describe('Slack channel', () => {
         latest: '1710000091.000100',
         inclusive: false,
         oldest: expect.any(String),
-        limit: 39,
+        limit: 9,
       },
     );
     const tailWindowCall =
       appRef.current.client.conversations.replies.mock.calls[1]?.[0];
     expect(Number(tailWindowCall.oldest)).toBeCloseTo(1709996491.0001, 5);
     expect(tailWindowCall).not.toHaveProperty('cursor');
-    expect(result.messages).toHaveLength(50);
+    expect(result.messages).toHaveLength(10);
     expect(
       result.messages?.map((message) => message.external_message_id),
     ).toEqual([
       '1710000000.000100',
       ...Array.from(
-        { length: 10 },
-        (_, index) => `17100000${String(index + 1).padStart(2, '0')}.000100`,
-      ),
-      ...Array.from(
-        { length: 39 },
-        (_, index) => `1710000${String(index + 51).padStart(3, '0')}.000100`,
+        { length: 9 },
+        (_, index) => `1710000${String(index + 81).padStart(3, '0')}.000100`,
       ),
     ]);
     expect(
       new Set(result.messages?.map((message) => message.external_message_id)),
-    ).toHaveProperty('size', 50);
+    ).toHaveProperty('size', 10);
     expect(result.messages?.at(-1)).toEqual(
       expect.objectContaining({
         external_message_id: '1710000089.000100',
@@ -2390,7 +2386,7 @@ describe('Slack channel', () => {
         external_message_id: '1710000091.000100',
         thread_id: '1710000000.000100',
       },
-      limits: { channelMessages: 30, threadMessages: 50 },
+      limits: { channelMessages: 30, threadMessages: 10 },
     });
 
     expect(appRef.current.client.conversations.replies).toHaveBeenCalledTimes(
@@ -2408,12 +2404,8 @@ describe('Slack channel', () => {
     ).toEqual([
       '1710000000.000100',
       ...Array.from(
-        { length: 10 },
-        (_, index) => `17100000${String(index + 1).padStart(2, '0')}.000100`,
-      ),
-      ...Array.from(
-        { length: 39 },
-        (_, index) => `1710000${String(index + 52).padStart(3, '0')}.000100`,
+        { length: 9 },
+        (_, index) => `1710000${String(index + 82).padStart(3, '0')}.000100`,
       ),
     ]);
   });
@@ -2752,7 +2744,7 @@ describe('Slack channel', () => {
     });
 
     const message = opts.onMessage.mock.calls[0][1];
-    expect(message.thread_id).toBe('1710000000.000100');
+    expect(message.thread_id).toBeUndefined();
     expect(message.attachments[0]).toEqual(
       expect.objectContaining({
         storageRef: expect.stringMatching(

--- a/apps/core/test/unit/runtime/conversation-context.test.ts
+++ b/apps/core/test/unit/runtime/conversation-context.test.ts
@@ -142,14 +142,14 @@ describe('buildConversationContextPacket', () => {
     expect(repository.getFirstThreadMessages).toHaveBeenCalledWith(
       'grp:1',
       'thread-1',
-      11,
+      1,
       { providerAccountId: 'acct-1' },
     );
     expect(repository.getLatestThreadMessages).toHaveBeenCalledWith(
       'grp:1',
       'thread-1',
       current,
-      50,
+      10,
       { providerAccountId: 'acct-1' },
     );
     expect(packet.activeThreadContext.map((message) => message.id)).toEqual([
@@ -214,7 +214,7 @@ describe('buildConversationContextPacket', () => {
     expect(packet.metadata.activeThreadRootPresent).toBe(true);
   });
 
-  it('does not mark a full before-or-at thread window complete after excluding the current message', async () => {
+  it('marks a complete prior-thread window after excluding the current message', async () => {
     const threadMessages = sequence(50, (index) => ({
       id: index === 50 ? 'current' : `thread-${index}`,
       thread_id: 'thread-1',
@@ -225,8 +225,10 @@ describe('buildConversationContextPacket', () => {
       getRecentTopLevelMessagesBefore: vi.fn().mockResolvedValue([]),
       getFirstThreadMessages: vi
         .fn()
-        .mockResolvedValue(threadMessages.slice(0, 11)),
-      getLatestThreadMessages: vi.fn().mockResolvedValue(threadMessages),
+        .mockResolvedValue(threadMessages.slice(0, 1)),
+      getLatestThreadMessages: vi
+        .fn()
+        .mockResolvedValue(threadMessages.slice(-10)),
     };
 
     const packet = await buildConversationContextPacket({
@@ -241,19 +243,20 @@ describe('buildConversationContextPacket', () => {
       'grp:1',
       'thread-1',
       current,
-      50,
+      10,
       { providerAccountId: undefined },
     );
-    expect(packet.activeThreadContext).toHaveLength(49);
-    expect(packet.activeThreadContext.map((message) => message.id)).toEqual(
-      Array.from({ length: 49 }, (_, index) => `thread-${index + 1}`),
-    );
+    expect(packet.activeThreadContext).toHaveLength(10);
+    expect(packet.activeThreadContext.map((message) => message.id)).toEqual([
+      'thread-1',
+      ...Array.from({ length: 9 }, (_, index) => `thread-${index + 41}`),
+    ]);
     expect(packet.activeThreadContext).not.toContain(current);
-    expect(packet.metadata.activeThreadCount).toBe(49);
-    expect(packet.metadata.activeThreadWindowComplete).toBe(false);
+    expect(packet.metadata.activeThreadCount).toBe(10);
+    expect(packet.metadata.activeThreadWindowComplete).toBe(true);
   });
 
-  it('bounds long threads to root plus first 10 replies and latest 39 replies deterministically without duplicates', async () => {
+  it('bounds long threads to the root plus nine latest replies deterministically without duplicates', async () => {
     const threadMessages = sequence(70, (index) => ({
       id: `thread-${index}`,
       thread_id: 'thread-1',
@@ -265,7 +268,7 @@ describe('buildConversationContextPacket', () => {
       getFirstThreadMessages: vi
         .fn()
         .mockResolvedValue([
-          ...threadMessages.slice(0, 11).reverse(),
+          ...threadMessages.slice(0, 1).reverse(),
           threadMessages[3],
         ]),
       getLatestThreadMessages: vi
@@ -284,13 +287,12 @@ describe('buildConversationContextPacket', () => {
       repository,
     });
 
-    expect(packet.activeThreadContext).toHaveLength(50);
+    expect(packet.activeThreadContext).toHaveLength(10);
     expect(packet.activeThreadContext.map((message) => message.id)).toEqual([
       'thread-1',
-      ...Array.from({ length: 10 }, (_, index) => `thread-${index + 2}`),
-      ...Array.from({ length: 39 }, (_, index) => `thread-${index + 31}`),
+      ...Array.from({ length: 9 }, (_, index) => `thread-${index + 61}`),
     ]);
-    expect(new Set(packet.activeThreadContext.map((m) => m.id)).size).toBe(50);
+    expect(new Set(packet.activeThreadContext.map((m) => m.id)).size).toBe(10);
     expect(packet.activeThreadContext.at(-1)?.id).toBe('thread-69');
     expect(packet.currentMessages).toEqual([current]);
     expect(packet.metadata.activeThreadRootPresent).toBe(true);
@@ -324,7 +326,7 @@ describe('buildConversationContextPacket', () => {
       repository,
     });
 
-    expect(packet.activeThreadContext).toHaveLength(50);
+    expect(packet.activeThreadContext).toHaveLength(10);
     expect(packet.metadata.activeThreadWindowComplete).toBe(true);
     expect(packet.metadata.activeThreadRootPresent).toBe(false);
   });

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -5792,7 +5792,7 @@ describe('createGroupProcessor', () => {
         providerAccountId: 'telegram_account_2',
         threadId: '42',
         latestMessage: current,
-        limits: { channelMessages: 30, threadMessages: 50 },
+        limits: { channelMessages: 30, threadMessages: 10 },
       });
       expect((deps.opsRepository as any).storeMessage).toHaveBeenNthCalledWith(
         1,
@@ -6024,7 +6024,7 @@ describe('createGroupProcessor', () => {
         conversationJid: 'tg:-100123',
         threadId: '42',
         latestMessage: current,
-        limits: { channelMessages: 30, threadMessages: 50 },
+        limits: { channelMessages: 30, threadMessages: 10 },
       });
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
@@ -6105,7 +6105,7 @@ describe('createGroupProcessor', () => {
           conversationJid: 'tg:-100123',
           threadId: '42',
           latestMessage: current,
-          limits: { channelMessages: 30, threadMessages: 50 },
+          limits: { channelMessages: 30, threadMessages: 10 },
         });
         expect(settled).toBe(false);
 
@@ -6402,10 +6402,10 @@ describe('createGroupProcessor', () => {
         .mockResolvedValue([]);
       (deps.opsRepository as any).getFirstThreadMessages = vi
         .fn()
-        .mockResolvedValue(storedThreadMessages.slice(0, 11));
+        .mockResolvedValue(storedThreadMessages.slice(0, 1));
       (deps.opsRepository as any).getLatestThreadMessages = vi
         .fn()
-        .mockResolvedValue(storedThreadMessages);
+        .mockResolvedValue(storedThreadMessages.slice(-10));
 
       const { processGroupMessages } = createGroupProcessor(deps);
       await processGroupMessages('sl:C123::thread:1710000000.000000');
@@ -6413,7 +6413,10 @@ describe('createGroupProcessor', () => {
       expect(channel.hydrateConversationContext).not.toHaveBeenCalled();
       expect(mockFormatConversationContextMessages).toHaveBeenCalledWith(
         expect.objectContaining({
-          activeThreadContext: storedThreadMessages,
+          activeThreadContext: [
+            storedThreadMessages[0],
+            ...storedThreadMessages.slice(-9),
+          ],
           currentMessages: [current],
         }),
         'UTC',
@@ -6476,7 +6479,7 @@ describe('createGroupProcessor', () => {
         conversationJid: 'dc:thread-1',
         threadId: 'discord-thread-1',
         latestMessage: current,
-        limits: { channelMessages: 30, threadMessages: 50 },
+        limits: { channelMessages: 30, threadMessages: 10 },
       });
     });
 

--- a/docs/architecture/cross-provider-conversation-context-goal-prompt.md
+++ b/docs/architecture/cross-provider-conversation-context-goal-prompt.md
@@ -25,10 +25,10 @@ Before every live agent turn, Gantry builds a transient context packet:
 
 - Channel message: current message plus the last 30 stored top-level messages
   before it.
-- Thread/reply-chain/topic message: thread root plus up to 50 stored messages
+- Thread/reply-chain/topic message: thread root plus up to 10 stored messages
   with the same canonical `thread_id`.
-- Long thread/reply-chain/topic: root plus first 10 replies plus latest 39
-  replies, deduped and ordered.
+- Long thread/reply-chain/topic: root plus latest 9 replies, deduped and
+  ordered.
 - Existing Gantry continuity/memory stays separate and is injected through the
   existing turn-context path.
 
@@ -70,8 +70,9 @@ present.
      message, timezone, and message repository.
    - Output: sectioned context data with `recentChannelContext`,
      `activeThreadContext`, `currentMessages`, and metadata counts.
-   - Keep constants internal for v1: channel limit 30, thread limit 50, long
-     thread first 10 plus latest 39.
+
+- Keep constants internal for v1: channel limit 30, thread limit 10, long
+  thread root plus latest 9 replies.
 
 2. Add narrow message repository reads.
    - Read last N top-level inbound messages before a cursor/message.

--- a/docs/decisions/0087-client-signoff.md
+++ b/docs/decisions/0087-client-signoff.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+confirmed_by: "Yash Khurana"
+date: 2026-07-30
+---
+
+# Client sign-off for issue #352 Slack mention context and thread history
+
+## Context
+<!-- Why this decision was needed; the forces at play. -->
+
+## Decision
+<!-- What was decided, in one or two sentences. -->
+
+## Consequences
+<!-- What follows: tradeoffs accepted, doors closed, work implied. -->


### PR DESCRIPTION
## Goal

Fix Slack context selection so a top-level bot mention can use the preceding channel discussion.

## Why

A top-level `@bot` mention was saved as a synthetic thread root. Gantry then selected an empty thread context instead of the normal channel history.

## What changed

- Keep top-level Slack mentions in channel scope; only Slack’s real `thread_ts` creates thread scope.
- Keep genuine threads isolated to their own message history.
- Limit thread context to the root plus the 9 newest previous replies.
- Align Slack history hydration and regression tests with the same behavior.

## Verification

- Focused unit suite: 352 tests passed.
- Type-check and architecture checks passed.
- Autoreview and secret scan passed with no actionable findings.

## Issue

Fixes #352