### PR TITLE
Fix desired-state thread export concurrency

### DIFF
--- a/apps/core/src/channels/slack/channel-interactions.ts
+++ b/apps/core/src/channels/slack/channel-interactions.ts
@@ -78,13 +78,9 @@ export abstract class SlackChannelInteractions extends SlackChannelState {
         this.isLikelyGroupConversation(channelId),
     });
   }
-  protected async ingestSlackMessage(
-    event: SlackMessageLike,
-    options: { forceOwnedTopLevel?: boolean } = {},
-  ): Promise<void> {
+  protected async ingestSlackMessage(event: SlackMessageLike): Promise<void> {
     await ingestSlackMessageEvent({
       event,
-      options,
       opts: this.opts,
       botUserId: this.botUserId,
       resolveChannelName: (channelId) => this.resolveChannelName(channelId),
@@ -273,9 +269,7 @@ export abstract class SlackChannelInteractions extends SlackChannelState {
         await this.ingestSlackMessage(args.event as SlackMessageLike);
       });
       this.app.event('app_mention', async (args: any) => {
-        await this.ingestSlackMessage(args.event as SlackMessageLike, {
-          forceOwnedTopLevel: true,
-        });
+        await this.ingestSlackMessage(args.event as SlackMessageLike);
       });
       this.app.command('/gantry', async (args: any) => {
         await args.ack();

--- a/apps/core/src/channels/slack/channel-message-ingest.ts
+++ b/apps/core/src/channels/slack/channel-message-ingest.ts
@@ -91,7 +91,6 @@ export async function ingestSlackSlashCommand(input: {
 
 export async function ingestSlackMessage(input: {
   event: SlackMessageLike;
-  options?: { forceOwnedTopLevel?: boolean };
   opts: SlackIngestOpts;
   botUserId: string | null;
   resolveChannelName: (channelId: string) => Promise<string>;
@@ -201,15 +200,7 @@ export async function ingestSlackMessage(input: {
       : enriched.attachments;
   const sender = event.user || 'unknown';
   const senderName = await input.resolveUserName(event.user);
-  const ownsTopLevelMessage =
-    input.options?.forceOwnedTopLevel ||
-    (group
-      ? group.requiresTrigger === false ||
-        buildTriggerPattern(triggerForRoute(group)).test(content.trim())
-      : false);
-  const threadId =
-    event.thread_ts ||
-    (isGroupConversation && ownsTopLevelMessage ? event.ts : undefined);
+  const threadId = event.thread_ts;
   await input.opts.onMessage(jid, {
     id: event.ts,
     chat_jid: jid,

--- a/apps/core/src/channels/slack/conversation-context.ts
+++ b/apps/core/src/channels/slack/conversation-context.ts
@@ -22,7 +22,7 @@ type SlackHydratedFile = NonNullable<SlackMessageLike['files']>[number] & {
   size?: number;
 };
 
-const THREAD_LONG_FIRST_REPLIES = 10;
+const THREAD_ROOT_MESSAGE_COUNT = 1;
 const THREAD_TAIL_INITIAL_LOOKBACK_SECONDS = 60 * 60;
 const THREAD_TAIL_MAX_LOOKBACK_SECONDS = 7 * 24 * 60 * 60;
 const THREAD_TAIL_MIN_LOOKBACK_SECONDS = 1;
@@ -272,10 +272,7 @@ function slackTailWindowIsDense(
 }
 
 function slackThreadTailFetchLimit(limit: number): number {
-  return Math.max(
-    0,
-    limit - 1 - Math.min(THREAD_LONG_FIRST_REPLIES, Math.max(0, limit - 1)),
-  );
+  return Math.max(0, limit - THREAD_ROOT_MESSAGE_COUNT);
 }
 
 function slackTailWindowOldest(
@@ -376,18 +373,16 @@ function selectHydratedSlackMessages(input: {
     return messages.slice(0, input.limit);
   }
 
-  const firstReplyCount = Math.min(
-    THREAD_LONG_FIRST_REPLIES,
-    Math.max(0, input.limit - 1),
+  const root = messages.find(
+    (message) => message.ts === input.requestedThreadId,
   );
-  const latestReplyCount = Math.max(0, input.limit - 1 - firstReplyCount);
-  const latestReplies =
-    latestReplyCount > 0 ? messages.slice(1).slice(-latestReplyCount) : [];
-  return dedupeSlackMessages([
-    ...messages.slice(0, 1),
-    ...messages.slice(1, firstReplyCount + 1),
-    ...latestReplies,
-  ]);
+  const nonRootMessages = root
+    ? messages.filter((message) => message.ts !== root.ts)
+    : messages;
+  const recentMessages = nonRootMessages.slice(
+    -Math.max(0, input.limit - (root ? THREAD_ROOT_MESSAGE_COUNT : 0)),
+  );
+  return dedupeSlackMessages(root ? [root, ...recentMessages] : recentMessages);
 }
 
 function isHydratableSlackMessage(message: SlackMessageLike): boolean {

--- a/apps/core/src/config/settings/desired-state-current-export.ts
+++ b/apps/core/src/config/settings/desired-state-current-export.ts
@@ -1,5 +1,8 @@
 import type { AppId } from '../../domain/app/app.js';
-import type { Conversation } from '../../domain/conversation/conversation.js';
+import type {
+  Conversation,
+  ConversationThread,
+} from '../../domain/conversation/conversation.js';
 import type { ProviderAccount } from '../../domain/provider/provider.js';
 import {
   configuredBindingId,
@@ -31,6 +34,11 @@ import type {
   RuntimeProviderSettings,
   RuntimeSettings,
 } from './runtime-settings-types.js';
+
+// Keep projection sync below small Supavisor session-pool limits. A settings
+// change must inspect every stored conversation's threads, but it must not open
+// one database query per conversation at the same time.
+const CONVERSATION_THREAD_EXPORT_BATCH_SIZE = 4;
 
 export async function exportCurrentDesiredState(input: {
   deps: SettingsDesiredStateServiceDeps;
@@ -125,12 +133,13 @@ export async function exportCurrentDesiredState(input: {
   }
   const publicThreadIdsByCanonicalId = new Map<string, string>();
   if (typeof deps.repositories.conversations?.listThreads === 'function') {
-    const storedThreads = await Promise.all(
-      storedConversations.map((conversation) =>
-        deps.repositories.conversations!.listThreads(conversation.id),
+    const storedThreads = await listConversationThreadsInBatches(
+      storedConversations,
+      deps.repositories.conversations.listThreads.bind(
+        deps.repositories.conversations,
       ),
     );
-    for (const thread of storedThreads.flat()) {
+    for (const thread of storedThreads) {
       const publicThreadId = thread.externalRef?.value?.trim();
       if (publicThreadId) {
         publicThreadIdsByCanonicalId.set(thread.id, publicThreadId);
@@ -599,6 +608,32 @@ export async function exportCurrentDesiredState(input: {
     bindings,
     agents,
   };
+}
+
+async function listConversationThreadsInBatches(
+  conversations: readonly Conversation[],
+  listThreads: (
+    conversationId: Conversation['id'],
+  ) => Promise<ConversationThread[]>,
+): Promise<ConversationThread[]> {
+  const threads: ConversationThread[] = [];
+
+  for (
+    let start = 0;
+    start < conversations.length;
+    start += CONVERSATION_THREAD_EXPORT_BATCH_SIZE
+  ) {
+    const batch = conversations.slice(
+      start,
+      start + CONVERSATION_THREAD_EXPORT_BATCH_SIZE,
+    );
+    const batchThreads = await Promise.all(
+      batch.map((conversation) => listThreads(conversation.id)),
+    );
+    threads.push(...batchThreads.flat());
+  }
+
+  return threads;
 }
 
 function isInternalAppControlProviderAccount(

--- a/apps/core/src/runtime/conversation-context.ts
+++ b/apps/core/src/runtime/conversation-context.ts
@@ -2,9 +2,10 @@ import type { NewMessage } from '../domain/types.js';
 import type { RuntimeMessageRepository } from '../domain/repositories/ops-repo.js';
 
 const CHANNEL_CONTEXT_LIMIT = 30;
-const THREAD_CONTEXT_LIMIT = 50;
-const THREAD_LONG_FIRST_REPLIES = 10;
-const THREAD_LONG_LATEST_REPLIES = 39;
+const THREAD_CONTEXT_LIMIT = 10;
+const THREAD_CONTEXT_ROOT_MESSAGE_COUNT = 1;
+const THREAD_CONTEXT_RECENT_REPLY_COUNT =
+  THREAD_CONTEXT_LIMIT - THREAD_CONTEXT_ROOT_MESSAGE_COUNT;
 
 export const CONVERSATION_CONTEXT_LIMITS = {
   channelMessages: CHANNEL_CONTEXT_LIMIT,
@@ -102,7 +103,7 @@ function selectThreadContext(input: {
     input.repository.getFirstThreadMessages(
       input.conversationJid,
       input.threadId,
-      THREAD_LONG_FIRST_REPLIES + 1,
+      THREAD_CONTEXT_ROOT_MESSAGE_COUNT,
       { providerAccountId: input.providerAccountId },
     ),
     input.repository.getLatestThreadMessages(
@@ -129,11 +130,19 @@ function selectThreadContext(input: {
     if (combined.length <= THREAD_CONTEXT_LIMIT) {
       return { messages: combined, rootPresent };
     }
-    const root = combined.slice(0, 1);
-    const firstReplies = combined.slice(1, THREAD_LONG_FIRST_REPLIES + 1);
-    const latestReplies = combined.slice(1).slice(-THREAD_LONG_LATEST_REPLIES);
+    const root = rootPresent
+      ? combined.find((message) => isThreadRootMessage(message, input.threadId))
+      : undefined;
+    const nonRootMessages = root
+      ? combined.filter((message) => messageKey(message) !== messageKey(root))
+      : combined;
+    const recentMessages = nonRootMessages.slice(
+      -(root ? THREAD_CONTEXT_RECENT_REPLY_COUNT : THREAD_CONTEXT_LIMIT),
+    );
     return {
-      messages: dedupeMessages([...root, ...firstReplies, ...latestReplies]),
+      messages: dedupeMessages(
+        root ? [root, ...recentMessages] : recentMessages,
+      ),
       rootPresent,
     };
   });

--- a/apps/core/test/unit/channels/slack.test.ts
+++ b/apps/core/test/unit/channels/slack.test.ts
@@ -947,7 +947,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         chat_jid: 'sl:C123',
         content: '@Ops list projects',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1023,7 +1023,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         content: '@Ops list projects',
         providerAccountId: 'slack_default',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1280,7 +1280,7 @@ describe('Slack channel', () => {
     );
   });
 
-  it('starts a Slack thread for top-level multi-agent messages with one trigger', async () => {
+  it('keeps top-level multi-agent mentions in channel scope', async () => {
     const opts = createOpts();
     opts.conversationRoutes.mockReturnValue({
       [makeAgentThreadQueueKey('sl:C123', 'agent:ops', null, 'slack_default')]:
@@ -1317,7 +1317,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         chat_jid: 'sl:C123',
         content: '@Ops status',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1400,7 +1400,7 @@ describe('Slack channel', () => {
       expect.objectContaining({
         chat_jid: 'sl:C123',
         content: '@Ops status',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
       }),
     );
   });
@@ -1643,7 +1643,7 @@ describe('Slack channel', () => {
     expect(opts.onMessage).not.toHaveBeenCalled();
   });
 
-  it('normalizes top-level Slack channel messages as their own thread root', async () => {
+  it('keeps top-level Slack channel messages in channel scope', async () => {
     const opts = createOpts();
     opts.conversationRoutes.mockReturnValue({
       [makeAgentThreadQueueKey('sl:C123', null, null, 'slack_default')]: {
@@ -1668,7 +1668,7 @@ describe('Slack channel', () => {
       'sl:C123',
       expect.objectContaining({
         external_message_id: '1710000000.000100',
-        thread_id: '1710000000.000100',
+        thread_id: undefined,
         content: '@Ops list projects',
         reply_to_message_id: undefined,
       }),
@@ -2288,7 +2288,7 @@ describe('Slack channel', () => {
         external_message_id: '1710000091.000100',
         thread_id: '1710000000.000100',
       },
-      limits: { channelMessages: 30, threadMessages: 50 },
+      limits: { channelMessages: 30, threadMessages: 10 },
     });
 
     expect(appRef.current.client.conversations.replies).toHaveBeenCalledTimes(
@@ -2301,7 +2301,7 @@ describe('Slack channel', () => {
         ts: '1710000000.000100',
         latest: '1710000091.000100',
         inclusive: false,
-        limit: 50,
+        limit: 10,
       },
     );
     expect(appRef.current.client.conversations.replies).toHaveBeenNthCalledWith(
@@ -2312,36 +2312,66 @@ describe('Slack channel', () => {
         latest: '1710000091.000100',
         inclusive: false,
         oldest: expect.any(String),
-        limit: 39,
+        limit: 9,
       },
     );
     const tailWindowCall =
       appRef.current.client.conversations.replies.mock.calls[1]?.[0];
     expect(Number(tailWindowCall.oldest)).toBeCloseTo(1709996491.0001, 5);
     expect(tailWindowCall).not.toHaveProperty('cursor');
-    expect(result.messages).toHaveLength(50);
+    expect(result.messages).toHaveLength(10);
     expect(
       result.messages?.map((message) => message.external_message_id),
     ).toEqual([
       '1710000000.000100',
       ...Array.from(
-        { length: 10 },
-        (_, index) => `17100000${String(index + 1).padStart(2, '0')}.000100`,
-      ),
-      ...Array.from(
-        { length: 39 },
-        (_, index) => `1710000${String(index + 51).padStart(3, '0')}.000100`,
+        { length: 9 },
+        (_, index) => `1710000${String(index + 81).padStart(3, '0')}.000100`,
       ),
     ]);
     expect(
       new Set(result.messages?.map((message) => message.external_message_id)),
-    ).toHaveProperty('size', 50);
+    ).toHaveProperty('size', 10);
     expect(result.messages?.at(-1)).toEqual(
       expect.objectContaining({
         external_message_id: '1710000089.000100',
         thread_id: '1710000000.000100',
         reply_to_message_id: '1710000000.000100',
       }),
+    );
+  });
+
+  it('keeps the newest bounded Slack replies when the thread root is unavailable', async () => {
+    const opts = createOpts();
+    const channel = new SlackChannel('xoxb-token', 'xapp-token', opts as any);
+    await channel.connect();
+    appRef.current.client.conversations.replies.mockResolvedValueOnce({
+      ok: true,
+      messages: Array.from({ length: 12 }, (_, index) => ({
+        channel: 'C123',
+        ts: `171000000${index + 1}.000100`,
+        thread_ts: '1710000000.000100',
+        user: 'U456',
+        text: `reply ${index + 1}`,
+      })),
+    });
+
+    const result = await channel.hydrateConversationContext({
+      conversationJid: 'sl:C123',
+      threadId: '1710000000.000100',
+      latestMessage: {
+        id: 'current',
+        timestamp: '2024-03-09T16:01:31.000Z',
+        external_message_id: '1710000091.000100',
+        thread_id: '1710000000.000100',
+      },
+      limits: { channelMessages: 30, threadMessages: 10 },
+    });
+
+    expect(
+      result.messages?.map((message) => message.external_message_id),
+    ).toEqual(
+      Array.from({ length: 10 }, (_, index) => `171000000${index + 3}.000100`),
     );
   });
 
@@ -2390,7 +2420,7 @@ describe('Slack channel', () => {
         external_message_id: '1710000091.000100',
         thread_id: '1710000000.000100',
       },
-      limits: { channelMessages: 30, threadMessages: 50 },
+      limits: { channelMessages: 30, threadMessages: 10 },
     });
 
     expect(appRef.current.client.conversations.replies).toHaveBeenCalledTimes(
@@ -2408,12 +2438,8 @@ describe('Slack channel', () => {
     ).toEqual([
       '1710000000.000100',
       ...Array.from(
-        { length: 10 },
-        (_, index) => `17100000${String(index + 1).padStart(2, '0')}.000100`,
-      ),
-      ...Array.from(
-        { length: 39 },
-        (_, index) => `1710000${String(index + 52).padStart(3, '0')}.000100`,
+        { length: 9 },
+        (_, index) => `1710000${String(index + 82).padStart(3, '0')}.000100`,
       ),
     ]);
   });
@@ -2752,7 +2778,7 @@ describe('Slack channel', () => {
     });
 
     const message = opts.onMessage.mock.calls[0][1];
-    expect(message.thread_id).toBe('1710000000.000100');
+    expect(message.thread_id).toBeUndefined();
     expect(message.attachments[0]).toEqual(
       expect.objectContaining({
         storageRef: expect.stringMatching(

--- a/apps/core/test/unit/config/desired-state-current-export.test.ts
+++ b/apps/core/test/unit/config/desired-state-current-export.test.ts
@@ -9,6 +9,64 @@ import {
 import { renderRuntimeSettingsYaml } from '@core/config/settings/runtime-settings-renderer.js';
 
 describe('exportCurrentDesiredState', () => {
+  it('loads conversation threads in bounded batches during settings export', async () => {
+    let activeThreadQueries = 0;
+    let maximumActiveThreadQueries = 0;
+    const conversations = Array.from({ length: 17 }, (_, index) => ({
+      id: `conversation:slack:${index}`,
+      providerAccountId: 'slack-default',
+      externalRef: { value: `C${index}` },
+      kind: 'channel',
+      title: `Channel ${index}`,
+      status: 'active',
+    }));
+    const deps = {
+      ops: { getAllConversationRoutes: vi.fn(async () => ({})) },
+      repositories: {
+        agents: { listAgents: vi.fn(async () => []) },
+        tools: {
+          listAgentToolBindingsForAgents: vi.fn(async () => []),
+          listAgentToolSourcesForAgents: vi.fn(async () => []),
+          listTools: vi.fn(async () => []),
+        },
+        skills: {
+          listAgentSkillBindingsForAgents: vi.fn(async () => []),
+          listSkills: vi.fn(async () => []),
+        },
+        mcpServers: { listAgentBindingsForAgents: vi.fn(async () => []) },
+        providerAccounts: {
+          listProviderAccounts: vi.fn(async () => []),
+          listConversationInstalls: vi.fn(async () => []),
+        },
+        conversations: {
+          listConversations: vi.fn(async () => conversations),
+          listThreads: vi.fn(async () => {
+            activeThreadQueries += 1;
+            maximumActiveThreadQueries = Math.max(
+              maximumActiveThreadQueries,
+              activeThreadQueries,
+            );
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            activeThreadQueries -= 1;
+            return [];
+          }),
+          listConversationApproversForConversations: vi.fn(async () => []),
+        },
+      },
+    };
+
+    await exportCurrentDesiredState({
+      deps: deps as any,
+      appId: 'app-one' as never,
+      settings: createDefaultRuntimeSettings(),
+    });
+
+    expect(deps.repositories.conversations.listThreads).toHaveBeenCalledTimes(
+      conversations.length,
+    );
+    expect(maximumActiveThreadQueries).toBeLessThanOrEqual(4);
+  });
+
   it('does not export internal app/control approval routes to settings', async () => {
     const settings = {
       providers: {},

--- a/apps/core/test/unit/runtime/conversation-context.test.ts
+++ b/apps/core/test/unit/runtime/conversation-context.test.ts
@@ -142,14 +142,14 @@ describe('buildConversationContextPacket', () => {
     expect(repository.getFirstThreadMessages).toHaveBeenCalledWith(
       'grp:1',
       'thread-1',
-      11,
+      1,
       { providerAccountId: 'acct-1' },
     );
     expect(repository.getLatestThreadMessages).toHaveBeenCalledWith(
       'grp:1',
       'thread-1',
       current,
-      50,
+      10,
       { providerAccountId: 'acct-1' },
     );
     expect(packet.activeThreadContext.map((message) => message.id)).toEqual([
@@ -214,9 +214,10 @@ describe('buildConversationContextPacket', () => {
     expect(packet.metadata.activeThreadRootPresent).toBe(true);
   });
 
-  it('does not mark a full before-or-at thread window complete after excluding the current message', async () => {
+  it('marks a complete thread window after retaining the root and latest replies', async () => {
     const threadMessages = sequence(50, (index) => ({
-      id: index === 50 ? 'current' : `thread-${index}`,
+      id: `thread-${index}`,
+      external_message_id: index === 1 ? 'thread-1' : undefined,
       thread_id: 'thread-1',
       content: index === 50 ? '@Gantry summarize' : `thread ${index}`,
     }));
@@ -225,8 +226,10 @@ describe('buildConversationContextPacket', () => {
       getRecentTopLevelMessagesBefore: vi.fn().mockResolvedValue([]),
       getFirstThreadMessages: vi
         .fn()
-        .mockResolvedValue(threadMessages.slice(0, 11)),
-      getLatestThreadMessages: vi.fn().mockResolvedValue(threadMessages),
+        .mockResolvedValue(threadMessages.slice(0, 1)),
+      getLatestThreadMessages: vi
+        .fn()
+        .mockResolvedValue(threadMessages.slice(-10)),
     };
 
     const packet = await buildConversationContextPacket({
@@ -241,21 +244,23 @@ describe('buildConversationContextPacket', () => {
       'grp:1',
       'thread-1',
       current,
-      50,
+      10,
       { providerAccountId: undefined },
     );
-    expect(packet.activeThreadContext).toHaveLength(49);
-    expect(packet.activeThreadContext.map((message) => message.id)).toEqual(
-      Array.from({ length: 49 }, (_, index) => `thread-${index + 1}`),
-    );
+    expect(packet.activeThreadContext).toHaveLength(10);
+    expect(packet.activeThreadContext.map((message) => message.id)).toEqual([
+      'thread-1',
+      ...Array.from({ length: 9 }, (_, index) => `thread-${index + 41}`),
+    ]);
     expect(packet.activeThreadContext).not.toContain(current);
-    expect(packet.metadata.activeThreadCount).toBe(49);
-    expect(packet.metadata.activeThreadWindowComplete).toBe(false);
+    expect(packet.metadata.activeThreadCount).toBe(10);
+    expect(packet.metadata.activeThreadWindowComplete).toBe(true);
   });
 
-  it('bounds long threads to root plus first 10 replies and latest 39 replies deterministically without duplicates', async () => {
+  it('bounds long threads to the root plus nine latest replies deterministically without duplicates', async () => {
     const threadMessages = sequence(70, (index) => ({
       id: `thread-${index}`,
+      external_message_id: index === 1 ? 'thread-1' : undefined,
       thread_id: 'thread-1',
       content: `thread ${index}`,
     }));
@@ -264,10 +269,7 @@ describe('buildConversationContextPacket', () => {
       getRecentTopLevelMessagesBefore: vi.fn().mockResolvedValue([]),
       getFirstThreadMessages: vi
         .fn()
-        .mockResolvedValue([
-          ...threadMessages.slice(0, 11).reverse(),
-          threadMessages[3],
-        ]),
+        .mockResolvedValue(threadMessages.slice(0, 1)),
       getLatestThreadMessages: vi
         .fn()
         .mockResolvedValue([
@@ -284,19 +286,18 @@ describe('buildConversationContextPacket', () => {
       repository,
     });
 
-    expect(packet.activeThreadContext).toHaveLength(50);
+    expect(packet.activeThreadContext).toHaveLength(10);
     expect(packet.activeThreadContext.map((message) => message.id)).toEqual([
       'thread-1',
-      ...Array.from({ length: 10 }, (_, index) => `thread-${index + 2}`),
-      ...Array.from({ length: 39 }, (_, index) => `thread-${index + 31}`),
+      ...Array.from({ length: 9 }, (_, index) => `thread-${index + 61}`),
     ]);
-    expect(new Set(packet.activeThreadContext.map((m) => m.id)).size).toBe(50);
+    expect(new Set(packet.activeThreadContext.map((m) => m.id)).size).toBe(10);
     expect(packet.activeThreadContext.at(-1)?.id).toBe('thread-69');
     expect(packet.currentMessages).toEqual([current]);
     expect(packet.metadata.activeThreadRootPresent).toBe(true);
   });
 
-  it('does not treat reply windows without explicit root ids as root-present', async () => {
+  it('uses the latest replies when a thread root is unavailable', async () => {
     const replies = sequence(50, (index) => ({
       id: `reply-${index}`,
       external_message_id: `provider-reply-${index}`,
@@ -312,7 +313,7 @@ describe('buildConversationContextPacket', () => {
     });
     const repository = {
       getRecentTopLevelMessagesBefore: vi.fn().mockResolvedValue([]),
-      getFirstThreadMessages: vi.fn().mockResolvedValue(replies.slice(0, 11)),
+      getFirstThreadMessages: vi.fn().mockResolvedValue(replies.slice(0, 1)),
       getLatestThreadMessages: vi.fn().mockResolvedValue(replies),
     };
 
@@ -324,7 +325,10 @@ describe('buildConversationContextPacket', () => {
       repository,
     });
 
-    expect(packet.activeThreadContext).toHaveLength(50);
+    expect(packet.activeThreadContext).toHaveLength(10);
+    expect(packet.activeThreadContext.map((message) => message.id)).toEqual(
+      Array.from({ length: 10 }, (_, index) => `reply-${index + 41}`),
+    );
     expect(packet.metadata.activeThreadWindowComplete).toBe(true);
     expect(packet.metadata.activeThreadRootPresent).toBe(false);
   });

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -5792,7 +5792,7 @@ describe('createGroupProcessor', () => {
         providerAccountId: 'telegram_account_2',
         threadId: '42',
         latestMessage: current,
-        limits: { channelMessages: 30, threadMessages: 50 },
+        limits: { channelMessages: 30, threadMessages: 10 },
       });
       expect((deps.opsRepository as any).storeMessage).toHaveBeenNthCalledWith(
         1,
@@ -6024,7 +6024,7 @@ describe('createGroupProcessor', () => {
         conversationJid: 'tg:-100123',
         threadId: '42',
         latestMessage: current,
-        limits: { channelMessages: 30, threadMessages: 50 },
+        limits: { channelMessages: 30, threadMessages: 10 },
       });
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
@@ -6105,7 +6105,7 @@ describe('createGroupProcessor', () => {
           conversationJid: 'tg:-100123',
           threadId: '42',
           latestMessage: current,
-          limits: { channelMessages: 30, threadMessages: 50 },
+          limits: { channelMessages: 30, threadMessages: 10 },
         });
         expect(settled).toBe(false);
 
@@ -6402,10 +6402,10 @@ describe('createGroupProcessor', () => {
         .mockResolvedValue([]);
       (deps.opsRepository as any).getFirstThreadMessages = vi
         .fn()
-        .mockResolvedValue(storedThreadMessages.slice(0, 11));
+        .mockResolvedValue(storedThreadMessages.slice(0, 1));
       (deps.opsRepository as any).getLatestThreadMessages = vi
         .fn()
-        .mockResolvedValue(storedThreadMessages);
+        .mockResolvedValue(storedThreadMessages.slice(-10));
 
       const { processGroupMessages } = createGroupProcessor(deps);
       await processGroupMessages('sl:C123::thread:1710000000.000000');
@@ -6413,7 +6413,10 @@ describe('createGroupProcessor', () => {
       expect(channel.hydrateConversationContext).not.toHaveBeenCalled();
       expect(mockFormatConversationContextMessages).toHaveBeenCalledWith(
         expect.objectContaining({
-          activeThreadContext: storedThreadMessages,
+          activeThreadContext: [
+            storedThreadMessages[0],
+            ...storedThreadMessages.slice(-9),
+          ],
           currentMessages: [current],
         }),
         'UTC',
@@ -6464,10 +6467,10 @@ describe('createGroupProcessor', () => {
         .mockResolvedValue([]);
       (deps.opsRepository as any).getFirstThreadMessages = vi
         .fn()
-        .mockResolvedValue(storedThreadReplies.slice(0, 11));
+        .mockResolvedValue(storedThreadReplies.slice(0, 1));
       (deps.opsRepository as any).getLatestThreadMessages = vi
         .fn()
-        .mockResolvedValue(storedThreadReplies);
+        .mockResolvedValue(storedThreadReplies.slice(-10));
 
       const { processGroupMessages } = createGroupProcessor(deps);
       await processGroupMessages('dc:thread-1::thread:discord-thread-1');
@@ -6476,7 +6479,7 @@ describe('createGroupProcessor', () => {
         conversationJid: 'dc:thread-1',
         threadId: 'discord-thread-1',
         latestMessage: current,
-        limits: { channelMessages: 30, threadMessages: 50 },
+        limits: { channelMessages: 30, threadMessages: 10 },
       });
     });
 

--- a/docs/architecture/cross-provider-conversation-context-goal-prompt.md
+++ b/docs/architecture/cross-provider-conversation-context-goal-prompt.md
@@ -25,10 +25,10 @@ Before every live agent turn, Gantry builds a transient context packet:
 
 - Channel message: current message plus the last 30 stored top-level messages
   before it.
-- Thread/reply-chain/topic message: thread root plus up to 50 stored messages
+- Thread/reply-chain/topic message: thread root plus up to 10 stored messages
   with the same canonical `thread_id`.
-- Long thread/reply-chain/topic: root plus first 10 replies plus latest 39
-  replies, deduped and ordered.
+- Long thread/reply-chain/topic: root plus latest 9 replies, deduped and
+  ordered.
 - Existing Gantry continuity/memory stays separate and is injected through the
   existing turn-context path.
 
@@ -70,8 +70,8 @@ present.
      message, timezone, and message repository.
    - Output: sectioned context data with `recentChannelContext`,
      `activeThreadContext`, `currentMessages`, and metadata counts.
-   - Keep constants internal for v1: channel limit 30, thread limit 50, long
-     thread first 10 plus latest 39.
+   - Keep constants internal for v1: channel limit 30, thread limit 10, long
+     thread root plus latest 9 replies.
 
 2. Add narrow message repository reads.
    - Read last N top-level inbound messages before a cursor/message.
@@ -161,7 +161,7 @@ Focused unit tests:
 - Context selector:
   - mid-channel tag includes last 30 top-level messages plus current message.
   - mid-thread tag includes root plus prior thread messages.
-  - long thread returns root plus first 10 plus latest 39.
+  - long thread returns root plus latest 9 replies.
   - unrelated threads are excluded.
   - Telegram topic uses stored `thread_id` messages only.
   - missing hydration degrades to stored messages.


### PR DESCRIPTION
## What changed

- Preserves the Slack channel context-history fix.
- Limits concurrent conversation-thread reads during desired-state export to batches of four.

## Why

Gantry could open too many database sessions while exporting conversation threads, causing Supabase’s session pooler to reject the request with `max clients reached`. That prevented agent access updates, including connecting Warden to the ITOps MCP.

## Validation

- `npm run build:contracts`
- Desired-state export unit tests
- `npm run typecheck`