### PR TITLE
fix(slack): make permission approvals reliably visible

### DIFF
--- a/apps/core/src/channels/slack/permission-approval-delivery.ts
+++ b/apps/core/src/channels/slack/permission-approval-delivery.ts
@@ -120,6 +120,18 @@ export async function requestSlackPermissionApproval(input: {
   const threadTs = slackThreadTsFromThreadId(input.request.threadId);
   const threadPayload = threadTs ? { thread_ts: threadTs } : {};
   const userIds = [...new Set(input.approverUserIds || [])].filter(Boolean);
+  const visiblePromptText =
+    'Approval required from a configured approver. Only configured approvers can decide this action.';
+  const visiblePromptBlocks = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*Approval required*\nA configured approver must decide this action.',
+      },
+    },
+    actionsBlock,
+  ];
   const postPromptDeliveryFailureNotice = async (reason: string) => {
     try {
       await input.app.client.chat.postMessage({
@@ -134,31 +146,32 @@ export async function requestSlackPermissionApproval(input: {
       );
     }
   };
-  const postPrivatePrompt = async (
-    blocks: unknown[],
-  ): Promise<{ ts?: string } | null> => {
-    let first: { ts?: string } | null = null;
-    let lastError: unknown;
+  const postVisiblePrompt = async (): Promise<{ ts?: string } | null> => {
+    const sent = (await input.app.client.chat.postMessage({
+      channel: input.channelId,
+      text: visiblePromptText,
+      ...threadPayload,
+      blocks: visiblePromptBlocks as any,
+    })) as { ts?: string; message_ts?: string };
+    return { ts: sent.ts || sent.message_ts };
+  };
+  const postPrivateDetails = async (blocks: unknown[]): Promise<void> => {
     for (const user of userIds) {
       try {
-        const sent = (await input.app.client.chat.postEphemeral({
+        await input.app.client.chat.postEphemeral({
           channel: input.channelId,
           user,
           text: promptText,
           ...threadPayload,
           blocks: blocks as any,
-        })) as { ts?: string; message_ts?: string };
-        first ||= { ts: sent.ts || sent.message_ts };
+        });
       } catch (err) {
-        lastError = err;
-        logger.debug(
+        logger.warn(
           { jid: input.jid, requestId: input.request.requestId, user, err },
           'Slack ephemeral permission prompt failed for approver',
         );
       }
     }
-    if (!first && lastError) throw lastError;
-    return first;
   };
   try {
     if (userIds.length === 0) {
@@ -180,27 +193,16 @@ export async function requestSlackPermissionApproval(input: {
     }
     let response: { ts?: string } | null;
     try {
-      response = await postPrivatePrompt([...contentBlocks, actionsBlock]);
+      response = await postVisiblePrompt();
     } catch (blocksErr) {
       logger.warn(
         { jid: input.jid, requestId: input.request.requestId, err: blocksErr },
-        'Slack native permission blocks rejected; retrying with simple layout',
+        'Slack visible permission prompt could not be delivered',
       );
-      const simpleBlocks = [
-        {
-          type: 'section',
-          text: { type: 'mrkdwn', text: promptText },
-        },
-        actionsBlock,
-      ];
-      try {
-        response = await postPrivatePrompt(simpleBlocks);
-      } catch (simpleErr) {
-        const reason =
-          'Approval prompt could not be shown to any configured Slack approver. Check that the approver is a member of this conversation and that the Slack app can post ephemeral messages here.';
-        await postPromptDeliveryFailureNotice(reason);
-        throw simpleErr;
-      }
+      const reason =
+        'Approval prompt could not be posted to this Slack thread. Check that the Slack app can post messages here and retry.';
+      await postPromptDeliveryFailureNotice(reason);
+      throw blocksErr;
     }
     const messageTs = response?.ts;
     if (!messageTs) {
@@ -275,6 +277,9 @@ export async function requestSlackPermissionApproval(input: {
       return await decision;
     }
     input.onPromptDelivered?.(messageTs);
+    // Ephemeral details preserve the richer prompt for active approvers, but the
+    // durable thread card above is the sole required action surface.
+    await postPrivateDetails(contentBlocks);
     return await decision;
   } catch (err) {
     if (err instanceof DurableInteractionPersistenceError) throw err;

--- a/apps/core/test/unit/channels/slack.test.ts
+++ b/apps/core/test/unit/channels/slack.test.ts
@@ -625,9 +625,10 @@ function requestSlackUserAnswer(
 }
 
 function latestSlackPermissionActionValue(actionId: string) {
-  const blocks = vi
-    .mocked(appRef.current.client.chat.postEphemeral)
-    .mock.calls.at(-1)?.[0]?.blocks as Array<{
+  const promptCall = vi
+    .mocked(appRef.current.client.chat.postMessage)
+    .mock.calls.at(-1)?.[0];
+  const blocks = promptCall?.blocks as Array<{
     type?: string;
     elements?: Array<{ action_id?: string; value?: string }>;
   }>;
@@ -4297,14 +4298,21 @@ describe('Slack channel', () => {
       },
     });
     await flushSlackPromptRegistration();
-    const postCall = vi
+    const privateDetailsCall = vi
       .mocked(appRef.current.client.chat.postEphemeral)
       .mock.calls.at(-1)?.[0];
-    expect(postCall?.user).toBe('U_APPROVER');
-    expect(postCall?.thread_ts).toBe('1711111111.000100');
-    expect(postCall?.text).toContain(
+    expect(privateDetailsCall?.user).toBe('U_APPROVER');
+    expect(privateDetailsCall?.thread_ts).toBe('1711111111.000100');
+    expect(privateDetailsCall?.text).toContain(
       'Approval applies to the parent conversation.',
     );
+    expect(JSON.stringify(privateDetailsCall?.blocks || [])).not.toContain(
+      'git status --short',
+    );
+    const postCall = vi
+      .mocked(appRef.current.client.chat.postMessage)
+      .mock.calls.at(-1)?.[0];
+    expect(postCall?.thread_ts).toBe('1711111111.000100');
     expect(JSON.stringify(postCall?.blocks || [])).not.toContain(
       'git status --short',
     );
@@ -4375,7 +4383,9 @@ describe('Slack channel', () => {
     );
     expect(respond).toHaveBeenCalledWith({ delete_original: true });
     expect(appRef.current.client.chat.update).not.toHaveBeenCalled();
-    expect(appRef.current.client.chat.postMessage).not.toHaveBeenCalled();
+    expect(appRef.current.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C123' }),
+    );
   });
 
   it('opens durable Slack permission full-view payloads after channel restart', async () => {
@@ -4446,7 +4456,7 @@ describe('Slack channel', () => {
     );
   });
 
-  it('replaces an approved Slack ephemeral through response_url when removal fails', async () => {
+  it('replaces an approved Slack permission card through response_url when removal fails', async () => {
     const channel = new SlackChannel(
       'xoxb-token',
       'xapp-token',
@@ -4490,7 +4500,9 @@ describe('Slack channel', () => {
         text: expect.stringContaining('Allowed once:'),
       }),
     );
-    expect(appRef.current.client.chat.postMessage).not.toHaveBeenCalled();
+    expect(appRef.current.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C123' }),
+    );
   });
 
   it('routes recovered Slack clicks through application orchestrator transport hooks', async () => {
@@ -5127,7 +5139,7 @@ describe('Slack channel', () => {
     });
   });
 
-  it('leaves a Slack permission ephemeral stale without response_url and posts no receipt', async () => {
+  it('leaves a Slack permission card stale without response_url and posts no receipt', async () => {
     const channel = new SlackChannel(
       'xoxb-token',
       'xapp-token',
@@ -5167,7 +5179,9 @@ describe('Slack channel', () => {
     expect(respond).not.toHaveBeenCalled();
     expect(appRef.current.client.chat.delete).not.toHaveBeenCalled();
     expect(appRef.current.client.chat.update).not.toHaveBeenCalled();
-    expect(appRef.current.client.chat.postMessage).not.toHaveBeenCalled();
+    expect(appRef.current.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C123' }),
+    );
 
     const retryRespond = vi.fn().mockResolvedValue({});
     await appRef.current.actionHandlers.get('gantry_perm_decision_cancel')?.({
@@ -5315,7 +5329,7 @@ describe('Slack channel', () => {
     await expect(secondApproval).resolves.toMatchObject({ approved: false });
   });
 
-  it('posts Slack approval prompts ephemerally to approvers', async () => {
+  it('posts a durable, neutral Slack approval card and private details to approvers', async () => {
     defaultSlackPermissionApproverIds.add('U_APPROVER');
     const channel = new SlackChannel(
       'xoxb-token',
@@ -5333,7 +5347,15 @@ describe('Slack channel', () => {
     expect(appRef.current.client.chat.postEphemeral).toHaveBeenCalledWith(
       expect.objectContaining({ channel: 'C123', user: 'U_APPROVER' }),
     );
-    expect(appRef.current.client.chat.postMessage).not.toHaveBeenCalled();
+    expect(appRef.current.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C123',
+        text: 'Approval required from a configured approver. Only configured approvers can decide this action.',
+        blocks: expect.arrayContaining([
+          expect.objectContaining({ type: 'actions' }),
+        ]),
+      }),
+    );
     const actionHandler = appRef.current.actionHandlers.get(
       'gantry_perm_decision_allow_once',
     );
@@ -5486,7 +5508,8 @@ describe('Slack channel', () => {
       channel.requestPermissionApproval('sl:C123', batch, onPromptDelivered),
     ).resolves.toMatchObject({ approved: false });
 
-    expect(appRef.current.client.chat.postEphemeral).toHaveBeenCalledOnce();
+    expect(appRef.current.client.chat.postEphemeral).not.toHaveBeenCalled();
+    expect(appRef.current.client.chat.postMessage).toHaveBeenCalledOnce();
     expect(bindPendingPermissionPrompt).toHaveBeenCalledTimes(2);
     expect(onPromptDelivered).not.toHaveBeenCalled();
     expect((channel as any).pendingPermissionPrompts.size).toBe(0);
@@ -5567,7 +5590,7 @@ describe('Slack channel', () => {
     );
   });
 
-  it('scopes Slack ephemeral permission prompts to this account approvers', async () => {
+  it('scopes Slack private permission details to this account approvers', async () => {
     const base = createOpts({ default: [], agents: {} });
     const channel = new SlackChannel('xoxb-token', 'xapp-token', {
       ...base,
@@ -5612,7 +5635,9 @@ describe('Slack channel', () => {
     expect(appRef.current.client.chat.postEphemeral).not.toHaveBeenCalledWith(
       expect.objectContaining({ user: 'U_OTHER_ACCOUNT' }),
     );
-    expect(appRef.current.client.chat.postMessage).not.toHaveBeenCalled();
+    expect(appRef.current.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C123' }),
+    );
 
     await channel.disconnect();
     await expect(approvalPromise).resolves.toEqual(
@@ -5690,7 +5715,7 @@ describe('Slack channel', () => {
     );
     await flushSlackPromptRegistration();
     const actionsBlock =
-      appRef.current.client.chat.postEphemeral.mock.calls[0]?.[0].blocks.find(
+      appRef.current.client.chat.postMessage.mock.calls[0]?.[0].blocks.find(
         (block: any) => block.type === 'actions',
       );
     expect(actionsBlock.elements[0].value).toContain(


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
