### PR TITLE
fix slack attachment file reads

### DIFF
--- a/apps/core/src/channels/slack/channel-state.ts
+++ b/apps/core/src/channels/slack/channel-state.ts
@@ -1,10 +1,8 @@
-import path from 'path';
+import path from 'node:path';
 
 import { App } from '@slack/bolt';
 
 import { logger } from '../../infrastructure/logging/logger.js';
-import { createInboundAttachmentStorageRef } from '../../shared/inbound-attachment-writer.js';
-import { ensurePrivateDirSync } from '../../shared/private-fs.js';
 import { findConversationRoutesForChat } from '../../shared/thread-queue-key.js';
 import {
   NewMessage,
@@ -32,17 +30,15 @@ import {
   tryNativeStreamStart,
   tryNativeStreamStop,
 } from './native-stream.js';
-import { writeSlackAttachmentResponse } from './attachment-download.js';
 import type { DurableQuestionCallback } from '../../application/interactions/pending-interaction-durability.js';
 import {
   cancelMatchingPendingQuestions,
   type InteractionCancellationResult,
 } from '../interaction-settlement.js';
-
-interface SlackAttachmentDownload {
-  filePath: string;
-  storageRef: string;
-}
+import {
+  downloadSlackAttachmentToFolder,
+  type SlackAttachmentDownloadResult,
+} from './inbound-attachment-download.js';
 
 type SlackMessageAttachments = NonNullable<NewMessage['attachments']>;
 type UQSelection = { selected: string | string[]; answeredBy?: string };
@@ -565,9 +561,9 @@ export abstract class SlackChannelState {
     },
     threadId?: string,
     targetFolder?: string,
-  ): Promise<SlackAttachmentDownload | null> {
+  ): Promise<SlackAttachmentDownloadResult> {
     const url = file.url_private_download || file.url_private;
-    if (!url) return null;
+    if (!url) return { status: 'unavailable', reason: 'missing_download_url' };
     const groups = targetFolder
       ? []
       : findConversationRoutesForChat(
@@ -576,46 +572,26 @@ export abstract class SlackChannelState {
           threadId,
           this.opts.providerAccountId,
         );
-    if (!targetFolder && groups.length < 1) return null;
+    if (!targetFolder && groups.length < 1) {
+      return { status: 'unavailable', reason: 'no_matching_route' };
+    }
     const filename = this.sanitizeFilename(
       file.name || file.title || 'attachment.bin',
     );
-    const storageRef = createInboundAttachmentStorageRef(filename);
     const folders = targetFolder
       ? [targetFolder]
       : Array.from(new Set(groups.map(([, group]) => group.folder)));
-    if (folders.length !== 1) return null;
-
-    try {
-      const groupDir = resolveWorkspaceFolderPath(folders[0]);
-      const attachDir = path.join(groupDir, 'attachments');
-      ensurePrivateDirSync(attachDir);
-      const destPath = path.join(groupDir, ...storageRef.split('/'));
-      const resp = await fetch(url, {
-        headers: {
-          authorization: `Bearer ${this.botToken}`,
-        },
-      });
-      if (!resp.ok) {
-        logger.warn(
-          { jid, status: resp.status, filename },
-          'Failed to download Slack attachment',
-        );
-        return null;
-      }
-
-      const wrote = await writeSlackAttachmentResponse(
-        resp,
-        groupDir,
-        storageRef,
-      );
-      if (!wrote) return null;
-      return { filePath: destPath, storageRef };
-    } catch (err) {
-      if (isFileExistsError(err)) throw err;
-      logger.warn({ jid, err, filename }, 'Slack attachment download failed');
-      return null;
+    if (folders.length !== 1) {
+      return { status: 'unavailable', reason: 'ambiguous_route' };
     }
+
+    return downloadSlackAttachmentToFolder({
+      botToken: this.botToken,
+      jid,
+      filename,
+      url,
+      groupDir: resolveWorkspaceFolderPath(folders[0]),
+    });
   }
 
   protected async enrichMessage(
@@ -630,21 +606,27 @@ export abstract class SlackChannelState {
 
     if (Array.isArray(event.files)) {
       for (const file of event.files) {
-        const download = await this.downloadSlackAttachment(
+        const downloadResult = await this.downloadSlackAttachment(
           jid,
           file,
           event.thread_ts,
           targetFolder,
         );
         const label = file.name || file.title || 'attachment';
-        lines.push(`Attachment: ${label}`);
+        lines.push(
+          downloadResult.status === 'downloaded'
+            ? `Attachment: ${label}`
+            : `Attachment: ${label} (download unavailable: ${downloadResult.reason})`,
+        );
         const attachment: SlackMessageAttachments[number] = {
           id: file.id ? `slack-file:${file.id}` : undefined,
           kind: file.mimetype?.startsWith('image/') ? 'image' : 'file',
           contentType: file.mimetype,
           externalId: file.id,
         };
-        if (download) attachment.storageRef = download.storageRef;
+        if (downloadResult.status === 'downloaded') {
+          attachment.storageRef = downloadResult.download.storageRef;
+        }
         attachments.push(attachment);
       }
     }
@@ -685,13 +667,4 @@ export abstract class SlackChannelState {
   ): Promise<boolean> {
     return tryNativeStreamStop({ app: this.app, channelId, streamTs });
   }
-}
-
-function isFileExistsError(error: unknown): boolean {
-  let current = error;
-  while (typeof current === 'object' && current !== null) {
-    if ('code' in current && current.code === 'EEXIST') return true;
-    current = 'cause' in current ? current.cause : null;
-  }
-  return false;
 }

--- a/apps/core/src/channels/slack/inbound-attachment-download.ts
+++ b/apps/core/src/channels/slack/inbound-attachment-download.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { logger } from '../../infrastructure/logging/logger.js';
+import { createInboundAttachmentStorageRef } from '../../shared/inbound-attachment-writer.js';
+import { ensurePrivateDirSync } from '../../shared/private-fs.js';
+import { writeSlackAttachmentResponse } from './attachment-download.js';
+
+export interface SlackAttachmentDownload {
+  filePath: string;
+  storageRef: string;
+}
+
+export type SlackAttachmentDownloadResult =
+  | { status: 'downloaded'; download: SlackAttachmentDownload }
+  | { status: 'unavailable'; reason: string };
+
+export async function downloadSlackAttachmentToFolder(input: {
+  botToken: string;
+  jid: string;
+  filename: string;
+  url: string;
+  groupDir: string;
+}): Promise<SlackAttachmentDownloadResult> {
+  const storageRef = createInboundAttachmentStorageRef(input.filename);
+  try {
+    const attachDir = path.join(input.groupDir, 'attachments');
+    ensurePrivateDirSync(attachDir);
+    const destPath = path.join(input.groupDir, ...storageRef.split('/'));
+    const resp = await fetch(input.url, {
+      headers: {
+        authorization: `Bearer ${input.botToken}`,
+      },
+    });
+    if (!resp.ok) {
+      logger.warn(
+        { jid: input.jid, status: resp.status, filename: input.filename },
+        'Failed to download Slack attachment',
+      );
+      return { status: 'unavailable', reason: `slack_http_${resp.status}` };
+    }
+
+    const wrote = await writeSlackAttachmentResponse(
+      resp,
+      input.groupDir,
+      storageRef,
+    );
+    if (!wrote) return { status: 'unavailable', reason: 'write_rejected' };
+    const stat = fs.statSync(destPath);
+    if (!stat.isFile() || stat.size < 0) {
+      logger.warn(
+        { jid: input.jid, filename: input.filename, storageRef },
+        'Slack attachment write did not produce a readable file',
+      );
+      return { status: 'unavailable', reason: 'written_file_unreadable' };
+    }
+    return {
+      status: 'downloaded',
+      download: { filePath: destPath, storageRef },
+    };
+  } catch (err) {
+    if (isFileExistsError(err)) throw err;
+    logger.warn(
+      { jid: input.jid, err, filename: input.filename },
+      'Slack attachment download failed',
+    );
+    return { status: 'unavailable', reason: 'download_failed' };
+  }
+}
+
+function isFileExistsError(error: unknown): boolean {
+  let current = error;
+  while (typeof current === 'object' && current !== null) {
+    if ('code' in current && current.code === 'EEXIST') return true;
+    current = 'cause' in current ? current.cause : null;
+  }
+  return false;
+}

--- a/apps/core/src/jobs/ipc-file-artifact-handlers.ts
+++ b/apps/core/src/jobs/ipc-file-artifact-handlers.ts
@@ -11,6 +11,7 @@ import {
   normalizeFileArtifactScope,
 } from '../domain/file-artifacts/virtual-path.js';
 import { memoryAgentIdForWorkspaceFolder } from '../memory/app-memory-boundaries.js';
+import { readWorkspaceMessageAttachment } from '../platform/workspace-message-attachment.js';
 import { sourceAgentHasAdminToolCapability } from './ipc-admin-authorization.js';
 import { createTaskResponder, toTrimmedString } from './ipc-shared.js';
 import type { TaskContext, TaskHandler } from './ipc-types.js';
@@ -55,6 +56,46 @@ const fileArtifactHandler: TaskHandler = async (context) => {
   }
 
   try {
+    if (action === 'read') {
+      const artifactId = toTrimmedString(payload.artifactId, { maxLen: 160 });
+      const rawPath = toTrimmedString(payload.path, { maxLen: 1000 });
+      const rawScope = toTrimmedString(payload.scope, { maxLen: 160 });
+      if (!artifactId && !rawScope && rawPath?.startsWith('attachments/')) {
+        const result = await readWorkspaceMessageAttachment(
+          sourceAgentFolder,
+          rawPath,
+        );
+        if (result.status !== 'resolved') {
+          reject(
+            result.status === 'missing'
+              ? 'Workspace attachment is missing.'
+              : result.reason,
+            result.status === 'missing' ? 'not_found' : 'invalid_request',
+          );
+          return;
+        }
+        acceptData('Workspace attachment read.', {
+          ok: true,
+          attachment: {
+            filename: result.attachment.filename,
+            contentType: result.attachment.contentType,
+            sizeBytes: result.attachment.sizeBytes,
+          },
+          content: encodeFileArtifactContent(
+            workspaceAttachmentContentForRead(result.attachment),
+            {
+              offset: typeof payload.offset === 'number' ? payload.offset : 0,
+              limit:
+                typeof payload.readLimit === 'number'
+                  ? payload.readLimit
+                  : DEFAULT_READ_LIMIT_BYTES,
+            },
+          ),
+        });
+        return;
+      }
+    }
+
     const store = context.deps.getFileArtifactStore?.();
     if (!store) {
       reject('FileArtifact storage is not ready.', 'preflight_failed');
@@ -281,6 +322,20 @@ function decodeFileArtifactContent(
   }
   if (encoding === 'base64') return Buffer.from(content, 'base64');
   return content;
+}
+
+function workspaceAttachmentContentForRead(input: {
+  contentType: string;
+  content: Uint8Array;
+}): Uint8Array | string {
+  if (
+    input.contentType.startsWith('text/') ||
+    input.contentType === 'application/json' ||
+    input.contentType === 'application/xml'
+  ) {
+    return Buffer.from(input.content).toString('utf-8');
+  }
+  return input.content;
 }
 
 function encodeFileArtifactContent(

--- a/apps/core/src/runner/mcp/tools/file.ts
+++ b/apps/core/src/runner/mcp/tools/file.ts
@@ -65,7 +65,7 @@ const fileToolSchema = {
 export function registerFileTools(server: McpServer): void {
   server.tool(
     'file',
-    'List, read, write, or promote Gantry FileArtifacts by virtual scope/path. Descriptors are compact by default; file content is returned only by read. Host filesystem paths and storage refs are never exposed.',
+    'List, read, write, or promote Gantry FileArtifacts by virtual scope/path. Read inbound channel attachment refs such as attachments/report.md with action=read and path=<gantry_ref>. Descriptors are compact by default; file content is returned only by read. Host filesystem paths and backend storage refs are never exposed.',
     fileToolSchema,
     async (args) => {
       const result = await handleFileToolAction(args);
@@ -108,6 +108,8 @@ async function requestHostFileArtifactAction(
       ? (response.data as Record<string, unknown>)
       : {};
   if (typeof data.content === 'string') return data.content;
+  const encodedContent = decodeReadContent(data.content);
+  if (encodedContent) return encodedContent;
   if (Array.isArray(data.artifacts)) {
     if (data.artifacts.length === 0) return 'No files found.';
     const lines = data.artifacts.map((entry) => {
@@ -127,6 +129,20 @@ async function requestHostFileArtifactAction(
     ? String(artifact.virtualPath ?? artifact.path ?? '')
     : '';
   return path ? `Saved ${path}.` : 'Done.';
+}
+
+function decodeReadContent(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.encoding === 'utf8' && typeof record.text === 'string') {
+    return record.text;
+  }
+  if (record.encoding === 'base64' && typeof record.data === 'string') {
+    return `[base64 attachment content]\n${record.data}`;
+  }
+  return undefined;
 }
 
 export function measureFileToolPayloadSize(value: unknown): number {

--- a/apps/core/test/unit/channels/slack.test.ts
+++ b/apps/core/test/unit/channels/slack.test.ts
@@ -3518,6 +3518,63 @@ describe('Slack channel', () => {
     ).toEqual(Buffer.alloc(8));
   });
 
+  it('does not expose a gantry attachment ref when Slack download fails', async () => {
+    const opts = createOpts();
+    opts.conversationRoutes.mockReturnValue({
+      [makeAgentThreadQueueKey('sl:C123', 'agent:ops', null, 'slack_default')]:
+        {
+          folder: 'slack_ops',
+          name: 'Ops',
+          providerAccountId: 'slack_default',
+        },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        headers: { get: () => null },
+      }),
+    );
+    const channel = new SlackChannel('xoxb-token', 'xapp-token', opts as any);
+    await channel.connect();
+
+    const handlers = appRef.current.eventHandlers.get('message') || [];
+    await handlers[0]({
+      event: {
+        channel: 'C123',
+        ts: '1710000000.000100',
+        user: 'U123',
+        text: 'see file',
+        files: [
+          {
+            id: 'F123',
+            name: 'Scout_Agent_Skills.md',
+            mimetype: 'text/markdown',
+            url_private_download: 'https://files.slack.test/skills.md',
+          },
+        ],
+      },
+    });
+
+    expect(opts.onMessage).toHaveBeenCalledWith(
+      'sl:C123',
+      expect.objectContaining({
+        content:
+          'see file\nAttachment: Scout_Agent_Skills.md (download unavailable: slack_http_403)',
+        attachments: [
+          expect.objectContaining({
+            externalId: 'F123',
+            contentType: 'text/markdown',
+          }),
+        ],
+      }),
+    );
+    expect(opts.onMessage.mock.calls[0][1].attachments[0]).not.toHaveProperty(
+      'storageRef',
+    );
+  });
+
   it('does not download Slack attachments through a different provider account route', async () => {
     const opts = createOpts();
     opts.providerAccountId = 'slack_alpha';

--- a/apps/core/test/unit/jobs/ipc-file-artifact-handlers.test.ts
+++ b/apps/core/test/unit/jobs/ipc-file-artifact-handlers.test.ts
@@ -82,6 +82,7 @@ function contextFor(input: {
   data: Record<string, unknown>;
   ipcBaseDir?: string;
   writeFileArtifact: ReturnType<typeof vi.fn>;
+  readFileArtifact?: ReturnType<typeof vi.fn>;
 }) {
   return {
     data: input.data,
@@ -89,6 +90,7 @@ function contextFor(input: {
     ipcBaseDir: input.ipcBaseDir,
     deps: {
       getFileArtifactStore: () => ({
+        readFileArtifact: input.readFileArtifact,
         writeFileArtifact: input.writeFileArtifact,
       }),
       getToolRepository: () => ({
@@ -150,6 +152,109 @@ describe('file artifact IPC handlers', () => {
           scope: 'default',
           path: 'notes/result.txt',
           version: 1,
+        },
+      },
+    });
+  });
+
+  it('reads workspace message attachments through the file tool path', async () => {
+    const runtimeHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gantry-file-ipc-'),
+    );
+    runtimeHomes.push(runtimeHome);
+    const { fileArtifactTaskHandlers, taskData } =
+      await loadFileArtifactHandlers(runtimeHome);
+    const attachmentDir = path.join(
+      runtimeHome,
+      'agents',
+      'main_agent',
+      'attachments',
+    );
+    fs.mkdirSync(attachmentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(attachmentDir, 'skills.md'),
+      '# ATS Skills\nRead this file.',
+      { mode: 0o600 },
+    );
+    const writeFileArtifact = vi.fn();
+
+    await fileArtifactTaskHandlers.file_artifact(
+      contextFor({
+        data: taskData('read-workspace-attachment', {
+          payload: {
+            action: 'read',
+            path: 'attachments/skills.md',
+          },
+        }),
+        writeFileArtifact,
+      }),
+    );
+
+    expect(writeFileArtifact).not.toHaveBeenCalled();
+    expect(
+      readResponse(runtimeHome, 'read-workspace-attachment'),
+    ).toMatchObject({
+      ok: true,
+      data: {
+        ok: true,
+        attachment: {
+          filename: 'skills.md',
+          contentType: 'text/markdown',
+        },
+        content: {
+          encoding: 'utf8',
+          text: '# ATS Skills\nRead this file.',
+        },
+      },
+    });
+  });
+
+  it('does not shadow scoped FileArtifact reads under attachments paths', async () => {
+    const runtimeHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gantry-file-ipc-'),
+    );
+    runtimeHomes.push(runtimeHome);
+    const { fileArtifactTaskHandlers, taskData } =
+      await loadFileArtifactHandlers(runtimeHome);
+    const writeFileArtifact = vi.fn();
+    const readFileArtifact = vi.fn(async () => ({
+      artifact: makeArtifact({
+        virtualScope: 'default',
+        virtualPath: 'attachments/skills.md',
+        content: 'from artifact store',
+      }),
+      content: 'from artifact store',
+    }));
+
+    await fileArtifactTaskHandlers.file_artifact(
+      contextFor({
+        data: taskData('read-scoped-attachment-artifact', {
+          payload: {
+            action: 'read',
+            scope: 'default',
+            path: 'attachments/skills.md',
+          },
+        }),
+        readFileArtifact,
+        writeFileArtifact,
+      }),
+    );
+
+    expect(readFileArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        virtualScope: 'default',
+        virtualPath: 'attachments/skills.md',
+      }),
+    );
+    expect(
+      readResponse(runtimeHome, 'read-scoped-attachment-artifact'),
+    ).toMatchObject({
+      ok: true,
+      data: {
+        ok: true,
+        content: {
+          encoding: 'utf8',
+          text: 'from artifact store',
         },
       },
     });

--- a/apps/core/test/unit/runner/mcp/file-tool.test.ts
+++ b/apps/core/test/unit/runner/mcp/file-tool.test.ts
@@ -100,4 +100,32 @@ describe('mcp__gantry__file', () => {
       handleFileToolAction({ action: 'read', path: 'notes/today.md' }),
     ).resolves.toContain('That file action was rejected:');
   });
+
+  it('returns structured utf8 read content from host IPC', async () => {
+    const writeIpcFile = vi.fn();
+    const waitForTaskResponse = vi.fn(async () => ({
+      ok: true,
+      data: {
+        ok: true,
+        content: {
+          encoding: 'utf8',
+          text: '# ATS Skills\nRead this file.',
+          offset: 0,
+          bytesReturned: 28,
+          totalBytes: 28,
+          truncated: false,
+        },
+      },
+    }));
+    vi.doMock('@core/runner/mcp/ipc.js', () => ({
+      writeIpcFile,
+      waitForTaskResponse,
+    }));
+    const { handleFileToolAction } =
+      await import('@core/runner/mcp/tools/file.js');
+
+    await expect(
+      handleFileToolAction({ action: 'read', path: 'attachments/skills.md' }),
+    ).resolves.toBe('# ATS Skills\nRead this file.');
+  });
 });


### PR DESCRIPTION
Allow the file MCP tool to read inbound Slack attachment refs from the workspace attachment store after normal file-read approval, instead of looking only in FileArtifacts. Keep failed Slack downloads out of attachment refs, preserve scoped FileArtifact reads under attachments paths, and add focused coverage for download failures, attachment reads, and structured file-tool content.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
