### PR TITLE
fix(runtime): guarantee a durable assistant message for every streaming turn

### DIFF
--- a/apps/core/src/adapters/storage/postgres/repositories/runtime-event-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/runtime-event-repository.postgres.ts
@@ -272,6 +272,14 @@ export class PostgresRuntimeEventRepository implements RuntimeEventRepository {
         ),
       );
     }
+    if (filter.conversationIds?.length) {
+      conditions.push(
+        inArray(
+          pgSchema.runtimeEventsPostgres.conversationId,
+          filter.conversationIds,
+        ),
+      );
+    }
     if (filter.threadId !== undefined) {
       conditions.push(
         eq(pgSchema.runtimeEventsPostgres.threadId, filter.threadId),

--- a/apps/core/src/application/sessions/session-interaction-module.ts
+++ b/apps/core/src/application/sessions/session-interaction-module.ts
@@ -255,14 +255,7 @@ export class SessionInteractionModule {
     // `conversation_route_conversation_id_noncanonical` when a route predates
     // the canonical id — so asking only for the canonical id silently returns
     // [] for runs recorded under the older one.
-    const conversationIds =
-      await this.deps.repositories.messages.listConversationIdsForJid(
-        appSession.conversationJid,
-      );
-    const canonical = appSession.canonicalConversationId as string | undefined;
-    const candidates = Array.from(
-      new Set([...(canonical ? [canonical] : []), ...conversationIds]),
-    );
+    const candidates = await this.feedConversationIds(appSession);
     if (candidates.length === 0) return { runs: [] };
     const lists = await Promise.all(
       candidates.map((conversationId) =>
@@ -435,7 +428,10 @@ export class SessionInteractionModule {
     limit?: number;
   }): Promise<RuntimeEvent[]> {
     const session = await this.requireSession(input);
-    return this.deps.runtimeEvents.list(this.eventFilter(session, input));
+    const conversationIds = await this.feedConversationIds(session);
+    return this.deps.runtimeEvents.list(
+      this.eventFilter(session, input, conversationIds),
+    );
   }
 
   async subscribeEvents(input: {
@@ -445,7 +441,10 @@ export class SessionInteractionModule {
     limit?: number;
   }) {
     const session = await this.requireSession(input);
-    return this.deps.runtimeEvents.subscribe(this.eventFilter(session, input));
+    const conversationIds = await this.feedConversationIds(session);
+    return this.deps.runtimeEvents.subscribe(
+      this.eventFilter(session, input, conversationIds),
+    );
   }
 
   async waitForVisibleEvent(input: {
@@ -536,13 +535,26 @@ export class SessionInteractionModule {
     return webhook.webhookId;
   }
 
+  /** Every conversation row this session's jid maps to, canonical first. */
+  private async feedConversationIds(
+    session: SessionAppRecord,
+  ): Promise<string[]> {
+    const rows =
+      await this.deps.repositories.messages.listConversationIdsForJid(
+        session.conversationJid,
+      );
+    const canonical = session.canonicalConversationId as string | undefined;
+    return Array.from(new Set([...(canonical ? [canonical] : []), ...rows]));
+  }
+
   private eventFilter(
     session: SessionAppRecord,
     input: { afterEventId?: number; limit?: number },
+    conversationIds: string[],
   ): RuntimeEventFilter {
     return {
       appId: session.appId as never,
-      conversationId: session.canonicalConversationId as never,
+      conversationIds: conversationIds as never,
       afterEventId:
         input.afterEventId && input.afterEventId > 0
           ? (input.afterEventId as never)

--- a/apps/core/src/application/sessions/session-interaction-module.ts
+++ b/apps/core/src/application/sessions/session-interaction-module.ts
@@ -228,19 +228,7 @@ export class SessionInteractionModule {
       await this.deps.repositories.messages.listConversationIdsForJid(
         session.conversationJid,
       );
-    if (conversationIds.length === 0) {
-      // Say why the feed is empty. A silent [] here is indistinguishable from
-      // "the assistant never replied", which is what made the missing-message
-      // failure undiagnosable.
-      console.warn(
-        JSON.stringify({
-          event: 'session_messages_no_conversation_rows',
-          sessionId: input.sessionId,
-          conversationJid: session.conversationJid,
-        }),
-      );
-      return { messages: [] };
-    }
+    if (conversationIds.length === 0) return { messages: [] };
     const lists = await Promise.all(
       conversationIds.map((conversationId) =>
         this.deps.repositories.messages.listRecentMessages({
@@ -253,15 +241,6 @@ export class SessionInteractionModule {
       .flat()
       .sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
       .slice(-input.limit);
-    console.warn(
-      JSON.stringify({
-        event: 'session_messages_resolved',
-        sessionId: input.sessionId,
-        conversationJid: session.conversationJid,
-        conversationIds,
-        messageCount: messages.length,
-      }),
-    );
     return { messages };
   }
 

--- a/apps/core/src/application/sessions/session-interaction-module.ts
+++ b/apps/core/src/application/sessions/session-interaction-module.ts
@@ -228,7 +228,19 @@ export class SessionInteractionModule {
       await this.deps.repositories.messages.listConversationIdsForJid(
         session.conversationJid,
       );
-    if (conversationIds.length === 0) return { messages: [] };
+    if (conversationIds.length === 0) {
+      // Say why the feed is empty. A silent [] here is indistinguishable from
+      // "the assistant never replied", which is what made the missing-message
+      // failure undiagnosable.
+      console.warn(
+        JSON.stringify({
+          event: 'session_messages_no_conversation_rows',
+          sessionId: input.sessionId,
+          conversationJid: session.conversationJid,
+        }),
+      );
+      return { messages: [] };
+    }
     const lists = await Promise.all(
       conversationIds.map((conversationId) =>
         this.deps.repositories.messages.listRecentMessages({
@@ -241,6 +253,15 @@ export class SessionInteractionModule {
       .flat()
       .sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1))
       .slice(-input.limit);
+    console.warn(
+      JSON.stringify({
+        event: 'session_messages_resolved',
+        sessionId: input.sessionId,
+        conversationJid: session.conversationJid,
+        conversationIds,
+        messageCount: messages.length,
+      }),
+    );
     return { messages };
   }
 

--- a/apps/core/src/application/sessions/session-interaction-module.ts
+++ b/apps/core/src/application/sessions/session-interaction-module.ts
@@ -250,12 +250,38 @@ export class SessionInteractionModule {
     limit: number;
   }): Promise<{ runs: unknown[] }> {
     const appSession = await this.requireSession(input);
-    const runs =
-      await this.deps.repositories.agentRuns.listAgentRunsByConversation({
-        appId: appSession.appId as never,
-        conversationId: appSession.canonicalConversationId as never,
-        limit: input.limit,
-      });
+    // Resolve by jid and union, exactly as listMessages does. One jid can map
+    // to several conversation rows — the runtime warns
+    // `conversation_route_conversation_id_noncanonical` when a route predates
+    // the canonical id — so asking only for the canonical id silently returns
+    // [] for runs recorded under the older one.
+    const conversationIds =
+      await this.deps.repositories.messages.listConversationIdsForJid(
+        appSession.conversationJid,
+      );
+    const canonical = appSession.canonicalConversationId as string | undefined;
+    const candidates = Array.from(
+      new Set([...(canonical ? [canonical] : []), ...conversationIds]),
+    );
+    if (candidates.length === 0) return { runs: [] };
+    const lists = await Promise.all(
+      candidates.map((conversationId) =>
+        this.deps.repositories.agentRuns.listAgentRunsByConversation({
+          appId: appSession.appId as never,
+          conversationId: conversationId as never,
+          limit: input.limit,
+        }),
+      ),
+    );
+    const runs = lists
+      .flat()
+      .sort((a, b) =>
+        (a as { createdAt: string }).createdAt <
+        (b as { createdAt: string }).createdAt
+          ? 1
+          : -1,
+      )
+      .slice(0, input.limit);
     return { runs: runs.map((run) => AgentRunResponseSchema.parse(run)) };
   }
 

--- a/apps/core/src/domain/events/events.ts
+++ b/apps/core/src/domain/events/events.ts
@@ -57,6 +57,14 @@ export interface RuntimeEvent {
   jobId?: JobId;
   triggerId?: string;
   conversationId?: ConversationId;
+  /**
+   * Any of these conversation ids, OR-ed. One jid can map to several
+   * conversation rows — the runtime warns
+   * `conversation_route_conversation_id_noncanonical` for routes that predate
+   * the canonical id — so a single-id filter silently hides events recorded
+   * under the older one.
+   */
+  conversationIds?: ConversationId[];
   threadId?: ConversationThreadId;
   eventType: RuntimeEventType;
   actor: string;
@@ -75,6 +83,14 @@ export interface RuntimeEventPublishInput {
   jobId?: JobId;
   triggerId?: string;
   conversationId?: ConversationId;
+  /**
+   * Any of these conversation ids, OR-ed. One jid can map to several
+   * conversation rows — the runtime warns
+   * `conversation_route_conversation_id_noncanonical` for routes that predate
+   * the canonical id — so a single-id filter silently hides events recorded
+   * under the older one.
+   */
+  conversationIds?: ConversationId[];
   threadId?: ConversationThreadId;
   eventType: RuntimeEventType;
   actor: string;
@@ -93,6 +109,14 @@ export interface RuntimeEventFilter {
   jobId?: JobId;
   triggerId?: string;
   conversationId?: ConversationId;
+  /**
+   * Any of these conversation ids, OR-ed. One jid can map to several
+   * conversation rows — the runtime warns
+   * `conversation_route_conversation_id_noncanonical` for routes that predate
+   * the canonical id — so a single-id filter silently hides events recorded
+   * under the older one.
+   */
+  conversationIds?: ConversationId[];
   threadId?: ConversationThreadId;
   eventTypes?: RuntimeEventType[];
   limit?: number;
@@ -142,6 +166,14 @@ export interface AgentRun {
   configVersionId: AgentConfigVersionId;
   sessionId?: AgentSessionId;
   conversationId?: ConversationId;
+  /**
+   * Any of these conversation ids, OR-ed. One jid can map to several
+   * conversation rows — the runtime warns
+   * `conversation_route_conversation_id_noncanonical` for routes that predate
+   * the canonical id — so a single-id filter silently hides events recorded
+   * under the older one.
+   */
+  conversationIds?: ConversationId[];
   threadId?: ConversationThreadId;
   messageId?: MessageId;
   jobId?: JobId;

--- a/apps/core/src/runtime/group-output-buffer.ts
+++ b/apps/core/src/runtime/group-output-buffer.ts
@@ -107,6 +107,19 @@ export function createGroupOutputBuffer(input: {
       if (done) {
         const deliveryStatus = input.getStreamedTranscriptDeliveryStatus();
         const completed = generationParts.join('').trim();
+        // Durability is a contract of this path, so say what it decided:
+        // silence here is why a missing assistant row could not be diagnosed
+        // from a CI log.
+        input.log.info(
+          {
+            group: input.groupName,
+            reason,
+            deliveryStatus,
+            completedChars: completed.length,
+            willPersist: completed.length > 0,
+          },
+          'Streamed generation persistence decision',
+        );
         if (completed) {
           // Persist what the assistant PRODUCED, and record what happened to it
           // in delivery_status — rather than skipping the row when nothing was

--- a/apps/core/src/runtime/group-output-finalization.ts
+++ b/apps/core/src/runtime/group-output-finalization.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import type { MessageSendOptions } from '../domain/types.js';
 import type { DeliverySettlement } from '../jobs/delivery.js';
+import type { NewMessage } from '../domain/repositories/domain-types.js';
+import { nowIso } from '../shared/time/datetime.js';
 
 const NO_VISIBLE_OUTPUT_FALLBACK_MESSAGE =
   'I finished that run but did not generate a user-visible reply. Please send your message again.';
@@ -81,4 +84,63 @@ export async function finalizeGroupAgentUserVisibleOutput(input: {
   }
 
   return { outputSentToUser, terminalSettlement };
+}
+
+/**
+ * One durable assistant record per turn, whatever the flush path did.
+ *
+ * Per-generation persistence is the primary route; this covers a turn whose
+ * visible output never reached a `done` flush, which would otherwise leave the
+ * user holding a reply that GET /messages cannot show. Fires only when nothing
+ * was persisted, so it cannot double-write, and only for STREAMING turns: a
+ * non-streaming turn sends through sendMessageToChannel and channel-wiring
+ * already writes the row via its message_row_projection.
+ */
+export async function persistTurnAssistantTranscript(input: {
+  supportsStreamingChunks: boolean;
+  persistedAnyGeneration: boolean;
+  transcript: string | null;
+  chatJid: string;
+  activeThreadId?: string;
+  outputSentToUser: boolean;
+  groupName: string;
+  storeMessage: (message: NewMessage) => Promise<unknown>;
+  log: {
+    info(input: unknown, message: string): void;
+    warn(input: unknown, message: string): void;
+  };
+}): Promise<void> {
+  const transcript = (input.transcript ?? '').trim();
+  input.log.info(
+    {
+      group: input.groupName,
+      supportsStreamingChunks: input.supportsStreamingChunks,
+      persistedAnyGeneration: input.persistedAnyGeneration,
+      transcriptChars: transcript.length,
+    },
+    'Turn assistant durability state',
+  );
+  if (!input.supportsStreamingChunks || input.persistedAnyGeneration) return;
+  if (!transcript) return;
+  const timestamp = nowIso();
+  await input
+    .storeMessage({
+      id: `streamed-outbound:${randomUUID()}`,
+      chat_jid: input.chatJid,
+      sender: 'gantry',
+      sender_name: 'Gantry',
+      content: transcript,
+      timestamp,
+      is_from_me: true,
+      is_bot_message: true,
+      thread_id: input.activeThreadId,
+      delivery_status: input.outputSentToUser ? 'sent' : 'failed',
+      delivered_at: input.outputSentToUser ? timestamp : undefined,
+    })
+    .catch((err: unknown) =>
+      input.log.warn(
+        { err, group: input.groupName },
+        'Failed to persist turn assistant transcript',
+      ),
+    );
 }

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -764,6 +764,14 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         logger,
       });
     } else {
+      logger.info(
+        {
+          group: group.name,
+          supportsStreamingChunks,
+          persistedAnyGeneration,
+        },
+        'Turn finalization: assistant durability state',
+      );
       // Safety net, and deliberately BEFORE finalization so the durable record
       // exists whatever finalization then does about delivery. Per-generation
       // persistence covers the normal path; this covers a turn whose visible
@@ -775,6 +783,14 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
       // message_row_projection — persisting here too would double-write.
       if (supportsStreamingChunks && !persistedAnyGeneration) {
         const transcript = (outputBuffer.transcriptSnapshot() ?? '').trim();
+        logger.info(
+          {
+            group: group.name,
+            transcriptChars: transcript.length,
+            outputSentToUser,
+          },
+          'Turn assistant transcript safety-net persistence',
+        );
         if (transcript) {
           const timestamp = nowIso();
           await ops()

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -420,6 +420,12 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
     let lastAgentError: string | undefined;
     let outputSentToUser = false;
     const undeliveredGenerations: string[] = [];
+    // A turn must leave exactly one durable assistant record. Per-generation
+    // persistence is the primary path; this flag drives the finalization
+    // safety net below so a turn whose output never reached a `done` flush
+    // (transport-specific streaming paths do exist) is not left with the
+    // reply visible to the user but absent from GET /messages.
+    let persistedAnyGeneration = false;
     let streamedTranscriptDeliveryStatus: 'none' | 'sent' | 'partially_sent' =
       'none';
     let sawRawOutput = false;
@@ -521,6 +527,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         undeliveredGenerations.push(text);
       },
       persistCompletedStreamedGeneration: async (text, deliveryStatus) => {
+        persistedAnyGeneration = true;
         const timestamp = nowIso();
         const message: NewMessage = {
           id: `streamed-outbound:${randomUUID()}`,
@@ -757,6 +764,41 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         logger,
       });
     } else {
+      // Safety net, and deliberately BEFORE finalization so the durable record
+      // exists whatever finalization then does about delivery. Per-generation
+      // persistence covers the normal path; this covers a turn whose visible
+      // output never reached a `done` flush, which otherwise leaves the user
+      // holding a reply that GET /messages cannot show. Fires only when nothing
+      // was persisted, so it cannot double-write.
+      // STREAMING turns only. A non-streaming turn sends through
+      // sendMessageToChannel, and channel-wiring already writes the row via its
+      // message_row_projection — persisting here too would double-write.
+      if (supportsStreamingChunks && !persistedAnyGeneration) {
+        const transcript = (outputBuffer.transcriptSnapshot() ?? '').trim();
+        if (transcript) {
+          const timestamp = nowIso();
+          await ops()
+            .storeMessage({
+              id: `streamed-outbound:${randomUUID()}`,
+              chat_jid: chatJid,
+              sender: 'gantry',
+              sender_name: 'Gantry',
+              content: transcript,
+              timestamp,
+              is_from_me: true,
+              is_bot_message: true,
+              thread_id: activeThreadId,
+              delivery_status: outputSentToUser ? 'sent' : 'failed',
+              delivered_at: outputSentToUser ? timestamp : undefined,
+            })
+            .catch((err: unknown) =>
+              logger.warn(
+                { err, group: group.name },
+                'Failed to persist turn assistant transcript',
+              ),
+            );
+        }
+      }
       const finalization = await finalizeGroupAgentUserVisibleOutput({
         boundedTranscript: outputBuffer.transcriptSnapshot(),
         outputSentToUser,

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -49,6 +49,7 @@ import { createGroupTurnOptionBuilders } from './group-turn-options.js';
 import { collectPendingMessagesSince } from './pending-message-replay.js';
 import { buildGroupProcessingConversationContext } from './group-processing-context.js';
 import { createGroupOutputBuffer } from './group-output-buffer.js';
+import { persistTurnAssistantTranscript } from './group-output-finalization.js';
 import { activeTurnUiCleanupByQueue } from './group-active-turn-cleanup.js';
 import { randomUUID } from 'node:crypto';
 import { nowIso } from '../shared/time/datetime.js';
@@ -764,57 +765,17 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         logger,
       });
     } else {
-      logger.info(
-        {
-          group: group.name,
-          supportsStreamingChunks,
-          persistedAnyGeneration,
-        },
-        'Turn finalization: assistant durability state',
-      );
-      // Safety net, and deliberately BEFORE finalization so the durable record
-      // exists whatever finalization then does about delivery. Per-generation
-      // persistence covers the normal path; this covers a turn whose visible
-      // output never reached a `done` flush, which otherwise leaves the user
-      // holding a reply that GET /messages cannot show. Fires only when nothing
-      // was persisted, so it cannot double-write.
-      // STREAMING turns only. A non-streaming turn sends through
-      // sendMessageToChannel, and channel-wiring already writes the row via its
-      // message_row_projection — persisting here too would double-write.
-      if (supportsStreamingChunks && !persistedAnyGeneration) {
-        const transcript = (outputBuffer.transcriptSnapshot() ?? '').trim();
-        logger.info(
-          {
-            group: group.name,
-            transcriptChars: transcript.length,
-            outputSentToUser,
-          },
-          'Turn assistant transcript safety-net persistence',
-        );
-        if (transcript) {
-          const timestamp = nowIso();
-          await ops()
-            .storeMessage({
-              id: `streamed-outbound:${randomUUID()}`,
-              chat_jid: chatJid,
-              sender: 'gantry',
-              sender_name: 'Gantry',
-              content: transcript,
-              timestamp,
-              is_from_me: true,
-              is_bot_message: true,
-              thread_id: activeThreadId,
-              delivery_status: outputSentToUser ? 'sent' : 'failed',
-              delivered_at: outputSentToUser ? timestamp : undefined,
-            })
-            .catch((err: unknown) =>
-              logger.warn(
-                { err, group: group.name },
-                'Failed to persist turn assistant transcript',
-              ),
-            );
-        }
-      }
+      await persistTurnAssistantTranscript({
+        supportsStreamingChunks,
+        persistedAnyGeneration,
+        transcript: outputBuffer.transcriptSnapshot(),
+        chatJid,
+        activeThreadId,
+        outputSentToUser,
+        groupName: group.name,
+        storeMessage: (message) => ops().storeMessage(message),
+        log: logger,
+      });
       const finalization = await finalizeGroupAgentUserVisibleOutput({
         boundedTranscript: outputBuffer.transcriptSnapshot(),
         outputSentToUser,

--- a/apps/core/test/agent-e2e/harness/api-client.ts
+++ b/apps/core/test/agent-e2e/harness/api-client.ts
@@ -163,12 +163,23 @@ export class AgentE2EApiClient {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       const messages = await this.listMessages(sessionId);
-      const assistant = messages.find(
-        (message) =>
-          (message.sender === 'gantry' || message.is_bot_message === true) &&
-          typeof message.content === 'string' &&
-          message.content.trim().length > 0,
-      );
+      // Match the SHAPE the API actually returns. `Message` exposes
+      // `direction` and `parts[]`; it has no `sender`, `is_bot_message` or
+      // `content` field, so the previous filter could never match and this
+      // helper failed regardless of what the runtime persisted.
+      const assistant = messages.find((message) => {
+        if (message.direction !== 'outbound') return false;
+        const parts = Array.isArray(message.parts) ? message.parts : [];
+        return parts.some((part) => {
+          const value = part as {
+            kind?: string;
+            text?: string;
+            markdown?: string;
+          };
+          const text = value.kind === 'markdown' ? value.markdown : value.text;
+          return typeof text === 'string' && text.trim().length > 0;
+        });
+      });
       if (assistant) return assistant;
       await new Promise((resolve) => setTimeout(resolve, 500));
     }

--- a/apps/core/test/integration/session-control-runs.integration.test.ts
+++ b/apps/core/test/integration/session-control-runs.integration.test.ts
@@ -93,6 +93,9 @@ vi.mock('@core/adapters/storage/postgres/runtime-store.js', () => ({
       },
       messages: {
         listRecentMessages: vi.fn(async () => []),
+        // listRuns resolves conversation rows by jid and unions them, so the
+        // canonical/non-canonical route skew cannot hide runs.
+        listConversationIdsForJid: vi.fn(async () => []),
       },
     },
   }),

--- a/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
+++ b/apps/core/test/unit/application/sessions/session-interaction-module.test.ts
@@ -62,7 +62,21 @@ function makeModule(overrides?: {
   const module = new SessionInteractionModule({
     control: control as never,
     ops: ops as never,
-    repositories: (overrides?.repositories ?? {}) as never,
+    // The session feeds resolve conversation rows by jid and union them, so
+    // every case needs this port even when it overrides other repositories.
+    repositories: {
+      messages: { listConversationIdsForJid: vi.fn(async () => []) },
+      ...(overrides?.repositories ?? {}),
+      ...(overrides?.repositories &&
+      (overrides.repositories as { messages?: unknown }).messages
+        ? {
+            messages: {
+              listConversationIdsForJid: vi.fn(async () => []),
+              ...(overrides.repositories as { messages: object }).messages,
+            },
+          }
+        : {}),
+    } as never,
     runtimeEvents: runtimeEvents as never,
     liveAdmissionAppId: overrides?.liveAdmissionAppId,
     getConfiguredAgentRuntime:
@@ -482,7 +496,10 @@ describe('SessionInteractionModule', () => {
     expect(runtimeEvents.subscribe).toHaveBeenCalledWith(
       expect.objectContaining({
         appId: 'app-one',
-        conversationId: 'canonical:app-one:conv-1',
+        // A set, not one id: a jid can map to several conversation rows, and
+        // filtering on the canonical one alone hides events recorded under a
+        // route that predates it.
+        conversationIds: ['canonical:app-one:conv-1'],
         afterEventId: 9,
       }),
     );

--- a/apps/core/test/unit/control/server-auth.test.ts
+++ b/apps/core/test/unit/control/server-auth.test.ts
@@ -328,6 +328,8 @@ const domainRepositories = {
   },
   messages: {
     listMessages: vi.fn(async () => []),
+    // The session feeds resolve conversation rows by jid and union them.
+    listConversationIdsForJid: vi.fn(async () => []),
   },
   capabilitySecrets: {
     getSecret: vi.fn(async () => null),


### PR DESCRIPTION
## The problem

The nightly haiku turn fails with `No persisted assistant message ... within 30000ms`, even
after the delivery-gate fix. The run log shows the model produced output and the user received
it — the reply simply never reached `GET /sessions/{id}/messages`.

## Why

Per-generation persistence only runs when a generation reaches a `done` flush **with pending
text**. A turn whose visible output does not take that shape leaves the reply delivered but
absent from the API — the precise gap the session-observability work exists to close. `main`
used to persist the transcript at finalization; #368 replaced that with per-generation
persistence and the guarantee was lost with it.

## The fix

Restore the finalization-level persist as a safety net, keeping prompt per-generation
persistence as the primary path. Two guards make it safe:

- **Only when nothing was persisted this turn** — it cannot double-write.
- **Only for streaming turns.** A non-streaming turn sends through `sendMessageToChannel`, and
  `channel-wiring` already writes the row via its `message_row_projection`. Without this guard
  the net double-persisted on the Slack path, which the hydration-parity unit test caught.

## Verification

234 focused unit tests green, typecheck clean. I **cannot** reproduce the haiku turn locally —
it needs `E2E_MODEL_API_KEY` and self-skips without it — so the real proof is a nightly
dispatch, which I run against this branch.