### PR TITLE
docs: final response-latency program ledger

### DIFF
--- a/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
+++ b/docs/architecture/messaging-hotpath-and-liveness-goal-prompt.md
@@ -54,6 +54,11 @@ false)` then runner calls it again with memory (`live-execution.ts:224-244`,
    but is the FAST-PATH question, deferred to model-management's inline-lane
    discussion, NOT this cycle — noted, not fixed here.
 
+## Program ledger pointer
+
+See the FINAL program ledger below (added 2026-08-02) for every phase's
+shipped/measured/deferred status.
+
 ### Durable history premise status
 
 | Slice                                    | Real-Postgres result                                                                                                                                                                                                                                                                                                                                                                          | What did not improve                                                                                                                                                                                                                                                      |
@@ -499,3 +504,41 @@ the whole stage behavior-free (`apps/core/src/runtime/group-progress-heartbeats.
 | Docs/prompts                | **Changed**             | This goal prompt must carry these corrected contracts before stage execution (`AGENTS.md:203-204`).                                                                                                                                                                                  |
 | Audit/events                | **Changed**             | A5 changes scheduling, but not content, of `credential.model.used`; OTel streaming remains independent (`apps/core/src/adapters/llm/anthropic-claude-agent/gantry-model-gateway.ts:502-580`, `apps/core/src/adapters/llm/observability/genai-spans.ts:350-497`).                     |
 | Tests/verification          | **Changed**             | Add statement-count/first-contact/FK tests, cursor-race tests, exactly-once memory-hydration tests, retained-audit-before-handler-exit tests, and per-adapter zero-post edit-failure tests at the corresponding seams above.                                                         |
+
+## Program ledger (FINAL — 2026-08-02)
+
+Every phase of the response-latency program, what actually shipped, what was
+measured, and what deliberately did not happen. Primary metric: inbound message
+received → first content-bearing channel delivery. Measurements are
+deterministic operation/statement counts on real Postgres, not wall-clock.
+
+| Phase | Shipped as | Measured result | What did not improve / deferred |
+| --- | --- | --- | --- |
+| LAT-GATE-0 — prerequisite gates | merged pre-program | Gates green before any hot-path edit. | — |
+| LAT-0 — baseline harness | merged | Deterministic S1–S12 scenario harness, named operation counters, Postgres-gated query counting; S11 (500-job) and S12 (5,000-marker IPC) baselines recorded. | Production behavior unchanged by design — this phase measures, it does not speed. |
+| LAT-1 — bounded concurrent remote MCP startup | merged | Remote MCP connect/list runs as a bounded batch; first visible output waits on the slowest batch, not the sum of all servers. | Worker cold-start itself (workspace/sandbox/egress) untouched — deferred to the model-management inline-lane discussion (audit item 6). |
+| LAT-2 — one immutable per-turn access snapshot | merged | Tool bindings, enabled skills, and MCP rows load once per turn; every derived view reads the snapshot. | — |
+| LAT-3A — single memory hydration | merged | `getAgentTurnContext` hydrates exactly once per ordinary turn (was twice: admission + runner), asserted at the real repository seam. | — |
+| LAT-3B — cursor-fenced replay reuse | merged | Admission's validated batch feeds the turn under a cursor fence; the group processor's duplicate window fetch no longer does duplicate work. | The two fetch call sites still exist structurally; the fence makes the second authoritative (audit item 3's ~14-LOC deletion became a fencing fix instead). |
+| LAT-4A — fused inbound-envelope persistence | merged | One inbound Slack envelope persists in **19** sequential statements (from 20) via the insert-vs-update split (`RETURNING (xmax = 0)`); metadata rides the ingress op. | The remaining ~19 are the canonical-graph re-upserts — that is LAT-4B, which is **decision-gated and not started** (the graph-write table in this doc is its input). |
+| LAT-5A — coverage-reporting port | merged (#355, repair #357) | Hydration emits one observation per actual provider request with real cursors/bounds; coverage claims became measurable instead of inferred. | Reporting only — no latency change by design. |
+| GH-352 — thread windows + trigger-only allowlist | merged (#359) | Channel window restored to 50; thread turns carry root + first 10 + latest 39 plus the same-30 channel background; allowlist is trigger-only (`mode:'drop'` removed). | — |
+| LAT-5B — durable history coverage | merged (#367) | Provider-history calls per covered turn: **1 → 0**; guard cost: exactly **+1** SQL statement (1 → 2, single generation-aware read); post-reconnect packet re-hydrates exactly once. Trust requires durable generation + stable local distrust epoch + owned live inbound stream. | First/uncovered and first-post-reconnect packets still pay the provider call and synchronous persist; the 2.5s deadline is a ceiling, not a saving. Multi-process stale-trust window deferred (D-0036, trigger recorded). Telegram excluded (no hydration hook). |
+| LAT-4B — graph-write reduction | **not started** | — | Decision-gated on the keep/kill table below; ~19 statements of stable-identity re-upserts remain the largest un-taken win on the write path. |
+| Phase 6 — skill-artifact caching | **partially superseded** | RACE-1/decision 0066 delivered app/content-addressed refs + read-time hash verification. | Remaining scope (read cache, layout reconciliation, bounded materialization) is measurement-gated and unscheduled. |
+| Phase 7 — direct in-process LLM forwarding | **not started** | — | Decision-gated; the gateway's streaming-audit await (audit item 5) was NOT fixed separately to avoid colliding with the deepagents/SDK audit that owns that hot path. |
+| Phase 9 — warm runtime resources | **not started** | — | Measurement-gated; no measurement has justified it yet. |
+| Part B — ambient liveness | **not shipped in this lane** | — | The replace-only heartbeat card, reaction lifecycle, and dead-plumbing deletions remain open items of this doc; the governing no-clutter principle is enforced today only by the absence of status text. |
+
+Spun out of this program and shipped through the same lifecycle: the
+conversation-file trust program (FILE-1A #365, FILE-1B #371 — see
+`conversation-file-trust-program.md`), which grew from the hydration work's
+attachment findings.
+
+Honest net position: the hot path's redundant synchronous work is measurably
+reduced (one hydration, fenced replay, 19-statement envelope, zero
+provider-history calls on covered turns), the measurement harness that proves
+it is durable, and the two largest remaining wins (LAT-4B graph writes,
+Phase 7 forwarding) are explicitly decision-gated rather than silently
+abandoned. Part B never started; the liveness half of this doc is still a
+to-do list, not a changelog.


### PR DESCRIPTION
## What this is

The response-latency program's closing deliverable: one table in the goal-prompt doc covering every phase — what shipped, the deterministic measurement that proves it, and what deliberately did not improve.

Headlines: one memory hydration per turn (was two), cursor-fenced replay, 19-statement inbound envelope (was 20), zero provider-history calls on covered turns (was one, at +1 SQL statement), thread windows restored, and the measurement harness that keeps these claims honest. Explicitly not done and gated rather than abandoned: LAT-4B graph-write reduction (decision-gated, largest remaining write-path win), Phase 7 in-process forwarding (decision-gated), Phase 9 warm resources (measurement-gated), and all of Part B ambient liveness.

Docs-only; recorded through a Forge quickfix window.