### PR TITLE
PERF-4: expire finished live-admission work items after 30 days

### DIFF
--- a/apps/core/src/adapters/storage/postgres/repositories/live-admission-work-item-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/live-admission-work-item-repository.postgres.ts
@@ -18,6 +18,11 @@ type EnqueueLiveAdmissionWorkItemInput = Parameters<
   LiveAdmissionWorkItemRepository['enqueueLiveAdmissionWorkItem']
 >[0];
 
+const LIVE_ADMISSION_RETENTION_DELETE_BATCH_SIZE = 5_000;
+const LIVE_ADMISSION_RETENTION_MAX_BATCHES_PER_SWEEP = 4;
+const LIVE_ADMISSION_RETENTION_LOCK_KEY =
+  'live_admission_terminal_retention_sweep';
+
 function toLiveAdmissionWorkItem(
   row: LiveAdmissionWorkItemRow,
 ): LiveAdmissionWorkItem {
@@ -345,6 +350,42 @@ export async function settleLiveAdmissionWorkItem(
     )
     .returning({ id: items.id });
   return rows.length > 0;
+}
+
+export async function deleteExpiredTerminalLiveAdmissionWorkItems(
+  db: CanonicalDb,
+  cutoffIso: string,
+): Promise<{ deleted: number; more: boolean }> {
+  let deleted = 0;
+  // Bounded per invocation so a large first-deploy backlog cannot stall the
+  // scheduler maintenance pass; the caller re-runs while `more` is true.
+  for (let i = 0; i < LIVE_ADMISSION_RETENTION_MAX_BATCHES_PER_SWEEP; i++) {
+    const batchCount = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${LIVE_ADMISSION_RETENTION_LOCK_KEY}))`,
+      );
+      const items = pgSchema.liveAdmissionWorkItemsPostgres;
+      const result = await tx.execute<{ id: string }>(sql`
+        WITH expired AS (
+          SELECT ${items.id}
+          FROM ${items}
+          WHERE ${items.state} IN ('completed', 'failed', 'canceled')
+            AND coalesce(${items.endedAt}, ${items.updatedAt}) < ${cutoffIso}
+          ORDER BY coalesce(${items.endedAt}, ${items.updatedAt}) ASC, ${items.id} ASC
+          LIMIT ${LIVE_ADMISSION_RETENTION_DELETE_BATCH_SIZE}
+        )
+        DELETE FROM ${items}
+        WHERE ${items.id} IN (SELECT id FROM expired)
+        RETURNING ${items.id}
+      `);
+      return result.rows.length;
+    });
+    deleted += batchCount;
+    if (batchCount < LIVE_ADMISSION_RETENTION_DELETE_BATCH_SIZE) {
+      return { deleted, more: false };
+    }
+  }
+  return { deleted, more: true };
 }
 
 async function findLiveAdmissionWorkItemByIdempotencyKey(

--- a/apps/core/src/adapters/storage/postgres/repositories/live-turn-repository.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/live-turn-repository.postgres.ts
@@ -35,6 +35,7 @@ import type { CanonicalDb } from './canonical-graph-repository.postgres.js';
 import { activeRunLeaseFence } from './run-lease-fence.postgres.js';
 import {
   claimLiveAdmissionWorkItems,
+  deleteExpiredTerminalLiveAdmissionWorkItems,
   deferLiveAdmissionWorkItem,
   enqueueLiveAdmissionWorkItem,
   renewLiveAdmissionWorkItemClaim,
@@ -141,6 +142,12 @@ export class PostgresLiveTurnRepository implements LiveTurnCoordinationRepositor
     now?: string;
   }): Promise<boolean> {
     return settleLiveAdmissionWorkItem(this.db, input);
+  }
+
+  async deleteExpiredTerminalLiveAdmissionWorkItems(
+    cutoffIso: string,
+  ): Promise<{ deleted: number; more: boolean }> {
+    return deleteExpiredTerminalLiveAdmissionWorkItems(this.db, cutoffIso);
   }
 
   async claimLiveTurn(input: {

--- a/apps/core/src/domain/ports/live-turns.ts
+++ b/apps/core/src/domain/ports/live-turns.ts
@@ -249,6 +249,13 @@ export interface LiveAdmissionWorkItemRepository {
     >;
     now?: string;
   }): Promise<boolean>;
+  /**
+   * Deletes terminal work items older than the cutoff in bounded batches.
+   * A provider delivery replayed after retention expires is admitted as new.
+   */
+  deleteExpiredTerminalLiveAdmissionWorkItems(
+    cutoffIso: string,
+  ): Promise<{ deleted: number; more: boolean }>;
 }
 
 export interface LiveTurnCommandAppendResult {

--- a/apps/core/src/infrastructure/pgboss/live-admission-retention.ts
+++ b/apps/core/src/infrastructure/pgboss/live-admission-retention.ts
@@ -1,0 +1,37 @@
+import { logger } from '../logging/logger.js';
+import { toIso } from '../../shared/time/datetime.js';
+
+export const LIVE_ADMISSION_TERMINAL_RETENTION_MS = 30 * 86_400_000;
+export const LIVE_ADMISSION_RETENTION_SWEEP_INTERVAL_MS = 6 * 60 * 60_000;
+
+/**
+ * Runs the terminal-row retention sweep if the interval has elapsed and
+ * returns the new last-sweep timestamp, or the unchanged one when the sweep
+ * was skipped, failed, or only partially drained. A failed sweep must not
+ * count as done (it would suppress retries for the full interval) nor abort
+ * the caller's maintenance pass; a partial drain leaves the guard unlatched
+ * so the next maintenance tick continues in bounded slices.
+ */
+export async function sweepTerminalLiveAdmissionsIfDue(input: {
+  sweep?: (cutoffIso: string) => Promise<{ deleted: number; more: boolean }>;
+  lastSweepAt: number | null;
+  now: number;
+}): Promise<number | null> {
+  const { sweep, lastSweepAt, now } = input;
+  if (!sweep) return lastSweepAt;
+  if (
+    lastSweepAt !== null &&
+    now - lastSweepAt < LIVE_ADMISSION_RETENTION_SWEEP_INTERVAL_MS
+  ) {
+    return lastSweepAt;
+  }
+  try {
+    const { more } = await sweep(
+      toIso(now - LIVE_ADMISSION_TERMINAL_RETENTION_MS),
+    );
+    return more ? lastSweepAt : now;
+  } catch (err) {
+    logger.warn({ err }, 'Live-admission retention sweep failed');
+    return lastSweepAt;
+  }
+}

--- a/apps/core/src/infrastructure/pgboss/pgboss-keys.ts
+++ b/apps/core/src/infrastructure/pgboss/pgboss-keys.ts
@@ -1,0 +1,32 @@
+import { createHash } from 'node:crypto';
+
+const PGBOSS_KEY_PREFIX = 'gantry';
+
+function pgBossKey(kind: string, value: string): string {
+  return `${PGBOSS_KEY_PREFIX}.${kind}.${Buffer.from(value).toString('base64url')}`;
+}
+
+export function pgBossGroupId(workspaceKey: string): string {
+  return pgBossKey('group', workspaceKey);
+}
+
+export function pgBossJobKey(jobId: string): string {
+  return pgBossKey('job', jobId);
+}
+
+export function pgBossSendId(jobId: string, slot: string): string {
+  const bytes = createHash('sha256')
+    .update(`${PGBOSS_KEY_PREFIX}:send:${jobId}:${slot}`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}

--- a/apps/core/src/infrastructure/pgboss/scheduler-engine.ts
+++ b/apps/core/src/infrastructure/pgboss/scheduler-engine.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { PgBoss, type Job as PgBossJob } from 'pg-boss';
 
 import {
@@ -38,6 +38,8 @@ import {
   schedulerDeliveryPriorityForJob,
 } from './scheduler-admission.js';
 import { recoverExpiredWorkerLeases } from './scheduler-worker-recovery.js';
+import { pgBossGroupId, pgBossJobKey, pgBossSendId } from './pgboss-keys.js';
+import { sweepTerminalLiveAdmissionsIfDue } from './live-admission-retention.js';
 import type {
   SchedulerDependencies,
   SchedulerDispatchPayload,
@@ -54,7 +56,6 @@ import {
 
 const SCHEDULER_QUEUE = 'gantry.jobs';
 const SCHEDULER_QUEUE_DEAD_LETTER = 'gantry.jobs.dead_letter';
-const PGBOSS_KEY_PREFIX = 'gantry';
 const STALE_ONCE_REENQUEUE_THROTTLE_MS = 60_000;
 export const SCHEDULER_MAINTENANCE_SYNC_INTERVAL_MS = 60_000;
 
@@ -76,35 +77,6 @@ interface PgBossSchedulerCallbacks {
     jobs: readonly Job[],
     deps: SchedulerDependencies,
   ) => Promise<void>;
-}
-
-function pgBossKey(kind: string, value: string): string {
-  return `${PGBOSS_KEY_PREFIX}.${kind}.${Buffer.from(value).toString('base64url')}`;
-}
-
-function pgBossGroupId(workspaceKey: string): string {
-  return pgBossKey('group', workspaceKey);
-}
-
-function pgBossJobKey(jobId: string): string {
-  return pgBossKey('job', jobId);
-}
-
-function pgBossSendId(jobId: string, slot: string): string {
-  const bytes = createHash('sha256')
-    .update(`${PGBOSS_KEY_PREFIX}:send:${jobId}:${slot}`)
-    .digest()
-    .subarray(0, 16);
-  bytes[6] = (bytes[6] & 0x0f) | 0x50;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-  const hex = bytes.toString('hex');
-  return [
-    hex.slice(0, 8),
-    hex.slice(8, 12),
-    hex.slice(12, 16),
-    hex.slice(16, 20),
-    hex.slice(20, 32),
-  ].join('-');
 }
 
 function scheduleSlotForJob(job: Job): string {
@@ -136,6 +108,7 @@ export class PgBossSchedulerEngine {
   private readonly scheduleSignatures = new Map<string, string>();
   private maintenanceTimer: ReturnType<typeof setInterval> | null = null;
   private starvationAlerter: CapabilityStarvationAlerter | null = null;
+  private lastLiveAdmissionRetentionSweepAt: number | null = null;
 
   constructor(
     private readonly deps: SchedulerDependencies,
@@ -275,6 +248,7 @@ export class PgBossSchedulerEngine {
   private async syncAllJobs(): Promise<void> {
     const boss = this.requireBoss();
     await this.callbacks.registerSystemJobs(this.deps);
+    await this.sweepTerminalLiveAdmissionsIfDue();
     await this.recoverExpiredWorkerLeases();
     const released = await this.deps.opsRepository.releaseStaleJobLeases();
     if (released.length > 0) {
@@ -306,6 +280,15 @@ export class PgBossSchedulerEngine {
     for (const jobId of this.scheduleSignatures.keys()) {
       if (!liveJobIds.has(jobId)) await this.clearDeletedJob(boss, jobId);
     }
+  }
+
+  private async sweepTerminalLiveAdmissionsIfDue(): Promise<void> {
+    this.lastLiveAdmissionRetentionSweepAt =
+      await sweepTerminalLiveAdmissionsIfDue({
+        sweep: this.deps.sweepTerminalLiveAdmissions,
+        lastSweepAt: this.lastLiveAdmissionRetentionSweepAt,
+        now: currentTimeMs(),
+      });
   }
 
   private async scanCapabilityStarvation(jobs: readonly Job[]): Promise<void> {

--- a/apps/core/src/jobs/scheduler.ts
+++ b/apps/core/src/jobs/scheduler.ts
@@ -177,6 +177,12 @@ export async function startSchedulerLoop(
     opsRepository: deps.opsRepository ?? getRuntimeRepositories(),
     hasLiveAdmissionBacklog:
       deps.hasLiveAdmissionBacklog ?? hasQueuedLiveAdmissionWork,
+    sweepTerminalLiveAdmissions:
+      deps.sweepTerminalLiveAdmissions ??
+      ((cutoffIso: string) =>
+        getRuntimeStorage().repositories.liveTurns.deleteExpiredTerminalLiveAdmissionWorkItems(
+          cutoffIso,
+        )),
   };
   const warn = (context: Record<string, unknown>, message: string): void =>
     logger.warn(context, message);

--- a/apps/core/src/jobs/types.ts
+++ b/apps/core/src/jobs/types.ts
@@ -34,6 +34,9 @@ export interface SchedulerDependencies {
   /** Process role; persisted on the worker_instances row at registration. */
   processRole?: ProcessRole;
   hasLiveAdmissionBacklog?: () => Promise<boolean>;
+  sweepTerminalLiveAdmissions?: (
+    cutoffIso: string,
+  ) => Promise<{ deleted: number; more: boolean }>;
   conversationRoutes: () => Record<string, ConversationRoute>;
   queue: GroupQueue;
   onProcess: (

--- a/apps/core/test/integration/live-admission-work-items.postgres.integration.test.ts
+++ b/apps/core/test/integration/live-admission-work-items.postgres.integration.test.ts
@@ -208,6 +208,66 @@ maybeDescribe('live admission work items (Postgres)', () => {
     ).resolves.toMatchObject({ outcome: 'enqueued' });
   });
 
+  it('deletes only expired terminal work items', async () => {
+    const appId = 'app-terminal-retention';
+    const oldAt = '2026-07-03T00:00:00.000Z';
+    const recentAt = '2026-07-05T00:00:00.000Z';
+    const cutoff = '2026-07-04T00:00:00.000Z';
+    const rows = [
+      ['retention-old-completed', 'completed', oldAt, oldAt],
+      ['retention-old-failed', 'failed', oldAt, oldAt],
+      ['retention-old-canceled', 'canceled', oldAt, null],
+      ['retention-old-queued', 'queued', oldAt, null],
+      ['retention-old-claimed', 'claimed', oldAt, null],
+      ['retention-old-deferred', 'deferred', oldAt, null],
+      ['retention-recent-completed', 'completed', recentAt, recentAt],
+      ['retention-recent-failed', 'failed', recentAt, recentAt],
+      ['retention-recent-canceled', 'canceled', recentAt, recentAt],
+    ] as const;
+    await Promise.all(
+      rows.map(([id], index) =>
+        liveTurns.enqueueLiveAdmissionWorkItem({
+          id,
+          ...base,
+          appId,
+          messageId: `message:retention:${index}`,
+          messageCursor: `2026-08-03T00:00:00.000Z::retention-${index}`,
+          idempotencyKey: `telegram:delivery:retention-${index}`,
+        }),
+      ),
+    );
+    const tableName = `${quotePostgresIdentifier(
+      runtime.schemaName,
+    )}.${quotePostgresIdentifier('live_admission_work_items')}`;
+    await Promise.all(
+      rows.map(([id, state, updatedAt, endedAt]) =>
+        runtime.service.pool.query(
+          `UPDATE ${tableName}
+           SET state = $2, updated_at = $3, ended_at = $4
+           WHERE id = $1`,
+          [id, state, updatedAt, endedAt],
+        ),
+      ),
+    );
+
+    await expect(
+      liveTurns.deleteExpiredTerminalLiveAdmissionWorkItems(cutoff),
+    ).resolves.toEqual({ deleted: 3, more: false });
+
+    const remaining = await runtime.service.pool.query<{ id: string }>(
+      `SELECT id FROM ${tableName} WHERE app_id = $1 ORDER BY id`,
+      [appId],
+    );
+    expect(remaining.rows.map(({ id }) => id)).toEqual([
+      'retention-old-claimed',
+      'retention-old-deferred',
+      'retention-old-queued',
+      'retention-recent-canceled',
+      'retention-recent-completed',
+      'retention-recent-failed',
+    ]);
+  });
+
   it('persists an overloaded canonical message without a work row or wakeup', async () => {
     const notifyLiveAdmissionWorkItem = vi.fn(async () => undefined);
     const messages = new CanonicalMessageOpsService(

--- a/apps/core/test/unit/runtime/task-scheduler-pgboss.test.ts
+++ b/apps/core/test/unit/runtime/task-scheduler-pgboss.test.ts
@@ -54,6 +54,7 @@ import {
   PgBossSchedulerEngine,
   SCHEDULER_MAINTENANCE_SYNC_INTERVAL_MS,
 } from '@core/infrastructure/pgboss/scheduler-engine.js';
+import { LIVE_ADMISSION_RETENTION_SWEEP_INTERVAL_MS } from '@core/infrastructure/pgboss/live-admission-retention.js';
 import { configureRunSlotBackend } from '@core/jobs/concurrency.js';
 import { JOB_INTERACTIVE_CAPACITY_RESERVED_DELAY_TEXT } from '@core/shared/scheduler-copy.js';
 import { nowMs, toIso } from '@core/shared/time/datetime.js';
@@ -104,6 +105,108 @@ describe('PgBossSchedulerEngine', () => {
     workerCoordination.getWorker.mockResolvedValue({ capabilities: [] });
     vi.clearAllMocks();
     configureRunSlotBackend(null);
+  });
+
+  it('sweeps terminal live-admission work items at most once per interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-03T00:00:00.000Z'));
+    try {
+      const sweepTerminalLiveAdmissions = vi
+        .fn()
+        .mockResolvedValue({ deleted: 3, more: false });
+      const engine = new PgBossSchedulerEngine(
+        {
+          conversationRoutes: () => ({}),
+          queue: {} as never,
+          onProcess: vi.fn(),
+          sendMessage: vi.fn(),
+          sweepTerminalLiveAdmissions,
+          opsRepository: {
+            releaseStaleJobLeases: vi.fn().mockResolvedValue([]),
+            getAllJobs: vi.fn().mockResolvedValue([]),
+          } as never,
+        },
+        {
+          registerSystemJobs: vi.fn().mockResolvedValue(undefined),
+          runJob: vi.fn().mockResolvedValue(undefined),
+          sweepCompletedOneTimeJobs: vi.fn().mockResolvedValue(false),
+        },
+      );
+      (engine as unknown as { boss: object }).boss = {};
+
+      await (
+        engine as unknown as { syncAllJobs: () => Promise<void> }
+      ).syncAllJobs();
+      await (
+        engine as unknown as { syncAllJobs: () => Promise<void> }
+      ).syncAllJobs();
+      vi.advanceTimersByTime(LIVE_ADMISSION_RETENTION_SWEEP_INTERVAL_MS - 1);
+      await (
+        engine as unknown as { syncAllJobs: () => Promise<void> }
+      ).syncAllJobs();
+
+      expect(sweepTerminalLiveAdmissions).toHaveBeenCalledTimes(1);
+      expect(sweepTerminalLiveAdmissions).toHaveBeenLastCalledWith(
+        '2026-07-04T00:00:00.000Z',
+      );
+
+      vi.advanceTimersByTime(1);
+      await (
+        engine as unknown as { syncAllJobs: () => Promise<void> }
+      ).syncAllJobs();
+      expect(sweepTerminalLiveAdmissions).toHaveBeenCalledTimes(2);
+      expect(sweepTerminalLiveAdmissions).toHaveBeenLastCalledWith(
+        '2026-07-04T06:00:00.000Z',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries the retention sweep on the next pass after a failure', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-03T00:00:00.000Z'));
+    try {
+      const sweepTerminalLiveAdmissions = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('db down'))
+        .mockResolvedValue({ deleted: 0, more: false });
+      const engine = new PgBossSchedulerEngine(
+        {
+          conversationRoutes: () => ({}),
+          queue: {} as never,
+          onProcess: vi.fn(),
+          sendMessage: vi.fn(),
+          sweepTerminalLiveAdmissions,
+          opsRepository: {
+            releaseStaleJobLeases: vi.fn().mockResolvedValue([]),
+            getAllJobs: vi.fn().mockResolvedValue([]),
+          } as never,
+        },
+        {
+          registerSystemJobs: vi.fn().mockResolvedValue(undefined),
+          runJob: vi.fn().mockResolvedValue(undefined),
+          sweepCompletedOneTimeJobs: vi.fn().mockResolvedValue(false),
+        },
+      );
+      (engine as unknown as { boss: object }).boss = {};
+      const sync = () =>
+        (
+          engine as unknown as { syncAllJobs: () => Promise<void> }
+        ).syncAllJobs();
+
+      // The failing sweep neither aborts the maintenance pass nor latches the
+      // interval guard: the very next pass retries.
+      await expect(sync()).resolves.toBeUndefined();
+      expect(sweepTerminalLiveAdmissions).toHaveBeenCalledTimes(1);
+      await sync();
+      expect(sweepTerminalLiveAdmissions).toHaveBeenCalledTimes(2);
+      // After the successful retry the guard holds again.
+      await sync();
+      expect(sweepTerminalLiveAdmissions).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('re-enqueues stale pending once jobs immediately and throttles repeated syncs', async () => {

--- a/plans/roadmap.json
+++ b/plans/roadmap.json
@@ -511,7 +511,7 @@
       "outcome": "Decided by record 0099: runtime is single-instance-authoritative for rate limits; cluster store deferred behind an explicit multi-instance revisit trigger. No code."
     },
     {
-      "status": "pending",
+      "status": "active",
       "key": "PERF-4",
       "title": "Live-admission: admission caps + terminal retention (decision required)",
       "epic": "runtime-hardening-audit",
@@ -566,9 +566,8 @@
         "docs/architecture/runtime-hardening-audit-2026-07-22.md"
       ],
       "order": 34,
-      "completed_at": "2026-08-03T04:16:02+00:00",
-      "history": ".factory/history/SIMP-2/",
-      "outcome": "The control server now builds its job and session services once at startup instead of assembling them on every request (22 construction sites collapsed to 2). Everything that can change while the server runs \u2014 storage readiness, reloadable settings, the credential broker \u2014 is read live through explicit getters, pinned by tests, so behavior is unchanged. The live-admission app id moved from the session module's constructor to the one method that uses it, making the per-caller difference explicit instead of a hidden constructor default."
+      "completed_at": "2026-08-03T04:30:48+00:00",
+      "outcome": "Merged PR #377: JobManagementService and SessionInteractionModule constructed once in the control composition root; live deps via getters; liveAdmissionAppId is a method argument."
     },
     {
       "status": "pending",
@@ -697,5 +696,5 @@
     }
   ],
   "generated_by": "human",
-  "updated_at": "2026-08-03T04:16:02+00:00"
+  "updated_at": "2026-08-03T04:19:33+00:00"
 }

--- a/plans/roadmap.json
+++ b/plans/roadmap.json
@@ -511,7 +511,7 @@
       "outcome": "Decided by record 0099: runtime is single-instance-authoritative for rate limits; cluster store deferred behind an explicit multi-instance revisit trigger. No code."
     },
     {
-      "status": "active",
+      "status": "done",
       "key": "PERF-4",
       "title": "Live-admission: admission caps + terminal retention (decision required)",
       "epic": "runtime-hardening-audit",
@@ -527,7 +527,10 @@
         "docs/architecture/runtime-hardening-audit-2026-07-22.md"
       ],
       "order": 32,
-      "notes": "Decision 0103 accepted 2026-08-03: 30-day TTL sweep of terminal rows via existing maintenance machinery. Remaining work is the sweep job + test."
+      "notes": "Decision 0103 accepted 2026-08-03: 30-day TTL sweep of terminal rows via existing maintenance machinery. Remaining work is the sweep job + test.",
+      "completed_at": "2026-08-03T08:11:00+00:00",
+      "history": ".factory/history/PERF-4/",
+      "outcome": "Finished work tickets in the live-admission table now expire after 30 days instead of accumulating forever. A maintenance sweep (riding the existing scheduler tick, at most every 6 hours per process) deletes expired terminal rows in bounded, lock-serialized batches; failures retry on the next tick and large backlogs drain in slices without blocking lease recovery. Queued and in-progress work is never touched. This completes PERF-4 \u2014 the size-caps half shipped earlier, and decision 0103 fixed the retention policy."
     },
     {
       "status": "done",
@@ -696,5 +699,5 @@
     }
   ],
   "generated_by": "human",
-  "updated_at": "2026-08-03T04:19:33+00:00"
+  "updated_at": "2026-08-03T08:11:00+00:00"
 }


### PR DESCRIPTION
## What this does, plainly

Every inbound message writes a "work ticket" into the live-admission table so work is never lost mid-crash. Finished tickets were kept forever, so the table only ever grew. Per decision 0103, finished tickets (completed/failed/canceled) are now kept for 30 days — enough history to debug recent behavior — then deleted by a housekeeping sweep. Queued or in-progress work is never touched.

## Technical delta

- `deleteExpiredTerminalLiveAdmissionWorkItems` on the live-turns port: single CTE DELETE on `state IN (terminal) AND coalesce(ended_at, updated_at) < cutoff`, advisory-lock serialized, bounded at 4×5000 rows per invocation with a `{deleted, more}` contract.
- Wired into scheduler maintenance as an optional injected dep (the 26 existing scheduler fixtures needed zero edits), behind a 6-hour per-process cadence guard. A failed sweep logs, doesn't latch the guard, and doesn't abort the maintenance pass; a partial drain resumes on the next 60-second tick in bounded slices.
- No new index, deliberately: the table is bounded once retention holds, and the upgrade path (partial `ended_at` index) is recorded in the plan if the sweep ever shows in slow logs.
- The scheduler engine was exactly at its 700-line budget, so the sweep lives in `live-admission-retention.ts` and the pgboss key helpers moved to `pgboss-keys.ts` (engine now 683 lines).
- Known trade per 0103: a provider redelivery of the same idempotency key >30 days after settle re-enqueues instead of replaying — far outside any real redelivery window, documented on the port.

## Evidence

- Stage closed through the harness (JUnit-proofed required test, measured diff).
- `verify.py` passed at the final commit; full Postgres integration lane green (54 files / 344 tests) including the new sweep case.
- Three local review rounds: two real findings (failed-sweep latched the retry guard; unbounded drain on the maintenance path), both fixed with pinning tests; final branch pass clean, "patch is correct (0.91)".
- Agent-e2e delta: none needed — no agent-visible behavior; DB retention only, pinned by unit + Postgres integration tests.

Evidence archive: `.factory/history/PERF-4/`.