### PR TITLE
Job ownership scopes to the conversation, not the thread/topic

### DIFF
--- a/apps/core/src/application/jobs/job-management-access.ts
+++ b/apps/core/src/application/jobs/job-management-access.ts
@@ -69,35 +69,16 @@ export function validateSchedulerUpdate(
       'Scheduler jobs cannot move outside the source group.',
     );
   }
-  if (updates.thread_id !== undefined) {
-    const requestedThreadId = updates.thread_id || null;
-    const authThreadId = normalizeOptional(access.authThreadId) ?? null;
-    if (requestedThreadId && requestedThreadId !== authThreadId) {
-      throw new ApplicationError(
-        'FORBIDDEN',
-        'threadId payload does not match authenticated thread binding.',
-      );
-    }
-  }
   if (updates.execution_context) {
     const contextConversationJid = normalizeOptional(
       updates.execution_context.conversationJid,
     );
-    const contextThreadId =
-      normalizeOptional(updates.execution_context.threadId) ?? null;
-    const authThreadId = normalizeOptional(access.authThreadId) ?? null;
     if (
       contextConversationJid !== normalizeOptional(access.originConversationJid)
     ) {
       throw new ApplicationError(
         'FORBIDDEN',
         'executionContext conversation must match authenticated conversation.',
-      );
-    }
-    if (contextThreadId !== authThreadId) {
-      throw new ApplicationError(
-        'FORBIDDEN',
-        'executionContext threadId must match authenticated thread binding.',
       );
     }
   }

--- a/apps/core/src/application/jobs/job-management-context-access.ts
+++ b/apps/core/src/application/jobs/job-management-context-access.ts
@@ -36,7 +36,6 @@ export async function resolveAuthenticatedRouteContextForUpdate(input: {
     assertExecutionContextMatchesAuthenticatedContext({
       executionContext: input.patchExecutionContext,
       authenticatedContext,
-      enforceThread: input.patchExecutionContext !== undefined,
     });
     return authenticatedContext;
   }

--- a/apps/core/src/application/jobs/job-management-helpers.ts
+++ b/apps/core/src/application/jobs/job-management-helpers.ts
@@ -157,7 +157,6 @@ export function authenticatedContextFromAccess(
 export function assertExecutionContextMatchesAuthenticatedContext(input: {
   executionContext?: JobExecutionContextInput;
   authenticatedContext: AuthenticatedJobRouteContext;
-  enforceThread?: boolean;
 }): JobExecutionContextInput {
   const expected = input.authenticatedContext;
   const provided =
@@ -176,15 +175,10 @@ export function assertExecutionContextMatchesAuthenticatedContext(input: {
       'executionContext workspaceKey must match the authenticated workspace key.',
     );
   }
-  if (
-    input.enforceThread !== false &&
-    (provided.threadId ?? null) !== (expected.threadId ?? null)
-  ) {
-    throw new ApplicationError(
-      'FORBIDDEN',
-      'executionContext threadId must match authenticated thread binding.',
-    );
-  }
+  // Threads/topics are NOT an ownership boundary (Ravi, 2026-08-11): a
+  // topic shares its parent conversation's membership, so ownership and
+  // control scope to the conversation (DM/group/channel). The thread stays
+  // purely a delivery route.
   return provided;
 }
 
@@ -259,10 +253,12 @@ export function routesBeyondAuthenticatedContext(input: {
   authenticatedContext: AuthenticatedJobRouteContext;
 }): JobNotificationRouteInput[] {
   const { routes, authenticatedContext } = input;
+  // Same conversation + same provider account = same trust boundary; a
+  // different TOPIC of that conversation is not "beyond context" (threads
+  // are delivery routing, not ownership).
   return routes.filter(
     (route) =>
       route.conversationJid !== authenticatedContext.conversationJid ||
-      (route.threadId ?? null) !== (authenticatedContext.threadId ?? null) ||
       (route.providerAccountId ?? null) !==
         (authenticatedContext.providerAccountId ?? null),
   );

--- a/apps/core/src/application/jobs/job-management-service.ts
+++ b/apps/core/src/application/jobs/job-management-service.ts
@@ -126,14 +126,7 @@ export class JobManagementService {
         'Scheduler jobs cannot be created outside the source group.',
       );
     }
-    const authThreadId = normalizeOptional(input.access.authThreadId);
-    const payloadThreadId = normalizeOptional(input.threadId);
-    if (payloadThreadId && payloadThreadId !== authThreadId) {
-      throw new ApplicationError(
-        'FORBIDDEN',
-        'threadId payload does not match authenticated thread binding.',
-      );
-    }
+    // threadId is delivery routing, not ownership (conversation-scoped model).
     const authenticatedContext = authenticatedContextFromAccess(
       access,
       workspaceKey,
@@ -160,11 +153,13 @@ export class JobManagementService {
           ? (existingJob?.execution_context ?? {
               conversationJid: authenticatedContext.conversationJid,
               workspaceKey: authenticatedContext.workspaceKey,
-              threadId: authThreadId ?? null,
+              threadId:
+                normalizeOptional(input.threadId) ??
+                normalizeOptional(input.access.authThreadId) ??
+                null,
             })
           : input.executionContext,
       authenticatedContext,
-      enforceThread: input.executionContext !== undefined,
     });
     const existingNotificationRoutes = normalizeStoredNotificationRoutes(
       existingJob?.notification_routes,

--- a/apps/core/src/application/jobs/job-management-update.ts
+++ b/apps/core/src/application/jobs/job-management-update.ts
@@ -91,10 +91,7 @@ export async function updateManagedJob(
     (normalizedExecutionContext.conversationJid !==
       authenticatedContext.conversationJid ||
       normalizedExecutionContext.workspaceKey !==
-        authenticatedContext.workspaceKey ||
-      (input.access &&
-        (normalizedExecutionContext.threadId ?? null) !==
-          (authenticatedContext.threadId ?? null)))
+        authenticatedContext.workspaceKey)
   ) {
     throw new ApplicationError(
       'FORBIDDEN',

--- a/apps/core/test/unit/application/jobs-use-cases.test.ts
+++ b/apps/core/test/unit/application/jobs-use-cases.test.ts
@@ -1654,15 +1654,15 @@ describe('job application use cases', () => {
       authThreadId: 'thread-1',
     };
 
-    expectThrowsCode(
-      () =>
-        validateSchedulerUpdate(
-          makeJob({ workspace_key: 'team', thread_id: 'thread-1' }),
-          { thread_id: 'thread-2' },
-          access,
-        ),
-      'FORBIDDEN',
-    );
+    // Threads/topics are delivery routing, not ownership: any thread of the
+    // owning conversation may be set, from any thread of that conversation.
+    expect(() =>
+      validateSchedulerUpdate(
+        makeJob({ workspace_key: 'team', thread_id: 'thread-1' }),
+        { thread_id: 'thread-2' },
+        access,
+      ),
+    ).not.toThrow();
     expect(() =>
       validateSchedulerUpdate(
         makeJob({ workspace_key: 'team', thread_id: 'thread-1' }),
@@ -2009,10 +2009,10 @@ describe('job application use cases', () => {
     expect(ops.upsertJob).not.toHaveBeenCalled();
   });
 
-  it('rejects IPC scheduler upsert thread ids without authenticated thread context', async () => {
+  it('accepts IPC scheduler upsert thread ids without authenticated thread context (threads are delivery routing, not ownership)', async () => {
     const ops = {
       getJobById: vi.fn(),
-      upsertJob: vi.fn(),
+      upsertJob: vi.fn(async (job: unknown) => ({ created: true, job })),
     };
     const service = new JobManagementService({
       ops: ops as unknown as RuntimeJobRepository,
@@ -2036,8 +2036,12 @@ describe('job application use cases', () => {
         scheduleValue: '60000',
         threadId: 'thread-1',
       }),
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    expect(ops.upsertJob).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({ created: true });
+    expect(ops.upsertJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        execution_context: expect.objectContaining({ threadId: 'thread-1' }),
+      }),
+    );
   });
 
   it('uses the role-specific reason when the process does not claim jobs', async () => {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -132,6 +132,42 @@ command templates, auth preflight, protected paths, denied environment
 overrides, and account label before runtime projection can create scoped
 command authority.
 
+### Approval Authority And Person-Scoped Grants
+
+Who may answer a permission prompt is kind-aware (decision 0118):
+
+- In a direct (1:1) conversation the DM participant is the approver - no
+  allowlist entry is needed. The person approving their own agent's request in
+  their own DM is the trust boundary.
+- In a group or channel the explicit `control_approvers` allowlist governs,
+  and an empty allowlist fails closed.
+
+Durable "allow for future" grants carry the acting person: a grant approved
+inside a DM (or for a DM-created scheduled job) is written private to that
+person and never widens the shared agent for other chats. A turn with no
+memory-established person - every group turn, and DMs the identity model deems
+ineligible - writes a shared grant, as before. The acting identity is the
+memory identity, host-stamped onto the permission request at creation from the
+spawn-time run registry; identity fields in worker payloads are never trusted.
+Scheduled grants resolve the person from the host-persisted job row and fail
+closed when the job cannot be resolved.
+
+Group conversations acquire their first approver from the installer
+(decision 0119): when a person the bot already knows from an existing direct
+conversation adds it to a group, the group registers, the installer is seeded
+as its first control approver, and an acknowledgement posts in the group. An
+unrecognised installer seeds nobody and registers nothing (fail-closed); the
+group gets one message naming the manual path. Only installer-identity
+extraction is provider-specific (Telegram and Slack today; Discord and Teams
+degrade to manual).
+
+Scheduled-job ownership scopes to the conversation - a DM, group, or
+channel - never to a thread or topic inside it. Threads share their parent
+conversation's membership, so they are delivery routing only: any topic of the
+owning conversation can view and control its jobs, and a job's notifications
+may target any topic of that conversation. Cross-conversation access still
+fails closed.
+
 ## Privilege Comparison (Host Runtime)
 
 | Capability                          | Authorization source                                        |
@@ -181,7 +217,8 @@ production or remote control mode is active.
 | Browser       | Browser persists only as canonical `Browser`; backend tool names and browser profile details are internal.                                                                                    |
 | Filesystem    | File writes and uploads pass through protected-path, sandbox, artifact, and capability policy before execution.                                                                               |
 | Network       | Model calls use the model gateway; tool egress uses Gantry's egress gateway and audited policy.                                                                                               |
-| Approvals     | Providers may render approval UX, but approver validation, choices, persistence, and audit are Gantry-owned records.                                                                          |
+| Approvals     | Providers may render approval UX, but approver validation, choices, persistence, and audit are Gantry-owned records. DMs are approved by their participant; groups by the control allowlist.  |
+| Persons       | Durable grants are person-scoped when the acting turn carries a memory-established person; person identity is host-stamped, never read from worker payloads (decision 0118).                  |
 | Continuations | Follow-up input enters an active run only when the queue/session/conversation policy admits it.                                                                                               |
 | Stop          | Stop/cancel invalidates stale worker output, permission responses, continuations, and finalization through run ownership and fencing.                                                         |
 

--- a/plans/quickfixes/20260810T185155-0000-Q-0024-662f-open-185155947105.json
+++ b/plans/quickfixes/20260810T185155-0000-Q-0024-662f-open-185155947105.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0024-662f",
+  "profile": "quickfix",
+  "reason": "job ownership/visibility scopes to conversation (DM/group/channel), not thread/topic - thread remains delivery route only (Ravi's directive)",
+  "started_at": "2026-08-10T18:51:55+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260810T191129-0000-Q-0024-662f-done-191129925226.json
+++ b/plans/quickfixes/20260810T191129-0000-Q-0024-662f-done-191129925226.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0024-662f",
+  "profile": "quickfix",
+  "reason": "job ownership/visibility scopes to conversation (DM/group/channel), not thread/topic - thread remains delivery route only (Ravi's directive)",
+  "started_at": "2026-08-10T18:51:55+00:00",
+  "completed_at": "2026-08-10T19:11:29+00:00",
+  "files": []
+}


### PR DESCRIPTION
## What this fixes

A scheduled job created in a Telegram topic (or Slack thread) couldn't be controlled from any other topic of the same group: editing, re-routing, or re-threading it came back FORBIDDEN, and moving its notifications to a sibling topic required a cross-context approval. That surfaced today when the KnackLabs lead job — pinned to one topic — looked lost from everywhere else.

Ravi's ruling (2026-08-11): **threads and topics are not an ownership boundary.** A topic shares its parent conversation's membership, so it's the same trust audience — ownership and control belong to the conversation (DM / group / channel). The thread is purely where notifications get delivered.

## What changed

- The six mutation guards that compared topic ids (upsert payload thread, execution-context thread echo, update-path thread patch, and the "beyond authenticated context" route classification) now match on conversation + provider account only.
- A job's delivery thread is now legitimately settable: create or update from any topic of the owning conversation, point notifications at any topic of it.
- Visibility needed no change — it was already conversation-scoped (`canAccessSchedulerJob` never compared threads). Cross-conversation boundaries (different group, different DM, different provider account, different workspace) are untouched and still fail closed.

The two tests pinning the old thread-scoped behavior now pin the new contract; the existing conversation-scoped visibility tests stay as regression guards.

## Verification

Full unit suite 8,765 green; typecheck / architecture / format clean; autoreview (codex gpt-5.6-sol high) clean — "removes thread identity from ownership while retaining conversation, workspace, group, and provider-account boundaries."

Agent-e2e delta: none — the changed surface is the scheduler authorization guards, covered by the jobs-use-cases contract tests; the live check is controlling the KnackLabs job from a sibling topic after merge.
