### PR TITLE
Autonomous runs decide permissions deterministically — no classifier (AUTODET-1)

### DIFF
--- a/apps/core/src/runtime/ipc-permission-classifier-decision.ts
+++ b/apps/core/src/runtime/ipc-permission-classifier-decision.ts
@@ -184,6 +184,9 @@ async function resolvePermissionIpcDecisionTail(input: {
   hostJobId?: string;
 }): Promise<PermissionApprovalDecision> {
   if (input.hostJobId) {
+    // Only trusted host-derived rail risk may ride an autonomous denial into
+    // the decision/audit path; without one, strip the worker-supplied fields
+    // rather than let an untrusted low/benign claim reach the grant card.
     if (input.railRisk) {
       input.request.risk_level = input.railRisk.level;
       if (input.railRisk.category) {
@@ -191,6 +194,9 @@ async function resolvePermissionIpcDecisionTail(input: {
       } else {
         delete input.request.risk_category;
       }
+    } else {
+      delete input.request.risk_level;
+      delete input.request.risk_category;
     }
     const reason = `Autonomous runs decide deterministically: ${input.request.toolName} has no declared grant.`;
     input.request.decisionReason = reason;

--- a/apps/core/src/runtime/ipc-permission-classifier-decision.ts
+++ b/apps/core/src/runtime/ipc-permission-classifier-decision.ts
@@ -66,12 +66,14 @@ export async function resolvePermissionIpcDecision(input: {
   const approvedCapabilityIds =
     agentSettings?.capabilities?.map(({ id }) => id) ?? [];
   const workspaceRoot = resolveWorkspaceFolderPath(input.sourceAgentFolder);
-  const fixedImageRestricted = input.request.responseKeyId
-    ? (permissionRunRestriction({
+  const runRestriction = input.request.responseKeyId
+    ? permissionRunRestriction({
         sourceAgentFolder: input.sourceAgentFolder,
         responseKeyId: input.request.responseKeyId,
-      })?.hideAuthorityTools ?? false)
-    : false;
+      })
+    : undefined;
+  const hostJobId = runRestriction?.jobId;
+  const fixedImageRestricted = runRestriction?.hideAuthorityTools ?? false;
   const protectedCapability = evaluateProtectedCapabilityToolUse(
     input.request.toolName,
     input.request.toolInput,
@@ -136,8 +138,8 @@ export async function resolvePermissionIpcDecision(input: {
           input.request.toolName,
           input.request.toolInput,
           {
-            isScheduledJob: Boolean(input.request.jobId),
-            jobId: input.request.jobId,
+            isScheduledJob: Boolean(hostJobId),
+            jobId: hostJobId,
             threadId: input.request.threadId,
             conversationId: input.request.targetJid ?? '',
           },
@@ -151,11 +153,12 @@ export async function resolvePermissionIpcDecision(input: {
             capability,
           ]),
         ),
-        ...(input.request.jobId
+        ...(hostJobId
           ? { autonomousAllowedToolRules: policy.rules }
           : { allowedToolRules: policy.rules }),
       });
     },
+    skipClassifierVerdictCache: Boolean(hostJobId),
     tail: () =>
       resolvePermissionIpcDecisionTail({
         ...input,
@@ -164,6 +167,7 @@ export async function resolvePermissionIpcDecision(input: {
         railRisk,
         railRequiresApproval,
         railApprovalReason,
+        hostJobId,
       }),
   });
 }
@@ -177,7 +181,29 @@ async function resolvePermissionIpcDecisionTail(input: {
   railRisk?: PermissionDeterministicRailRisk;
   railRequiresApproval?: boolean;
   railApprovalReason?: string;
+  hostJobId?: string;
 }): Promise<PermissionApprovalDecision> {
+  if (input.hostJobId) {
+    if (input.railRisk) {
+      input.request.risk_level = input.railRisk.level;
+      if (input.railRisk.category) {
+        input.request.risk_category = input.railRisk.category;
+      } else {
+        delete input.request.risk_category;
+      }
+    }
+    const reason = `Autonomous runs decide deterministically: ${input.request.toolName} has no declared grant.`;
+    input.request.decisionReason = reason;
+    return withRequestRisk(input.request, {
+      ...decisionForMode(
+        input.request,
+        'cancel',
+        'deterministic_rails',
+        'machine',
+      ),
+      reason,
+    });
+  }
   const route = input.request.targetJid
     ? findConversationRouteForQueue(
         input.deps.conversationRoutes?.() ?? {},

--- a/apps/core/src/runtime/permission-decision-coordinator.ts
+++ b/apps/core/src/runtime/permission-decision-coordinator.ts
@@ -41,6 +41,8 @@ export interface CoordinatePermissionDecisionInput {
   effectHash?: string;
   /** Classifier-verdict cache (Task C); read only on a rail fall-through. */
   decisionMemory?: PermissionDecisionMemoryRepository;
+  /** Host-verified autonomous runs never read classifier verdicts. */
+  skipClassifierVerdictCache?: boolean;
   tail: () => Promise<PermissionApprovalDecision>;
 }
 
@@ -84,6 +86,7 @@ export async function coordinatePermissionDecision(
       ? await input.reviewedRuleDecision()
       : input.reviewedRuleDecision;
   if (reviewedRuleDecision?.status === 'allow') {
+    input.request.decisionReason = reviewedRuleDecision.reason;
     return {
       ...decisionForMode(
         input.request,
@@ -126,7 +129,11 @@ export async function coordinatePermissionDecision(
   }
   // CACHE STAGE (cache-hit-only shortcut). Reachable only past hard-deny/
   // locked/fixed-image (PERM-1 precedence, checked above) and past the rails.
-  if (input.effectHash && input.decisionMemory) {
+  if (
+    !input.skipClassifierVerdictCache &&
+    input.effectHash &&
+    input.decisionMemory
+  ) {
     const cached = await input.decisionMemory.getClassifierVerdict({
       appId: input.request.appId ?? 'default',
       agentFolder: input.request.sourceAgentFolder,

--- a/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
+++ b/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
@@ -1,7 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
 
 import { eq } from 'drizzle-orm';
 import {
@@ -51,13 +48,40 @@ import {
   buildJobListVisibilityMetadata,
   buildJobVisibilityMetadata,
 } from '@core/application/jobs/job-visibility-metadata.js';
+import { runDurablePermissionInteraction } from '@core/application/interactions/durable-interaction-handler.js';
+import {
+  configurePendingInteractionDurability,
+  configurePendingInteractionPermissionPersistence,
+} from '@core/application/interactions/pending-interaction-durability.js';
+import {
+  configureSetupPausePermissionPrompt,
+  type SetupPausePermissionPromptDeps,
+} from '@core/application/jobs/setup-pause-permission-prompt.js';
+import {
+  appendSetupPauseRequirementAfterPersistentGrant,
+  setupPausePersistentGrantIsCurrent,
+} from '@core/app/bootstrap/setup-pause-permission-wiring.js';
 import type { JobUpsertInput } from '@core/domain/repositories/ops-repo.js';
-import type { ConversationRoute, JobRun } from '@core/domain/types.js';
+import type {
+  ConversationRoute,
+  JobRun,
+  PermissionApprovalDecision,
+  PermissionApprovalRequest,
+} from '@core/domain/types.js';
 import { PgBossSchedulerEngine } from '@core/infrastructure/pgboss/scheduler-engine.js';
 import { configureRunSlotBackend } from '@core/jobs/concurrency.js';
 import { _resetSchedulerLoopForTests, runJob } from '@core/jobs/scheduler.js';
+import {
+  requestPermissionReviewSuggestions,
+  requestPermissionSetupDecisionOptions,
+} from '@core/jobs/request-permission-review.js';
 import { registerWorkerInstance } from '@core/jobs/worker-identity.js';
+import { resolveWorkspaceFolderPath } from '@core/platform/workspace-folder.js';
+import { formatAutonomousToolDenial } from '@core/shared/autonomous-tool-denial.js';
+import { registerWorkerPermissionRunRestriction } from '@core/runtime/agent-spawn-permission-run-restriction.js';
 import type { AgentOutput } from '@core/runtime/agent-spawn.js';
+import { resolvePermissionIpcDecision } from '@core/runtime/ipc-permission-classifier-decision.js';
+import { unregisterPermissionRunRestriction } from '@core/runtime/permission-decision-coordinator.js';
 
 import {
   createPostgresIntegrationRuntime,
@@ -174,6 +198,9 @@ maybeDescribe('job lifecycle (Postgres)', () => {
   });
 
   afterEach(async () => {
+    configureSetupPausePermissionPrompt(null);
+    configurePendingInteractionDurability(null);
+    configurePendingInteractionPermissionPersistence(null);
     await schedulerEngine?.stop();
     schedulerEngine = undefined;
   });
@@ -411,27 +438,153 @@ maybeDescribe('job lifecycle (Postgres)', () => {
     });
   });
 
-  it('terminates and audits an autonomous ungranted-tool dead-end', async () => {
+  it('AUTODET-1-2 > deny pause grant resume complete loop with no auto_classifier provenance', async () => {
     const harness = createRuntimeFlowHarness();
-    const permissionRoot = mkdtempSync(
-      join(tmpdir(), 'gantry-job-permission-'),
-    );
-    const ipcDir = join(permissionRoot, 'ipc');
-    vi.stubEnv('GANTRY_WORKSPACE_GROUP_DIR', join(permissionRoot, 'group'));
-    vi.stubEnv('GANTRY_WORKSPACE_EXTRA_DIR', join(permissionRoot, 'extra'));
-    vi.stubEnv('GANTRY_IPC_DIR', ipcDir);
-    vi.stubEnv('GANTRY_IPC_INPUT_DIR', join(ipcDir, 'input'));
-    vi.stubEnv('GANTRY_IPC_AUTH_TOKEN', 'job-lifecycle-test-secret');
-    vi.stubEnv('GANTRY_AUTONOMOUS_PERMISSION_TIMEOUT_MS', '0');
-    vi.stubEnv('GANTRY_JOB_ID', 'job:integration:ungranted-tool');
-    vi.resetModules();
-    const { createCanUseToolCallback } =
-      await import('@core/adapters/llm/anthropic-claude-agent/runner/tool-permission-gate.js');
+    const job = makeJob('job:integration:autodet-fix-and-continue', {
+      silent: false,
+    });
+    const command = 'npm test -- unit';
+    const recoveryAction = `request_access ${JSON.stringify({
+      target: { kind: 'run_command', argvPattern: command },
+      temporaryOnly: false,
+      reason: 'Approve exact command access, then resume the job.',
+    })}`;
+    const classifierConsult = vi.fn(async () => ({
+      risk_level: 'low' as const,
+      risk_category: 'benign' as const,
+      reason: 'Classifier would allow this command.',
+      latencyMs: 1,
+    }));
+    const requestPermissionApproval = vi.fn();
+    const decisions: Array<{
+      runId: string;
+      decision: PermissionApprovalDecision;
+    }> = [];
     const runnerInputs: Record<string, unknown>[] = [];
-    const runnerFrames: AgentOutput[] = [];
-    let permissionDecision: Awaited<
-      ReturnType<ReturnType<typeof createCanUseToolCallback>>
-    >;
+    let setupRequest: PermissionApprovalRequest | undefined;
+    let resolveGrantDecision:
+      | ((decision: PermissionApprovalDecision) => void)
+      | undefined;
+    const grantDecision = new Promise<PermissionApprovalDecision>((resolve) => {
+      resolveGrantDecision = resolve;
+    });
+    configurePendingInteractionDurability({
+      repository: runtime.repositories.workerCoordination,
+      warn: vi.fn(),
+    });
+    configurePendingInteractionPermissionPersistence({
+      opsRepository: runtime.ops,
+      beforePersistentGrant: (request, updates) =>
+        setupPausePersistentGrantIsCurrent(runtime.ops, request, updates),
+      afterPersistentGrant: (request, updates) =>
+        appendSetupPauseRequirementAfterPersistentGrant(
+          runtime.ops,
+          request,
+          updates,
+        ),
+      getToolRepository: () => runtime.repositories.tools,
+      getPermissionRepository: () => runtime.repositories.permissions,
+      mirrorAgentToolRulesToSettings: vi.fn(async () => undefined),
+      onSchedulerChanged: vi.fn(),
+      publishRuntimeEvent: (event) =>
+        runtime.storageRuntime.runtimeEvents
+          .publish(event)
+          .then(() => undefined),
+    });
+    const runPermissionInteraction = vi.fn<
+      SetupPausePermissionPromptDeps['runPermissionInteraction']
+    >((request, delivered, began) =>
+      runDurablePermissionInteraction({
+        request,
+        sourceAgentFolder: request.sourceAgentFolder,
+        skipPromptWhenAlreadyPending: true,
+        beforePrompt: began,
+        prompt: async (durableRequest) => {
+          setupRequest = durableRequest;
+          delivered('setup-card-1');
+          return grantDecision;
+        },
+      }),
+    );
+    configureSetupPausePermissionPrompt({
+      appId: 'default',
+      getJobById: async (jobId) =>
+        (await runtime.ops.getJobById(jobId)) ?? undefined,
+      runPermissionInteraction,
+      cancelPermissionApproval: async () => 'not_found',
+      reviewStoredRequirement: async ({ toolInput }) => {
+        const suggestions = requestPermissionReviewSuggestions(toolInput);
+        return suggestions?.length
+          ? {
+              suggestions,
+              decisionOptions: requestPermissionSetupDecisionOptions(toolInput),
+            }
+          : null;
+      },
+    });
+
+    const resolveHostDecision = async (input: Record<string, unknown>) => {
+      const responseKeyId = `autodet-${randomUUID()}`;
+      const runId = String(input.runId);
+      registerWorkerPermissionRunRestriction({
+        sourceAgentFolder: job.workspace_key,
+        responseKeyId,
+        hideAuthorityTools: false,
+        runKind: 'scheduled',
+        jobId: job.id,
+        runId,
+      });
+      try {
+        return await resolvePermissionIpcDecision({
+          request: {
+            requestId: `permission-${randomUUID()}`,
+            responseKeyId,
+            sourceAgentFolder: job.workspace_key,
+            appId: 'default',
+            agentId: String(input.agentId),
+            runId,
+            jobId: job.id,
+            targetJid: 'tg:job-lifecycle',
+            threadId: 'thread-job-lifecycle',
+            toolName: 'RunCommand',
+            toolInput: { command },
+            unattended: true,
+            decisionReason:
+              'Worker matcher found no matching allowedTools rule.',
+          },
+          sourceAgentFolder: job.workspace_key,
+          deps: {
+            conversationRoutes: () => ({}),
+            requestPermissionApproval,
+            classifierConsult,
+            publishRuntimeEvent: (event) =>
+              runtime.storageRuntime.runtimeEvents
+                .publish(event)
+                .then(() => undefined),
+            getToolRepository: () => runtime.repositories.tools,
+            getPermissionRuntimeSettings: () => ({
+              agents: {
+                [job.workspace_key]: {
+                  permissionMode: 'auto' as const,
+                  capabilities: [],
+                },
+              },
+              permissions: {
+                autoMode: {},
+                trustedRoots: [resolveWorkspaceFolderPath(job.workspace_key)],
+              },
+              memory: { llm: { models: { extractor: 'sonnet' } } },
+            }),
+          } as never,
+        });
+      } finally {
+        unregisterPermissionRunRestriction({
+          sourceAgentFolder: job.workspace_key,
+          responseKeyId,
+        });
+      }
+    };
+
     const runAgent = async (
       _group: ConversationRoute,
       input: Record<string, unknown>,
@@ -439,100 +592,111 @@ maybeDescribe('job lifecycle (Postgres)', () => {
       onOutput?: (output: AgentOutput) => void | Promise<void>,
     ): Promise<AgentOutput> => {
       runnerInputs.push(input);
-      const canUseTool = createCanUseToolCallback({
-        agentInput: {
-          prompt: String(input.prompt),
-          appId: String(input.appId),
-          agentId: String(input.agentId),
-          runId: String(input.runId),
-          isScheduledJob: input.isScheduledJob === true,
-          jobId: String(input.jobId),
-          chatJid: String(input.chatJid),
-          threadId: String(input.threadId),
-          workspaceFolder: basename(ipcDir),
-          permissionMode: 'default',
-          allowedTools: Array.isArray(input.toolPolicyRules)
-            ? (input.toolPolicyRules as string[])
-            : [],
-        },
-        sdkEnv: {},
-        workspaceFolder: basename(ipcDir),
-        memoryBlock: '',
-        capabilities: {
-          allowedTools: [],
-          alwaysAllowedTools: [],
-          permissionMode: 'default',
-        },
-        primeToolAttempts: [],
-        getNewSessionId: () => undefined,
-        emitInteractionBoundary: () => undefined,
-        recordToolActivity: () => undefined,
-      });
-      const outputSpy = vi
-        .spyOn(console, 'log')
-        .mockImplementation((value: unknown) => {
-          if (typeof value !== 'string' || !value.startsWith('{"status"')) {
-            return;
-          }
-          const output = JSON.parse(value) as AgentOutput;
-          if (output.runtimeEvents?.length) runnerFrames.push(output);
+      const decision = await resolveHostDecision(input);
+      decisions.push({ runId: String(input.runId), decision });
+      if (decision.approved) {
+        await onOutput?.({
+          status: 'success',
+          result: null,
+          runtimeEvents: [
+            {
+              appId: String(input.appId),
+              agentId: String(input.agentId),
+              runId: String(input.runId),
+              jobId: job.id,
+              conversationId: 'tg:job-lifecycle',
+              threadId: 'thread-job-lifecycle',
+              eventType: 'job.tool_activity',
+              actor: 'runner',
+              responseMode: 'none',
+              payload: {
+                phase: 'permission_allowed',
+                tool: 'RunCommand',
+                mode: decision.mode,
+                decided_by: decision.decidedBy,
+                source: decision.source,
+                repeatableForFutureRuns: decision.repeatableForFutureRuns,
+                reason: decision.reason,
+              },
+            },
+          ],
         });
-      try {
-        permissionDecision = await canUseTool(
-          'Bash',
-          { command: 'npm test -- unit' },
-          {
-            title: 'Run command',
-            displayName: 'Bash',
-            description: 'Run the job command',
-            decisionReason: 'The scheduled job needs this command',
-            suggestions: [],
-            toolUseID: 'tool-use-job-lifecycle',
-            signal: new AbortController().signal,
-          },
-        );
-      } finally {
-        outputSpy.mockRestore();
+        return { status: 'success', result: 'command completed' };
       }
-      for (const frame of runnerFrames) await onOutput?.(frame);
-      return { status: 'success', result: 'blocked' };
-    };
-    const job = makeJob('job:integration:ungranted-tool');
-    await runtime.ops.upsertJob(job);
-
-    try {
-      await runJob(
-        (await runtime.ops.getJobById(job.id))!,
-        {
-          conversationRoutes: () => ({
-            'tg:job-lifecycle': makeConversationRoute(),
-          }),
-          queue: {} as never,
-          onProcess: () => {},
-          sendMessage: harness.channel.sendMessage,
-          opsRepository: runtime.ops,
-          runAgent: runAgent as never,
-          runnerSandboxProvider: {} as never,
-        },
-        'tg:job-lifecycle',
-      );
-
-      const permissionRequestsDir = join(ipcDir, 'permission-requests');
-      const requestFiles = readdirSync(permissionRequestsDir);
-      expect(requestFiles).toHaveLength(1);
-      expect(
-        JSON.parse(
-          readFileSync(join(permissionRequestsDir, requestFiles[0]!), 'utf8'),
-        ),
-      ).toMatchObject({
-        jobId: job.id,
-        toolName: 'RunCommand',
-        unattended: true,
+      await onOutput?.({
+        status: 'success',
+        result: null,
+        runtimeEvents: [
+          {
+            appId: String(input.appId),
+            agentId: String(input.agentId),
+            runId: String(input.runId),
+            jobId: job.id,
+            conversationId: 'tg:job-lifecycle',
+            threadId: 'thread-job-lifecycle',
+            eventType: 'job.tool_activity',
+            actor: 'runner',
+            responseMode: 'none',
+            payload: {
+              phase: 'permission_wait',
+              tool: 'RunCommand',
+              reason: decision.reason,
+              recovery_action: recoveryAction,
+            },
+          },
+          {
+            appId: String(input.appId),
+            agentId: String(input.agentId),
+            runId: String(input.runId),
+            jobId: job.id,
+            conversationId: 'tg:job-lifecycle',
+            threadId: 'thread-job-lifecycle',
+            eventType: 'job.tool_activity',
+            actor: 'runner',
+            responseMode: 'none',
+            payload: {
+              phase: 'permission_denied',
+              tool: 'RunCommand',
+              grantable: true,
+              decided_by: decision.decidedBy,
+              source: decision.source,
+              reason: decision.reason,
+              recovery_action: recoveryAction,
+            },
+          },
+        ],
       });
-    } finally {
-      vi.unstubAllEnvs();
-      rmSync(permissionRoot, { recursive: true, force: true });
-    }
+      return {
+        status: 'error',
+        error: formatAutonomousToolDenial({
+          toolName: 'RunCommand',
+          reason: decision.reason ?? 'Permission denied.',
+          grantable: true,
+          recoveryAction,
+        }),
+      };
+    };
+    await runtime.ops.upsertJob(job);
+    const deps = {
+      conversationRoutes: () => ({
+        'tg:job-lifecycle': makeConversationRoute(),
+      }),
+      queue: {} as never,
+      onProcess: () => {},
+      sendMessage: harness.channel.sendMessage,
+      opsRepository: runtime.ops,
+      runAgent: runAgent as never,
+      runnerSandboxProvider: {} as never,
+      // Readiness preflight resolves the job tool policy through this hook;
+      // without it the granted binding is invisible and the rerun re-pauses.
+      getToolRepository: () => runtime.repositories.tools,
+    };
+
+    await runJob(
+      (await runtime.ops.getJobById(job.id))!,
+      deps,
+      'tg:job-lifecycle',
+    );
 
     expect(runnerInputs).toHaveLength(1);
     expect(runnerInputs[0]).toMatchObject({
@@ -540,53 +704,35 @@ maybeDescribe('job lifecycle (Postgres)', () => {
       jobId: job.id,
       toolPolicyRules: [],
     });
-    expect(permissionDecision).toMatchObject({
-      behavior: 'deny',
-      interrupt: true,
-      message: expect.stringContaining(
-        'Tool not on autonomous run allowlist: RunCommand',
-      ),
+    expect(decisions[0]?.decision).toMatchObject({
+      approved: false,
+      mode: 'cancel',
+      decidedBy: 'deterministic_rails',
+      reason:
+        'Autonomous runs decide deterministically: RunCommand has no declared grant.',
     });
-    expect(
-      runnerFrames
-        .flatMap((frame) => frame.runtimeEvents ?? [])
-        .map((event) => [event.eventType, event.payload]),
-    ).toEqual(
-      expect.arrayContaining([
-        [
-          'job.tool_activity',
-          expect.objectContaining({
-            phase: 'permission_wait',
-            tool: 'RunCommand',
-            recovery_action: expect.stringContaining('request_access'),
-          }),
-        ],
-        [
-          'job.tool_activity',
-          expect.objectContaining({
-            phase: 'permission_denied',
-            tool: 'RunCommand',
-          }),
-        ],
-      ]),
-    );
-    const runs = await runtime.ops.listJobRuns(job.id);
-    expect(runs).toHaveLength(1);
-    expect(runs[0]).toMatchObject({
+    expect(classifierConsult).not.toHaveBeenCalled();
+    expect(requestPermissionApproval).not.toHaveBeenCalled();
+    expect(runPermissionInteraction).toHaveBeenCalledOnce();
+    expect(setupRequest).toMatchObject({
+      jobId: job.id,
+      toolName: 'request_permission',
+      decisionOptions: ['allow_persistent_rule', 'cancel'],
+      suggestions: [
+        expect.objectContaining({
+          type: 'addRules',
+          rules: [{ toolName: 'RunCommand', ruleContent: command }],
+        }),
+      ],
+    });
+
+    const deniedRuns = await runtime.ops.listJobRuns(job.id);
+    expect(deniedRuns).toHaveLength(1);
+    expect(deniedRuns[0]).toMatchObject({
       status: 'failed',
       ended_at: expect.any(String),
-      error_summary: expect.stringContaining(
-        'Tool not on autonomous run allowlist: RunCommand',
-      ),
+      error_summary: expect.stringContaining('RunCommand'),
     });
-    expect(runs.some((run) => run.status === 'running')).toBe(false);
-    const leases = await runtime.service.pool.query<{ status: string }>(
-      `SELECT status
-         FROM ${quotePostgresIdentifier(runtime.schemaName)}.run_leases
-        WHERE run_id = $1`,
-      [runs[0]!.run_id],
-    );
-    expect(leases.rows).toEqual([{ status: 'failed' }]);
     await expect(runtime.ops.getJobById(job.id)).resolves.toMatchObject({
       status: 'paused',
       pause_reason: 'Setup required',
@@ -598,25 +744,82 @@ maybeDescribe('job lifecycle (Postgres)', () => {
       lease_expires_at: null,
     });
 
-    const events = await runtime.ops.listRecentJobEvents(20, {
+    const persistentDecision: PermissionApprovalDecision = {
+      approved: true,
+      mode: 'allow_persistent_rule',
+      decidedBy: 'job-owner',
+      decisionClassification: 'user_permanent',
+      updatedPermissions: setupRequest!.suggestions,
+    };
+    resolveGrantDecision?.(persistentDecision);
+    await vi.waitFor(
+      async () => {
+        await expect(runtime.ops.getJobById(job.id)).resolves.toMatchObject({
+          status: 'active',
+          pause_reason: null,
+          setup_state: expect.objectContaining({ state: 'ready' }),
+        });
+      },
+      { timeout: 5_000 },
+    );
+
+    await runJob(
+      (await runtime.ops.getJobById(job.id))!,
+      deps,
+      'tg:job-lifecycle',
+    );
+
+    expect(runnerInputs).toHaveLength(2);
+    expect(decisions[1]?.decision).toMatchObject({
+      approved: true,
+      mode: 'allow_once',
+      decidedBy: 'reviewed_rule',
+      reason: expect.stringContaining('Allowed by'),
+    });
+    expect(runPermissionInteraction).toHaveBeenCalledOnce();
+    expect(classifierConsult).not.toHaveBeenCalled();
+    expect(requestPermissionApproval).not.toHaveBeenCalled();
+    expect(
+      decisions.every(
+        ({ runId, decision }) =>
+          runId.length > 0 && decision.decidedBy !== 'auto_classifier',
+      ),
+    ).toBe(true);
+
+    const runs = await runtime.ops.listJobRuns(job.id);
+    expect(runs).toHaveLength(2);
+    expect(runs.map((run) => run.status)).toEqual(
+      expect.arrayContaining(['failed', 'completed']),
+    );
+    await expect(runtime.ops.getJobById(job.id)).resolves.toMatchObject({
+      status: 'active',
+      pause_reason: null,
+      setup_state: expect.objectContaining({ state: 'ready' }),
+    });
+
+    const events = await runtime.ops.listRecentJobEvents(100, {
       job_id: job.id,
     });
-    expect(events.map((event) => event.event_type)).toEqual(
+    const toolDecisions = events
+      .filter((event) => event.event_type === 'job.tool_activity')
+      .map((event) => JSON.parse(event.payload ?? '{}'))
+      .filter((payload) =>
+        ['permission_denied', 'permission_allowed'].includes(payload.phase),
+      );
+    expect(toolDecisions).toHaveLength(2);
+    expect(toolDecisions).toEqual(
       expect.arrayContaining([
-        'run.failed',
-        'job.setup_required',
-        'job.tool_denied',
-        'job.failed',
-        'job.run.failed',
+        expect.objectContaining({
+          phase: 'permission_denied',
+          decided_by: 'deterministic_rails',
+        }),
+        expect.objectContaining({
+          phase: 'permission_allowed',
+          decided_by: 'reviewed_rule',
+        }),
       ]),
     );
-    const deniedEvent = events.find(
-      (event) => event.event_type === 'job.tool_denied',
-    );
-    expect(JSON.parse(deniedEvent?.payload ?? '{}')).toMatchObject({
-      denied_tool: 'RunCommand',
-      recovery_kind: 'persistent_capability',
-      recovery_action: expect.stringContaining('request_access'),
-    });
+    expect(events.every((event) => event.job_id === job.id)).toBe(true);
+    expect(JSON.stringify(events)).not.toContain('auto_classifier');
   });
 });

--- a/apps/core/test/unit/adapters/deepagents-terminal-denial-turn.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-terminal-denial-turn.test.ts
@@ -55,6 +55,97 @@ afterEach(() => {
 });
 
 describe('DeepAgents terminal permission denial', () => {
+  it('AUTODET-1-1 > deepagents lane observes identical terminal outcome for same grants', async () => {
+    const [{ fakeModel }, { AIMessage }, { tool }] = await Promise.all([
+      import('@langchain' + '/core/testing'),
+      import('@langchain' + '/core/messages'),
+      import('@langchain' + '/core/tools'),
+    ]);
+    const model = fakeModel()
+      .respondWithTools([{ name: 'denied_tool', args: {} }])
+      .respond(new AIMessage('should never continue'));
+    harness.model = model;
+
+    let gate:
+      | {
+          onPermissionDenied?: (input: {
+            toolName: string;
+            reason: string;
+            grantable: boolean;
+            recoveryAction: string;
+          }) => never;
+        }
+      | undefined;
+    const hostReason =
+      'Autonomous runs decide deterministically: mcp__gantry__browser_open has no declared grant.';
+    harness.tools = [
+      tool(
+        async () =>
+          gate!.onPermissionDenied!(
+            deepAgentsDenial(
+              { capabilityRequestToolsHidden: false },
+              'mcp__gantry__browser_open',
+              {
+                toolName: 'mcp__gantry__browser_open',
+                toolInput: { url: 'https://example.com' },
+              },
+              hostReason,
+            ),
+          ),
+        {
+          name: 'denied_tool',
+          description: 'Host deterministically denies an undeclared tool.',
+          schema: z.object({}),
+        },
+      ),
+    ];
+    harness.connect.mockImplementationOnce(async (input) => {
+      gate = input.gate;
+      return { tools: harness.tools, close: harness.close };
+    });
+    const emit = vi.fn();
+
+    await expect(
+      runDeepAgentTurn({
+        agentInput: {
+          prompt: 'Use denied_tool.',
+          workspaceFolder: '/tmp/workspace',
+          chatJid: 'conversation:test',
+          appId: 'default',
+          agentId: 'agent-1',
+          runId: 'run-1',
+          jobId: 'job-1',
+          isScheduledJob: true,
+          modelCredentialEnv: {
+            OPENAI_BASE_URL: 'http://127.0.0.1:4567/openai',
+            OPENAI_API_KEY: 'gtw_test',
+          },
+        },
+        provider: 'openai',
+        modelId: 'gpt-5.5',
+        newSessionId: 'session-1',
+        includeMemoryContext: true,
+        emit,
+      }),
+    ).rejects.toThrow(
+      'Tool not on autonomous run allowlist: mcp__gantry__browser_open.',
+    );
+    expect(emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeEvents: [
+          expect.objectContaining({
+            payload: expect.objectContaining({
+              phase: 'permission_denied',
+              terminal: true,
+              grantable: true,
+              reason: hostReason,
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
   it('a non-grantable locked-agent denial stays instruction-only with no approval offered', async () => {
     process.env.GANTRY_AGENT_ACCESS_PRESET = 'locked';
     const [{ fakeModel }, { AIMessage }, { tool }] = await Promise.all([

--- a/apps/core/test/unit/jobs/execution-finalization.test.ts
+++ b/apps/core/test/unit/jobs/execution-finalization.test.ts
@@ -54,6 +54,50 @@ function makeDeps(): {
 }
 
 describe('execution finalization', () => {
+  it('AUTODET-1-2 > pause card renders grant-naming reason', async () => {
+    const { deps, sendMessage } = makeDeps();
+    const diagnostics = createJobRunDiagnostics();
+    diagnostics.terminalToolDenial = {
+      toolName: 'RunCommand',
+      grantable: true,
+      reason: 'Worker matcher found no matching allowedTools rule.',
+      recoveryAction:
+        'request_access {"target":{"kind":"run_command","argvPattern":"npm test -- unit"},"temporaryOnly":false,"reason":"Grant exact test command access."}',
+    };
+
+    await finalizeSchedulerJobRun({
+      currentJob: makeJob({
+        silent: false,
+        notification_routes: [
+          {
+            conversationJid: 'tg:job-owner',
+            threadId: 'thread-1',
+            label: 'primary',
+          },
+        ],
+      }),
+      deps,
+      scheduledFor: '2024-01-01T00:00:00.000Z',
+      now: '2024-01-01T00:00:01.000Z',
+      error:
+        'Permission denied. Worker matcher found no matching allowedTools rule.',
+      diagnostics,
+      pausedForSetupDuringRun: false,
+      deletedDuringRun: false,
+      runtimeAppId: 'default',
+      runId: 'run-grant-naming-card',
+      publishRuntimeEvent: vi.fn(async () => undefined),
+    });
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage.mock.calls[0]?.[1]).toContain(
+      'Approve exact command access, then resume the job.',
+    );
+    expect(sendMessage.mock.calls[0]?.[1]).not.toContain(
+      'Worker matcher found no matching allowedTools rule.',
+    );
+  });
+
   it('classifies an Anthropic autonomous denial as failed for fresh retry, not resumably paused', async () => {
     const { deps, updateJob } = makeDeps();
     const state = await finalizeSchedulerJobRun({

--- a/apps/core/test/unit/runner/tool-permission-gate.test.ts
+++ b/apps/core/test/unit/runner/tool-permission-gate.test.ts
@@ -852,11 +852,13 @@ describe('tool permission gate', () => {
     );
   });
 
-  it('keeps a scheduled worker-local miss terminal when the host denies the ungranted command', async () => {
+  it('AUTODET-1-1 > anthropic lane worker-local miss hands off and observes deterministic terminal outcome', async () => {
+    const hostReason =
+      'Autonomous runs decide deterministically: RunCommand has no declared grant.';
     permissionMock.requestPermissionApproval.mockResolvedValueOnce({
       approved: false,
-      reason: 'No reviewed capability or command rule matched.',
-      decidedBy: 'runtime',
+      reason: hostReason,
+      decidedBy: 'deterministic_rails',
     });
     const canUseTool = makeCallback({
       agentInput: {
@@ -876,7 +878,10 @@ describe('tool permission gate', () => {
       canUseTool(
         'RunCommand',
         { command: '/opt/homebrew/bin/gog sheets delete sheet-1' },
-        makePermissionOptions({ displayName: 'RunCommand' }) as never,
+        makePermissionOptions({
+          displayName: 'RunCommand',
+          decisionReason: undefined,
+        }) as never,
       ),
     ).resolves.toEqual(
       expect.objectContaining({
@@ -888,6 +893,11 @@ describe('tool permission gate', () => {
       }),
     );
     expect(permissionMock.requestPermissionApproval).toHaveBeenCalledTimes(1);
+    const approvalRequest =
+      permissionMock.requestPermissionApproval.mock.calls[0]?.[0];
+    expect(approvalRequest?.decisionReason).toContain(
+      'Tool not on autonomous run allowlist: RunCommand',
+    );
   });
 
   it('allows scheduled jobs to read local time without a custom command grant', async () => {

--- a/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
+++ b/apps/core/test/unit/runtime/ipc-interaction-handler.test.ts
@@ -1593,19 +1593,18 @@ describe('ipc-interaction-handler', () => {
   );
 
   it.each(['Bash', 'RunCommand'])(
-    'emits structured permission events, decision reasons, and redacted %s command telemetry',
+    'emits structured interactive permission events, decision reasons, and redacted %s command telemetry',
     async (toolName) => {
       const claimedPath = path.join(tempDir, 'claimed-bash-permission.json');
       fs.writeFileSync(claimedPath, '{}');
-      // The request's jobId is untrusted; the host stamps it from the run
-      // registry, so a scheduled-run test must register its restriction.
+      // The request's jobId is untrusted; an interactive host restriction
+      // strips it and preserves the human-approval telemetry path.
       const envelope = createIpcAuthEnvelope('main_agent', null);
       registerPermissionRunRestriction({
         sourceAgentFolder: 'main_agent',
         responseKeyId: envelope.responseKeyId,
         hideAuthorityTools: false,
-        runKind: 'scheduled',
-        jobId: 'job:test',
+        runKind: 'interactive',
         runId: 'run:test',
       });
       const publishRuntimeEvent = vi.fn(async () => undefined);
@@ -1646,7 +1645,7 @@ describe('ipc-interaction-handler', () => {
           runId: 'run:test',
           runLeaseToken: 'lease-token',
           runLeaseFencingVersion: 7,
-          jobId: 'job:test',
+          jobId: 'worker-forged-job',
           targetJid: 'tg:team',
           threadId: 'thread:test',
           toolName,
@@ -1688,7 +1687,7 @@ describe('ipc-interaction-handler', () => {
           appId: 'app:test',
           agentId: 'agent:test',
           runId: 'run:test',
-          jobId: 'job:test',
+          jobId: undefined,
           conversationId: 'tg:team',
           threadId: 'thread:test',
           correlationId: 'perm-bash-once',

--- a/apps/core/test/unit/runtime/ipc-permission-classifier-decision.test.ts
+++ b/apps/core/test/unit/runtime/ipc-permission-classifier-decision.test.ts
@@ -136,17 +136,34 @@ describe('IPC permission classifier decision', () => {
             toolName: 'mcp__crm__update_record',
             toolInput: { id: 'customer-1' },
             unattended: true,
+            // Worker-asserted risk must be stripped from the denial: without a
+            // host-derived rail risk, no untrusted low/benign claim may reach
+            // the decision/audit path or the grant card.
+            risk_level: 'low',
+            risk_category: 'benign',
           },
           sourceAgentFolder: 'main_agent',
           deps,
         }),
-      ).resolves.toMatchObject({
-        approved: false,
-        mode: 'cancel',
-        decidedBy: 'deterministic_rails',
-        reason:
-          'Autonomous runs decide deterministically: mcp__crm__update_record has no declared grant.',
-      });
+      ).resolves.toSatisfy(
+        (decision: {
+          approved: boolean;
+          mode: string;
+          decidedBy?: string;
+          reason?: string;
+          risk_level?: string;
+          risk_category?: string;
+        }) =>
+          !decision.approved &&
+          decision.mode === 'cancel' &&
+          decision.decidedBy === 'deterministic_rails' &&
+          decision.reason ===
+            'Autonomous runs decide deterministically: mcp__crm__update_record has no declared grant.' &&
+          // The worker-asserted low/benign claim must never survive: either
+          // trusted rail risk replaced it, or the fields were stripped.
+          decision.risk_level !== 'low' &&
+          decision.risk_category !== 'benign',
+      );
     } finally {
       unregisterPermissionRunRestriction({
         sourceAgentFolder: 'main_agent',

--- a/apps/core/test/unit/runtime/ipc-permission-classifier-decision.test.ts
+++ b/apps/core/test/unit/runtime/ipc-permission-classifier-decision.test.ts
@@ -7,7 +7,9 @@ import type {
 } from '@core/domain/types.js';
 import type { PermissionDecisionMemoryRepository } from '@core/domain/ports/permission-decision-memory.js';
 import { resolveWorkspaceFolderPath } from '@core/platform/workspace-folder.js';
+import { registerWorkerPermissionRunRestriction } from '@core/runtime/agent-spawn-permission-run-restriction.js';
 import { resolvePermissionIpcDecision } from '@core/runtime/ipc-permission-classifier-decision.js';
+import { unregisterPermissionRunRestriction } from '@core/runtime/permission-decision-coordinator.js';
 
 async function resolveWithClassifierRisk(input: {
   toolName: string;
@@ -81,6 +83,103 @@ async function resolveWithClassifierRisk(input: {
 }
 
 describe('IPC permission classifier decision', () => {
+  it('AUTODET-1-1 > jobId requests never reach the classifier; miss is deterministic_rails terminal deny', async () => {
+    const responseKeyId = 'autodet-job-response-key';
+    const classifierConsult = vi.fn(async () => ({
+      risk_level: 'low' as const,
+      risk_category: 'benign' as const,
+      reason: 'Classifier would allow.',
+      latencyMs: 1,
+    }));
+    const getClassifierVerdict = vi.fn(async () => ({
+      decision: 'allow' as const,
+      reason: 'Cached classifier allow.',
+      risk_level: 'low' as const,
+      risk_category: 'benign' as const,
+    }));
+    const putClassifierVerdict = vi.fn(async () => undefined);
+    const requestPermissionApproval = vi.fn();
+    const deps = {
+      conversationRoutes: () => ({}),
+      requestPermissionApproval,
+      classifierConsult,
+      publishRuntimeEvent: vi.fn(async () => undefined),
+      getPermissionDecisionMemoryRepository: () => ({
+        getClassifierVerdict,
+        putClassifierVerdict,
+      }),
+      getPermissionRuntimeSettings: () => ({
+        agents: { main_agent: { permissionMode: 'auto' as const } },
+        permissions: {
+          autoMode: {},
+          trustedRoots: [resolveWorkspaceFolderPath('main_agent')],
+        },
+        memory: { llm: { models: { extractor: 'sonnet' } } },
+      }),
+    } as never;
+
+    registerWorkerPermissionRunRestriction({
+      sourceAgentFolder: 'main_agent',
+      responseKeyId,
+      hideAuthorityTools: false,
+      runKind: 'scheduled',
+      jobId: 'host-job-1',
+      runId: 'host-run-1',
+    });
+    try {
+      await expect(
+        resolvePermissionIpcDecision({
+          request: {
+            requestId: 'autodet-host-job-miss',
+            responseKeyId,
+            sourceAgentFolder: 'main_agent',
+            toolName: 'mcp__crm__update_record',
+            toolInput: { id: 'customer-1' },
+            unattended: true,
+          },
+          sourceAgentFolder: 'main_agent',
+          deps,
+        }),
+      ).resolves.toMatchObject({
+        approved: false,
+        mode: 'cancel',
+        decidedBy: 'deterministic_rails',
+        reason:
+          'Autonomous runs decide deterministically: mcp__crm__update_record has no declared grant.',
+      });
+    } finally {
+      unregisterPermissionRunRestriction({
+        sourceAgentFolder: 'main_agent',
+        responseKeyId,
+      });
+    }
+
+    expect(classifierConsult).not.toHaveBeenCalled();
+    expect(getClassifierVerdict).not.toHaveBeenCalled();
+    expect(putClassifierVerdict).not.toHaveBeenCalled();
+    expect(requestPermissionApproval).not.toHaveBeenCalled();
+
+    await expect(
+      resolvePermissionIpcDecision({
+        request: {
+          requestId: 'autodet-worker-forged-job-id',
+          sourceAgentFolder: 'main_agent',
+          jobId: 'worker-forged-job',
+          toolName: 'mcp__crm__update_record',
+          toolInput: { id: 'customer-2' },
+          unattended: true,
+        },
+        sourceAgentFolder: 'main_agent',
+        deps,
+      }),
+    ).resolves.toMatchObject({
+      approved: true,
+      decidedBy: 'cached_classifier_verdict',
+    });
+    expect(getClassifierVerdict).toHaveBeenCalledOnce();
+    expect(classifierConsult).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['destructive', 'rm -rf ./build', 'destructive'],
     ['credential', 'cat ~/.ssh/id_rsa', 'secret'],

--- a/apps/core/test/unit/runtime/permission-decision-coordinator.test.ts
+++ b/apps/core/test/unit/runtime/permission-decision-coordinator.test.ts
@@ -43,6 +43,89 @@ const reviewedAllow: ToolPolicyDecision = {
 };
 
 describe('coordinatePermissionDecision', () => {
+  it('AUTODET-1-1 > host allow records host match reason; worker no-match text is diagnostic only', async () => {
+    const hostRequest = {
+      ...request,
+      decisionReason: 'Tool not on autonomous run allowlist: FileRead.',
+    };
+
+    await expect(
+      coordinatePermissionDecision({
+        request: hostRequest,
+        reviewedRuleDecision: reviewedAllow,
+        tail: vi.fn(),
+      }),
+    ).resolves.toMatchObject({
+      approved: true,
+      decidedBy: 'reviewed_rule',
+      reason: reviewedAllow.reason,
+    });
+    expect(hostRequest.decisionReason).toBe(reviewedAllow.reason);
+
+    const responseKeyId = 'autodet-reviewed-rule-response-key';
+    registerWorkerPermissionRunRestriction({
+      sourceAgentFolder: 'main_agent',
+      responseKeyId,
+      hideAuthorityTools: false,
+      runKind: 'scheduled',
+      jobId: 'job-1',
+      runId: 'run-1',
+    });
+    const workerMiss = 'Worker found no local autonomous rule.';
+    const ipcRequest = {
+      requestId: 'autodet-reviewed-rule-allow',
+      responseKeyId,
+      sourceAgentFolder: 'main_agent',
+      appId: 'default',
+      agentId: 'agent:test',
+      toolName: 'mcp__gantry__send_message',
+      toolInput: { text: 'status' },
+      decisionReason: workerMiss,
+      unattended: true,
+    };
+    try {
+      const decision = await resolvePermissionIpcDecision({
+        request: ipcRequest,
+        sourceAgentFolder: 'main_agent',
+        deps: {
+          conversationRoutes: () => ({}),
+          requestPermissionApproval: vi.fn(),
+          getToolRepository: () => ({
+            listAgentToolBindings: vi.fn(async () => [
+              {
+                status: 'active',
+                toolId: 'tool:send-message',
+                personId: null,
+              },
+            ]),
+            getTool: vi.fn(async () => ({
+              appId: 'default',
+              name: 'mcp__gantry__send_message',
+            })),
+          }),
+          getPermissionRuntimeSettings: () => ({
+            agents: { main_agent: { permissionMode: 'auto' as const } },
+            permissions: { autoMode: {}, trustedRoots: [] },
+            memory: { llm: { models: { extractor: 'sonnet' } } },
+          }),
+        } as never,
+      });
+
+      expect(decision).toMatchObject({
+        approved: true,
+        decidedBy: 'reviewed_rule',
+        reason: 'Allowed by autonomous tool rule mcp__gantry__send_message.',
+      });
+      expect(ipcRequest.decisionReason).toBe(decision.reason);
+      expect(ipcRequest.decisionReason).not.toBe(workerMiss);
+    } finally {
+      unregisterPermissionRunRestriction({
+        sourceAgentFolder: 'main_agent',
+        responseKeyId,
+      });
+    }
+  });
+
   it('never promotes a human decision whose approverRef collides with a machine decider', async () => {
     const { decisionForMode } =
       await import('@core/domain/permission-decision.js');

--- a/docs/architecture/autonomous-jobs.md
+++ b/docs/architecture/autonomous-jobs.md
@@ -75,9 +75,11 @@ must not start arbitrary MCP servers as a readiness side effect.
 ## Execution
 
 Scheduled job execution keeps protected capability and memory guards active
-before autonomous allowance. Eligible `auto`/`auto_strict` requests get a
-bounded classifier decision, but a request that still needs a human cannot hold
-the unattended runner indefinitely. The job enters the setup-required recovery
+before autonomous allowance. Per
+[decision 0121](../decisions/0121-autodet-no-classifier-autonomous.md), a
+host-verified `jobId` makes the permission path deterministic: reviewed agent
+authority allows, while a miss becomes a terminal denial without consulting
+the classifier or its verdict cache. The job enters the setup-required recovery
 path and delivers its approval through the existing job/source-conversation
 route. The current implementation releases the old lease and schedules new
 work after approval; same-fenced-run tool-call resume and explicit

--- a/docs/architecture/capability-management.md
+++ b/docs/architecture/capability-management.md
@@ -396,7 +396,7 @@ permissions:
     model: haiku # optional; defaults to the memory extractor slot model
 ```
 
-The full worker IPC order is:
+For interactive runs, the full worker IPC order is:
 
 ```text
 hard deny -> locked preset -> fixed image -> reviewed agent rule/capability
@@ -473,6 +473,12 @@ decision-memory repository. Inline third-party MCP uses the host coordinator
 and classifier without the cache. Core-tool paths use the same hard precedence
 and durable human interaction but do not all invoke classifier or cache.
 
+Autonomous runs are the explicit exception. Per
+[decision 0121](../decisions/0121-autodet-no-classifier-autonomous.md), a
+host-verified `jobId` skips both cached classifier verdicts and classifier
+consultation. Reviewed agent authority still allows; a miss deterministically
+denies and enters the existing setup-pause approval flow.
+
 Conversation-level data exposure is governed by Agent Access and the
 channel's approver configuration, not by this gate: whoever may converse
 with an agent may receive what its granted capabilities can already read.
@@ -485,10 +491,10 @@ Every classifier consultation verdict (including failure-coded asks) is publishe
 `permission.classifier_decision` runtime event, so the audit trail is
 complete and queryable.
 
-Unattended runs (scheduled jobs) get the same treatment: where a zero-timeout
-permission request used to deny immediately, an auto-mode runner waits a
-bounded classifier window; the host answers eligible requests allow-or-deny
-within it and denies ineligible ones immediately.
+Unattended runs (scheduled jobs) do not use auto-mode classification. Their
+zero-timeout tool call is answered from deterministic host authority: a
+reviewed-rule match allows, and a miss denies terminally so the job can pause
+and request a durable grant.
 
 Promotion is based only on explicitly human-attributed approvals; classifier
 auto-allows and system-generated decisions never increment the counter. After

--- a/docs/decisions/0121-autodet-no-classifier-autonomous.md
+++ b/docs/decisions/0121-autodet-no-classifier-autonomous.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-08-11
+stories: [AUTODET-1]
+---
+
+# Autonomous Runs Decide Permissions Deterministically — Classifier Is Interactive-Only
+
+## Context
+
+On a scheduled (jobId-bearing) run, a tool call that misses the host's
+reviewed rules fell through to the auto-mode classifier. The classifier's
+"allow" rescued the call non-deterministically (`decidedBy: auto_classifier` —
+45 RunCommand survivals in production logs); its "ask" is unanswerable on an
+autonomous run, so the runtime cancelled it — a terminal denial (0115) that
+paused the job with a card. The same granted `send_message` call was cancelled
+at 08:53 and allowed at 10:01 on 2026-08-11 (KnackLabs Lead Maintenance).
+A permission decision that depends on a model's judgment call cannot be part
+of an unattended pipeline whose "ask" has no listener. CLIRUN-1 (0120) removed
+this non-determinism for local-CLI capabilities; this decision removes it for
+every tool.
+
+## Decision
+
+An autonomous run's permission decision is a pure function of its declared
+grants. The host decision tail never consults the classifier for a
+jobId-bearing request: a reviewed-rule match allows; a miss is a deterministic
+terminal denial (typed provenance `deterministic_rails`, per 0107) routed to
+the existing pause + one grantable card (SCHED-6/CAPRULE-1). Granting from the
+card resumes the job and is permanent: granted implies matched, forever. The
+classifier remains in the interactive path only, where a human can answer its
+ask. The autonomy predicate is the host-verified run-registry jobId, never a
+worker-supplied field.
+
+## Consequences
+
+- Same job, same call, same decision, every run. The pause-on-a-granted-tool
+  class is structurally closed.
+- Calls the classifier used to luckily allow now deny until declared: at most
+  one grantable card per genuinely missing tool, then silence. Trade accepted
+  explicitly by Ravi (chat, 2026-08-11 — "Remove entirely").
+- Rejected alternative (do NOT re-propose): classifier as allow-only rescue on
+  autonomous runs — keeps ask-terminal safe but preserves
+  same-call-different-day outcomes; rejected by Ravi 2026-08-11.
+- Reconciled with 0043: the classifier's risk-only charter governs what it
+  judges; this decision narrows where it runs.
+- send_message is own-conversation-only by contract (no destination
+  parameter); a destination-bearing send tool is a separate future decision,
+  not covered here.

--- a/docs/specs/autonomous-deterministic-permissions.md
+++ b/docs/specs/autonomous-deterministic-permissions.md
@@ -1,0 +1,63 @@
+---
+slug: autonomous-deterministic-permissions
+title: Autonomous runs decide permissions deterministically
+status: confirmed
+saved: 2026-08-11T10:45:00+00:00
+---
+
+# Autonomous runs decide permissions deterministically — no classifier
+
+**Status:** confirmed — Ravi, in chat, 2026-08-11 (classifier removed entirely from autonomous runs)
+**Origin:** live incident 2026-08-11. The KnackLabs job paused at 08:53 with a
+"needs send_message access" card; the identical call at 10:01 was allowed. Log
+survey across all scheduled runs: `RunCommand` 45× allowed by `auto_classifier`
+/ 15× cancelled; `send_message` 1× allowed / 1× cancelled. Same disease
+CLIRUN-1 (decision 0120) cured for local-CLI capabilities, still live for every
+other tool.
+
+## Problem
+
+On an autonomous (scheduled) run, a tool call that misses the deterministic
+rule matcher falls through to the non-deterministic classifier. Decision 0115
+makes an autonomous "ask" terminal, so the classifier's mood decides between
+"run completes" and "job pauses with a buttonless card". A granted tool
+(`mcp__gantry__send_message` is in the job's tool list) can still pause the job
+because granted-tool state and the autonomous matcher disagree.
+
+## Outcome
+
+An autonomous run's permission decision is a pure function of its declared
+grants. Same job, same call → same decision, every run.
+
+1. **Classifier removed from the autonomous path.** Matched rule → allow.
+   No match → terminal deny with the existing grantable pause card
+   (SCHED-6/CAPRULE-1 machinery, unchanged). The classifier remains for
+   interactive runs only, where a human can answer the ask.
+2. **Granted means matched.** Any tool present in the job's effective allowed
+   tools matches the autonomous matcher — the send_message
+   granted-but-unmatched wart is impossible by construction.
+3. **send_message destination rule.** Deterministic shape: sending to the run's
+   own conversation/thread is allowed when the tool is granted; any other
+   destination requires an explicitly declared destination grant, else terminal
+   deny with card. No payload judgment.
+4. **No silent degradation.** Terminal denies keep the one-notification pause
+   card with the request_access recovery (existing behavior).
+
+## Non-goals
+
+- No change to interactive-run classification.
+- No new grant UI; the existing card/grant flow is the recovery path.
+- No revisiting 0115 (ask stays terminal on autonomous runs).
+- RunCommand leaf-rule syntax unchanged; this fixes who decides, not rule shape.
+
+## Acceptance
+
+- Replay of the 08:53 send_message call under the new engine: allowed
+  deterministically (own-thread) — no classifier invocation logged.
+- A call to an ungranted tool on an autonomous run: terminal deny + card, no
+  classifier invocation.
+- Log/event assertion: `decidedBy=auto_classifier` never appears with a
+  `jobId`-bearing run after cutover.
+- Fix-and-continue: granting from the pause card resumes the job
+  automatically; the re-run uses the grant and completes without re-asking.
+  A pause is one interruption per genuinely missing tool, never a dead end.

--- a/docs/specs/autonomous-deterministic-permissions.md
+++ b/docs/specs/autonomous-deterministic-permissions.md
@@ -13,7 +13,8 @@ saved: 2026-08-11T10:45:00+00:00
 survey across all scheduled runs: `RunCommand` 45× allowed by `auto_classifier`
 / 15× cancelled; `send_message` 1× allowed / 1× cancelled. Same disease
 CLIRUN-1 (decision 0120) cured for local-CLI capabilities, still live for every
-other tool.
+other tool. The binding auto-mode contract is recorded in
+[decision 0121](../decisions/0121-autodet-no-classifier-autonomous.md).
 
 ## Problem
 

--- a/plans/roadmap.json
+++ b/plans/roadmap.json
@@ -1124,6 +1124,25 @@
       "completed_at": "2026-08-11T09:33:53+00:00",
       "history": ".factory/history/CLIRUN-1/",
       "outcome": "Local-CLI capabilities (gog/sheets) are now invoked structurally instead of the agent hand-writing shell. The agent calls capability_run with the capability id and an argument list; the host validates the argv arity-exactly against the reviewed template, verifies the executable in place, and runs it in the existing sandbox with bounded output. No shell string exists, so pipes/redirects/chaining/globs are impossible, authorization is the deterministic granted-capability check (no flaky classifier, no autonomous terminal denial), and the RunCommand projection is retired so no shell fallback remains. This closes the class that paused KnackLabs on gog|head, for any CLI. Deep executable-identity hardening is deferred (D-0056)."
+    },
+    {
+      "key": "AUTODET-1",
+      "title": "Autonomous runs decide permissions deterministically \u2014 no classifier",
+      "story": "As an operator, my scheduled jobs never pause on a tool the job already has \u2014 the same call gets the same decision every run, and only a genuinely undeclared tool produces the one grantable pause card.",
+      "acceptance_criteria": [
+        "No autonomous-run permission decision is made by the classifier (decidedBy=auto_classifier never appears with a jobId run)",
+        "A tool in the job's effective allowed tools always matches the autonomous matcher (granted implies matched)",
+        "send_message to the run's own conversation/thread is deterministically allowed when granted; other destinations terminally deny with the grantable card",
+        "Ungranted tool on an autonomous run: terminal deny + existing pause card, no classifier invocation",
+        "Granting from the pause card resumes the job automatically; the re-run uses the grant and completes without re-asking (fix-and-continue proven end to end)"
+      ],
+      "order": 58,
+      "status": "active",
+      "epic": "permission-engine",
+      "skill": "backend",
+      "kind": "feature",
+      "depends_on": [],
+      "spec": "docs/specs/autonomous-deterministic-permissions.md"
     }
   ],
   "epics": [
@@ -1212,5 +1231,5 @@
     }
   ],
   "generated_by": "human",
-  "updated_at": "2026-08-11T09:33:53+00:00"
+  "updated_at": "2026-08-11T11:12:43+00:00"
 }

--- a/plans/roadmap.json
+++ b/plans/roadmap.json
@@ -1137,12 +1137,15 @@
         "Granting from the pause card resumes the job automatically; the re-run uses the grant and completes without re-asking (fix-and-continue proven end to end)"
       ],
       "order": 58,
-      "status": "active",
+      "status": "done",
       "epic": "permission-engine",
       "skill": "backend",
       "kind": "feature",
       "depends_on": [],
-      "spec": "docs/specs/autonomous-deterministic-permissions.md"
+      "spec": "docs/specs/autonomous-deterministic-permissions.md",
+      "completed_at": "2026-08-11T13:43:58+00:00",
+      "history": ".factory/history/AUTODET-1/",
+      "outcome": "Scheduled jobs no longer live or die by a model's mood. An autonomous run's tool permissions are now a pure function of what the job was granted: a granted tool always runs, an ungranted one pauses the job once with a single grant card, and tapping Allow resumes the job permanently - the same call gets the same answer every run. The classifier that used to coin-flip these decisions (45 lucky allows, 15 dead jobs in the logs, including the KnackLabs send_message pause) now serves interactive chats only, where a human can actually answer its ask. Decision 0121 pins the contract; the whole loop is proven end to end on live Postgres."
     }
   ],
   "epics": [
@@ -1231,5 +1234,5 @@
     }
   ],
   "generated_by": "human",
-  "updated_at": "2026-08-11T11:12:43+00:00"
+  "updated_at": "2026-08-11T13:43:58+00:00"
 }


### PR DESCRIPTION
## What this does

Scheduled jobs no longer live or die by a model's mood. An autonomous run's tool permissions are now a pure function of what the job was granted: a granted tool always runs, an ungranted one pauses the job **once** with a single grant card, and tapping Allow resumes the job permanently — the same call gets the same answer every run.

## Why

The permission classifier sat in the scheduled-run decision path, and its "ask" is unanswerable on an autonomous run (decision 0115 makes it a terminal, buttonless pause). Production logs: **45 RunCommands survived on classifier luck, 15 calls killed jobs** — including the KnackLabs Lead Maintenance job's `send_message`, which was cancelled at 08:53 and allowed at 10:01 on the same day for the identical call. CLIRUN-1 (0120) cured this class for local CLIs; this finishes the job for every tool. Ravi rejected the "classifier as allow-only rescue" alternative explicitly — pinned in decision 0121 so it never gets re-proposed.

## The change (one seam)

- **Host tail guard** (`ipc-permission-classifier-decision.ts`): a host-verified jobId — from the run registry via `responseKeyId`, never the worker-supplied field — selects autonomous rules, bypasses live **and cached** classifier verdicts, and turns a reviewed-rule miss into a deterministic terminal denial (`decidedBy: deterministic_rails`) with a grant-naming reason. A forged worker jobId cannot trigger autonomous behavior; an omitted one cannot escape it.
- **Truthful attribution** (`permission-decision-coordinator.ts`): reviewed-rule allows now record the host's match reason instead of the worker's local-miss diagnostic (the confusing "allowed, but no rule matched" pairing is gone).
- **Review hardening**: worker-asserted `risk_level`/`risk_category` are stripped from autonomous denials unless host-derived rail risk replaces them — untrusted low/benign claims can no longer reach the audit trail or grant cards.
- Downstream is untouched: the SCHED-6/CAPRULE-1 pause + one-card + grant + resume machinery is reused as-is. Interactive chats keep the classifier unchanged.

## Proof

- Guard unit lanes (both runner lanes: anthropic gate + DeepAgents facade/shell), cache/classifier bypass, forged-jobId, reason attribution: green.
- **Fix-and-continue proven end to end on live Postgres**: deny → pause + one card → persistent grant through the real durable-interaction machinery → readiness resume → reviewed-rule allow → completion, with zero `auto_classifier` provenance and no second card.
- Full `verify.py` green (post-fix), whole-branch autoreview clean (2 rounds; round 1 found the risk-metadata leak, fixed above).

## Notes

- `send_message` destinations: the tool has no destination parameter — own-conversation-only by construction, so the spec's destination-grant clause is satisfied by construction; a destination-bearing send tool is a named future decision.
- Follow-up worth a look (recorded in review evidence): `execution-readiness` silently evaluates with `deps.getToolRepository?.()` — an absent repository reads as "no bindings" instead of failing loudly; this cost three debugging rounds in the integration proof.
- Expected behavior shift: calls the classifier used to luckily allow now deny until declared — at most one grantable card each, then determinism (trade accepted by Ravi, 2026-08-11).

Decision: `docs/decisions/0121-autodet-no-classifier-autonomous.md` · Spec: `docs/specs/autonomous-deterministic-permissions.md`
