### PR TITLE
Recovery-proposal tools are birthright — the agent can always ask (0123)

### DIFF
--- a/apps/core/src/domain/permission-deterministic-rails.ts
+++ b/apps/core/src/domain/permission-deterministic-rails.ts
@@ -88,6 +88,18 @@ const GANTRY_INPUT_GATED_BIRTHRIGHT_TOOLS = new Set([
   'procedure_save',
   'task_cancel',
   'task_message',
+  // Human-gated recovery proposals (0052 as amended by 0123, Ravi 2026-08-12:
+  // system tools never need approval). These tools only create review
+  // metadata — every effect requires an authenticated human decision — so
+  // gating them deadlocks recovery: the CAPFIX-1 amendment card could never
+  // be raised by the autonomous runs that need it. Input-gated: complete,
+  // inspectable inputs pass; redacted/truncated inputs still fail closed.
+  // They remain EXCLUDED from durable exact-tool grants (admin-mcp-tools).
+  'request_access',
+  'request_skill_install',
+  'request_skill_proposal',
+  'request_skill_dependency_install',
+  'request_mcp_server',
 ]);
 const DESTRUCTIVE_EXECUTABLE =
   /^(?:dd|mkfs(?:\..+)?|rm|rmdir|shred|truncate|unlink)$/;

--- a/apps/core/test/unit/bootstrap/inline-agent-loop-tools.test.ts
+++ b/apps/core/test/unit/bootstrap/inline-agent-loop-tools.test.ts
@@ -1249,8 +1249,10 @@ describe('inline core tool bootstrap', () => {
 
   it.each([
     ['ask', 'mcp__crm__read'],
-    ['auto', 'mcp__gantry__request_access'],
-    ['auto_strict', 'mcp__gantry__request_access'],
+    // request_access moved to input-gated birthright (0123); tool_consent
+    // stays on the ladder (0052) and keeps this test's intent.
+    ['auto', 'mcp__gantry__tool_consent'],
+    ['auto_strict', 'mcp__gantry__tool_consent'],
   ] as const)(
     'does not consult in mode %s for ineligible/non-auto tool %s',
     async (permissionMode, toolName) => {

--- a/apps/core/test/unit/shared/permission-deterministic-rails.test.ts
+++ b/apps/core/test/unit/shared/permission-deterministic-rails.test.ts
@@ -839,7 +839,6 @@ describe('permission deterministic rails', () => {
     'mcp__gantry__async_run_command',
     'mcp__gantry__async_mcp_call',
     'mcp__gantry__delegate_task',
-    'mcp__gantry__request_access',
     'mcp__gantry__tool_consent',
     'mcp__gantry__scheduler_upsert_job',
     'mcp__gantry__scheduler_update_job',
@@ -861,6 +860,40 @@ describe('permission deterministic rails', () => {
         evaluatePermissionDeterministicRails({
           request: request('unused', {
             toolName,
+            toolInput: undefined,
+          }),
+        }),
+      ).toMatchObject({ railOutcome: 'ask' });
+    },
+  );
+
+  it.each([
+    'request_access',
+    'request_skill_install',
+    'request_skill_proposal',
+    'request_skill_dependency_install',
+    'request_mcp_server',
+  ])(
+    'human-gated recovery proposal %s is input-gated birthright (0052 as amended)',
+    (tool) => {
+      // Complete, inspectable input: birthright — these tools only create
+      // review metadata; every effect requires a human decision.
+      expect(
+        evaluatePermissionDeterministicRails({
+          request: request('unused', {
+            toolName: `mcp__gantry__${tool}`,
+            toolInput: {
+              target: { kind: 'capability', id: 'google.sheets.values.get' },
+              reason: 'recovery',
+            },
+          }),
+        }),
+      ).toMatchObject({ railOutcome: 'allow', decidedBy: 'birthright' });
+      // Missing/redacted input still fails closed.
+      expect(
+        evaluatePermissionDeterministicRails({
+          request: request('unused', {
+            toolName: `mcp__gantry__${tool}`,
             toolInput: undefined,
           }),
         }),

--- a/docs/decisions/0052-birthright-self-surface.md
+++ b/docs/decisions/0052-birthright-self-surface.md
@@ -40,8 +40,15 @@ safely to an ask only on concealed input.
 ## Consequences
 - External/side-effecting tools (`mcp_call_tool`, `async_run_command`,
   `async_mcp_call`, `delegate_task`, `RunCommand`, `FileWrite/Edit`, `file`,
-  `AgentDelegation`) and requests/consents (`request_*`, `*_consent`,
+  `AgentDelegation`) and consents (`*_consent`,
   `pattern_candidate_decision`) STAY on the ladder — unchanged.
+- AMENDED by 0123 (2026-08-12): the five human-gated recovery-proposal tools
+  (`request_access`, `request_skill_install`, `request_skill_proposal`,
+  `request_skill_dependency_install`, `request_mcp_server`) moved to the
+  input-gated birthright set — they only create review metadata, every effect
+  requires a human decision, and gating them deadlocked the CAPFIX-1
+  amendment card on the runs that needed it. Other `request_*`/consent tools
+  stay laddered.
 - The birthright set supersedes `BENIGN_GANTRY_MCP_TOOLS` (a subset); the
   redaction-gated benign shortcut is removed.
 - Memory/brain content-safety stays in the existing memory-review, NOT the

--- a/docs/decisions/0123-recovery-proposal-birthright.md
+++ b/docs/decisions/0123-recovery-proposal-birthright.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-08-12
+stories: [CAPFIX-1]
+---
+
+# Human-Gated Recovery Proposals Are Birthright — System Tools Never Need Approval
+
+## Context
+
+Live incident, 2026-08-12: the first real CAPFIX-1 amendment card was never
+raised. The KnackLabs job hit the sheets template mismatch, followed the
+guidance to propose an amendment via `request_access` — and that tool call was
+itself terminally denied by the AUTODET-1 deterministic gate (0121), because
+0052 deliberately left all `request_*` tools on the permission ladder and
+CAPFIX-1 never reconciled the collision. Worse, the resulting pause card was
+buttonless: exact tool grants for `request_access` are (rightly) refused as
+durable authority, so the recovery classifier marked the blocker
+non-grantable. The tool that asks for fixes needed a fix nobody could grant.
+Ravi's ruling in chat: "System tools should never be needed for approval.
+What's the point if the agent needs to ask for approval for its own tools."
+
+## Decision
+
+The five human-gated recovery-proposal tools — `request_access`,
+`request_skill_install`, `request_skill_proposal`,
+`request_skill_dependency_install`, `request_mcp_server` — are INPUT-GATED
+BIRTHRIGHT on every run, interactive and autonomous (added to the 0052
+input-gated set in permission-deterministic-rails). Rationale: these tools
+only create review metadata; every effect requires an authenticated human
+decision, so the human decision IS the authority and pre-gating the ask is a
+deadlock by construction. Input-gating is retained: complete, inspectable
+inputs pass; redacted/truncated inputs still fail closed.
+
+Explicitly unchanged:
+- These tools remain EXCLUDED from durable exact-tool grants
+  (admin-mcp-tools): birthright at decision time, never a grantable
+  authority.
+- 0115 (autonomous denial terminal), 0121 (no classifier on autonomous runs),
+  and 0122 (amendment card) all stand — this decision is what makes 0122
+  reachable from the runs that need it.
+- Fixed-image/locked-agent tool hiding and the yolo denylist still apply.
+
+## Consequences
+
+- Autonomous runs can always ASK: template amendments, skill installs, MCP
+  server requests all surface as human cards instead of buttonless dead ends.
+- Amends 0052: its "all request_* tools stay on the ladder" clause is
+  superseded for exactly this five-tool set; the input-independent birthright
+  list is unchanged.
+- Rejected alternatives (do NOT re-propose): durable exact-tool grants for
+  recovery tools; unconditional input-independent birthright (loses the
+  fail-closed redaction guard); reviving the autonomous classifier for them.
+- Follow-up (CAPFIX-2 scope): the job-lifecycle e2e should drive the real
+  mismatch → request_access → card path end to end.

--- a/docs/specs/capability-version-bump-card.md
+++ b/docs/specs/capability-version-bump-card.md
@@ -1,0 +1,66 @@
+---
+slug: capability-version-bump-card
+title: Capability executable update via grantable card
+status: confirmed
+saved: 2026-08-12T04:00:00+00:00
+---
+
+# Capability executable update via grantable card
+
+**Status:** confirmed — Ravi, in chat, 2026-08-12 ("merge and take it as next")
+**Origin:** CAPFIX-1 (decision 0122) deliberately excluded executable identity
+(path/hash/version) from the amendment card — binary changes stay a separate
+deliberate re-review. But every `brew upgrade gog` changes the binary hash, so
+each upgrade fails EVERY capability on that executable closed with no recovery
+surface. This is a when, not an if: the guaranteed next breakage class.
+
+## Problem
+
+`capability_run` verifies the executable's bytes against the pinned
+`executableHash` (0120) and fails closed on mismatch — correct, but today the
+only fix is operator surgery. The agent cannot ask, the human cannot approve,
+and every scheduled job using that executable produces nothing until someone
+edits the catalog by hand.
+
+## Outcome
+
+The CAPFIX-1 pattern applied to executable identity:
+
+1. **Agent-raised update proposal** on an `executable_identity_mismatch`
+   rejection (new `request_access` target kind): capabilityId + the observed
+   current hash/version of the on-disk binary as evidence. The host verifies
+   the binary itself (same in-place identity checks as invocation: outside the
+   agent-writable root, not group/other-writable, hash of real bytes) — the
+   agent's claim is never trusted.
+2. **Plain-language card, stronger framing than a template fix**: "The tool
+   behind Google Sheets was updated on this machine (v0.9.0 → v0.10.0).
+   Approving trusts the new version for everything this capability already
+   does." Can/cannot restated; buttons "Trust update" / "Deny". Technical
+   delta (old/new hash, version strings, path) in the collapsed full view.
+3. **Approval performs a CAS identity update** for ALL capabilities pinned to
+   that executable path in one approval (one upgrade = one card, not one per
+   capability), templates untouched, provenance + prior identity in the same
+   amendment-history mechanism.
+4. **Fix-and-continue**: blocked jobs resume; deny is terminal per observed
+   hash (a further upgrade proposes again).
+
+## Non-goals
+
+- No automatic trust of new binaries under any condition.
+- No template changes through this card (CAPFIX-1 owns those; a combined
+  upgrade+reshape lands as two cards).
+- No downgrade special-casing: any hash change is the same flow.
+- No package-manager integration; the trigger is the invocation-time mismatch.
+
+## Acceptance
+
+- Live proof: upgrade (or reinstall) `gog`, trigger a sheets job → one card
+  covering all three sheets capabilities → approve → jobs resume and write
+  leads; a second upgrade repeats the flow.
+- Host-verified evidence only: a forged hash/version in the proposal is
+  ignored; the card shows what the HOST measured on disk.
+- Deny is terminal per (executablePath, observed hash) until the binary
+  changes again; timeouts/system outcomes leave pending and redispatch.
+- One card per executable per upgrade, regardless of capability count.
+- Card body contains no hashes/paths (collapsed details only); a non-technical
+  reader decides from the version framing alone.


### PR DESCRIPTION
## What this does

The agent can now always **ask** — on any run. The five recovery-proposal tools (`request_access`, `request_skill_install`, `request_skill_proposal`, `request_skill_dependency_install`, `request_mcp_server`) become input-gated birthright: they only create review metadata, every effect requires an authenticated human decision, so the human decision IS the authority and pre-gating the ask was a deadlock by construction.

## Why (live incident, this morning)

The first real CAPFIX-1 amendment card was never raised. The KnackLabs job hit its sheets template mismatch, correctly tried to propose the fix via `request_access` — and that call was terminally denied by the AUTODET-1 deterministic gate, because decision 0052 deliberately left all `request_*` tools on the permission ladder and CAPFIX-1 never reconciled the collision. The pause card was buttonless on top: exact grants for `request_access` are (rightly) refused as durable authority, so the blocker rendered as prose with no Approve. The tool that asks for fixes needed a fix nobody could grant. Ravi's ruling: **system tools should never need approval.**

## The change

- One set-membership change in `permission-deterministic-rails.ts`: the five tools join the existing input-gated birthright set (same mechanism as `send_message`/`todo_update`/`memory_save`): complete, inspectable inputs → birthright allow; redacted/truncated inputs still fail closed.
- Explicitly unchanged: no durable exact-tool grants for these tools, no classifier revival, 0115/0121/0122 all stand, fixed-image hiding and the yolo denylist still apply.
- Decision `0123` records the ruling and the rejected alternatives; `0052` carries the amendment note.

## Proof

- Rails unit table: all five tools allow with complete input, ask on missing/redacted input; the old non-birthright expectation removed only for `request_access`.
- 173 permission-related unit files green; typecheck + architecture green; autoreview clean first pass (0.91).
- Live proof after merge: re-run the KnackLabs job → the amendment card finally reaches Telegram with Approve fix / Deny.

Decision: `docs/decisions/0123-recovery-proposal-birthright.md`
