### PR TITLE
Projection: recovery proposals visible to no-permission workers (0123 part 2)

### DIFF
--- a/apps/core/src/adapters/llm/anthropic-claude-agent/agent-capabilities.ts
+++ b/apps/core/src/adapters/llm/anthropic-claude-agent/agent-capabilities.ts
@@ -133,6 +133,7 @@ const RUNNER_SUPPRESSED_GANTRY_MCP_TOOL_NAME_SET = new Set<string>([
 function gantryMcpAllowedTools(input: {
   configuredTools?: readonly string[];
   hideAuthorityTools?: boolean;
+  accessPreset?: string;
   asyncTaskToolsEnabled?: boolean;
   memoryReviewerIsControlApprover?: boolean;
   callableAgentManifest?: readonly CallableAgentToolManifestEntry[];
@@ -142,6 +143,10 @@ function gantryMcpAllowedTools(input: {
   const selectedNames = new Set(
     selectedGantryMcpToolNames(input.configuredTools ?? [], {
       excludeAuthorityTools: input.hideAuthorityTools === true,
+      // Fixed-image hiding must not strip the birthright recovery proposals
+      // (0123); the locked preset routes through the locked base set instead.
+      keepRecoveryProposals:
+        input.hideAuthorityTools === true && input.accessPreset !== 'locked',
       asyncTaskToolsEnabled: input.asyncTaskToolsEnabled === true,
       memoryReviewerIsControlApprover:
         input.memoryReviewerIsControlApprover === true,
@@ -175,6 +180,7 @@ function gantryMcpAllowedTools(input: {
 function defaultAllowedTools(input: {
   configuredTools?: readonly string[];
   hideAuthorityTools?: boolean;
+  accessPreset?: string;
   asyncTaskToolsEnabled?: boolean;
   memoryReviewerIsControlApprover?: boolean;
   callableAgentManifest?: readonly CallableAgentToolManifestEntry[];
@@ -236,6 +242,7 @@ const sdkToolsProvider: AgentCapabilityProvider = {
               ...defaultAllowedTools({
                 configuredTools: ctx.configuredAllowedTools,
                 hideAuthorityTools: ctx.hideAuthorityTools,
+                accessPreset: ctx.accessPreset,
                 asyncTaskToolsEnabled: ctx.asyncTaskToolsEnabled,
                 memoryReviewerIsControlApprover:
                   ctx.memoryReviewerIsControlApprover,
@@ -247,6 +254,7 @@ const sdkToolsProvider: AgentCapabilityProvider = {
           : defaultAllowedTools({
               configuredTools: ctx.configuredAllowedTools,
               hideAuthorityTools: ctx.hideAuthorityTools,
+              accessPreset: ctx.accessPreset,
               asyncTaskToolsEnabled: ctx.asyncTaskToolsEnabled,
               memoryReviewerIsControlApprover:
                 ctx.memoryReviewerIsControlApprover,

--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-mcp-env.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/gantry-mcp-env.ts
@@ -65,6 +65,11 @@ export function buildGantryMcpProjection(
     input.configuredAllowedTools,
     {
       excludeAuthorityTools: input.hideAuthorityTools,
+      // 0123: birthright recovery proposals stay visible to no-permission
+      // workers; locked agents never see them.
+      keepRecoveryProposals:
+        input.hideAuthorityTools === true &&
+        env.GANTRY_AGENT_ACCESS_PRESET !== 'locked',
       memoryReviewerIsControlApprover,
       asyncTaskToolsEnabled,
       chatJid: env.GANTRY_CHAT_JID,
@@ -95,6 +100,11 @@ export function buildGantryMcpProjection(
     input.configuredAllowedTools,
     {
       excludeAuthorityTools: input.hideAuthorityTools,
+      // 0123: birthright recovery proposals stay visible to no-permission
+      // workers; locked agents never see them.
+      keepRecoveryProposals:
+        input.hideAuthorityTools === true &&
+        env.GANTRY_AGENT_ACCESS_PRESET !== 'locked',
       memoryReviewerIsControlApprover,
       asyncTaskToolsEnabled,
     },

--- a/apps/core/src/runner/gantry-mcp-tool-surface.ts
+++ b/apps/core/src/runner/gantry-mcp-tool-surface.ts
@@ -3,6 +3,7 @@ import {
   ALL_GANTRY_MCP_TOOL_NAMES,
   ASYNC_TASK_GANTRY_MCP_TOOL_NAMES,
   AUTHORITY_CHANGING_GANTRY_MCP_TOOL_NAMES,
+  RECOVERY_PROPOSAL_GANTRY_MCP_TOOL_NAMES,
   BASELINE_GANTRY_MCP_TOOL_NAMES,
   DEFAULT_GANTRY_MCP_TOOL_NAMES,
   DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES,
@@ -79,6 +80,10 @@ export interface GantryMcpToolSelectionOptions extends MemoryIpcActionSelectionO
   asyncTaskToolsEnabled?: boolean;
   chatJid?: string;
   permissionLane?: 'interactive' | 'autonomous';
+  // Fixed-image (no-permission) workers keep the birthright recovery
+  // proposals visible (0123); LOCKED agents never set this — locked means
+  // never raising an approval prompt.
+  keepRecoveryProposals?: boolean;
 }
 
 export function gantryMcpFullToolName(toolName: string): string {
@@ -133,6 +138,15 @@ export function selectedGantryMcpToolNames(
     }
     for (const toolName of ADMIN_MCP_TOOL_NAMES) {
       names.delete(toolName);
+    }
+    if (options.keepRecoveryProposals) {
+      // Recovery proposals stay visible (0123): birthright review-metadata
+      // tools raise no worker-side prompt, and hiding them leaves autonomous
+      // runs unable to ask for fixes (the CAPFIX-1 card could never be
+      // raised). Locked agents never pass this flag.
+      for (const toolName of RECOVERY_PROPOSAL_GANTRY_MCP_TOOL_NAMES) {
+        names.add(toolName);
+      }
     }
   }
   if (options.permissionLane === 'autonomous') {

--- a/apps/core/src/shared/admin-mcp-tools.ts
+++ b/apps/core/src/shared/admin-mcp-tools.ts
@@ -109,6 +109,19 @@ export const DELEGATED_TASK_GANTRY_MCP_TOOL_NAMES = [
   'task_message',
 ] as const;
 
+// Human-gated recovery proposals (decision 0123): these tools only create
+// review metadata — every effect requires an authenticated human decision —
+// so they are input-gated birthright and must stay VISIBLE to no-permission
+// (fixed-image) workers, or autonomous runs cannot ask for fixes. Locked
+// agents still hide them: locked means never raising an approval prompt.
+export const RECOVERY_PROPOSAL_GANTRY_MCP_TOOL_NAMES = [
+  'request_access',
+  'request_skill_install',
+  'request_skill_proposal',
+  'request_skill_dependency_install',
+  'request_mcp_server',
+] as const;
+
 // A tool is excluded from durable grants if granting it durably would let the
 // agent change what it or another agent is permitted to do, alter runtime
 // configuration or topology, or restart the service. The canonical tool-name

--- a/apps/core/test/unit/adapters/deepagents-gantry-mcp-env.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-gantry-mcp-env.test.ts
@@ -160,7 +160,7 @@ describe('buildGantryMcpProjection', () => {
     expect(projection.env.GANTRY_BROWSER_IPC_AUTH_TOKEN).toBeUndefined();
   });
 
-  it('drops authority-changing request tools when hideAuthorityTools is set', () => {
+  it('keeps birthright recovery proposals visible when hideAuthorityTools is set (0123)', () => {
     const open = buildGantryMcpProjection({
       configuredAllowedTools: [],
       hideAuthorityTools: false,
@@ -172,7 +172,22 @@ describe('buildGantryMcpProjection', () => {
       processEnv: BASE_ENV,
     });
     expect(open.selectedToolNames).toContain('request_access');
-    expect(hidden.selectedToolNames).not.toContain('request_access');
-    expect(hidden.selectedToolNames).not.toContain('request_mcp_server');
+    // Recovery proposals only create review metadata — hiding them left
+    // autonomous runs unable to ask for fixes. Other authority tools stay hidden.
+    expect(hidden.selectedToolNames).toContain('request_access');
+    expect(hidden.selectedToolNames).toContain('request_mcp_server');
+    expect(hidden.selectedToolNames).not.toContain(
+      'request_agent_profile_update',
+    );
+    expect(hidden.selectedToolNames).not.toContain('request_settings_update');
+  });
+
+  it('locked agents still hide recovery proposals', () => {
+    const locked = buildGantryMcpProjection({
+      configuredAllowedTools: [],
+      hideAuthorityTools: true,
+      processEnv: { ...BASE_ENV, GANTRY_AGENT_ACCESS_PRESET: 'locked' },
+    });
+    expect(locked.selectedToolNames).not.toContain('request_access');
   });
 });

--- a/apps/core/test/unit/runner/agent-capabilities.test.ts
+++ b/apps/core/test/unit/runner/agent-capabilities.test.ts
@@ -1038,9 +1038,7 @@ describe('agent capability composition', () => {
     ]);
     for (const toolName of NO_PERMISSION_HIDDEN_GANTRY_MCP_TOOL_NAMES) {
       if (recoveryProposals.has(toolName)) {
-        expect(profile.allowedTools).toContain(
-          gantryMcpFullToolName(toolName),
-        );
+        expect(profile.allowedTools).toContain(gantryMcpFullToolName(toolName));
         continue;
       }
       expect(profile.allowedTools).not.toContain(

--- a/apps/core/test/unit/runner/agent-capabilities.test.ts
+++ b/apps/core/test/unit/runner/agent-capabilities.test.ts
@@ -1027,8 +1027,22 @@ describe('agent capability composition', () => {
     });
 
     // Authority-changing, scheduler, and reviewed mutation tools are not
-    // projected as allowed tools.
+    // projected as allowed tools — EXCEPT the birthright recovery proposals
+    // (0123), which must stay visible or autonomous runs cannot ask for fixes.
+    const recoveryProposals = new Set<string>([
+      'request_access',
+      'request_skill_install',
+      'request_skill_proposal',
+      'request_skill_dependency_install',
+      'request_mcp_server',
+    ]);
     for (const toolName of NO_PERMISSION_HIDDEN_GANTRY_MCP_TOOL_NAMES) {
+      if (recoveryProposals.has(toolName)) {
+        expect(profile.allowedTools).toContain(
+          gantryMcpFullToolName(toolName),
+        );
+        continue;
+      }
       expect(profile.allowedTools).not.toContain(
         gantryMcpFullToolName(toolName),
       );


### PR DESCRIPTION
## What this does

Completes decision 0123. PR #413 made the five recovery-proposal tools birthright at the **permission** layer — but the fixed-image no-permission **projection** still stripped them from the tool surface, so a scheduled worker literally could not see `request_access`. Live run e0345ab9 proved it: the agent hit the sheets mismatch and could only narrate the amendment it was supposed to propose.

## The change

- The five recovery-proposal tools stay projected for hidden-authority (fixed-image) workers, on both runner lanes (anthropic SDK capabilities + DeepAgents env projection).
- Locked agents still never see them: locked means never raising an approval prompt, and the exemption is flag-gated so the locked base set is untouched.
- All other authority-changing/admin tools remain hidden exactly as before.

## Proof

- Surface + locked-surface + capabilities + DeepAgents env suites updated and green; locked strictness pinned by a new test.
- Full 651-file unit sweep green; typecheck + architecture green; autoreview clean first pass.
- Live proof after merge: re-run the KnackLabs job — the agent can finally CALL `request_access`, and the amendment card lands with buttons.

Decision: `docs/decisions/0123-recovery-proposal-birthright.md` (this is its projection half)