### PR TITLE
fix(llm): strip internal metadata before provider forwarding

### DIFF
--- a/apps/core/src/control/server/http.ts
+++ b/apps/core/src/control/server/http.ts
@@ -12,6 +12,8 @@ export type ControlRequestLogEntry = {
   appId?: string;
   modelAlias?: string;
   modelRouteId?: string;
+  correlationId?: string;
+  taskType?: string;
   requestBodyBytes?: number;
   responseBodyBytes?: number;
   clientDisconnected?: boolean;

--- a/apps/core/src/control/server/routes/llm.ts
+++ b/apps/core/src/control/server/routes/llm.ts
@@ -66,6 +66,8 @@ type ResolvedLlmRequest = {
   alias: string;
   provider: ModelProviderDefinition;
   tail: string;
+  correlationId?: string;
+  taskType?: string;
 };
 
 export async function handleLlmRoutes(
@@ -230,6 +232,10 @@ async function handleAdmittedLlmRequest(
       appId: auth.appId,
       modelAlias: resolved.alias,
       modelRouteId: resolved.entry.modelRoute.id,
+      ...(resolved.correlationId
+        ? { correlationId: resolved.correlationId }
+        : {}),
+      ...(resolved.taskType ? { taskType: resolved.taskType } : {}),
       requestBodyBytes: resolved.body.byteLength,
       ...(responseBodyBytes !== undefined ? { responseBodyBytes } : {}),
       ...(clientDisconnected ? { clientDisconnected: true } : {}),
@@ -341,6 +347,9 @@ function resolveLlmRequest(
     sendError(res, 400, 'INVALID_MODEL', compatibilityError);
     return null;
   }
+  const metadata =
+    endpoint === 'chat_completions' ? stringMetadata(body.metadata) : {};
+  if (endpoint === 'chat_completions') delete body.metadata;
   body.model = resolution.entry.modelRoute.providerModelId;
   return {
     endpoint,
@@ -348,6 +357,10 @@ function resolveLlmRequest(
     entry: resolution.entry,
     alias: resolution.alias,
     provider,
+    ...(metadata.correlation_id
+      ? { correlationId: metadata.correlation_id }
+      : {}),
+    ...(metadata.task_type ? { taskType: metadata.task_type } : {}),
     tail:
       endpoint === 'messages'
         ? '/v1/messages'
@@ -355,6 +368,15 @@ function resolveLlmRequest(
           ? '/v1/messages/count_tokens'
           : chatCompletionsTail(provider),
   };
+}
+
+function stringMetadata(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
 }
 
 function parseBody(

--- a/apps/core/test/unit/control/llm-routes.test.ts
+++ b/apps/core/test/unit/control/llm-routes.test.ts
@@ -536,6 +536,10 @@ describe('direct LLM control routes', () => {
         ],
         response_format: { type: 'json_object' },
         reasoning_effort: 'medium',
+        metadata: {
+          correlation_id: 'scrape:run-1:task-1',
+          task_type: 'manipal.scrape.normalization.full',
+        },
       },
     });
     const res = new TestResponse();
@@ -564,6 +568,13 @@ describe('direct LLM control routes', () => {
     expect(upstreamBody.tools[0].type).toBe('function');
     expect(upstreamBody.response_format).toEqual({ type: 'json_object' });
     expect(upstreamBody.reasoning_effort).toBe('medium');
+    expect(upstreamBody.metadata).toBeUndefined();
+    expect(requestLogs).toContainEqual(
+      expect.objectContaining({
+        correlationId: 'scrape:run-1:task-1',
+        taskType: 'manipal.scrape.normalization.full',
+      }),
+    );
   });
 
   it.each([

--- a/apps/core/test/unit/control/sdk-transport.test.ts
+++ b/apps/core/test/unit/control/sdk-transport.test.ts
@@ -160,6 +160,37 @@ describe('@gantry/sdk ingress signature verification', () => {
 });
 
 describe('@gantry/sdk transport', () => {
+  it('preserves array-wrapped provider errors', async () => {
+    const port = await listen((_req, res) => {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify([
+          {
+            error: {
+              code: 400,
+              status: 'INVALID_ARGUMENT',
+              message: 'Unknown name "metadata": Cannot find field.',
+            },
+          },
+        ]),
+      );
+    });
+    const client = new GantryClient({
+      apiKey: 'test-key',
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+
+    await expect(
+      client.llm.chatCompletions({
+        model: 'manipal.scrape.workspace_bucket',
+        messages: [{ role: 'user', content: 'Return JSON.' }],
+      }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      message: 'Unknown name "metadata": Cannot find field.',
+    });
+  });
+
   it('does not send an undefined content-type header for GET requests', async () => {
     const port = await listen((req, res) => {
       expect(req.method).toBe('GET');

--- a/examples/nextjs-workflows/package.json
+++ b/examples/nextjs-workflows/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@gantry/sdk": "0.7.0",
+    "@gantry/sdk": "0.7.1",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gantry/runtime",
-  "version": "1.2.52",
+  "version": "1.2.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gantry/runtime",
-      "version": "1.2.52",
+      "version": "1.2.53",
       "license": "MIT",
       "workspaces": [
         "packages/contracts",
@@ -80,7 +80,7 @@
       "name": "@gantry/example-nextjs-workflows",
       "version": "0.0.0",
       "devDependencies": {
-        "@gantry/sdk": "0.7.0",
+        "@gantry/sdk": "0.7.1",
         "@types/node": "^24.0.0",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -10505,7 +10505,7 @@
     },
     "packages/sdk": {
       "name": "@gantry/sdk",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@gantry/contracts": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gantry/runtime",
-  "version": "1.2.52",
+  "version": "1.2.53",
   "description": "Provider-neutral agent runtime. Lightweight, secure, customizable.",
   "author": "Gantry Contributors",
   "license": "MIT",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gantry/sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Node.js SDK for the Gantry runtime control API: sessions, jobs, agents, memory, webhooks, and ingress signing.",
   "author": "Gantry Contributors",
   "license": "MIT",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -92,18 +92,19 @@ export interface GantryError extends Error {
 function toError(input: unknown): GantryError {
   const fallback = new Error('Gantry request failed') as GantryError;
   fallback.code = 'UNKNOWN_ERROR';
+  const envelope = Array.isArray(input) && input.length > 0 ? input[0] : input;
   if (
-    input &&
-    typeof input === 'object' &&
-    'error' in input &&
-    input.error &&
-    typeof input.error === 'object'
+    envelope &&
+    typeof envelope === 'object' &&
+    'error' in envelope &&
+    envelope.error &&
+    typeof envelope.error === 'object'
   ) {
-    const error = input.error as Record<string, unknown>;
+    const error = envelope.error as Record<string, unknown>;
     const next = new Error(
       String(error.message || 'Gantry request failed'),
     ) as GantryError;
-    next.code = String(error.code || 'UNKNOWN_ERROR');
+    next.code = String(error.status || error.code || 'UNKNOWN_ERROR');
     next.details =
       error.details && typeof error.details === 'object'
         ? (error.details as Record<string, unknown>)


### PR DESCRIPTION
## Summary
- consume Agent.Tender correlation metadata inside Gantry and strip it before forwarding to Gemini
- preserve correlation ID and scrape task type in Gantry request logs
- preserve array-wrapped Gemini provider errors in the SDK instead of reducing them to a generic Gantry error
- bump Gantry runtime to 1.2.53 and SDK to 0.7.1

## Validation
- focused Gantry route and SDK tests: 58 passed
- SDK build passed
- local Gantry image built and direct structured Gemini request returned 200
- real headed scrape: workspace bucketing, full normalization, missing-field normalization, and CAPTCHA calls all returned 200 through Gantry

## Baseline Notes
- the target branch has unrelated existing full-suite, lint, formatting, and architecture failures; no files outside this focused fix were changed to address them.