### PR TITLE
CAPSAFE-1: prefix-wildcard CLI-command capability permissions (delete the widening machinery)

### DIFF
--- a/apps/core/src/jobs/capability-template-compiler.ts
+++ b/apps/core/src/jobs/capability-template-compiler.ts
@@ -1,7 +1,9 @@
 import { parseBashCommand } from '../shared/bash-command-parser.js';
 import { validateLocalCliCommandTemplate } from '../shared/semantic-capabilities.js';
+import { localCliCommandTemplateMatchesArgv } from '../shared/tool-rule-matcher.js';
 
 export type CapabilityTemplateCompilation =
+  | { kind: 'covered' }
   | { kind: 'instruction'; prefixMatches: number }
   | {
       kind: 'proposal';
@@ -16,7 +18,7 @@ export function compileCapabilityTemplateMismatch(input: {
   observedArgs: readonly string[];
 }): CapabilityTemplateCompilation {
   const observedArgv = [input.executablePath, ...input.observedArgs];
-  const candidates = input.commandTemplates.flatMap((template) => {
+  const parsedTemplates = input.commandTemplates.flatMap((template) => {
     const validation = validateLocalCliCommandTemplate(
       input.executablePath,
       template,
@@ -31,6 +33,22 @@ export function compileCapabilityTemplateMismatch(input: {
       return [];
     }
     const tokens = parsed.leaves[0]!.argv;
+    return [{ template, tokens }];
+  });
+
+  if (
+    parsedTemplates.some(({ template }) =>
+      localCliCommandTemplateMatchesArgv({
+        executablePath: input.executablePath,
+        template,
+        argv: observedArgv,
+      }),
+    )
+  ) {
+    return { kind: 'covered' };
+  }
+
+  const candidates = parsedTemplates.flatMap(({ tokens }) => {
     const firstNonLiteral = tokens.findIndex(
       (token, index) =>
         index > 0 && (token.includes('*') || token.startsWith('-')),
@@ -43,58 +61,62 @@ export function compileCapabilityTemplateMismatch(input: {
     ) {
       return [];
     }
-    return [{ tokens, prefixLength: literalPrefix.length }];
+    return [{ tokens }];
   });
 
   const prefixMatches = candidates.length;
-  if (prefixMatches !== 1) return { kind: 'instruction', prefixMatches };
-  const candidate = candidates[0]!;
-  if (candidate.tokens.some((token) => token.includes('*') && token !== '*')) {
+  if (prefixMatches === 0) return { kind: 'instruction', prefixMatches };
+  const proposalSets = candidates.map((candidate) =>
+    compileCandidate({
+      executablePath: input.executablePath,
+      candidate,
+      observedArgv,
+    }),
+  );
+  if (proposalSets.some((templates) => templates === null)) {
     return { kind: 'instruction', prefixMatches };
   }
-  // The reviewed template's LEADING positional wildcards — the run of `*`
-  // right after the literal subcommand prefix — are a MAXIMUM, not a required
-  // count: the observed call may supply FEWER of them and then switch to flags
-  // (or simply stop). But a wildcard that is the VALUE of a reviewed literal
-  // flag later in the template (for example the `*` in `... --account *`) is
-  // NOT optional and stays required. Match literal tokens exactly; end the
-  // leading positional run at the first observed flag or the end of the argv,
-  // so a flag-form call (for example `--values-json`) is proposed instead of
-  // dead-ending on an instruction card. Required literals and required
-  // flag-value wildcards still fall to instruction, so neither the pinned
-  // subcommand nor an already-reviewed flag's value can be shortened away.
-  let cursor = 0;
-  let sawTrailingLiteral = false;
-  for (; cursor < candidate.tokens.length; cursor += 1) {
+  const canonicalProposalSets = proposalSets.map((templates) =>
+    canonicalTemplateSet(templates!),
+  );
+  const proposedTemplates = canonicalProposalSets[0]!;
+  if (
+    canonicalProposalSets.some(
+      (templates) => !templateSetsEqual(proposedTemplates, templates),
+    )
+  ) {
+    return { kind: 'instruction', prefixMatches };
+  }
+  return { kind: 'proposal', prefixMatches, proposedTemplates, observedArgv };
+}
+
+function compileCandidate(input: {
+  executablePath: string;
+  candidate: { tokens: string[] };
+  observedArgv: readonly string[];
+}): string[] | null {
+  const { candidate, observedArgv } = input;
+  if (candidate.tokens.some((token) => token.includes('*') && token !== '*')) {
+    return null;
+  }
+  for (let cursor = 0; cursor < candidate.tokens.length; cursor += 1) {
     const pattern = candidate.tokens[cursor]!;
     const value = observedArgv[cursor];
     if (pattern === '*') {
-      if (sawTrailingLiteral) {
-        // Required value of an already-reviewed literal flag.
-        if (value === undefined || value.startsWith('-')) {
-          return { kind: 'instruction', prefixMatches };
-        }
-      } else if (value === undefined || value.startsWith('-')) {
-        // Leading positional wildcard: optional (trailing positionals are a max).
-        break;
+      // A terminal wildcard is the reviewed remainder and would have matched
+      // in the shared coverage check. Non-terminal wildcards consume exactly
+      // one non-flag argv entry; they are never optional compiler slots.
+      if (
+        cursor === candidate.tokens.length - 1 ||
+        value === undefined ||
+        value.startsWith('-')
+      ) {
+        return null;
       }
-    } else if (value === undefined || pattern !== value) {
-      return { kind: 'instruction', prefixMatches };
-    } else if (cursor >= candidate.prefixLength) {
-      // A literal matched AFTER the subcommand prefix is a reviewed flag; every
-      // wildcard that follows it is a required flag-value, not an optional
-      // trailing positional — even when no positional wildcard preceded it.
-      sawTrailingLiteral = true;
-    }
-  }
-  // A break is only legitimate on a positional wildcard: every remaining
-  // template token must itself be a positional wildcard, because a template
-  // cannot require a literal AFTER the observed call switched to flags.
-  if (candidate.tokens.slice(cursor).some((token) => token !== '*')) {
-    return { kind: 'instruction', prefixMatches };
+    } else if (value === undefined || pattern !== value) return null;
   }
 
-  const trailing = observedArgv.slice(cursor);
+  const trailing = observedArgv.slice(candidate.tokens.length);
   const positional: string[] = [];
   const flags: Array<{ name: string; value: string }> = [];
   let index = 0;
@@ -114,20 +136,20 @@ export function compileCapabilityTemplateMismatch(input: {
       !value ||
       value.startsWith('-')
     ) {
-      return { kind: 'instruction', prefixMatches };
+      return null;
     }
     flags.push({ name, value });
     index += 2;
   }
   if (positional.length === 0 && flags.length === 0) {
-    return { kind: 'instruction', prefixMatches };
+    return null;
   }
 
   // Tokens were DECODED by the parser; a bare join would silently merge a
   // quoted literal like 'named range' into two tokens and authorize a
   // different shape. Serialize every literal with safe shell quoting.
   const baseTokens = [
-    ...candidate.tokens.slice(0, cursor).map(shellQuoteToken),
+    ...candidate.tokens.map(shellQuoteToken),
     ...positional.map(() => '*'),
   ];
   const proposedTemplates = [baseTokens.join(' ')];
@@ -142,9 +164,23 @@ export function compileCapabilityTemplateMismatch(input: {
         !validateLocalCliCommandTemplate(input.executablePath, template).ok,
     )
   ) {
-    return { kind: 'instruction', prefixMatches };
+    return null;
   }
-  return { kind: 'proposal', prefixMatches, proposedTemplates, observedArgv };
+  return proposedTemplates;
+}
+
+function canonicalTemplateSet(templates: readonly string[]): string[] {
+  return [...new Set(templates.map((template) => template.trim()))].sort();
+}
+
+function templateSetsEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((template, index) => template === right[index])
+  );
 }
 
 function shellQuoteToken(token: string): string {

--- a/apps/core/src/jobs/ipc-capability-run-handler.ts
+++ b/apps/core/src/jobs/ipc-capability-run-handler.ts
@@ -83,7 +83,13 @@ export async function compileAndRecordHostCapabilityTemplateMismatch(input: {
     }),
   );
   if (compilations.some((candidate) => candidate.kind === 'covered')) {
+    // The current catalog ALREADY authorizes this argv — a concurrent amendment
+    // landed between the failed match and this read, or the mismatch was
+    // replayed. Signal the caller to RE-ATTEMPT under current authority instead
+    // of blocking the job on an administrator instruction; the action is only a
+    // defensive fallback if the re-attempt still cannot authorize.
     return {
+      covered: true as const,
       action: instructionSetupAction(
         `Ask an administrator to review the command template for capability "${input.capabilityId}".`,
       ),
@@ -261,11 +267,17 @@ const capabilityRunHandler: TaskHandler = async (context) => {
     () => deadline.abort(),
     Math.max(0, deadlineAt - Date.now()),
   );
-  try {
-    const result = await runStructuredLocalCliCapability({
+  // A template mismatch is refused BEFORE the sandbox spawns, so re-attempting
+  // a now-covered call has no double-execution risk. Capture the narrowed
+  // request identity into locals — a closure re-widens property narrowings.
+  const invocationAppId = data.appId;
+  const invocationAgentId = data.agentId;
+  const invocationConversationId = data.chatJid;
+  const runInvocation = () =>
+    runStructuredLocalCliCapability({
       repository,
-      appId: data.appId,
-      agentId: data.agentId,
+      appId: invocationAppId,
+      agentId: invocationAgentId,
       personId: restriction.memoryUserId,
       capabilityId,
       args,
@@ -274,12 +286,13 @@ const capabilityRunHandler: TaskHandler = async (context) => {
       runnerSandboxProvider,
       egressProxyUrl: gateway.proxyUrl,
       signal: deadline.signal,
-      conversationId: data.chatJid,
+      conversationId: invocationConversationId,
       threadId: data.authThreadId,
       runId: restriction.runId,
       jobId: restriction.jobId,
     });
-    acceptData('Capability command completed.', result);
+  try {
+    acceptData('Capability command completed.', await runInvocation());
   } catch (error) {
     if (error instanceof StructuredLocalCliInvocationError) {
       if (error.code === 'capability_template_mismatch') {
@@ -314,8 +327,29 @@ const capabilityRunHandler: TaskHandler = async (context) => {
             proposalRepository,
             now: new Date().toISOString(),
           });
+          if ('covered' in outcome && outcome.covered) {
+            // Race resolved: the catalog now authorizes this argv. Re-attempt
+            // once under current authority instead of blocking the job on a
+            // setup instruction.
+            try {
+              acceptData(
+                'Capability command completed.',
+                await runInvocation(),
+              );
+              return;
+            } catch (retryError) {
+              if (
+                !(retryError instanceof StructuredLocalCliInvocationError) ||
+                retryError.code !== 'capability_template_mismatch'
+              ) {
+                throw retryError;
+              }
+              // Still unauthorized after the race window: fall back to the
+              // instruction below.
+            }
+          }
           action = outcome.action;
-          if (outcome.review) {
+          if ('review' in outcome && outcome.review) {
             startCapabilityTemplateAmendmentReview({
               deps: context.deps,
               repository: proposalRepository,

--- a/apps/core/src/jobs/ipc-capability-run-handler.ts
+++ b/apps/core/src/jobs/ipc-capability-run-handler.ts
@@ -72,10 +72,9 @@ export async function compileAndRecordHostCapabilityTemplateMismatch(input: {
   const localCliBindings = (capability?.implementationBindings ?? []).filter(
     (binding) => binding.kind === 'local_cli' && binding.executablePath,
   );
-  // Exactly-one applies to the MATCHING template across the WHOLE
-  // catalog: exactly one prefix match total, and it must be eligible - a
-  // same-prefix ineligible template in a sibling binding makes the match
-  // ambiguous (review R2/R3).
+  // Prefix candidates across every local-CLI binding may converge only when
+  // all are eligible and compile to the same canonical proposal set. Any
+  // covered call, ineligible candidate, or divergent set creates no amendment.
   const compilations = localCliBindings.map((binding) =>
     compileCapabilityTemplateMismatch({
       executablePath: binding.executablePath!,
@@ -83,16 +82,36 @@ export async function compileAndRecordHostCapabilityTemplateMismatch(input: {
       observedArgs: input.observedArgs,
     }),
   );
+  if (compilations.some((candidate) => candidate.kind === 'covered')) {
+    return {
+      action: instructionSetupAction(
+        `Ask an administrator to review the command template for capability "${input.capabilityId}".`,
+      ),
+    };
+  }
   const totalPrefixMatches = compilations.reduce(
-    (sum, candidate) => sum + candidate.prefixMatches,
+    (sum, candidate) =>
+      sum + (candidate.kind === 'covered' ? 0 : candidate.prefixMatches),
     0,
   );
   const proposals = compilations.filter(
     (candidate): candidate is typeof candidate & { kind: 'proposal' } =>
       candidate.kind === 'proposal',
   );
+  const proposalPrefixMatches = proposals.reduce(
+    (sum, candidate) => sum + candidate.prefixMatches,
+    0,
+  );
+  const canonicalProposedTemplates = proposals[0]?.proposedTemplates ?? [];
+  const proposalsConverge = proposals.every((candidate) =>
+    templateSetsEqual(canonicalProposedTemplates, candidate.proposedTemplates),
+  );
   const compilation =
-    totalPrefixMatches === 1 && proposals.length === 1 ? proposals[0]! : null;
+    totalPrefixMatches > 0 &&
+    proposalPrefixMatches === totalPrefixMatches &&
+    proposalsConverge
+      ? proposals[0]!
+      : null;
   if (!compilation) {
     return {
       action: instructionSetupAction(
@@ -129,6 +148,16 @@ export async function compileAndRecordHostCapabilityTemplateMismatch(input: {
     },
     review: result.review,
   };
+}
+
+function templateSetsEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((template, index) => template === right[index])
+  );
 }
 
 const capabilityRunHandler: TaskHandler = async (context) => {

--- a/apps/core/src/jobs/structured-local-cli-invocation.ts
+++ b/apps/core/src/jobs/structured-local-cli-invocation.ts
@@ -4,8 +4,6 @@ import path from 'node:path';
 
 import { resolveAgentToolRuntimePolicy } from '../application/agents/agent-tool-runtime-rules.js';
 import type { ToolCatalogRepository } from '../domain/ports/repositories.js';
-import type { BashCommandLeaf } from '../shared/bash-command-parser.js';
-import { parseBashCommand } from '../shared/bash-command-parser.js';
 import type { SemanticCapabilityDefinition } from '../shared/semantic-capabilities.js';
 import type { RunnerSandboxProvider } from '../shared/runner-sandbox-provider.js';
 import { sanitizeOutboundLlmText } from '../shared/sensitive-material.js';
@@ -15,6 +13,7 @@ import {
   CAPABILITY_RUN_MAX_TOTAL_ARG_BYTES,
   CAPABILITY_RUN_OUTPUT_MAX_BYTES,
 } from '../shared/structured-local-cli.js';
+import { localCliCommandTemplateMatchesArgv } from '../shared/tool-rule-matcher.js';
 import { resolveHomeRelativePaths } from '../runtime/agent-spawn-runtime-policy.js';
 import {
   DEFAULT_ASYNC_COMMAND_TIMEOUT_MS,
@@ -140,13 +139,13 @@ async function resolveGrantedLocalCliInvocation(input: {
     if (binding.kind !== 'local_cli') continue;
     const executable = binding.executablePath?.trim();
     if (!executable) continue;
-    const leaf: BashCommandLeaf = {
-      argv: [executable, ...input.args],
-      commandText: '',
-      redirects: [],
-    };
+    const argv = [executable, ...input.args];
     const reviewed = (binding.commandTemplates ?? []).some((template) =>
-      structuredArgvMatchesTemplate(template, leaf.argv),
+      localCliCommandTemplateMatchesArgv({
+        executablePath: executable,
+        template,
+        argv,
+      }),
     );
     if (!reviewed) continue;
     const verifiedExecutable = await verifyImmutableExecutable(
@@ -179,7 +178,7 @@ async function resolveGrantedLocalCliInvocation(input: {
     );
   throw new StructuredLocalCliInvocationError(
     'capability_template_mismatch',
-    `Arguments are outside the reviewed pattern for capability "${capabilityId}". Reviewed args patterns: ${reviewedArgPatterns.join(' or ')}. Re-call capability_run with an args array matching one pattern ("*" = exactly one value; flags only where a pattern shows them). Never run this capability through Bash/RunCommand.`,
+    `Arguments are outside the reviewed pattern for capability "${capabilityId}". Reviewed args patterns: ${reviewedArgPatterns.join(' or ')}. Re-call capability_run with an args array matching one pattern (a terminal standalone "*" covers the remaining args; a non-terminal "*" covers one non-flag positional value). Never run this capability through Bash/RunCommand.`,
   );
 }
 
@@ -211,42 +210,6 @@ function validateStructuredArgs(args: readonly string[]): void {
 
 function invalidArgs(message: string): StructuredLocalCliInvocationError {
   return new StructuredLocalCliInvocationError('invalid_args', message);
-}
-
-// Structured argv authorization is ARITY-EXACT and positional — deliberately
-// stricter than the shell RunCommand matcher, whose trailing `*` could cover a
-// whole command suffix. Here the invocation argv must have the SAME length as
-// the reviewed template argv, each literal token must match exactly, and each
-// wildcard must match exactly ONE argument that is NOT a flag (a positional
-// wildcard can never absorb an injected `--flag`). This is the structured
-// capability boundary: the agent cannot append extra subcommands, flags, or
-// operands beyond what the reviewed template shape allows.
-function structuredArgvMatchesTemplate(
-  template: string,
-  argv: readonly string[],
-): boolean {
-  const parsed = parseBashCommand(template.trim());
-  if (!parsed.ok || parsed.leaves.length !== 1) return false;
-  const patterns = parsed.leaves[0]?.argv ?? [];
-  if (patterns.length !== argv.length) return false; // arity-exact
-  for (let index = 0; index < patterns.length; index += 1) {
-    const pattern = patterns[index] as string;
-    const value = argv[index] as string;
-    if (!globMatches(pattern, value)) return false;
-    // A non-flag pattern (literal or wildcard) must not match a flag argument,
-    // so a positional `*` cannot absorb an injected flag.
-    if (!pattern.startsWith('-') && value.startsWith('-')) return false;
-  }
-  return true;
-}
-
-function globMatches(pattern: string, value: string): boolean {
-  if (!pattern.includes('*')) return pattern === value;
-  const escaped = pattern
-    .split('*')
-    .map((part) => part.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))
-    .join('.*');
-  return new RegExp(`^${escaped}$`).test(value);
 }
 
 // Bind execution to the verified bytes, TOCTOU-safe, WITHOUT relocating the

--- a/apps/core/src/shared/capability-template-widening.ts
+++ b/apps/core/src/shared/capability-template-widening.ts
@@ -62,6 +62,10 @@ function extendsByTrailingInputsOnly(input: {
   if (current.prefix.some((token, index) => proposed.prefix[index] !== token)) {
     return false;
   }
+  // Under the local-CLI matcher a final `*` is the argv remainder, not one
+  // positional slot. Adding the first one therefore grants new authority and
+  // must receive the stronger expanded warning.
+  if (current.slotCount === 0 && proposed.slotCount > 0) return false;
   return proposed.slotCount >= current.slotCount;
 }
 

--- a/apps/core/src/shared/tool-rule-matcher.ts
+++ b/apps/core/src/shared/tool-rule-matcher.ts
@@ -554,6 +554,36 @@ export function bashScopeMatchesLeaf(
   if (patternArgs[0].includes('*')) return false;
   const argv = leafArgvForScope(patternArgs, leaf.argv);
   if (!argv) return false;
+  return argvPatternMatches(patternArgs, argv, 'one-arg');
+}
+
+export function localCliCommandTemplateMatchesArgv(input: {
+  executablePath: string;
+  template: string;
+  argv: readonly string[];
+}): boolean {
+  if (hasBashShellControlSyntax(input.template)) return false;
+  const parsedTemplate = parseBashCommand(input.template.trim());
+  if (!parsedTemplate.ok || parsedTemplate.leaves.length !== 1) return false;
+  const leaf = parsedTemplate.leaves[0];
+  if (!leaf || leaf.redirects.length > 0) return false;
+  const patternArgs = leaf.argv;
+  if (patternArgs.length < 2) return false;
+  if (patternArgs[1]?.includes('*')) return false;
+  if (
+    patternArgs[0] !== input.executablePath ||
+    input.argv[0] !== input.executablePath
+  ) {
+    return false;
+  }
+  return argvPatternMatches(patternArgs, input.argv, 'one-non-flag');
+}
+
+function argvPatternMatches(
+  patternArgs: readonly string[],
+  argv: readonly string[],
+  nonTerminalWildcard: 'one-arg' | 'one-non-flag',
+): boolean {
   const hasTrailingRestWildcard = patternArgs.at(-1) === '*';
   if (hasTrailingRestWildcard) {
     if (argv.length < patternArgs.length - 1) return false;
@@ -565,6 +595,17 @@ export function bashScopeMatchesLeaf(
     if (pattern === '*' && index === patternArgs.length - 1) return true;
     const value = argv[index];
     if (value === undefined) return false;
+    // one-non-flag (structured local CLI): a non-flag pattern — literal, bare
+    // `*`, or a mixed glob like `*foo` — must never absorb a flag argument, so
+    // an injected `--flag` cannot land in a reviewed positional slot. RunCommand
+    // (one-arg) keeps its historical flag-permissive positional behavior.
+    if (
+      nonTerminalWildcard === 'one-non-flag' &&
+      !pattern.startsWith('-') &&
+      value.startsWith('-')
+    ) {
+      return false;
+    }
     if (pattern === '*') continue;
     if (!globPatternMatches(pattern, value)) return false;
   }

--- a/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
+++ b/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
@@ -87,6 +87,7 @@ import {
   startCapabilityTemplateAmendmentReview,
 } from '@core/jobs/ipc-capability-template-amendment.js';
 import { recoverCapabilityTemplateApprovalIntents } from '@core/jobs/capability-template-approval-intent-recovery.js';
+import { compileAndRecordHostCapabilityTemplateMismatch } from '@core/jobs/ipc-capability-run-handler.js';
 import { recheckPausedSetupJobsAfterRequestAccessGrant } from '@core/jobs/request-access-job-recovery.js';
 import { runStructuredLocalCliCapability } from '@core/jobs/structured-local-cli-invocation.js';
 import { resolveWorkspaceFolderPath } from '@core/platform/workspace-folder.js';
@@ -222,7 +223,7 @@ maybeDescribe('job lifecycle (Postgres)', () => {
     schedulerEngine = undefined;
   });
 
-  it('CAPFIX-1-2 mismatch proposal card approval amends resumes and runs structured argv', async () => {
+  it('CAPSAFE-1-LIFECYCLE', async () => {
     // The fixture executable must live OUTSIDE the agent-writable workspace
     // root (which realpaths under os.tmpdir() in this harness): CLIRUN-1's
     // executable-identity guard rejects workspace-local binaries by design.
@@ -236,24 +237,29 @@ maybeDescribe('job lifecycle (Postgres)', () => {
     const executableHash = `sha256:${createHash('sha256')
       .update(executableBody)
       .digest('hex')}`;
-    const capabilityId = `google.sheets.values.get.${randomUUID()}`;
-    const otherJobId = `job:integration:capfix-other:${randomUUID()}`;
+    const capabilityId = `google.sheets.values.write.${randomUUID()}`;
+    const otherJobId = `job:integration:capsafe-other:${randomUUID()}`;
     const agentId = `agent:job_lifecycle_agent` as never;
     const toolId = `tool:capability:${capabilityId}` as never;
+    const initialTemplates = [
+      `${executable} sheets update *`,
+      `${executable} sheets append`,
+      `${executable} sheets clear`,
+    ];
     const capability = buildLocalCliSemanticCapability({
       capabilityId,
-      displayName: 'Google Sheets lead reader',
+      displayName: 'Google Sheets values writer',
       category: 'Google Sheets',
-      risk: 'read',
-      can: 'read lead rows from the selected sheet',
+      risk: 'write',
+      can: 'write values to the selected sheet',
       cannot: 'change unrelated sheets',
       executablePath: executable,
       executableVersion: '1.0.0',
       executableHash,
-      commandTemplates: [`${executable} sheets get *`],
+      commandTemplates: initialTemplates,
       authPreflightCommand: `${executable} auth status`,
     });
-    const job = makeJob(`job:integration:capfix:${randomUUID()}`, {
+    const job = makeJob(`job:integration:capsafe:${randomUUID()}`, {
       status: 'paused',
       next_run: null,
       pause_reason: 'Setup required',
@@ -284,6 +290,10 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         ],
       },
     });
+
+    const spawnInputs: Array<{ command: string; args: string[] }> = [];
+    const invocationCwds: string[] = [];
+    const valuesJson = '[["lead-1","Doe, Jane"]]';
 
     try {
       await runtime.repositories.agents.saveAgent({
@@ -321,7 +331,7 @@ maybeDescribe('job lifecycle (Postgres)', () => {
       });
       await runtime.ops.upsertJob(job);
 
-      const invoke = () => {
+      const invoke = (args: string[]) => {
         const child = new EventEmitter() as EventEmitter & {
           stdout: PassThrough;
           stderr: PassThrough;
@@ -335,20 +345,28 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         const started = new Promise<void>((resolve) => {
           child.once('spawn', resolve);
         });
+        const cwd = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'gantry-capfix-cwd-'),
+        );
+        invocationCwds.push(cwd);
         const result = runStructuredLocalCliCapability({
           repository: runtime.repositories.tools,
           appId: 'default',
           agentId,
           capabilityId,
-          args: ['sheets', 'get', 'sheet-1', 'Leads!A:B'],
+          args,
           // cwd doubles as the agent-writable root in the executable-identity
           // guard — it must NOT contain the fixture executable.
-          cwd: fs.mkdtempSync(path.join(os.tmpdir(), 'gantry-capfix-cwd-')),
+          cwd,
           env: { PATH: '/usr/bin', HOME: os.homedir() },
           runnerSandboxProvider: {
             id: 'capfix-test-sandbox',
             enforcing: true,
-            start: () => {
+            start: (input) => {
+              spawnInputs.push({
+                command: input.command,
+                args: [...input.args],
+              });
               queueMicrotask(() => child.emit('spawn'));
               return child as never;
             },
@@ -360,31 +378,79 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         return { child, started, result };
       };
 
-      await expect(invoke().result).rejects.toMatchObject({
+      const coveredArgs = [
+        'sheets',
+        'update',
+        'sheet-1',
+        'Leads!A1:B1',
+        '--values-json',
+        valuesJson,
+      ];
+      const coveredInvocation = invoke(coveredArgs);
+      await coveredInvocation.started;
+      coveredInvocation.child.emit('close', 0, null);
+      await expect(coveredInvocation.result).resolves.toEqual({
+        stdout: 'command completed',
+        stderr: '',
+      });
+      expect(spawnInputs.at(-1)).toEqual({
+        command: executable,
+        args: coveredArgs,
+      });
+      const proposalsAfterCoveredCall = await runtime.service.pool.query<{
+        count: number;
+      }>(
+        'select count(*)::int as count from capability_template_amendment_proposals where capability_id = $1',
+        [capabilityId],
+      );
+      expect(proposalsAfterCoveredCall.rows).toEqual([{ count: 0 }]);
+
+      const proposedArgs = [
+        'sheets',
+        'append',
+        'sheet-1',
+        'Leads!A1:B1',
+        '--values-json',
+        valuesJson,
+      ];
+      await expect(invoke(proposedArgs).result).rejects.toMatchObject({
         code: 'capability_template_mismatch',
       });
-      const proposedTemplates = [`${executable} sheets get * *`];
-      const recorded = await recordCapabilityTemplateAmendment({
+      const recorded = await compileAndRecordHostCapabilityTemplateMismatch({
         appId: 'default',
         agentId,
         requestedBy: 'job_lifecycle_agent',
+        capabilityId,
+        observedArgs: proposedArgs,
         jobId: job.id,
         conversationJid: 'tg:job-lifecycle',
         threadId: 'thread-job-lifecycle',
-        capabilityId,
-        proposedTemplates,
-        observedArgv: [executable, 'sheets', 'get', 'sheet-1', 'Leads!A:B'],
         toolRepository: runtime.repositories.tools,
         proposalRepository: runtime.repositories.capabilityTemplateAmendments,
         now,
       });
-      expect(recorded).toMatchObject({
-        ok: true,
-        code: 'capability_amendment_proposal_recorded',
+      expect(recorded.action).toEqual({
+        kind: 'fix_proposal',
+        proposalId: expect.any(String),
       });
-      if (!recorded.ok || !recorded.review) {
+      if (!recorded.review) {
         throw new Error('Expected a recorded amendment review.');
       }
+      const proposedTemplates = [
+        `${executable} sheets append * *`,
+        `${executable} sheets append * * --values-json *`,
+      ];
+      expect(recorded.review.proposal).toMatchObject({
+        proposedTemplates,
+        observedArgv: [executable, ...proposedArgs],
+      });
+      const proposalsAfterMismatch = await runtime.service.pool.query<{
+        count: number;
+      }>(
+        'select count(*)::int as count from capability_template_amendment_proposals where capability_id = $1',
+        [capabilityId],
+      );
+      expect(proposalsAfterMismatch.rows).toEqual([{ count: 1 }]);
       await runtime.ops.upsertJob({
         ...job,
         setup_state: {
@@ -473,6 +539,7 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         review: recorded.review,
       });
       await finished;
+      expect(requestPermissionApproval).toHaveBeenCalledTimes(1);
 
       const updatedTool = await runtime.repositories.tools.getTool(toolId);
       const updatedCapability = semanticCapabilityFromToolCatalogItem({
@@ -483,10 +550,17 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         executablePath: executable,
         executableHash,
         executableVersion: '1.0.0',
-        // Amendments ADD reviewed forms; the previously approved template
-        // survives alongside the new one.
-        commandTemplates: [`${executable} sheets get *`, ...proposedTemplates],
       });
+      // Amendments ADD reviewed forms; the previously approved templates survive
+      // alongside the new ones. Compare as SETS: authorization is
+      // `templates.some(match)`, so order is irrelevant, and canonicalization
+      // stores the merged templates in sorted order.
+      expect(
+        [
+          ...(updatedCapability?.implementationBindings[0]?.commandTemplates ??
+            []),
+        ].sort(),
+      ).toEqual([...initialTemplates, ...proposedTemplates].sort());
       const history = await runtime.service.pool.query<{
         prior_templates: string[];
         amended_templates: string[];
@@ -496,11 +570,13 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         'select prior_templates, amended_templates, approved_by, audit_event_id from capability_template_amendment_history where proposal_id = $1',
         [recorded.review.proposal.id],
       );
-      expect(history.rows[0]).toMatchObject({
-        prior_templates: [`${executable} sheets get *`],
-        amended_templates: [`${executable} sheets get *`, ...proposedTemplates],
-        approved_by: 'person:ravi',
-      });
+      expect(history.rows[0]?.approved_by).toBe('person:ravi');
+      expect([...(history.rows[0]?.prior_templates ?? [])].sort()).toEqual(
+        [...initialTemplates].sort(),
+      );
+      expect([...(history.rows[0]?.amended_templates ?? [])].sort()).toEqual(
+        [...initialTemplates, ...proposedTemplates].sort(),
+      );
       const audit = await runtime.service.pool.query(
         'select id from permission_audit_events where id = $1',
         [history.rows[0]!.audit_event_id],
@@ -593,7 +669,7 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         ),
       ).resolves.toEqual({ status: 'already_amended' });
 
-      const invocation = invoke();
+      const invocation = invoke(proposedArgs);
       await invocation.started;
       invocation.child.emit('close', 0, null);
       // Empty stdout maps to the runner's success sentinel
@@ -602,28 +678,29 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         stdout: 'command completed',
         stderr: '',
       });
+      expect(spawnInputs.at(-1)).toEqual({
+        command: executable,
+        args: proposedArgs,
+      });
 
-      const deniedTemplates = [`${executable} sheets get * * *`];
-      const denied = await recordCapabilityTemplateAmendment({
+      const deniedArgs = ['sheets', 'clear', 'sheet-1', 'Archive!A:B'];
+      await expect(invoke(deniedArgs).result).rejects.toMatchObject({
+        code: 'capability_template_mismatch',
+      });
+      const denied = await compileAndRecordHostCapabilityTemplateMismatch({
         appId: 'default',
         agentId,
         requestedBy: 'job_lifecycle_agent',
-        conversationJid: 'tg:job-lifecycle',
         capabilityId,
-        proposedTemplates: deniedTemplates,
-        observedArgv: [
-          executable,
-          'sheets',
-          'get',
-          'sheet-1',
-          'Leads!A:B',
-          'extra',
-        ],
+        observedArgs: deniedArgs,
+        jobId: job.id,
+        conversationJid: 'tg:job-lifecycle',
+        threadId: 'thread-job-lifecycle',
         toolRepository: runtime.repositories.tools,
         proposalRepository: runtime.repositories.capabilityTemplateAmendments,
         now,
       });
-      if (!denied.ok || !denied.review) {
+      if (!denied.review) {
         throw new Error('Expected a denyable amendment review.');
       }
       let deniedFinish!: () => void;
@@ -651,41 +728,50 @@ maybeDescribe('job lifecycle (Postgres)', () => {
         review: denied.review,
       });
       await deniedFinished;
-      const deniedAgain = await recordCapabilityTemplateAmendment({
+      const deniedAgain = await compileAndRecordHostCapabilityTemplateMismatch({
         appId: 'default',
         agentId,
         requestedBy: 'job_lifecycle_agent',
-        conversationJid: 'tg:job-lifecycle',
         capabilityId,
-        proposedTemplates: deniedTemplates,
-        observedArgv: [
-          executable,
-          'sheets',
-          'get',
-          'sheet-1',
-          'Leads!A:B',
-          'extra',
-        ],
+        observedArgs: deniedArgs,
+        jobId: job.id,
+        conversationJid: 'tg:job-lifecycle',
+        threadId: 'thread-job-lifecycle',
         toolRepository: runtime.repositories.tools,
         proposalRepository: runtime.repositories.capabilityTemplateAmendments,
         now,
       });
-      expect(deniedAgain).toMatchObject({
-        ok: true,
-        code: 'capability_amendment_proposal_previously_denied',
-      });
-      expect(deniedAgain.ok && deniedAgain.review).toBeUndefined();
+      expect(deniedAgain.action.kind).toBe('instruction');
+      expect(deniedAgain.review).toBeUndefined();
       expect(deniedApproval).toHaveBeenCalledTimes(1);
+      const proposalsAfterRepeatedDeniedShape =
+        await runtime.service.pool.query<{ count: number }>(
+          'select count(*)::int as count from capability_template_amendment_proposals where capability_id = $1',
+          [capabilityId],
+        );
+      expect(proposalsAfterRepeatedDeniedShape.rows).toEqual([{ count: 2 }]);
+      expect(
+        await runtime.repositories.capabilityTemplateAmendments.getById(
+          denied.review.proposal.id,
+        ),
+      ).toMatchObject({
+        status: 'denied',
+        decidedBy: 'person:ravi',
+      });
       const afterDeny = semanticCapabilityFromToolCatalogItem({
         inputSchema: (await runtime.repositories.tools.getTool(toolId))
           ?.inputSchema,
       });
-      expect(afterDeny?.implementationBindings[0]?.commandTemplates).toEqual([
-        `${executable} sheets get *`,
-        ...proposedTemplates,
-      ]);
+      // Denial leaves the catalog untouched: same template SET as after the
+      // approval (order-insensitive, matching the earlier assertion).
+      expect(
+        [...(afterDeny?.implementationBindings[0]?.commandTemplates ?? [])].sort(),
+      ).toEqual([...initialTemplates, ...proposedTemplates].sort());
     } finally {
       fs.rmSync(executableDir, { recursive: true, force: true });
+      for (const cwd of invocationCwds) {
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
       // Shared-schema hygiene: later tests enumerate jobs and resolve the
       // shared agent's tool policy — leave neither the job nor the binding.
       await runtime.ops.deleteJob(job.id).catch(() => undefined);

--- a/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
+++ b/apps/core/test/integration/job-lifecycle.postgres.integration.test.ts
@@ -765,7 +765,9 @@ maybeDescribe('job lifecycle (Postgres)', () => {
       // Denial leaves the catalog untouched: same template SET as after the
       // approval (order-insensitive, matching the earlier assertion).
       expect(
-        [...(afterDeny?.implementationBindings[0]?.commandTemplates ?? [])].sort(),
+        [
+          ...(afterDeny?.implementationBindings[0]?.commandTemplates ?? []),
+        ].sort(),
       ).toEqual([...initialTemplates, ...proposedTemplates].sort());
     } finally {
       fs.rmSync(executableDir, { recursive: true, force: true });

--- a/apps/core/test/unit/application/gantry-tool-risk.test.ts
+++ b/apps/core/test/unit/application/gantry-tool-risk.test.ts
@@ -109,6 +109,13 @@ describe('gantryToolDefaultRisk', () => {
     expect(AUTO_APPROVE.has(risk!.risk_level)).toBe(false);
   });
 
+  it('keeps capability_run high-risk outside its dispatch-only runner boundary', () => {
+    const risk = gantryToolDefaultRisk('mcp__gantry__capability_run');
+
+    expect(risk?.risk_level).toBe('high');
+    expect(AUTO_APPROVE.has(risk!.risk_level)).toBe(false);
+  });
+
   // (c) unknown / unmapped gantry tools default to ask, never silent approve.
   it.each([
     'mcp__gantry__frobnicate_everything',

--- a/apps/core/test/unit/jobs/capability-template-compiler.test.ts
+++ b/apps/core/test/unit/jobs/capability-template-compiler.test.ts
@@ -1,8 +1,69 @@
 import { describe, expect, it } from 'vitest';
 
 import { compileCapabilityTemplateMismatch } from '@core/jobs/capability-template-compiler.js';
+import { classifyCapabilityTemplateProposal } from '@core/shared/capability-template-widening.js';
 
 const executablePath = '/usr/local/bin/gog';
+
+it('CAPSAFE-1-COMPILER', () => {
+  expect(
+    compileCapabilityTemplateMismatch({
+      executablePath,
+      commandTemplates: [`${executablePath} sheets update *`],
+      observedArgs: [
+        'sheets',
+        'update',
+        'sheet-1',
+        'Leads!A1:K1',
+        '--values-json',
+        '[["a","b,c"]]',
+      ],
+    }),
+  ).toMatchObject({ kind: 'covered' });
+
+  expect(
+    compileCapabilityTemplateMismatch({
+      executablePath,
+      commandTemplates: [
+        `${executablePath} sheets get`,
+        `${executablePath} sheets 'get'`,
+      ],
+      observedArgs: ['sheets', 'get', 'sheet-1'],
+    }),
+  ).toMatchObject({
+    kind: 'proposal',
+    prefixMatches: 2,
+    proposedTemplates: [`${executablePath} sheets get *`],
+  });
+
+  expect(
+    compileCapabilityTemplateMismatch({
+      executablePath,
+      commandTemplates: [
+        `${executablePath} sheets get`,
+        `${executablePath} sheets get sheet-1`,
+      ],
+      observedArgs: ['sheets', 'get', 'sheet-1', 'extra'],
+    }),
+  ).toMatchObject({ kind: 'instruction', prefixMatches: 2 });
+  expect(
+    compileCapabilityTemplateMismatch({
+      executablePath,
+      commandTemplates: [
+        `${executablePath} sheets get`,
+        `${executablePath} sheets get range-*`,
+      ],
+      observedArgs: ['sheets', 'get', 'range-a', 'extra'],
+    }),
+  ).toMatchObject({ kind: 'instruction', prefixMatches: 2 });
+
+  expect(
+    classifyCapabilityTemplateProposal({
+      currentTemplates: [`${executablePath} sheets get`],
+      proposedTemplates: [`${executablePath} sheets get *`],
+    }),
+  ).toBe('expanded');
+});
 
 describe('capability template mismatch compiler', () => {
   it('compiles trailing positional inputs against exactly one literal prefix', () => {
@@ -10,7 +71,7 @@ describe('capability template mismatch compiler', () => {
       compileCapabilityTemplateMismatch({
         executablePath,
         commandTemplates: [
-          `${executablePath} sheets get *`,
+          `${executablePath} sheets get`,
           `${executablePath} docs get *`,
         ],
         observedArgs: ['sheets', 'get', 'sheet-1', 'Leads!A:B'],
@@ -26,7 +87,7 @@ describe('capability template mismatch compiler', () => {
     expect(
       compileCapabilityTemplateMismatch({
         executablePath,
-        commandTemplates: [`${executablePath} sheets get *`],
+        commandTemplates: [`${executablePath} sheets get`],
         observedArgs: [
           'sheets',
           'get',
@@ -54,10 +115,34 @@ describe('capability template mismatch compiler', () => {
     });
   });
 
-  it('proposes the flag form when the observed call uses fewer positionals than the template before a flag', () => {
-    // Regression: a `--values-json` write against a `* * *` template must NOT
-    // dead-end on an instruction card just because the third positional `*`
-    // lines up with the flag. The observed uses two positionals, then a flag.
+  it('serializes multiple observed flags as one ordered template, not per-flag siblings', () => {
+    // Guards against option-injection over-widening: an observed multi-flag call
+    // must widen to a SINGLE template that preserves the observed flag order as
+    // literals (a later flag can never be reached without the earlier one), NOT
+    // a separate `--flag *` template per flag.
+    expect(
+      compileCapabilityTemplateMismatch({
+        executablePath,
+        commandTemplates: [`${executablePath} sheets get`],
+        observedArgs: [
+          'sheets',
+          'get',
+          '--account',
+          'owner@example.com',
+          '--json',
+          'true',
+        ],
+      }),
+    ).toMatchObject({
+      kind: 'proposal',
+      proposedTemplates: [
+        `${executablePath} sheets get`,
+        `${executablePath} sheets get --account * --json *`,
+      ],
+    });
+  });
+
+  it('recognizes a flagged call already covered by the terminal remainder', () => {
     expect(
       compileCapabilityTemplateMismatch({
         executablePath,
@@ -71,19 +156,10 @@ describe('capability template mismatch compiler', () => {
           '[["a","b,c"]]',
         ],
       }),
-    ).toMatchObject({
-      kind: 'proposal',
-      proposedTemplates: [
-        `${executablePath} sheets update * *`,
-        `${executablePath} sheets update * * --values-json *`,
-      ],
-    });
+    ).toMatchObject({ kind: 'covered' });
   });
 
-  it('proposes the flag form even when the observed call omits several trailing positional wildcards', () => {
-    // Regression: with a longer positional template the flag-form call has
-    // FEWER total tokens than the template, so a full-length precheck would
-    // reject it before the cursor ever reached the flag.
+  it('instructs when a flag arrives before required non-terminal wildcards', () => {
     expect(
       compileCapabilityTemplateMismatch({
         executablePath,
@@ -96,47 +172,13 @@ describe('capability template mismatch compiler', () => {
           '[["a","b,c"]]',
         ],
       }),
-    ).toMatchObject({
-      kind: 'proposal',
-      proposedTemplates: [
-        `${executablePath} sheets update *`,
-        `${executablePath} sheets update * --values-json *`,
-      ],
-    });
+    ).toMatchObject({ kind: 'instruction' });
   });
 
   it.each([
     {
-      name: 'zero literal-prefix matches',
-      templates: [`${executablePath} docs get *`],
-      args: ['sheets', 'get', 'sheet-1', 'Leads!A:B'],
-    },
-    {
-      name: 'multiple literal-prefix matches',
-      templates: [
-        `${executablePath} sheets get *`,
-        `${executablePath} sheets get * *`,
-      ],
-      args: ['sheets', 'get', 'sheet-1', 'Leads!A:B', 'extra'],
-    },
-    {
-      name: 'mixed glob',
-      templates: [`${executablePath} sheets get range-*`],
-      args: ['sheets', 'get', 'range-a', 'extra'],
-    },
-    {
-      name: 'shorter argv',
-      templates: [`${executablePath} sheets get * *`],
-      args: ['sheets', 'get', 'sheet-1'],
-    },
-    {
-      name: 'literal mismatch after the prefix',
-      templates: [`${executablePath} sheets get fixed`],
-      args: ['sheets', 'get', 'other', 'extra'],
-    },
-    {
       name: 'interleaved trailing flag and positional',
-      templates: [`${executablePath} sheets get *`],
+      template: `${executablePath} sheets get *`,
       args: [
         'sheets',
         'get',
@@ -148,22 +190,57 @@ describe('capability template mismatch compiler', () => {
     },
     {
       name: 'flag without a value',
-      templates: [`${executablePath} sheets get *`],
+      template: `${executablePath} sheets get *`,
       args: ['sheets', 'get', 'sheet-1', '--json'],
     },
     {
-      // A reviewed literal flag's value wildcard is NOT an optional trailing
-      // positional: dropping it must not build a valueless `--account` proposal.
-      name: 'reviewed flag value wildcard stays required',
-      templates: [`${executablePath} sheets get * --account *`],
+      name: 'reviewed flag followed by a remainder',
+      template: `${executablePath} sheets get * --account *`,
       args: ['sheets', 'get', 'sheet-1', '--account', '--json', 'v'],
     },
     {
-      // Same rule when the reviewed flag precedes ANY positional wildcard: the
-      // value stays required even with no leading positional run before it.
-      name: 'reviewed flag value stays required with no leading positional',
-      templates: [`${executablePath} sheets get --account *`],
+      name: 'reviewed flag and remainder with no leading positional',
+      template: `${executablePath} sheets get --account *`,
       args: ['sheets', 'get', '--account', '--json', 'v'],
+    },
+  ])('recognizes $name as covered authority', ({ template, args }) => {
+    expect(
+      compileCapabilityTemplateMismatch({
+        executablePath,
+        commandTemplates: [template],
+        observedArgs: args,
+      }),
+    ).toMatchObject({ kind: 'covered' });
+  });
+
+  it.each([
+    {
+      name: 'zero literal-prefix matches',
+      templates: [`${executablePath} docs get *`],
+      args: ['sheets', 'get', 'sheet-1', 'Leads!A:B'],
+    },
+    {
+      name: 'divergent literal-prefix matches',
+      templates: [
+        `${executablePath} sheets get`,
+        `${executablePath} sheets get sheet-1`,
+      ],
+      args: ['sheets', 'get', 'sheet-1', 'Leads!A:B', 'extra'],
+    },
+    {
+      name: 'mixed glob',
+      templates: [`${executablePath} sheets get range-*`],
+      args: ['sheets', 'get', 'range-a', 'extra'],
+    },
+    {
+      name: 'shorter argv',
+      templates: [`${executablePath} sheets get * * fixed`],
+      args: ['sheets', 'get', 'sheet-1'],
+    },
+    {
+      name: 'literal mismatch after the prefix',
+      templates: [`${executablePath} sheets get fixed`],
+      args: ['sheets', 'get', 'other', 'extra'],
     },
   ])('falls to instruction for $name', ({ templates, args }) => {
     expect(

--- a/apps/core/test/unit/jobs/ipc-capability-run-handler.test.ts
+++ b/apps/core/test/unit/jobs/ipc-capability-run-handler.test.ts
@@ -45,6 +45,69 @@ function localCliTool(commandTemplates = [`${executablePath} sheets get *`]) {
 }
 
 describe('host capability template mismatch flow', () => {
+  it('does not record an amendment when the reviewed remainder already covers the call', async () => {
+    const claimPending = vi.fn();
+    const result = await compileAndRecordHostCapabilityTemplateMismatch({
+      appId: 'app:test',
+      agentId: 'agent:main',
+      requestedBy: 'main_agent',
+      capabilityId: 'google.sheets.read',
+      observedArgs: [
+        'sheets',
+        'get',
+        'sheet-1',
+        'Leads!A:B',
+        '--account',
+        'owner@example.com',
+      ],
+      toolRepository: {
+        listTools: vi.fn(async () => [localCliTool()]),
+      } as never,
+      proposalRepository: { claimPending } as never,
+      now: '2026-08-14T00:00:00.000Z',
+    });
+
+    expect(result.action.kind).toBe('instruction');
+    expect(claimPending).not.toHaveBeenCalled();
+  });
+
+  it('records one proposal when equivalent prefix candidates converge', async () => {
+    const claimPending = vi.fn(async (input: Record<string, unknown>) => ({
+      created: true,
+      proposal: {
+        ...input,
+        status: 'pending',
+        createdAt: input.now,
+        updatedAt: input.now,
+      },
+    }));
+    const result = await compileAndRecordHostCapabilityTemplateMismatch({
+      appId: 'app:test',
+      agentId: 'agent:main',
+      requestedBy: 'main_agent',
+      capabilityId: 'google.sheets.read',
+      observedArgs: ['sheets', 'get', 'sheet-1'],
+      conversationJid: 'tg:owner',
+      toolRepository: {
+        listTools: vi.fn(async () => [
+          localCliTool([
+            `${executablePath} sheets get`,
+            `${executablePath} sheets 'get'`,
+          ]),
+        ]),
+      } as never,
+      proposalRepository: { claimPending } as never,
+      now: '2026-08-14T00:00:00.000Z',
+    });
+
+    expect(result.action.kind).toBe('fix_proposal');
+    expect(claimPending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proposedTemplates: [`${executablePath} sheets get *`],
+      }),
+    );
+  });
+
   it('records the compiler output and returns a fix-proposal blocker', async () => {
     const claimPending = vi.fn(async (input: Record<string, unknown>) => ({
       created: true,
@@ -72,7 +135,9 @@ describe('host capability template mismatch flow', () => {
       jobId: 'job-1',
       conversationJid: 'tg:owner',
       toolRepository: {
-        listTools: vi.fn(async () => [localCliTool()]),
+        listTools: vi.fn(async () => [
+          localCliTool([`${executablePath} sheets get`]),
+        ]),
       } as never,
       proposalRepository: { claimPending } as never,
       now: '2026-08-14T00:00:00.000Z',

--- a/apps/core/test/unit/jobs/ipc-capability-run-handler.test.ts
+++ b/apps/core/test/unit/jobs/ipc-capability-run-handler.test.ts
@@ -45,7 +45,7 @@ function localCliTool(commandTemplates = [`${executablePath} sheets get *`]) {
 }
 
 describe('host capability template mismatch flow', () => {
-  it('does not record an amendment when the reviewed remainder already covers the call', async () => {
+  it('signals covered (re-attempt, not block) when the reviewed remainder already authorizes the call', async () => {
     const claimPending = vi.fn();
     const result = await compileAndRecordHostCapabilityTemplateMismatch({
       appId: 'app:test',
@@ -67,7 +67,9 @@ describe('host capability template mismatch flow', () => {
       now: '2026-08-14T00:00:00.000Z',
     });
 
-    expect(result.action.kind).toBe('instruction');
+    // Covered = the catalog already authorizes this argv, so the caller must
+    // RE-ATTEMPT rather than block the job; no amendment is recorded.
+    expect('covered' in result && result.covered).toBe(true);
     expect(claimPending).not.toHaveBeenCalled();
   });
 

--- a/apps/core/test/unit/runner/capability-structured-invocation.test.ts
+++ b/apps/core/test/unit/runner/capability-structured-invocation.test.ts
@@ -282,16 +282,9 @@ describe('CLIRUN-1-1', () => {
   });
 });
 
-describe('CAPSAFE-1-MATCHER', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-    for (const dir of tempDirs.splice(0)) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('CAPSAFE-1-MATCHER shares terminal remainder authorization and keeps boundaries fail closed', async () => {
+it('CAPSAFE-1-MATCHER', async () => {
     vi.useFakeTimers();
+    try {
     const fixture = executableFixture();
     const tools = repository({
       ...fixture,
@@ -449,8 +442,13 @@ describe('CAPSAFE-1-MATCHER', () => {
         'approve',
       ]),
     ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      for (const dir of tempDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
   });
-});
 
 describe('CLIRUN-1-2', () => {
   afterEach(() => {

--- a/apps/core/test/unit/runner/capability-structured-invocation.test.ts
+++ b/apps/core/test/unit/runner/capability-structured-invocation.test.ts
@@ -283,8 +283,8 @@ describe('CLIRUN-1-1', () => {
 });
 
 it('CAPSAFE-1-MATCHER', async () => {
-    vi.useFakeTimers();
-    try {
+  vi.useFakeTimers();
+  try {
     const fixture = executableFixture();
     const tools = repository({
       ...fixture,
@@ -442,13 +442,13 @@ it('CAPSAFE-1-MATCHER', async () => {
         'approve',
       ]),
     ).toBe(true);
-    } finally {
-      vi.useRealTimers();
-      for (const dir of tempDirs.splice(0)) {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
+  } finally {
+    vi.useRealTimers();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }
+});
 
 describe('CLIRUN-1-2', () => {
   afterEach(() => {

--- a/apps/core/test/unit/runner/capability-structured-invocation.test.ts
+++ b/apps/core/test/unit/runner/capability-structured-invocation.test.ts
@@ -36,6 +36,7 @@ import type {
   RunnerSandboxProvider,
   RunnerSandboxSpawnInput,
 } from '@core/shared/runner-sandbox-provider.js';
+import { localCliCommandTemplateMatchesArgv } from '@core/shared/tool-rule-matcher.js';
 import { buildGantryAgentSystemPrompt } from '@core/runner/gantry-agent-system-prompt.js';
 
 type FakeChild = EventEmitter & {
@@ -207,22 +208,7 @@ describe('CLIRUN-1-1', () => {
     await expect(
       invocation({
         repository: tools,
-        args: ['records', 'list', '--config', '/tmp/other'],
-      }),
-    ).rejects.toMatchObject({ code: 'capability_template_mismatch' });
-    await expect(
-      invocation({
-        repository: tools,
         args: ['records', 'read', 'fixed', 'excess'],
-      }),
-    ).rejects.toMatchObject({ code: 'capability_template_mismatch' });
-    // Arity-exact: a wildcard template authorizes exactly one argument in the
-    // wildcard slot, never an extra trailing operand (the shell-glob suffix
-    // gap). `records list *` must NOT authorize an added second operand.
-    await expect(
-      invocation({
-        repository: tools,
-        args: ['records', 'list', 'customer-42', 'extra-operation'],
       }),
     ).rejects.toMatchObject({ code: 'capability_template_mismatch' });
 
@@ -293,6 +279,176 @@ describe('CLIRUN-1-1', () => {
       }),
     ).rejects.toThrow();
     expect(expired.start).not.toHaveBeenCalled();
+  });
+});
+
+describe('CAPSAFE-1-MATCHER', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('CAPSAFE-1-MATCHER shares terminal remainder authorization and keeps boundaries fail closed', async () => {
+    vi.useFakeTimers();
+    const fixture = executableFixture();
+    const tools = repository({
+      ...fixture,
+      templates: [
+        `${fixture.executable} records update *`,
+        `${fixture.executable} records * approve *`,
+        `${fixture.executable} records region-* archive *`,
+        `${fixture.executable} records read fixed`,
+      ],
+    });
+
+    const expectAuthorized = async (args: string[]) => {
+      const { provider, child, start } = fakeProvider();
+      const resultPromise = invocation({
+        repository: tools,
+        provider,
+        args,
+      });
+      await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+      expect(start.mock.calls[0]?.[0]).toMatchObject({
+        command: fs.realpathSync(fixture.executable),
+        args,
+      });
+      child.emit('close', 0, null);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(resultPromise).resolves.toEqual({
+        stdout: 'command completed',
+        stderr: '',
+      });
+    };
+
+    const structuredJsonValue = JSON.stringify([
+      ['a,b', '>', '$(not-executed)', ';'],
+    ]);
+    await expectAuthorized([
+      'records',
+      'update',
+      'sheet-1',
+      'A1:B2',
+      '--values-json',
+      structuredJsonValue,
+    ]);
+    await expectAuthorized(['records', 'update']);
+    await expectAuthorized([
+      'records',
+      'sheet-1',
+      'approve',
+      '--values-json',
+      structuredJsonValue,
+    ]);
+    await expectAuthorized([
+      'records',
+      'region-us',
+      'archive',
+      '--values-json',
+      structuredJsonValue,
+    ]);
+
+    const denied = fakeProvider();
+    for (const args of [
+      ['records', 'approve'],
+      ['records', 'sheet-1', 'extra', 'approve'],
+      ['records', '--sheet', 'approve'],
+      ['records', 'delete', 'sheet-1'],
+      ['records', 'region', 'us', 'archive'],
+      ['records', 'read', 'fixed', 'excess'],
+    ]) {
+      await expect(
+        invocation({ repository: tools, provider: denied.provider, args }),
+      ).rejects.toMatchObject({ code: 'capability_template_mismatch' });
+    }
+    expect(denied.start).not.toHaveBeenCalled();
+
+    for (const args of [
+      ['records', 'update', 'bad\0value'],
+      ['x'.repeat(CAPABILITY_RUN_MAX_ARG_BYTES + 1)],
+      Array.from({ length: CAPABILITY_RUN_MAX_ARGS + 1 }, () => 'x'),
+      Array.from({ length: 5 }, () =>
+        'x'.repeat(CAPABILITY_RUN_MAX_TOTAL_ARG_BYTES / 4),
+      ),
+    ]) {
+      await expect(
+        invocation({ repository: tools, provider: denied.provider, args }),
+      ).rejects.toMatchObject({ code: 'invalid_args' });
+    }
+    expect(denied.start).not.toHaveBeenCalled();
+
+    await expect(
+      invocation({
+        repository: tools,
+        provider: denied.provider,
+        capabilityId: 'acme.records.write',
+        args: ['records', 'update'],
+      }),
+    ).rejects.toMatchObject({ code: 'permission_denied' });
+    await expect(
+      invocation({
+        repository: repository({ ...fixture, personId: 'person:other' }),
+        provider: denied.provider,
+        personId: 'person:caller',
+        args: ['records', 'update'],
+      }),
+    ).rejects.toMatchObject({ code: 'permission_denied' });
+    await expect(
+      invocation({
+        repository: repository({
+          ...fixture,
+          hash: `sha256:${'0'.repeat(64)}`,
+          templates: [`${fixture.executable} records update *`],
+        }),
+        provider: denied.provider,
+        args: ['records', 'update'],
+      }),
+    ).rejects.toMatchObject({ code: 'executable_identity_mismatch' });
+    expect(denied.start).not.toHaveBeenCalled();
+
+    const matches = (
+      template: string,
+      argv = [fixture.executable, 'records'],
+    ) =>
+      localCliCommandTemplateMatchesArgv({
+        executablePath: fixture.executable,
+        template,
+        argv,
+      });
+    for (const template of [
+      `/different/acme records *`,
+      `acme records *`,
+      `${fixture.executable}* records *`,
+      `${fixture.executable} *`,
+      `${fixture.executable} records * | cat`,
+      `${fixture.executable} records * && echo nope`,
+      `${fixture.executable} records *;`,
+      `${fixture.executable} records * > output.txt`,
+      `TOKEN=x ${fixture.executable} records *`,
+    ]) {
+      expect(matches(template)).toBe(false);
+    }
+
+    // A mixed-glob positional pattern must not absorb an injected flag
+    // (option injection), but a legitimate non-flag value still authorizes.
+    expect(
+      matches(`${fixture.executable} records *foo approve *`, [
+        fixture.executable,
+        'records',
+        '--foo',
+        'approve',
+      ]),
+    ).toBe(false);
+    expect(
+      matches(`${fixture.executable} records *foo approve *`, [
+        fixture.executable,
+        'records',
+        'barfoo',
+        'approve',
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/apps/core/test/unit/runner/tool-permission-gate.test.ts
+++ b/apps/core/test/unit/runner/tool-permission-gate.test.ts
@@ -2,6 +2,12 @@ import dns from 'node:dns/promises';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  DURABLE_GRANT_EXCLUDED_DISPATCHERS,
+  HOST_AUTHORIZED_MCP_PROXY_DISPATCHERS,
+} from '@core/shared/admin-mcp-tools.js';
+import { gantryToolDefaultRisk } from '@core/application/permissions/gantry-tool-risk.js';
+
 const permissionMock = vi.hoisted(() => ({
   requestPermissionApproval: vi.fn(),
 }));
@@ -1341,4 +1347,18 @@ describe('tool permission gate', () => {
     );
     expect(permissionMock.requestPermissionApproval).toHaveBeenCalledTimes(1);
   });
+});
+
+it('CAPSAFE-1-BOUNDARY', () => {
+  // Decision 0130: the mcp__gantry__capability_run wrapper is DISPATCH-ONLY — the
+  // runner may only hand a schema-valid envelope to the host, which re-authorizes
+  // app/agent/person/capability/reviewed-template/executable before execution. The
+  // bypass grants NO command authority: capability_run is a host-authorized proxy
+  // dispatcher, is excluded from durable grants, and stays HIGH-risk with no
+  // classifier-derived or cached auto-allow.
+  expect(HOST_AUTHORIZED_MCP_PROXY_DISPATCHERS).toContain('capability_run');
+  expect(DURABLE_GRANT_EXCLUDED_DISPATCHERS).toContain('capability_run');
+  expect(gantryToolDefaultRisk('mcp__gantry__capability_run')?.risk_level).toBe(
+    'high',
+  );
 });

--- a/apps/core/test/unit/shared/capability-template-widening.test.ts
+++ b/apps/core/test/unit/shared/capability-template-widening.test.ts
@@ -43,10 +43,10 @@ describe('capability template widening classification', () => {
       kind: 'added_inputs',
     },
     {
-      name: 'added first trailing positional slot to an exact command',
+      name: 'added first terminal remainder wildcard',
       current: ['/usr/local/bin/gog sheets get'],
       proposed: ['/usr/local/bin/gog sheets get *'],
-      kind: 'added_inputs',
+      kind: 'expanded',
     },
     {
       name: 'kept template plus an added-inputs sibling',

--- a/docs/decisions/0129-capsafe-local-cli-terminal-wildcard.md
+++ b/docs/decisions/0129-capsafe-local-cli-terminal-wildcard.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-08-16
+stories: [CAPSAFE-1]
+---
+
+# Local-CLI terminal wildcard is a reviewed argv remainder
+
+## Context
+
+Structured local-CLI execution interprets every `*` in a reviewed command template
+as exactly one non-flag argv entry, and requires the invocation argv to have the
+same length as the template (arity-exact), rejecting any flag token
+(`structured-local-cli-invocation.ts`, the arity-exact/no-flag clauses). The
+scoped RunCommand rule matcher already interprets a final standalone `*` as "the
+remaining argv" (`tool-rule-matcher.ts:543`). The same template therefore means
+two different things on the two authorization paths.
+
+The divergence turns ordinary flags (e.g. `gog … --values-json`) and additional
+operands into repeated template amendments. Once overlapping templates accumulate,
+the amendment compiler counts multiple literal-prefix candidates and returns an
+administrator instruction instead of a proposal (`capability-template-compiler.ts:49`),
+so the recovery path fails closed. Net effect: an agent that already HOLDS a
+capability cannot perform a simple, safe operation, and the whole widening
+apparatus exists only to compensate for the over-strict base match. The exact-arity
+behavior is locked by a regression test, so changing it is a decision, not a bug fix.
+
+## Decision
+
+For `local_cli` command templates only:
+
+- The executable and the literal operation prefix match exactly (the hard boundary).
+- A non-terminal standalone `*` matches exactly one non-flag argv entry.
+- A final standalone `*` matches zero or more remaining argv entries, including flags
+  and flag values (the same "remaining argv" semantics the RunCommand matcher already
+  uses).
+- A mixed-token glob remains confined to a single argv entry.
+- Shell control syntax, redirection, environment assignments, and any executable
+  change remain invalid.
+- There is ONE shared matcher implementation used by dry-run authorization,
+  execution, and the compiler's coverage checks. No legacy exact-arity mode is kept.
+
+The amendment compiler first checks the observation against current authority; an
+already-covered call produces no amendment. For a genuine mismatch, multiple eligible
+source templates may produce a proposal only when their canonical proposal sets are
+identical; divergent results, mixed-glob candidates, or any ineligible competing
+candidate fall back to the administrator instruction. Widening classification becomes
+semantic (adding the first terminal remainder wildcard is an expanded-authority
+warning), not slot-count based.
+
+## Consequences
+
+Amends the arity-exact clauses in Decisions 0120 and 0122 and the exactly-one-template
+clause in Decision 0125. Existing templates change semantics cleanly; no compatibility
+format or fallback matcher is retained (per 0003 no-backcompat). A held capability's
+prefix now authorizes any invocation under it — flags included — so the common case
+needs no runtime widening, no card, and no classifier. The security boundary shifts to
+the executable + literal prefix: within a granted prefix, argument content is
+unbounded (the deliberate Claude-Code-style tradeoff for a feature that works).
+Executable identity, capability selection, person scope, sandboxing, egress, redaction,
+and approval provenance are unchanged.

--- a/docs/decisions/0130-capsafe-capability-run-dispatch-only.md
+++ b/docs/decisions/0130-capsafe-capability-run-dispatch-only.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+confirmed_by: "Ravi"
+date: 2026-08-16
+stories: [CAPSAFE-1]
+---
+
+# capability_run auto-allow is dispatch-only
+
+## Context
+
+`mcp__gantry__capability_run` is an unscoped dispatcher when judged by tool name alone,
+but its host handler resolves the selected semantic capability and validates the exact
+argv against the reviewed template before execution. Prompting for the wrapper itself
+duplicates authorization; classifying the wrapper as generically low-risk would let
+unrelated callers or a stale classifier verdict bypass the host boundary. As the
+terminal-wildcard change (0129) makes reviewed prefixes cover ordinary flags, it is
+important that this convenience never becomes a way to grant command authority from the
+runner or classifier side.
+
+## Decision
+
+The canonical `mcp__gantry__capability_run` wrapper may bypass runner-side approval only
+to dispatch to the Gantry host, and only when:
+
+- the request passed schema validation;
+- the YOLO denylist did not match; and
+- the canonical host handler will perform current target authorization.
+
+The bypass grants no command authority. Before execution the host re-resolves app, agent,
+person, run, conversation, selected capability, reviewed template, executable identity,
+sandbox, and egress policy. A template mismatch may still reach the host compiler but can
+never execute. `capability_run` remains high-risk in the generic Gantry risk map; it
+receives no classifier-derived or cached allow. Non-Gantry lookalikes, other unscoped
+dispatchers, malformed inputs, missing host authority, and unavailable repositories all
+fail closed through their existing paths.
+
+## Consequences
+
+There is one authorization implementation: the host capability resolver plus the shared
+argv matcher from 0129. The runner performs only a narrow dispatch hand-off. Interactive
+and autonomous execution retain the same durable capability authority, while mismatch
+recovery remains reachable. This keeps the simplification of 0129 safe: broadening what a
+prefix authorizes does not broaden who may authorize a prefix.

--- a/docs/specs/capsafe-1-blueprint.md
+++ b/docs/specs/capsafe-1-blueprint.md
@@ -56,17 +56,21 @@ export function localCliCommandTemplateMatchesArgv(input: {
 }): boolean;
 ```
 
-It should parse `template` with `parseBashCommand()` and fail closed unless all
-of these are true:
+It should fail closed unless all of these are true:
 
-1. Parsing succeeds and produces exactly one command leaf.
-2. The template leaf has no redirects.
-3. Both `template` and `argv` start with `executablePath` exactly. No wildcard,
+1. `hasBashShellControlSyntax(template)` is false. Check this before parsing so
+   a trailing control operator such as `;` or `&&` cannot pass merely because
+   `parseBashCommand()` produced one non-empty leaf.
+2. Parsing with `parseBashCommand()` succeeds and produces exactly one command
+   leaf.
+3. The template leaf has no redirects.
+4. Both the parsed template argv and invocation `argv` start with
+   `executablePath` exactly. No wildcard,
    interpreter alias, or basename match is allowed for the executable.
-4. At least one literal operation token follows the executable; existing
+5. At least one literal operation token follows the executable; existing
    `validateLocalCliCommandTemplate()` remains the catalog-write validation
    boundary for this invariant.
-5. The shared argv-pattern kernel matches the remaining tokens under the
+6. The shared argv-pattern kernel matches the remaining tokens under the
    local-CLI wildcard policy below.
 
 Factor the cardinality/token loop currently in `bashScopeMatchesLeaf()` into
@@ -109,8 +113,10 @@ reimplement wildcard or glob matching.
    interpreter projection. Move lines 557-571 into `argvPatternMatches()` and
    have the RunCommand wrapper call it with `one-arg`.
 2. Add `localCliCommandTemplateMatchesArgv()` beside that function. It owns the
-   simple-leaf/no-redirect/exact-executable checks and calls the kernel with
-   `one-non-flag`.
+   existing `hasBashShellControlSyntax()` pre-check, the
+   simple-leaf/no-redirect/exact-executable checks, and calls the kernel with
+   `one-non-flag`. Reuse the helper already imported by this module; do not add
+   another shell-syntax detector.
 3. Keep `leafArgvForScope()` at lines 574-586 RunCommand-only. Local CLI must
    not inherit Python interpreter aliases or generated-skill path projection.
 4. Reuse `globPatternMatches()` and `escapeRegex()` at lines 594-603. Do not add
@@ -161,7 +167,7 @@ suite or test name containing the exact identifier `CAPSAFE-1-MATCHER`.
 | Person-scope mismatch                                          | Current binding belongs to a different person                                                                     | Existing `permission_denied` proof remains green.                                                         |
 | Executable identity mismatch                                   | Wrong hash, writable executable, or executable under the agent-writable root                                      | Existing `executable_identity_mismatch` proofs remain green and the sandbox is not started.               |
 | Template executable mismatch                                   | Template starts with another executable, a basename, or an executable wildcard                                    | `localCliCommandTemplateMatchesArgv()` returns false.                                                     |
-| Shell control syntax in template                               | Pipe, `;`, `&&`, substitution, or multiple leaves in the reviewed template                                        | Wrapper returns false. Do not test these as argv data values.                                             |
+| Shell control syntax in template                               | Pipe, interior or trailing `;`/`&&`, substitution, or multiple leaves in the reviewed template                    | Wrapper returns false. Do not test these as argv data values.                                             |
 | Redirection in template                                        | `<`, `>`, or a parsed redirect on the reviewed template                                                           | Wrapper returns false even for a non-destructive redirect.                                                |
 | Environment assignment in template                             | A leading `TOKEN=x`, `CONFIG=x`, proxy, credential, or CA assignment                                              | Wrapper returns false; existing catalog validation remains unchanged.                                     |
 

--- a/docs/specs/capsafe-1-blueprint.md
+++ b/docs/specs/capsafe-1-blueprint.md
@@ -1,0 +1,227 @@
+# CAPSAFE-1 matcher cutover blueprint
+
+This blueprint is anchored to `a94ca0ee7`. Line numbers below describe that
+revision and are intended to make the next bounded implementation stage
+mechanical. Decisions 0129 and 0130 are the binding behavior.
+
+## Outcome and boundaries
+
+The matcher cutover should reuse the remaining-argv logic already owned by
+`apps/core/src/shared/tool-rule-matcher.ts`. The implementation should extract
+that logic into one argv-pattern kernel, add one exported local-CLI wrapper,
+and make structured execution and later compiler coverage call that wrapper.
+The private arity-exact matcher in
+`apps/core/src/jobs/structured-local-cli-invocation.ts` should be deleted in
+the same change; there is no legacy exact-arity mode.
+
+This changes command-shape matching only. It does not grant a capability and
+does not add a classifier or cached allow for `capability_run`. The host still
+resolves the current app, agent, person, capability selection, executable
+identity, sandbox, and egress policy before launch. Runner-side approval may
+only hand the validated dispatcher request to that host boundary, as required
+by Decision 0130.
+
+Shell syntax is invalid in a reviewed template, not in a structured argv data
+value. Do not scan or reinterpret `args` as shell text: `capability_run` passes
+an argv array directly to the sandbox runner, so a JSON value containing `>`,
+`;`, or `$()` is data and cannot create a pipe, redirect, or expansion.
+
+## Root cause confirmed
+
+| Location at `a94ca0ee7`                                                            | Current behavior                                                                                                   | Cutover consequence                                                                                |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `structured-local-cli-invocation.ts:111-184`, `resolveGrantedLocalCliInvocation()` | Current authority is resolved correctly, but lines 143-150 route each reviewed template through a private matcher. | Keep the authority/executable flow; replace only the matcher call and stale recovery wording.      |
+| `structured-local-cli-invocation.ts:216-241`, `structuredArgvMatchesTemplate()`    | Lines 231 and 236-238 require equal arity and prevent every non-flag pattern, including `*`, from matching a flag. | This is the rigidity to remove. Delete the function, its comment, and its callers.                 |
+| `structured-local-cli-invocation.ts:243-250`, `globMatches()`                      | Private mixed-token glob implementation used only by the private structured matcher.                               | Delete it; the shared matcher already owns equivalent single-argv glob matching.                   |
+| `tool-rule-matcher.ts:543-572`, `bashScopeMatchesLeaf()`                           | A final standalone `*` already matches the remaining argv, including zero entries; other patterns stay positional. | Extract its cardinality and token loop into the shared kernel instead of creating another matcher. |
+| `tool-rule-matcher.ts:594-603`, `globPatternMatches()` / `escapeRegex()`           | A mixed-token glob matches exactly one argv entry.                                                                 | Reuse unchanged from the shared kernel.                                                            |
+
+The launch ordering is already fail closed and must remain so:
+`runStructuredLocalCliCapability()` calls the resolver at
+`structured-local-cli-invocation.ts:64`; the resolver validates bounds at
+line 120, resolves current person-scoped authority at lines 122-137, matches a
+reviewed local-CLI binding at lines 139-151, verifies the immutable executable
+at lines 152-156, and only then returns an invocation for the sandbox runner.
+
+## Shared matcher contract
+
+Add this public, local-CLI-specific entry point beside
+`bashScopeMatchesLeaf()` in `tool-rule-matcher.ts`:
+
+```ts
+export function localCliCommandTemplateMatchesArgv(input: {
+  executablePath: string;
+  template: string;
+  argv: readonly string[];
+}): boolean;
+```
+
+It should parse `template` with `parseBashCommand()` and fail closed unless all
+of these are true:
+
+1. Parsing succeeds and produces exactly one command leaf.
+2. The template leaf has no redirects.
+3. Both `template` and `argv` start with `executablePath` exactly. No wildcard,
+   interpreter alias, or basename match is allowed for the executable.
+4. At least one literal operation token follows the executable; existing
+   `validateLocalCliCommandTemplate()` remains the catalog-write validation
+   boundary for this invariant.
+5. The shared argv-pattern kernel matches the remaining tokens under the
+   local-CLI wildcard policy below.
+
+Factor the cardinality/token loop currently in `bashScopeMatchesLeaf()` into
+this private kernel with an explicit non-terminal wildcard policy:
+
+```ts
+function argvPatternMatches(
+  patternArgs: readonly string[],
+  argv: readonly string[],
+  nonTerminalWildcard: 'one-arg' | 'one-non-flag',
+): boolean;
+```
+
+The algorithm is:
+
+- When the last pattern token is standalone `*`, compare the fixed prefix and
+  allow zero or more remaining argv entries. Reaching that terminal wildcard
+  returns `true`; flags and flag values are intentionally included.
+- Without a terminal standalone `*`, require equal lengths.
+- A non-terminal standalone `*` consumes exactly one argv entry. In
+  `one-non-flag` mode it fails when that value starts with `-`.
+- Literals compare exactly. A mixed-token glob delegates to
+  `globPatternMatches()` and therefore cannot span argv entries.
+- Missing values fail closed.
+
+`localCliCommandTemplateMatchesArgv()` must call the kernel with
+`one-non-flag`. `bashScopeMatchesLeaf()` must keep its existing normalization,
+safe-interpreter handling, and RunCommand behavior, then call the same kernel
+with `one-arg`. That avoids an unrelated RunCommand compatibility change while
+making the terminal-remainder implementation shared. Structured execution and
+the CAPSAFE compiler stage both import the local-CLI wrapper; neither should
+reimplement wildcard or glob matching.
+
+## Exact edit plan
+
+### `apps/core/src/shared/tool-rule-matcher.ts`
+
+1. Refactor `bashScopeMatchesLeaf()` at lines 543-572. Keep lines 547-556
+   responsible for RunCommand normalization, parsing, executable safety, and
+   interpreter projection. Move lines 557-571 into `argvPatternMatches()` and
+   have the RunCommand wrapper call it with `one-arg`.
+2. Add `localCliCommandTemplateMatchesArgv()` beside that function. It owns the
+   simple-leaf/no-redirect/exact-executable checks and calls the kernel with
+   `one-non-flag`.
+3. Keep `leafArgvForScope()` at lines 574-586 RunCommand-only. Local CLI must
+   not inherit Python interpreter aliases or generated-skill path projection.
+4. Reuse `globPatternMatches()` and `escapeRegex()` at lines 594-603. Do not add
+   a second regular-expression glob helper.
+
+### `apps/core/src/jobs/structured-local-cli-invocation.ts`
+
+1. At imports lines 7-8, remove `BashCommandLeaf` and `parseBashCommand`; import
+   `localCliCommandTemplateMatchesArgv()` from
+   `../shared/tool-rule-matcher.js`.
+2. In `resolveGrantedLocalCliInvocation()` lines 139-151, remove the synthetic
+   `BashCommandLeaf` and call the shared wrapper with the binding's pinned
+   executable, template, and `[executable, ...input.args]`.
+3. Keep grant selection at lines 122-137, executable verification at lines
+   152-160, `validateStructuredArgs()` at lines 186-210, and
+   `verifyImmutableExecutable()` at lines 260 onward unchanged.
+4. Update the mismatch guidance at lines 164-183. Remove the claim that every
+   `*` means exactly one value. State that a terminal standalone `*` covers the
+   remaining args while a non-terminal `*` covers one positional value.
+5. Delete lines 216-250 in full: the arity-exact comment,
+   `structuredArgvMatchesTemplate()`, and `globMatches()`.
+
+### Compiler reuse in the following bounded stage
+
+`compileCapabilityTemplateMismatch()` must import
+`localCliCommandTemplateMatchesArgv()` before proposing a widening. If the
+observed argv is already covered, it returns no amendment. Its candidate
+coverage checks must call the same wrapper rather than recreate terminal-`*`
+semantics. Genuine uncovered prefixes retain the existing host amendment path;
+the matcher stage does not delete that path.
+
+## Test matrix
+
+Put the proof in
+`apps/core/test/unit/runner/capability-structured-invocation.test.ts` under a
+suite or test name containing the exact identifier `CAPSAFE-1-MATCHER`.
+
+| Case                                                           | Reviewed template / input                                                                                         | Expected proof                                                                                            |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Terminal remainder with flags                                  | `<exe> records update *`; argv `records update sheet-1 A1:B2 --values-json [["a,b"]]`                             | Authorized; sandbox receives every argv entry byte-for-byte, including the comma-containing JSON value.   |
+| Terminal remainder with no suffix                              | `<exe> records update *`; argv `records update`                                                                   | Authorized because terminal `*` is zero-or-more.                                                          |
+| Non-terminal wildcard: one positional                          | `<exe> records * update *`; argv `records sheet-1 update --values-json payload`                                   | Authorized; the first `*` consumes exactly `sheet-1`, and the terminal `*` consumes the remainder.        |
+| Non-terminal wildcard: missing, excess before literal, or flag | Same template; omit the sheet id, add a second token before `update`, or place `--sheet` in the non-terminal slot | Denied with `capability_template_mismatch`; a non-terminal `*` is exactly one non-flag argv entry.        |
+| Wrong operation                                                | Reviewed `records update *`; invoke `records delete ...`                                                          | Denied with `capability_template_mismatch`; terminal remainder cannot cross the literal operation prefix. |
+| Mixed-token glob                                               | `<exe> records region-* update *`                                                                                 | `region-us` may match one argv entry; `region us` or a different literal path does not.                   |
+| Invalid structured args                                        | NUL, per-argument overflow, total-byte overflow, and argument-count overflow                                      | Existing `invalid_args` cases remain green and the sandbox is not started.                                |
+| No current grant                                               | Invoke a capability id absent from current person-scoped selections                                               | `permission_denied`; the matcher cannot manufacture authority.                                            |
+| Person-scope mismatch                                          | Current binding belongs to a different person                                                                     | Existing `permission_denied` proof remains green.                                                         |
+| Executable identity mismatch                                   | Wrong hash, writable executable, or executable under the agent-writable root                                      | Existing `executable_identity_mismatch` proofs remain green and the sandbox is not started.               |
+| Template executable mismatch                                   | Template starts with another executable, a basename, or an executable wildcard                                    | `localCliCommandTemplateMatchesArgv()` returns false.                                                     |
+| Shell control syntax in template                               | Pipe, `;`, `&&`, substitution, or multiple leaves in the reviewed template                                        | Wrapper returns false. Do not test these as argv data values.                                             |
+| Redirection in template                                        | `<`, `>`, or a parsed redirect on the reviewed template                                                           | Wrapper returns false even for a non-destructive redirect.                                                |
+| Environment assignment in template                             | A leading `TOKEN=x`, `CONFIG=x`, proxy, credential, or CA assignment                                              | Wrapper returns false; existing catalog validation remains unchanged.                                     |
+
+The existing assertions at
+`capability-structured-invocation.test.ts:207-227` encode the old behavior and
+are deletion/replacement targets: the flag suffix and extra operand under
+`records list *` must become authorized proofs. Keep the exact-template excess
+case at lines 213-218 as the no-terminal-wildcard falsifier.
+
+Focused implementation command:
+
+```bash
+npm run test:unit -- apps/core/test/unit/runner/capability-structured-invocation.test.ts -t CAPSAFE-1-MATCHER
+```
+
+Then run the stage command recorded by the decomposition:
+
+```bash
+npm run test:unit -- capability-structured-invocation
+```
+
+## Deletion and cleanup proof
+
+Delete in the matcher stage:
+
+- `structuredArgvMatchesTemplate()` and its arity-exact/no-flag comment;
+- the private `globMatches()` helper;
+- their now-unused parser and leaf-type imports;
+- stale mismatch copy saying `*` is always exactly one value;
+- tests/comments that require a terminal wildcard to reject extra args or
+  flags.
+
+Do not delete `validateStructuredArgs()`, current grant/person resolution,
+immutable executable verification, sandbox/egress enforcement, or the genuine
+mismatch amendment path. Those are independent fail-closed boundaries, and
+Decision 0130 relies on the host retaining them.
+
+After implementation, these searches should find no active structured
+arity-exact matcher or stale guidance:
+
+```bash
+rg -n "structuredArgvMatchesTemplate|arity-exact|exactly one value" apps/core/src/jobs/structured-local-cli-invocation.ts apps/core/test/unit/runner/capability-structured-invocation.test.ts
+rg -n "localCliCommandTemplateMatchesArgv" apps/core/src/jobs/structured-local-cli-invocation.ts apps/core/src/jobs/capability-template-compiler.ts apps/core/src/shared/tool-rule-matcher.ts
+```
+
+The first search should return no matches. After the compiler stage, the second
+should show one definition and the structured-execution/compiler callers.
+
+## Surface Impact Matrix
+
+| Surface                      | Classification      | Reason                                                                                                                                               |
+| ---------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime behavior             | Changed             | A terminal local-CLI `*` authorizes the remaining structured argv, including flags and values.                                                       |
+| `settings.yaml`              | Unchanged by design | Existing reviewed templates and capability selections remain the authority; no new field or format is introduced.                                    |
+| Postgres/runtime projection  | Unchanged by design | No schema or grant projection changes; current capability definitions are interpreted with the accepted semantics.                                   |
+| Control API                  | Unchanged by design | No request or response shape changes.                                                                                                                |
+| SDK/contracts                | Unchanged by design | `capability_run` remains `{ capabilityId, args[] }`.                                                                                                 |
+| CLI                          | Unchanged by design | The Gantry CLI surface is unchanged; only host matching of a selected local CLI capability changes.                                                  |
+| Gantry MCP tools/admin skill | Changed             | `capability_run` reaches the same host resolver, which now uses the shared terminal-remainder matcher. Its dispatcher bypass remains authority-free. |
+| Channel/provider adapters    | Unchanged by design | No provider callback or channel permission path changes.                                                                                             |
+| Docs/prompts                 | Changed             | Mismatch guidance must describe terminal remainder semantics; this blueprint records the cutover.                                                    |
+| Audit/events                 | Unchanged by design | Decision, mismatch, and execution audit paths remain current; only whether a reviewed call matches changes.                                          |
+| Tests/verification           | Changed             | Add the enumerated `CAPSAFE-1-MATCHER` matrix and remove arity-exact expectations.                                                                   |

--- a/docs/specs/capsafe-1.md
+++ b/docs/specs/capsafe-1.md
@@ -1,0 +1,81 @@
+---
+slug: capsafe-1
+title: CAPSAFE-1 Refactor CLI-command capability permissions to a simple prefix-wildcard model (delete the widening machinery)
+status: confirmed
+saved: 2026-08-16T00:00:00+00:00
+---
+
+# CAPSAFE-1 — Refactor CLI-command capability permissions to a simple prefix-wildcard model
+
+## Problem
+
+The CLI-command capability permission system is too rigid and, to compensate, has grown a
+large, brittle apparatus that is now KILLING the feature — an agent that holds a capability
+still cannot do simple, safe things (e.g. a comma-safe Google Sheets write with
+`gog … --values-json`), so it cannot help the user.
+
+Root of the rigidity: the reviewed command template match is ARITY-EXACT and forbids flags.
+`gog sheets update * * *` means "exactly three arguments, none starting with `-`". So
+`--values-json` is refused before the CLI ever runs
+(`apps/core/src/jobs/structured-local-cli-invocation.ts`), and there are two independent
+"exactly one prefix" gates (`capability-template-compiler.ts:50`,
+`ipc-capability-run-handler.ts:86-96`). To allow a new shape you must invoke the entire
+widening apparatus — the template compiler, the amendment/proposal flow, the mismatch→card
+path, and (as recently proposed) a classifier "shape" family + `documentedFlags` metadata.
+That apparatus exists ONLY because the base match is too rigid, and it is the complexity that
+is breaking the feature.
+
+## Reference: how simple this is elsewhere
+
+Claude Code models CLI permission as a plain prefix rule: `Bash(<prefix>:*)`, where `:*` means
+"anything after the prefix". `Bash(gog sheets update:*)` allows `gog sheets update <anything,
+including flags like --values-json>`. No arity check, no per-argument wildcards, no in-prefix
+flag restriction, no compiler, no amendment flow, no classifier. Grant a command prefix once;
+anything under it runs; the prefix is the security boundary. Codex CLI and similar agent tools
+use comparably simple sandbox/allowlist models, not arity-exact per-arg matching.
+
+## Intent (extreme simplicity via DELETION, not addition)
+
+Adopt the prefix-wildcard model. Change one semantic: a trailing `*` in a reviewed capability
+command template means "match everything after the prefix" (Claude Code's `:*`), NOT "exactly
+one non-flag argument". Then `gog sheets update *` already authorizes
+`gog sheets update <ss> <range> --values-json <json>` — nothing to widen, ever.
+
+This lets us DELETE, not build:
+- the arity-exact + no-flag-in-positional matching in `structured-local-cli-invocation.ts`;
+- the entire `capability-template-compiler.ts` (no widening needed);
+- the amendment/proposal flow + the mismatch→card/instruction path;
+- any `documentedFlags` schema field and `capability_shape` classifier family (never build);
+- the `request_access` command-shape plumbing.
+
+New model: a capability = a granted command prefix; any invocation matching the prefix runs.
+Changing what is allowed is a one-line human edit of the prefix (rare). No runtime negotiation,
+no LLM authorization of command shapes.
+
+## Acceptance criteria
+
+1. A capability whose reviewed template is a command prefix authorizes ANY invocation matching
+   that prefix, flags included (e.g. `gog sheets update *` allows `--values-json`).
+2. The prefix (executable + literal subcommand path) remains a hard boundary: an invocation
+   that does not match the prefix is refused.
+3. The template compiler, amendment/proposal flow, mismatch→card path, and shape-classifier
+   apparatus are DELETED (or reduced to the prefix matcher), not extended.
+4. Existing reviewed templates migrate cleanly to the prefix-match semantics with no capability
+   silently over- or under-authorized.
+5. Live proof: the KnackLabs agent writes to Sheets via `--values-json` with no widening step,
+   no card, no dead-end.
+
+## Out of scope
+
+- Non-CLI capability kinds. The per-job KnackLabs template hack.
+
+## Codex sol/xhigh design pass (stage 1)
+
+WEB-SEARCH how Claude Code, Codex CLI, and other agent tools implement CLI-command permission
+wildcards (prefix/glob allowlists), and cite the simplest proven model. Then produce the
+CONCRETE deletion refactor for myclaw: the exact matcher change in
+`structured-local-cli-invocation.ts`, every file/module to DELETE or shrink, how existing
+reviewed templates migrate to prefix semantics, the security analysis of the prefix-only
+boundary (what becomes unbounded within a prefix and why that is acceptable, matching Claude
+Code), and the minimal test set. Favour deletion; the smallest change that makes a held
+capability's prefix authorize any invocation under it. Read AGENTS.md + ponytail first.

--- a/harness.yaml
+++ b/harness.yaml
@@ -89,7 +89,7 @@ phases:
   implementation:
     owner: "codex:/codex:rescue"
     model: "gpt-5.6-sol"
-    reasoning: "medium (escalate effort to high for migrations/cross-domain/security-sensitive)"
+    reasoning: "xhigh (escalate effort to high for migrations/cross-domain/security-sensitive)"
     prompts: "factory/prompts/implementer.md"
     required_skills: # ENFORCED by feature type — the decomposition's user_facing flag:
       # the recorder refuses a user-facing testing artifact unless skills_used

--- a/plans/roadmap.json
+++ b/plans/roadmap.json
@@ -1237,6 +1237,25 @@
       "depends_on": [],
       "origin": "adhoc",
       "spec": "docs/specs/jobflow-lifecycle.md"
+    },
+    {
+      "key": "CAPSAFE-1",
+      "title": "Durable try-authorize-remember loop for CLI-command capability shapes",
+      "story": "As an autonomous agent, I can try a plausible command shape on a capability I already hold and get a real authorize decision (auto-allowed when low-risk, one-tap when not, remembered either way), so a safe CLI operation never dead-ends and never needs a hand-patch",
+      "acceptance_criteria": [
+        "A shape mismatch on an already-granted capability routes to the permission classifier and yields an auto-allow (low-risk documented-flag extension) or an approvable one-tap card, never a non-actionable instruction dead-end",
+        "The capability-template compiler proposes a flag-form widening even when redundant positional-count template variants share the literal prefix (two-template ambiguity resolved)",
+        "request_access distinguishes grant from command-shape so an agent can request a new command shape instead of bouncing off already-granted",
+        "An approved widening is remembered durably (survives restart; the agent stops re-asking)",
+        "Acceptance: the KnackLabs agent fixes its own Sheets writes via --values-json through one approvable card, producing a clean comma-safe write that is remembered"
+      ],
+      "order": 63,
+      "status": "active",
+      "epic": "permission-engine",
+      "skill": "backend",
+      "kind": "refactor",
+      "depends_on": [],
+      "spec": "docs/specs/capsafe-1.md"
     }
   ],
   "epics": [
@@ -1325,5 +1344,5 @@
     }
   ],
   "generated_by": "human",
-  "updated_at": "2026-08-12T12:24:03+00:00"
+  "updated_at": "2026-08-15T14:00:35+00:00"
 }

--- a/plans/roadmap.json
+++ b/plans/roadmap.json
@@ -1240,14 +1240,14 @@
     },
     {
       "key": "CAPSAFE-1",
-      "title": "Durable try-authorize-remember loop for CLI-command capability shapes",
-      "story": "As an autonomous agent, I can try a plausible command shape on a capability I already hold and get a real authorize decision (auto-allowed when low-risk, one-tap when not, remembered either way), so a safe CLI operation never dead-ends and never needs a hand-patch",
+      "title": "Prefix-wildcard CLI-command capability permissions (delete the widening machinery)",
+      "story": "As an autonomous agent, I can run any invocation under a capability's reviewed command PREFIX (flags and values included) with no per-shape negotiation, so a safe CLI operation never dead-ends and never needs a hand-patch \u2014 the reviewed executable + literal operation prefix is the security boundary, arguments within it are unbounded (Claude Code's Bash(<prefix>:*) model).",
       "acceptance_criteria": [
-        "A shape mismatch on an already-granted capability routes to the permission classifier and yields an auto-allow (low-risk documented-flag extension) or an approvable one-tap card, never a non-actionable instruction dead-end",
-        "The capability-template compiler proposes a flag-form widening even when redundant positional-count template variants share the literal prefix (two-template ambiguity resolved)",
-        "request_access distinguishes grant from command-shape so an agent can request a new command shape instead of bouncing off already-granted",
-        "An approved widening is remembered durably (survives restart; the agent stops re-asking)",
-        "Acceptance: the KnackLabs agent fixes its own Sheets writes via --values-json through one approvable card, producing a clean comma-safe write that is remembered"
+        "A held capability's reviewed template authorizes any invocation matching its executable + literal operation prefix, flags included: a terminal standalone * is the reviewed argv remainder; ONE shared matcher governs dry-run auth, execution, AND compiler coverage; no legacy exact-arity mode (decision 0129)",
+        "The prefix is a hard boundary: executable + literal operation prefix match exactly; a non-terminal * is exactly one non-flag arg (no flag injection, including mixed globs); shell-control/redirection/environment-assignment templates are refused",
+        "mcp__gantry__capability_run auto-allow is DISPATCH-ONLY: the runner may only hand a schema-valid envelope to the host which re-authorizes; the bypass grants NO command authority; capability_run stays HIGH-risk with no classifier-derived or cached allow (decision 0130)",
+        "An already-covered call records no amendment and resumes; a genuine uncovered prefix still asks once (mismatch -> proposal -> approve -> durable intent -> resume); denial is terminal",
+        "Acceptance: the end-to-end loop is proven on the real Postgres integration lane, with a comma-containing --values-json payload preserved byte-for-byte (the KnackLabs live write is owner-run after merge)"
       ],
       "order": 63,
       "status": "active",


### PR DESCRIPTION
## What this does, in plain terms

An agent that already holds a CLI capability (say, "write to this Google Sheet") kept getting **locked out** of safe, ordinary operations. Adding a single flag like `--values-json` — the comma-safe way to write a cell containing a comma — was refused before the command ever ran, and the "fix it" path dead-ended on an unhelpful "ask an administrator" card. A whole machine of template-widening, proposals, and classifier negotiation had grown up just to compensate, and that complexity is what was actually breaking the feature.

This PR **deletes** that rigidity instead of adding more to it. A capability's reviewed command **prefix** now authorizes any invocation under it — flags and values included — exactly like Claude Code's `Bash(<prefix>:*)` model. The executable plus the literal operation prefix (e.g. `gog sheets update`) is the security boundary; arguments within it are unbounded. Grant a prefix once, and safe operations under it just work — no per-shape negotiation, no card, no hand-patch.

## Why it's safe

The boundary got **tighter**, not looser, where it matters:
- The executable and the literal operation prefix must match **exactly** (a `*` can no longer stand in for the executable, which the old glob allowed).
- A non-terminal `*` is exactly **one non-flag** argument — an injected `--flag` can never land in a reviewed positional slot (this holds for mixed globs like `*foo` too).
- Shell control syntax, redirection, and environment-assignments in a template are refused; structured argv **data** (a JSON value containing `>`, `;`, `$()`) is never reinterpreted as shell.
- `mcp__gantry__capability_run` stays **dispatch-only**: the runner may only hand a schema-valid request to the host, which re-authorizes everything before execution. The bypass grants no command authority, stays high-risk, and gets no classifier or cached allow.

Two accepted decisions pin this so the rigidity can't creep back: **0129** (terminal `*` = reviewed argv remainder; one shared matcher; no legacy exact-arity) and **0130** (capability_run dispatch-only).

## The technical delta

- **Unify on one matcher.** Structured local-CLI authorization now uses the same remaining-argv matcher the scoped RunCommand rules already use (`tool-rule-matcher.ts`), via a shared `argvPatternMatches(one-arg | one-non-flag)` kernel. The divergent arity-exact matcher (`structuredArgvMatchesTemplate` + a private glob) is **deleted**. One implementation governs dry-run authorization, execution, and compiler coverage — they can never drift apart again.
- **Compiler reconciliation.** The template compiler reuses that shared matcher: an already-covered call records no amendment; overlapping prefix candidates propose only when their canonical sets are identical (else a clear instruction); the first terminal remainder wildcard is flagged as expanded authority.
- **Covered calls resume.** If the catalog already authorizes an argv (a race where an amendment landed first), the job now **re-attempts** under current authority instead of blocking on an admin instruction — the exact lock-out this initiative removes.

## How it's proven

- Per-stage adversarial autoreview plus one branch-wide integration pass — all clean. Review caught **three real bugs** the implementer's sandbox couldn't (it can't run tests): a mixed-glob flag-injection hole, two order-sensitive assertions, and the covered-call false-blocker. All fixed and locked with tests.
- End-to-end proof on the **real Postgres lane**: a broad reviewed suffix runs a comma-containing `--values-json '[["lead-1","Doe, Jane"]]'` write with **zero** amendments and the argv preserved byte-for-byte; a genuinely new command shape still asks **once** (approve → amend → durable resume); a denied shape stays terminal.
- Unit suite green (8,886 tests); typecheck clean.

## Note on CI

The pre-existing `memory-dreaming-chain` / brain integration failures are **not** from this change — they fail identically on the base commit (`f95f94518`), and this branch touches no memory/dream/brain code. The KnackLabs live Sheets write is owner-run after merge.
