### PR TITLE
fix(openai): route GPT-5.6 through Responses API

### DIFF
--- a/apps/core/src/adapters/llm/deepagents-langchain/AGENTS.md
+++ b/apps/core/src/adapters/llm/deepagents-langchain/AGENTS.md
@@ -27,9 +27,12 @@ provider string:
   `await initChatModel("openai:<id>", { apiKey, configuration: { baseURL }, streamUsage: true })`.
   The class prefix is **always** `openai:` (ChatOpenAI) — these hit OUR loopback
   gateway, not api.openai.com; the gateway routes to the real upstream by
-  `pathSegment`. `baseURL` is the RAW loopback gateway base
-  (`http://127.0.0.1:<port>/<seg>`, no `/v1`); the OpenAI SDK posts
-  `<baseURL>/chat/completions`, and the gateway prepends each provider's real
+  `pathSegment`. Native OpenAI receives the canonical gateway `/v1` base and
+  uses a direct `ChatOpenAI` Responses API model for GPT-5.6 or when reasoning
+  is explicitly enabled (required when function tools and reasoning are combined, and avoids the
+  universal wrapper reconstructing a Chat Completions model). Other compatible providers receive the
+  raw loopback gateway base (`http://127.0.0.1:<port>/<seg>`, no `/v1`); the
+  OpenAI SDK posts `<baseURL>/chat/completions`, and the gateway prepends each provider's real
   `upstreamPathPrefix`: groq `/openai/v1`, fireworks `/inference/v1`,
   perplexity no extra prefix, gemini `/v1beta/openai`, and
   deepseek/xai/together/cerebras `/v1`. Bedrock resolves to the regional
@@ -41,8 +44,9 @@ provider string:
   ADC/workload identity, service-account JSON from Google Secret Manager, or
   encrypted service-account JSON. Regional/multi-region Vertex routing is
   deferred until explicitly implemented and verified. The gateway allowlist permits
-  `/chat/completions` and
-  `/v1/chat/completions` for the DeepAgents lane; upstream confinement is
+  `/v1/chat/completions` and `/v1/responses` for native OpenAI, and
+  `/chat/completions` plus `/v1/chat/completions` for other DeepAgents providers;
+  upstream confinement is
   enforced by `upstreamPathPrefix`. Adding a provider requires the factory
   allowlist, provider registry, catalog entry, gateway auth/upstream behavior
   when credentials are not a plain bearer key, and official-doc-backed tests for

--- a/apps/core/src/adapters/llm/deepagents-langchain/runner/model-factory.ts
+++ b/apps/core/src/adapters/llm/deepagents-langchain/runner/model-factory.ts
@@ -1,4 +1,5 @@
 import { initChatModel } from 'langchain/chat_models/universal';
+import { ChatOpenAI } from '@langchain/openai';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { ChatOpenRouterInput } from '@langchain/openrouter';
 import type {
@@ -20,9 +21,11 @@ import { GantryChatOpenRouter } from './gantry-chat-openrouter.js';
 //   <id>", ...)` regardless of the real upstream provider, because we hit OUR
 //   loopback gateway (not api.openai.com); the gateway routes by pathSegment to
 //   the real upstream. `initChatModel` resolves ChatOpenAI and forwards `apiKey`
-//   + `configuration.baseURL` to it. The OpenAI SDK posts `<baseURL>/chat/
-//   completions` (baseURL is the raw loopback gateway base, no `/v1`), and the
-//   gateway prepends each provider's real upstreamPathPrefix.
+//   + `configuration.baseURL` to it. Native OpenAI uses the gateway's canonical
+//   `/v1` API base and switches to the Responses API when reasoning is enabled;
+//   this is required for reasoning plus function tools. Other compatible
+//   providers keep their raw gateway base because the gateway prepends each
+//   provider's real upstreamPathPrefix.
 // - `openrouter`: first-party `@langchain/openrouter` `ChatOpenRouter` (talks
 //   OpenRouter REST/chat-completions via fetch). `initChatModel` does NOT know
 //   `openrouter`, so it is constructed directly. Its `buildUrl()` appends
@@ -133,9 +136,42 @@ export async function buildRunnerModel(input: {
     // which routes to the real upstream (groq/deepseek/xai/...) by pathSegment.
     // initChatModel only knows the LangChain class, and ChatOpenAI is the right
     // class for every OpenAI-chat-completions-compatible upstream.
+    const sdkBaseURL =
+      provider === 'openai' ? `${trimTrailingSlash(baseURL)}/v1` : baseURL;
+    const useResponsesApi =
+      provider === 'openai' &&
+      (input.modelId.startsWith('gpt-5.6-') ||
+        (reasoningEffort !== undefined && reasoningEffort !== 'none'));
+    if (useResponsesApi) {
+      // Construct native OpenAI directly. The universal ConfigurableModel can
+      // reconstruct the bound model inside DeepAgents and fall back to Chat
+      // Completions, which rejects reasoning plus function tools for Luna.
+      const model = new ChatOpenAI({
+        model: input.modelId,
+        apiKey,
+        configuration: { baseURL: sdkBaseURL },
+        useResponsesApi: true,
+        ...(input.promptCacheKey
+          ? { modelKwargs: { prompt_cache_key: input.promptCacheKey } }
+          : {}),
+        ...(reasoningEffort ? { reasoning: { effort: reasoningEffort } } : {}),
+        ...(maxOutputTokens !== undefined
+          ? { maxTokens: maxOutputTokens }
+          : {}),
+        streamUsage: true,
+        ...(maxInputTokens !== undefined
+          ? { profile: { maxInputTokens } }
+          : {}),
+      });
+      return {
+        model,
+        endpointFamily: 'openai',
+        modelId: input.modelId,
+      };
+    }
     const model = await initChatModel(`openai:${input.modelId}`, {
       apiKey,
-      configuration: { baseURL },
+      configuration: { baseURL: sdkBaseURL },
       ...(input.promptCacheKey
         ? { modelKwargs: { prompt_cache_key: input.promptCacheKey } }
         : {}),

--- a/apps/core/test/agent-e2e/scenarios/gpt56-openai-turn.agent-e2e.test.ts
+++ b/apps/core/test/agent-e2e/scenarios/gpt56-openai-turn.agent-e2e.test.ts
@@ -1,0 +1,212 @@
+// Matrix §13 (real model, behavioral): seed an OpenAI credential through the
+// Control API, select `gpt-luna`, then run one real turn through the packaged
+// Gantry runtime. This specifically guards GPT-5.6 routing through OpenAI's
+// Responses API while function tools are bound by DeepAgents.
+//
+// Gating: requires E2E_OPENAI_MODEL_API_KEY (protected CI/local secret) and
+// GANTRY_TEST_DATABASE_URL (throwaway admin Postgres). The suite self-skips
+// when either is absent; the credential is encrypted in the disposable home.
+
+import fs from 'node:fs';
+import { globSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { AgentE2EApiClient, type SessionEvent } from '../harness/api-client.js';
+import {
+  redactText,
+  startEvidenceRun,
+  type EvidenceRun,
+} from '../harness/evidence.js';
+import {
+  startRuntimeHarness,
+  type RuntimeHarness,
+} from '../harness/runtime-harness.js';
+
+const apiKey = process.env.E2E_OPENAI_MODEL_API_KEY?.trim();
+const hasDb = Boolean(process.env.GANTRY_TEST_DATABASE_URL?.trim());
+if (!apiKey) {
+  process.stderr.write(
+    'gpt56-openai-turn skipped: E2E_OPENAI_MODEL_API_KEY not set\n',
+  );
+}
+const maybeDescribe = apiKey && hasDb ? describe : describe.skip;
+
+const BOOT_TIMEOUT_MS = 300_000;
+const TURN_TIMEOUT_MS = 180_000;
+
+interface ModelDefaultsResponse {
+  provider: { id: string; label: string } | null;
+  chat: {
+    configuredAlias: string | null;
+    effectiveAlias: string | null;
+    model: { id: string } | null;
+  };
+}
+
+function payloadOf(event: SessionEvent): Record<string, unknown> {
+  return event.payload && typeof event.payload === 'object'
+    ? (event.payload as Record<string, unknown>)
+    : {};
+}
+
+maybeDescribe('agent-e2e GPT-5.6 OpenAI turn (real model)', () => {
+  let harness: RuntimeHarness | undefined;
+  let api: AgentE2EApiClient;
+  let evidence: EvidenceRun | undefined;
+  let sawFailure = false;
+
+  async function step<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (error) {
+      sawFailure = true;
+      throw error;
+    }
+  }
+
+  afterAll(async () => {
+    if (evidence && harness) {
+      if (sawFailure) {
+        const secrets = harness.secrets.concat(apiKey ? [apiKey] : []);
+        const tail = redactText(harness.logs().slice(-24_000), secrets);
+        evidence.evidence.redactedFailure = tail.slice(-4_000);
+        console.error(`[gpt56-openai-turn] runtime log tail:\n${tail}`);
+        for (const agentLog of globSync(
+          path.join(harness.home, 'agents', '*', 'logs', '*.log'),
+        )) {
+          const body = fs.readFileSync(agentLog, 'utf8');
+          console.error(
+            `[gpt56-openai-turn] ${path.basename(agentLog)} tail:\n` +
+              redactText(body.slice(-8_000), secrets),
+          );
+        }
+      }
+      evidence.write(
+        process.env.AGENT_E2E_EVIDENCE_DIR ??
+          path.join(os.tmpdir(), 'gantry-agent-e2e-evidence'),
+      );
+    }
+    await harness?.teardown({ failed: sawFailure });
+  }, 60_000);
+
+  it(
+    'boots, seeds the OpenAI credential, and selects gpt-luna',
+    { timeout: BOOT_TIMEOUT_MS },
+    async () =>
+      step(async () => {
+        harness = await startRuntimeHarness({
+          scopes: [
+            'sessions:read',
+            'sessions:write',
+            'agents:admin',
+            'credentials:admin',
+          ],
+        });
+        api = new AgentE2EApiClient(harness.baseUrl, harness.apiKey);
+        evidence = startEvidenceRun({
+          scenario: 'gpt56-openai-turn',
+          secrets: [...harness.secrets, apiKey as string],
+        });
+
+        evidence.phase('seed-credential');
+        const seeded = await api.request<{ status: string }>(
+          'PUT',
+          '/v1/credentials/models/openai',
+          {
+            body: { authMode: 'api_key', payload: { apiKey } },
+          },
+        );
+        expect(seeded.status).toBe(200);
+        expect(seeded.body.status).toBe('active');
+
+        evidence.phase('select-model');
+        const patched = await api.request('PATCH', '/v1/models/defaults', {
+          body: { chat: 'gpt-luna' },
+        });
+        expect(patched.status).toBe(200);
+        const defaults = await api.request<ModelDefaultsResponse>(
+          'GET',
+          '/v1/models/defaults',
+        );
+        expect(defaults.status).toBe(200);
+        expect(defaults.body.chat.effectiveAlias).toBe('gpt-luna');
+        expect(defaults.body.provider?.id).toBe('openai');
+        evidence.evidence.modelAlias = defaults.body.chat.effectiveAlias ?? '';
+        evidence.evidence.provider = defaults.body.provider?.id ?? '';
+        evidence.evidence.modelRoute = defaults.body.chat.model?.id ?? '';
+      }),
+  );
+
+  it(
+    'completes a Responses API turn with durable run and reply records',
+    { timeout: TURN_TIMEOUT_MS },
+    async () =>
+      step(async () => {
+        if (!harness || !evidence) throw new Error('boot test did not run');
+
+        evidence.phase('onboard');
+        const created = await api.request<{ id: string }>(
+          'POST',
+          '/v1/agents',
+          { body: { appId: 'default', name: 'agent-e2e-gpt56-openai-turn' } },
+        );
+        expect(created.status).toBe(201);
+        expect(created.body.id).toMatch(/^agent:/);
+
+        const ensured = await api.request<{ sessionId: string }>(
+          'POST',
+          '/v1/sessions/ensure',
+          {
+            body: {
+              conversationId: 'gpt56-openai-turn-e2e',
+              agentId: created.body.id,
+              title: 'GPT-5.6 OpenAI turn e2e',
+            },
+          },
+        );
+        expect(ensured.status).toBe(200);
+        const sessionId = ensured.body.sessionId;
+        expect(sessionId).toBeTruthy();
+        evidence.evidence.sessionId = sessionId;
+
+        evidence.phase('turn');
+        const accepted = await api.postMessage(
+          sessionId,
+          'Reply with one short sentence confirming you are operational.',
+        );
+        expect(accepted.accepted).toBe(true);
+
+        const { reply, events } = await api.waitForDurableAssistantReply(
+          sessionId,
+          { timeoutMs: TURN_TIMEOUT_MS - 30_000 },
+        );
+        evidence.events.push(...events);
+
+        evidence.phase('verify');
+        const persistedMessage = await api.waitForPersistedAssistantMessage(
+          sessionId,
+          { timeoutMs: 30_000 },
+        );
+        const runs = await api.listRuns(sessionId);
+        expect(runs.length, 'session run is visible').toBeGreaterThan(0);
+        expect(
+          events.some((event) => event.eventType === 'run.started'),
+          'run.started is visible in the session event feed',
+        ).toBe(true);
+        expect(reply, 'durable assistant reply').toBeDefined();
+        expect(persistedMessage).toBeDefined();
+
+        const usage = events.find((event) => event.eventType === 'model.usage');
+        if (usage) {
+          const usagePayload = payloadOf(usage);
+          expect(String(usagePayload.modelAlias ?? '').toLowerCase()).toContain(
+            'luna',
+          );
+        }
+        evidence.finishPhases();
+      }),
+  );
+});

--- a/apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts
+++ b/apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts
@@ -818,11 +818,11 @@ maybeDescribe('DeepAgents (LangChain) runner boundary integration', () => {
         ),
       ).toBe(true);
       // The OpenAI SDK appends /chat/completions to the projected gateway
-      // baseUrl (.../openai); the real Gantry gateway maps that to
+      // baseUrl (.../openai/v1); the real Gantry gateway maps that to
       // api.openai.com/v1/chat/completions (proven in the gateway unit test).
       for (const request of gateway.requests) {
         expect(request.authorization).toBe('Bearer gtw_integrationtoken');
-        expect(request.path).toContain('/openai/chat/completions');
+        expect(request.path).toContain('/openai/v1/chat/completions');
         expect(request.body).not.toContain('gtw_');
       }
 

--- a/apps/core/test/unit/adapters/deepagents-model-factory.test.ts
+++ b/apps/core/test/unit/adapters/deepagents-model-factory.test.ts
@@ -14,6 +14,13 @@ const sandboxOpenrouterBaseUrl =
   'http://model-gateway.gantry.internal:4567/openrouter';
 const gatewayToken = 'gtw_token';
 
+async function inspectModel<T>(model: unknown): Promise<T> {
+  const configurable = model as { _getModelInstance?: () => Promise<T> };
+  return configurable._getModelInstance
+    ? configurable._getModelInstance()
+    : (model as T);
+}
+
 describe('deepagents model factory', () => {
   it('builds a ChatOpenAI via initChatModel for the openai provider', async () => {
     const resolved = await buildRunnerModel({
@@ -40,12 +47,30 @@ describe('deepagents model factory', () => {
     expect(underlying.constructor.name).toBe('ChatOpenAI');
     expect(underlying.model).toBe('gpt-5.5');
     expect(underlying.streamUsage).toBe(true);
-    expect(underlying.clientConfig?.baseURL).toBe(loopbackBaseUrl);
+    expect(underlying.clientConfig?.baseURL).toBe(`${loopbackBaseUrl}/v1`);
     expect(
       (underlying as { modelKwargs?: Record<string, unknown> }).modelKwargs,
     ).not.toHaveProperty('prompt_cache_key');
     expect(underlying.apiKey).toBe(gatewayToken);
     expect(resolved.modelId).toBe('gpt-5.5');
+  });
+
+  it('uses the Responses API for GPT-5.6 even without an explicit effort', async () => {
+    const resolved = await buildRunnerModel({
+      provider: 'openai',
+      modelId: 'gpt-5.6-luna',
+      gatewayBaseUrl: loopbackBaseUrl,
+      gatewayToken,
+    });
+    const model = resolved.model as unknown as {
+      constructor: { name: string };
+      useResponsesApi?: boolean;
+      clientConfig?: { baseURL?: string };
+    };
+
+    expect(model.constructor.name).toBe('ChatOpenAI');
+    expect(model.useResponsesApi).toBe(true);
+    expect(model.clientConfig?.baseURL).toBe(`${loopbackBaseUrl}/v1`);
   });
 
   it('adds prompt_cache_key to ChatOpenAI modelKwargs only when present', async () => {
@@ -95,23 +120,21 @@ describe('deepagents model factory', () => {
       configuredThinking: { mode: 'on' },
       maxOutputTokens: 4096,
     });
-    const underlying = await (
-      resolved.model as unknown as {
-        _getModelInstance: () => Promise<{
-          reasoning?: { effort?: string };
-          maxTokens?: number;
-          invocationParams(
-            options: Record<string, unknown>,
-          ): Record<string, unknown>;
-        }>;
-      }
-    )._getModelInstance();
+    const underlying = await inspectModel<{
+      reasoning?: { effort?: string };
+      useResponsesApi?: boolean;
+      maxTokens?: number;
+      invocationParams(
+        options: Record<string, unknown>,
+      ): Record<string, unknown>;
+    }>(resolved.model);
 
     expect(underlying.reasoning).toEqual({ effort: 'high' });
+    expect(underlying.useResponsesApi).toBe(true);
     expect(underlying.maxTokens).toBe(4096);
     expect(underlying.invocationParams({})).toMatchObject({
-      reasoning_effort: 'high',
-      max_completion_tokens: 4096,
+      reasoning: { effort: 'high' },
+      max_output_tokens: 4096,
     });
   });
 
@@ -126,17 +149,18 @@ describe('deepagents model factory', () => {
       gatewayToken,
       configuredThinking: thinking,
     });
-    const underlying = await (
-      resolved.model as unknown as {
-        _getModelInstance: () => Promise<{
-          invocationParams(
-            options: Record<string, unknown>,
-          ): Record<string, unknown>;
-        }>;
-      }
-    )._getModelInstance();
+    const underlying = await inspectModel<{
+      invocationParams(
+        options: Record<string, unknown>,
+      ): Record<string, unknown>;
+    }>(resolved.model);
 
-    expect(underlying.invocationParams({}).reasoning_effort).toBe(effort);
+    const invocation = underlying.invocationParams({});
+    if (effort === 'none') {
+      expect(invocation.reasoning_effort).toBe(effort);
+    } else {
+      expect(invocation.reasoning).toEqual({ effort });
+    }
   });
 
   it('does not inject reasoning or output controls when absent', async () => {
@@ -150,6 +174,7 @@ describe('deepagents model factory', () => {
       resolved.model as unknown as {
         _getModelInstance: () => Promise<{
           reasoning?: unknown;
+          useResponsesApi?: boolean;
           maxTokens?: number;
           invocationParams(
             options: Record<string, unknown>,
@@ -159,6 +184,7 @@ describe('deepagents model factory', () => {
     )._getModelInstance();
 
     expect(underlying.reasoning).toBeUndefined();
+    expect(underlying.useResponsesApi).toBe(false);
     expect(underlying.maxTokens).toBeUndefined();
     expect(underlying.invocationParams({}).reasoning_effort).toBeUndefined();
   });
@@ -422,7 +448,9 @@ describe('deepagents model factory', () => {
         }>;
       }
     )._getModelInstance();
-    expect(underlying.clientConfig?.baseURL).toBe(sandboxGatewayBaseUrl);
+    expect(underlying.clientConfig?.baseURL).toBe(
+      `${sandboxGatewayBaseUrl}/v1`,
+    );
   });
 
   it('rejects a non-gateway token', async () => {

--- a/docs/architecture/agent-e2e-test-matrix.md
+++ b/docs/architecture/agent-e2e-test-matrix.md
@@ -117,16 +117,16 @@ Legend: ✅ covered (cite) · 🔨 to build · 🏷 label-gated (live lane) · �
 
 ## 7. Capabilities
 
-| Scenario                                                                                          | Layer       | Status                                               |
-| ------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------- |
-| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection              | integration | ✅ configured-agent-tools.test.ts                    |
-| local_cli pinning (path/version/hash/templates); unrelated command denied                         | integration | ✅ semantic-capabilities.test.ts                     |
+| Scenario                                                                                          | Layer       | Status                                                   |
+| ------------------------------------------------------------------------------------------------- | ----------- | -------------------------------------------------------- |
+| Declare via settings surface → `capability:<id>` + scoped RunCommand rule projection              | integration | ✅ configured-agent-tools.test.ts                        |
+| local_cli pinning (path/version/hash/templates); unrelated command denied                         | integration | ✅ semantic-capabilities.test.ts                         |
 | Persisted selected binding → projection → real admission                                          | integration | ✅ mcp-capability-authoring.postgres.integration.test.ts |
-| Real-image preflight pass AND fail-closed                                                         | e2e         | 🔨                                                   |
-| Secret lifecycle store→retrieve→rotate→audit (all four in one test)                               | integration | 🔨                                                   |
-| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak                 | integration | ✅ capability-secret units; 🔨 through-sandbox chain |
-| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair  |
-| Real gog/Sheets tier (throwaway sheet)                                                            | e2e-live    | 🏷                                                   |
+| Real-image preflight pass AND fail-closed                                                         | e2e         | 🔨                                                       |
+| Secret lifecycle store→retrieve→rotate→audit (all four in one test)                               | integration | 🔨                                                       |
+| Tampered ciphertext → integrity error → capability unavailable, no plaintext leak                 | integration | ✅ capability-secret units; 🔨 through-sandbox chain     |
+| Egress: denylist blocks + `egress.connect` attribution (networkHosts = attribution NOT allowlist) | integration | ✅ egress-gateway.test.ts; 🔨 e2e with fixture pair      |
+| Real gog/Sheets tier (throwaway sheet)                                                            | e2e-live    | 🏷                                                       |
 
 ## 8. Memories
 
@@ -165,7 +165,7 @@ Legend: ✅ covered (cite) · 🔨 to build · 🏷 label-gated (live lane) · �
 | Corrupt-state seed via direct test-DB rows (documented API exception)                                                                                                                              | integration      | 🔨                                                                                                                     |
 | Providerless admission qualifies conversation/message/queue with ONE provider account (no silent turn drop, no parallel conversation)                                                              | unit/integration | ✅ canonical-message-ops-service.test.ts, message-loop.test.ts, live-admission-work-items.postgres.integration.test.ts |
 | API-session (`app:` JID) admission stamps the internal channel account `control:<appId>` so channel ownership matches and the turn spawns (was: "No channel owns JID" silent skip)                 | unit             | ✅ canonical-message-ops-service.test.ts (app-session admission)                                                       |
-| App-session streamed replies project into durable message ROWS promptly (before the long-lived run closes)                                                                          | integration      | ✅ fixed by Agent E2E reliability gate                                                                                  |
+| App-session streamed replies project into durable message ROWS promptly (before the long-lived run closes)                                                                                         | integration      | ✅ fixed by Agent E2E reliability gate                                                                                 |
 | GET /v1/sessions/{id}/runs returns the session's canonical-conversation runs with the safe public run fields (provider/execution internals excluded); session events feed exposes run.\* lifecycle | integration      | ✅ fixed by Agent E2E reliability gate                                                                                 |
 
 ## 12. Channel loop (Slack, dedicated test app)
@@ -178,13 +178,13 @@ Legend: ✅ covered (cite) · 🔨 to build · 🏷 label-gated (live lane) · �
 
 ## 13. Model matrix & policy gate
 
-| Scenario                                                                                 | Layer         | Status |
-| ---------------------------------------------------------------------------------------- | ------------- | ------ |
-| `haiku` + anthropic_sdk turn (required gate)                                             | e2e           | 🔨     |
-| `gpt-mini` + deepagents turn                                                             | e2e-live      | 🏷     |
-| Catalog base/head diff adds changed aliases to live matrix                               | CI policy job | 🔨     |
-| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨     |
-| `agent-e2e-gate` aggregates + branch protection verified                                 | CI            | 🔨     |
+| Scenario                                                                                 | Layer         | Status                                                      |
+| ---------------------------------------------------------------------------------------- | ------------- | ----------------------------------------------------------- |
+| `haiku` + anthropic_sdk turn (required gate)                                             | e2e           | 🔨                                                          |
+| `gpt-luna` + deepagents Responses API turn                                               | e2e-live      | 🏷 `gpt56-openai-turn.agent-e2e.test.ts` (credential-gated) |
+| Catalog base/head diff adds changed aliases to live matrix                               | CI policy job | 🔨                                                          |
+| Path-map classifies changed paths; UNKNOWN stays risky; `e2e-reviewed` acknowledges only | CI policy job | 🔨                                                          |
+| `agent-e2e-gate` aggregates + branch protection verified                                 | CI            | 🔨                                                          |
 
 ## 14. All-tools sweep
 

--- a/plans/quickfixes/20260816T185903-0000-Q-0029-b774-open-185903571321.json
+++ b/plans/quickfixes/20260816T185903-0000-Q-0029-b774-open-185903571321.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0029-b774",
+  "profile": "quickfix",
+  "reason": "Fix DeepAgents OpenAI gateway path mismatch found by live Telegram smoke test",
+  "started_at": "2026-08-16T18:59:03+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260816T192140-0000-Q-0029-b774-done-192140902189.json
+++ b/plans/quickfixes/20260816T192140-0000-Q-0029-b774-done-192140902189.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0029-b774",
+  "profile": "quickfix",
+  "reason": "Fix DeepAgents OpenAI gateway path mismatch found by live Telegram smoke test",
+  "started_at": "2026-08-16T18:59:03+00:00",
+  "completed_at": "2026-08-16T19:21:40+00:00",
+  "files": []
+}

--- a/plans/quickfixes/20260816T192720-0000-Q-0030-695f-open-192720292713.json
+++ b/plans/quickfixes/20260816T192720-0000-Q-0030-695f-open-192720292713.json
@@ -1,0 +1,12 @@
+{
+  "event": "open",
+  "id": "Q-0030-695f",
+  "profile": "lite",
+  "reason": "Ship the verified OpenAI GPT-5.6 Responses API compatibility fix",
+  "started_at": "2026-08-16T19:27:20+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "by": "user",
+  "base_sha": "f95f9451879d543b020ceff843d0642526a0a21b"
+}

--- a/plans/quickfixes/20260816T193651-0000-Q-0030-695f-done-193651913011.json
+++ b/plans/quickfixes/20260816T193651-0000-Q-0030-695f-done-193651913011.json
@@ -1,0 +1,71 @@
+{
+  "event": "done",
+  "id": "Q-0030-695f",
+  "profile": "lite",
+  "by": "user",
+  "reason": "Ship the verified OpenAI GPT-5.6 Responses API compatibility fix",
+  "base_sha": "f95f9451879d543b020ceff843d0642526a0a21b",
+  "started_at": "2026-08-16T19:27:20+00:00",
+  "completed_at": "2026-08-16T19:36:51+00:00",
+  "files": [
+    "apps/core/src/adapters/llm/deepagents-langchain/AGENTS.md",
+    "apps/core/src/adapters/llm/deepagents-langchain/runner/model-factory.ts",
+    "apps/core/test/agent-e2e/scenarios/gpt56-openai-turn.agent-e2e.test.ts",
+    "apps/core/test/integration/deepagents-langchain-boundary.postgres.integration.test.ts",
+    "apps/core/test/unit/adapters/deepagents-model-factory.test.ts"
+  ],
+  "reviews": {
+    "quality": {
+      "generated_by": "autoreview",
+      "score": 9,
+      "summary": "The required single autoreview pass found no accepted or actionable correctness findings in the OpenAI GPT-5.6 Responses API patch.",
+      "blocking_findings": [],
+      "non_blocking_findings": [],
+      "residual_risks": [
+        "The committed OpenAI live E2E scenario is credential-gated; the equivalent Telegram runtime path was exercised successfully outside the source-tree E2E harness."
+      ],
+      "recommendation": "approve",
+      "reviewed_scope": [
+        "OpenAI model factory routing",
+        "gateway path behavior",
+        "unit, Postgres integration, and agent E2E coverage"
+      ],
+      "aspect": "quality",
+      "recorded_at": "2026-08-16T19:36:51+00:00",
+      "commit": "6b47281473539b8750ac3f2c91d4481e9ffda416"
+    },
+    "performance": {
+      "generated_by": "autoreview",
+      "score": 9,
+      "summary": "The required single autoreview pass found no blocking performance or scalability issue in the bounded provider-routing change.",
+      "blocking_findings": [],
+      "non_blocking_findings": [],
+      "residual_risks": [],
+      "recommendation": "approve",
+      "reviewed_scope": [
+        "model construction path",
+        "streaming Responses API configuration"
+      ],
+      "aspect": "performance",
+      "recorded_at": "2026-08-16T19:36:51+00:00",
+      "commit": "6b47281473539b8750ac3f2c91d4481e9ffda416"
+    },
+    "security": {
+      "generated_by": "autoreview",
+      "score": 9,
+      "summary": "The required single autoreview pass and secret scan found no blocking security issue; provider credentials remain brokered through the Gantry gateway and are redacted from E2E evidence.",
+      "blocking_findings": [],
+      "non_blocking_findings": [],
+      "residual_risks": [],
+      "recommendation": "approve",
+      "reviewed_scope": [
+        "gateway credential boundary",
+        "E2E secret handling and redaction",
+        "staged-diff secret scan"
+      ],
+      "aspect": "security",
+      "recorded_at": "2026-08-16T19:36:51+00:00",
+      "commit": "6b47281473539b8750ac3f2c91d4481e9ffda416"
+    }
+  }
+}


### PR DESCRIPTION
## Type of Change

- [ ] Feature skill
- [ ] Utility skill
- [ ] Operational/container skill
- [x] Fix
- [ ] Simplification
- [ ] Documentation

## What & why

Gantry could not complete GPT-5.6 Luna turns through the native OpenAI provider when DeepAgents bound function tools. The runner used the Chat Completions route, while OpenAI requires these GPT-5.6 tool-enabled requests to use the Responses API. The gateway base path also omitted the canonical `/v1` segment expected by the native OpenAI SDK route.

## What this PR delivers

- Routes native OpenAI GPT-5.6 models through LangChain's Responses API integration.
- Uses the canonical Gantry OpenAI gateway base ending in `/v1`.
- Keeps non-OpenAI compatible providers and OpenRouter behavior unchanged.
- Preserves Chat Completions for compatible OpenAI models when Responses is not required.
- Adds regression coverage for GPT-5.6 Luna without an explicitly configured reasoning effort.

## Technical detail

The DeepAgents model factory now constructs `ChatOpenAI` directly with `useResponsesApi: true` for OpenAI GPT-5.6 models or explicit non-`none` reasoning. Direct construction prevents the universal configurable-model wrapper from reconstructing the bound model as Chat Completions after DeepAgents adds tools.

The native OpenAI gateway URL is normalized to `<gateway>/v1`; other OpenAI-compatible provider gateway URLs retain their existing shape.

## Evidence

- Focused model-factory unit suite: 31 tests passed.
- DeepAgents/Postgres boundary integration: 12 tests passed.
- Full runtime and example-app production build passed.
- Architecture checks passed.
- Live local Telegram turn using GPT-5.6 Luna completed and delivered successfully through Gantry.
- Staged-diff secret scan passed; no provider or Telegram credentials are committed.
- Required single autoreview pass was clean across quality, performance, and security, with no blocking findings.

## E2E delta

Adds `gpt56-openai-turn.agent-e2e.test.ts`, which boots the packaged runtime, seeds an OpenAI credential through the Control API, selects `gpt-luna`, sends a real agent turn, and verifies durable reply and run records. It is gated by `E2E_OPENAI_MODEL_API_KEY` and a disposable Postgres URL, so environments without the protected credential skip the external provider call explicitly.

The agent E2E matrix now cites this credential-gated GPT-5.6 Responses API scenario.

## For Skills

- [ ] SKILL.md contains instructions, not inline code
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
