### PR TITLE
fix: actionable recovery when an autonomous run denies a compound bash command

### DIFF
--- a/apps/core/src/shared/autonomous-bash-recovery-rule.ts
+++ b/apps/core/src/shared/autonomous-bash-recovery-rule.ts
@@ -1,3 +1,4 @@
+import type { BashCommandLeaf } from './bash-command-parser.js';
 import {
   bashExecutableName,
   nonDurableBashLeafReason,
@@ -7,6 +8,16 @@ import {
 import { containsGeneratedRuntimePath } from './generated-runtime-paths.js';
 import { normalizeRuntimeOwnedBashCommandForMatching } from './tool-rule-matcher.js';
 
+// A single reviewed-command leaf can back a durable autonomous RunCommand rule
+// only when it is not a stateful shell builtin, not an inline interpreter
+// (`node -e`, `python -c`, ...), and carries no destructive redirect.
+export function persistentAutonomousBashRecoveryRuleForLeaf(
+  leaf: BashCommandLeaf,
+): string | undefined {
+  if (nondurableLeafReason(leaf)) return undefined;
+  return normalizeBashLeafRuleContent(leaf);
+}
+
 export function persistentAutonomousBashRecoveryRule(
   command: string,
 ): string | undefined {
@@ -15,10 +26,75 @@ export function persistentAutonomousBashRecoveryRule(
   const parsed = parseBashCommand(normalized);
   if (!parsed.ok || parsed.leaves.length !== 1) return undefined;
   const [leaf] = parsed.leaves;
-  if (!leaf || nonDurableBashLeafReason(leaf)) return undefined;
-  if (inlineInterpreterLeaf(leaf.argv)) return undefined;
-  if (leaf.redirects.some((redirect) => redirect.destructive)) return undefined;
-  return normalizeBashLeafRuleContent(leaf);
+  return leaf ? persistentAutonomousBashRecoveryRuleForLeaf(leaf) : undefined;
+}
+
+export type AutonomousCompoundBashRecovery =
+  // Every part can be granted individually: the per-leaf reviewed-command rule
+  // contents (raw; the caller JSON-encodes them into request_access actions the
+  // same way the single-command recovery does).
+  | { kind: 'grantable'; rules: string[] }
+  // The compound cannot be granted. `reason` is a fixed, non-command-derived
+  // explanation; `part` (when present) is the safe 1-based index of the specific
+  // offending leaf, absent when the whole command is at fault (e.g. a pipe).
+  | { kind: 'blocked'; part?: number; reason: string };
+
+// A COMPOUND command (leaves joined by &&/||/;/pipe) can never be a single
+// durable rule. For a control-flow-only compound (&&/||/;, no data flow) this
+// tells the autonomous recovery to grant each part's access and re-run the
+// ORIGINAL command instead of dead-ending; a piped compound is blocked outright
+// (see below). Returns undefined for a single-leaf command (the caller already
+// has a scoped-rule path for that) or a command that cannot be parsed safely.
+export function autonomousCompoundBashRecovery(
+  command: string,
+): AutonomousCompoundBashRecovery | undefined {
+  const normalized = normalizeRuntimeOwnedBashCommandForMatching(command);
+  if (containsGeneratedRuntimePath(normalized)) return undefined;
+  const parsed = parseBashCommand(normalized);
+  if (!parsed.ok || parsed.leaves.length <= 1) return undefined;
+  // A pipe feeds one leaf's output into the next as DATA, and that data can be
+  // program text for whatever the downstream leaf runs (`data | julia`,
+  // `... | python`). Per-leaf durable rules cannot be proven safe without
+  // resolving each sink's stdin semantics, and enumerating every interpreter is
+  // unsound. So only offer per-leaf grants for control-flow-only compounds
+  // (`&&`/`||`/`;`, no data flow); block anything containing a pipe.
+  if (parsed.piped) {
+    return {
+      kind: 'blocked',
+      reason:
+        'it pipes data between commands, and a piped command may execute that data as its program.',
+    };
+  }
+  const rules: string[] = [];
+  for (let index = 0; index < parsed.leaves.length; index += 1) {
+    const leaf = parsed.leaves[index]!;
+    const reason = nondurableLeafReason(leaf);
+    const content = normalizeBashLeafRuleContent(leaf);
+    if (reason || !content) {
+      return {
+        kind: 'blocked',
+        part: index + 1,
+        reason: reason ?? 'a part cannot be expressed as a scoped rule.',
+      };
+    }
+    // Push the EXACT reviewed-command rule (no mutation): it is serialized with
+    // proper JSON escaping by the caller, so it authorizes the same leaf when
+    // the agent re-runs the original compound command.
+    rules.push(content);
+  }
+  return { kind: 'grantable', rules: [...new Set(rules)] };
+}
+
+function nondurableLeafReason(leaf: BashCommandLeaf): string | undefined {
+  const stateful = nonDurableBashLeafReason(leaf);
+  if (stateful) return stateful;
+  if (inlineInterpreterLeaf(leaf.argv)) {
+    return 'An inline interpreter command (node -e / python -c / ...) cannot be persisted as a scoped rule.';
+  }
+  if (leaf.redirects.some((redirect) => redirect.destructive)) {
+    return 'A destructive redirect cannot be persisted as a scoped rule.';
+  }
+  return undefined;
 }
 
 function inlineInterpreterLeaf(argv: readonly string[]): boolean {

--- a/apps/core/src/shared/autonomous-bash-recovery-rule.ts
+++ b/apps/core/src/shared/autonomous-bash-recovery-rule.ts
@@ -85,6 +85,44 @@ export function autonomousCompoundBashRecovery(
   return { kind: 'grantable', rules: [...new Set(rules)] };
 }
 
+// Full autonomous-run recovery guidance for a denied Bash command: a single
+// scoped RunCommand rule when the command is one durable leaf, an actionable
+// per-part grant for a control-flow-only compound, or a fixed "blocked"/dead-end
+// message. `escapeJson` is injected so the caller keeps one JSON-escaping impl.
+export function autonomousBashRecoveryMessage(
+  command: string | undefined,
+  escapeJson: (value: string) => string,
+): string {
+  const rule = command
+    ? persistentAutonomousBashRecoveryRule(command)
+    : undefined;
+  if (rule) {
+    return `request_access { "target": { "kind": "run_command", "argvPattern": "${escapeJson(rule)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scoped command access." }`;
+  }
+  // A COMPOUND command (&&/||/;/pipe) can never be one durable rule, but its
+  // parts usually can be — give an ACTIONABLE recovery instead of a dead end.
+  const compound = command
+    ? autonomousCompoundBashRecovery(command)
+    : undefined;
+  if (compound?.kind === 'grantable') {
+    const requests = compound.rules
+      .map(
+        (r) =>
+          `request_access { "target": { "kind": "run_command", "argvPattern": "${escapeJson(r)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scoped command access." }`,
+      )
+      .join(' ');
+    return `This is a compound command (${compound.rules.length} commands joined by &&/||/;); autonomous runs authorize one command at a time, so it cannot be granted as a single rule. Grant each part's access: ${requests} Then re-run the ORIGINAL command unchanged once every part is granted. Do not split it into separate runs — the &&/||/; control flow must be preserved.`;
+  }
+  if (compound?.kind === 'blocked') {
+    const detail =
+      compound.part !== undefined
+        ? `part ${compound.part} cannot be durably granted: ${compound.reason}`
+        : `it cannot be durably granted because ${compound.reason}`;
+    return `This is a compound command and cannot be fully approved for autonomous runs — ${detail} Reformulate the whole operation to use a reviewed semantic capability, or to individually-grantable commands that keep the same control flow — do not run only part of it.`;
+  }
+  return 'Update the autonomous run to use a reviewed semantic capability or invoke a scoped RunCommand(...) command directly. This command cannot be durably approved for autonomous runs.';
+}
+
 function nondurableLeafReason(leaf: BashCommandLeaf): string | undefined {
   const stateful = nonDurableBashLeafReason(leaf);
   if (stateful) return stateful;

--- a/apps/core/src/shared/bash-command-parser.ts
+++ b/apps/core/src/shared/bash-command-parser.ts
@@ -11,7 +11,9 @@ export interface BashCommandLeaf {
 }
 
 export type BashCommandParseResult =
-  | { ok: true; leaves: BashCommandLeaf[] }
+  // `piped` is true when the leaves are joined by at least one `|` (data flows
+  // between them), as opposed to control-flow-only `&&`/`||`/`;`.
+  | { ok: true; leaves: BashCommandLeaf[]; piped: boolean }
   | { ok: false; reason: string };
 
 const UNSAFE_COMMANDS = new Set([
@@ -249,6 +251,7 @@ function parseSegment(command: string): BashCommandParseResult {
   let token = '';
   let quote: "'" | '"' | null = null;
   let escaped = false;
+  let piped = false;
 
   const flushToken = () => {
     if (!token) return;
@@ -337,6 +340,7 @@ function parseSegment(command: string): BashCommandParseResult {
       const nested = parseSegment(command.slice(i + 1, end));
       if (!nested.ok) return nested;
       leaves.push(...nested.leaves);
+      if (nested.piped) piped = true;
       i = end;
       continue;
     }
@@ -362,6 +366,7 @@ function parseSegment(command: string): BashCommandParseResult {
       const flushed = flushLeaf();
       if (flushed) return flushed;
       if (ch === '|' && next === '|') i += 1;
+      else if (ch === '|') piped = true;
       continue;
     }
 
@@ -390,7 +395,7 @@ function parseSegment(command: string): BashCommandParseResult {
   if (leaves.length === 0) {
     return { ok: false, reason: 'Bash command has no executable leaves.' };
   }
-  return { ok: true, leaves };
+  return { ok: true, leaves, piped };
 }
 
 function parseRedirect(

--- a/apps/core/src/shared/tool-execution-policy-service.ts
+++ b/apps/core/src/shared/tool-execution-policy-service.ts
@@ -33,7 +33,7 @@ import { isGeneratedRuntimeToolResultPath } from './generated-runtime-paths.js';
 import { type SemanticCapabilityDefinition } from './semantic-capabilities.js';
 import { resolveCapabilityRules } from './tool-execution-capability-resolution.js';
 import {
-  autonomousCompoundBashRecovery,
+  autonomousBashRecoveryMessage,
   persistentAutonomousBashRecoveryRule,
 } from './autonomous-bash-recovery-rule.js';
 
@@ -599,35 +599,10 @@ function autonomousGrantRecovery(
   }
   const toolName = publicGantryToolNameForSdkTool(request.toolName);
   if (request.toolName === 'Bash') {
-    const command = commandText(request.input);
-    const rule = command
-      ? persistentAutonomousBashRecoveryRule(command)
-      : undefined;
-    if (!rule) {
-      // A COMPOUND command (&&/||/;/pipe) can never be one durable rule, but its
-      // parts usually can be — give an ACTIONABLE recovery instead of a dead end.
-      const compound = command
-        ? autonomousCompoundBashRecovery(command)
-        : undefined;
-      if (compound?.kind === 'grantable') {
-        const requests = compound.rules
-          .map(
-            (r) =>
-              `request_access { "target": { "kind": "run_command", "argvPattern": "${escapeJson(r)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scoped command access." }`,
-          )
-          .join(' ');
-        return `This is a compound command (${compound.rules.length} commands joined by &&/||/;); autonomous runs authorize one command at a time, so it cannot be granted as a single rule. Grant each part's access: ${requests} Then re-run the ORIGINAL command unchanged once every part is granted. Do not split it into separate runs — the &&/||/; control flow must be preserved.`;
-      }
-      if (compound?.kind === 'blocked') {
-        const detail =
-          compound.part !== undefined
-            ? `part ${compound.part} cannot be durably granted: ${compound.reason}`
-            : `it cannot be durably granted because ${compound.reason}`;
-        return `This is a compound command and cannot be fully approved for autonomous runs — ${detail} Reformulate the whole operation to use a reviewed semantic capability, or to individually-grantable commands that keep the same control flow — do not run only part of it.`;
-      }
-      return 'Update the autonomous run to use a reviewed semantic capability or invoke a scoped RunCommand(...) command directly. This command cannot be durably approved for autonomous runs.';
-    }
-    return `request_access { "target": { "kind": "run_command", "argvPattern": "${escapeJson(rule)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scoped command access." }`;
+    return autonomousBashRecoveryMessage(
+      commandText(request.input),
+      escapeJson,
+    );
   }
   if (isDurableGantryMcpToolFullName(request.toolName)) {
     return `request_access { "target": { "kind": "tool", "name": "${escapeJson(request.toolName)}" }, "temporaryOnly": false, "reason": "This autonomous run needs exact Gantry tool access." }`;
@@ -712,12 +687,10 @@ function thirdPartyMcpToolServerName(toolName: string): string | undefined {
 }
 
 function escapeJson(value: string): string {
-  // Proper JSON string-body escaping: handles backslashes, quotes, AND control
-  // characters (newlines/tabs -> \n/\t, others -> \uXXXX). A hand-rolled
-  // quote/backslash-only escaper would leave a literal newline that breaks out
-  // of the encoded value. JSON.stringify does NOT escape the non-C0 line
-  // controls U+0085 (NEL), U+2028, and U+2029, which render as line breaks, so
-  // escape them explicitly — this text is read by an autonomous agent.
+  // Full JSON string-body escaping (backslashes, quotes, C0 controls). This text
+  // is read by an autonomous agent, and JSON.stringify leaves the non-C0 line
+  // controls U+0085/U+2028/U+2029 literal, so escape those too — else an
+  // injected line break could split the guidance into a fake instruction.
   return JSON.stringify(value)
     .slice(1, -1)
     .replace(/\u0085/g, '\\u0085')

--- a/apps/core/src/shared/tool-execution-policy-service.ts
+++ b/apps/core/src/shared/tool-execution-policy-service.ts
@@ -32,7 +32,10 @@ import {
 import { isGeneratedRuntimeToolResultPath } from './generated-runtime-paths.js';
 import { type SemanticCapabilityDefinition } from './semantic-capabilities.js';
 import { resolveCapabilityRules } from './tool-execution-capability-resolution.js';
-import { persistentAutonomousBashRecoveryRule } from './autonomous-bash-recovery-rule.js';
+import {
+  autonomousCompoundBashRecovery,
+  persistentAutonomousBashRecoveryRule,
+} from './autonomous-bash-recovery-rule.js';
 
 export type ToolExecutionOrigin =
   | 'sdk'
@@ -601,6 +604,27 @@ function autonomousGrantRecovery(
       ? persistentAutonomousBashRecoveryRule(command)
       : undefined;
     if (!rule) {
+      // A COMPOUND command (&&/||/;/pipe) can never be one durable rule, but its
+      // parts usually can be — give an ACTIONABLE recovery instead of a dead end.
+      const compound = command
+        ? autonomousCompoundBashRecovery(command)
+        : undefined;
+      if (compound?.kind === 'grantable') {
+        const requests = compound.rules
+          .map(
+            (r) =>
+              `request_access { "target": { "kind": "run_command", "argvPattern": "${escapeJson(r)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scoped command access." }`,
+          )
+          .join(' ');
+        return `This is a compound command (${compound.rules.length} commands joined by &&/||/;); autonomous runs authorize one command at a time, so it cannot be granted as a single rule. Grant each part's access: ${requests} Then re-run the ORIGINAL command unchanged once every part is granted. Do not split it into separate runs — the &&/||/; control flow must be preserved.`;
+      }
+      if (compound?.kind === 'blocked') {
+        const detail =
+          compound.part !== undefined
+            ? `part ${compound.part} cannot be durably granted: ${compound.reason}`
+            : `it cannot be durably granted because ${compound.reason}`;
+        return `This is a compound command and cannot be fully approved for autonomous runs — ${detail} Reformulate the whole operation to use a reviewed semantic capability, or to individually-grantable commands that keep the same control flow — do not run only part of it.`;
+      }
       return 'Update the autonomous run to use a reviewed semantic capability or invoke a scoped RunCommand(...) command directly. This command cannot be durably approved for autonomous runs.';
     }
     return `request_access { "target": { "kind": "run_command", "argvPattern": "${escapeJson(rule)}" }, "temporaryOnly": false, "reason": "This autonomous run needs scoped command access." }`;
@@ -688,5 +712,15 @@ function thirdPartyMcpToolServerName(toolName: string): string | undefined {
 }
 
 function escapeJson(value: string): string {
-  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+  // Proper JSON string-body escaping: handles backslashes, quotes, AND control
+  // characters (newlines/tabs -> \n/\t, others -> \uXXXX). A hand-rolled
+  // quote/backslash-only escaper would leave a literal newline that breaks out
+  // of the encoded value. JSON.stringify does NOT escape the non-C0 line
+  // controls U+0085 (NEL), U+2028, and U+2029, which render as line breaks, so
+  // escape them explicitly — this text is read by an autonomous agent.
+  return JSON.stringify(value)
+    .slice(1, -1)
+    .replace(/\u0085/g, '\\u0085')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 }

--- a/apps/core/test/unit/shared/tool-execution-policy-service.test.ts
+++ b/apps/core/test/unit/shared/tool-execution-policy-service.test.ts
@@ -123,6 +123,143 @@ describe('ToolExecutionPolicyService', () => {
     ).not.toContain('scheduler_grant_tool');
   });
 
+  it('gives an actionable per-part recovery for a compound autonomous Bash denial', () => {
+    // Regression: the KnackLabs job dead-ended here — its agent ran the compound
+    // probe `which gog 2>/dev/null || echo "not found"`, which can never be one
+    // durable rule, so the recovery was a non-actionable "cannot be durably
+    // approved" message. It must now break the command into grantable parts.
+    const request = classifier.classify({
+      origin: 'sdk',
+      toolName: 'Bash',
+      toolInput: { command: 'which gog 2>/dev/null || echo "not found"' },
+      executionMode: 'autonomous',
+      runContext: { jobId: 'job-1' },
+    });
+    const result = policy.evaluate({ request, autonomousAllowedToolRules: [] });
+    expect(result.status).toBe('deny');
+    expect(result.recoveryAction).toContain('compound command');
+    // Actionable: a concrete durable request_access per grantable part.
+    expect(result.recoveryAction).toContain('"kind": "run_command"');
+    expect(result.recoveryAction).toContain('"temporaryOnly": false');
+    expect(result.recoveryAction).toContain('"argvPattern": "which gog"');
+    expect(result.recoveryAction).toContain('"argvPattern": "echo not found"');
+    // Correct semantics: grant each part's access, then re-run the ORIGINAL
+    // command (do NOT split — pipes/&&/|| semantics must be preserved).
+    expect(result.recoveryAction).toContain('re-run the ORIGINAL command');
+    expect(result.recoveryAction).toContain('control flow');
+    // Not the old dead end.
+    expect(result.recoveryAction).not.toContain(
+      'Update the autonomous run to use a reviewed semantic capability',
+    );
+  });
+
+  it('names the non-grantable part of a compound autonomous Bash command', () => {
+    const request = classifier.classify({
+      origin: 'sdk',
+      toolName: 'Bash',
+      toolInput: { command: 'cd /tmp && ls' },
+      executionMode: 'autonomous',
+      runContext: { jobId: 'job-1' },
+    });
+    const result = policy.evaluate({ request, autonomousAllowedToolRules: [] });
+    expect(result.status).toBe('deny');
+    expect(result.recoveryAction).toContain('compound command');
+    // Identifies WHICH part failed by safe 1-based index (cd is the 1st leaf).
+    expect(result.recoveryAction).toContain('part 1');
+    // A fixed, non-command-derived reason (constrained executable name only).
+    expect(result.recoveryAction).toContain('changes shell state');
+    // Must NOT advise executing a subset (blocked leaf may be a precondition).
+    expect(result.recoveryAction).toContain('do not run only part of it');
+    // SECURITY: the agent's raw command text is NOT embedded.
+    expect(result.recoveryAction).not.toContain('cd /tmp &&');
+  });
+
+  it('blocks a piped autonomous Bash command (data may be run as code)', () => {
+    // A pipe feeds one command's output into the next as data, and that data can
+    // be program text (`cat x | python`), so no per-leaf rule can be proven safe.
+    const request = classifier.classify({
+      origin: 'sdk',
+      toolName: 'Bash',
+      toolInput: { command: 'cat x | python' },
+      executionMode: 'autonomous',
+      runContext: { jobId: 'job-1' },
+    });
+    const result = policy.evaluate({ request, autonomousAllowedToolRules: [] });
+    expect(result.status).toBe('deny');
+    expect(result.recoveryAction).toContain('compound command');
+    expect(result.recoveryAction).toContain('pipes data');
+    expect(result.recoveryAction).toContain('do not run only part of it');
+    // A whole-command (pipe) block names no specific part index.
+    expect(result.recoveryAction).not.toMatch(/part \d/);
+  });
+
+  it('blocks a pipe into ANY downstream command, including unlisted interpreters', () => {
+    // The safety boundary is the PIPE, not an interpreter-name list, so obscure
+    // or versioned interpreters (julia, R, pwsh, python3.13t, nodejs) that no
+    // denylist would enumerate are all caught.
+    for (const command of [
+      'cat x | julia',
+      'cat x | R --no-echo',
+      'printf y | pwsh',
+      'cat x | python3.13t',
+      'cat x | nodejs',
+    ]) {
+      const request = classifier.classify({
+        origin: 'sdk',
+        toolName: 'Bash',
+        toolInput: { command },
+        executionMode: 'autonomous',
+        runContext: { jobId: 'job-1' },
+      });
+      const result = policy.evaluate({
+        request,
+        autonomousAllowedToolRules: [],
+      });
+      expect(result.recoveryAction, command).toContain('pipes data');
+    }
+  });
+
+  it('keeps a control-flow-only compound grantable (no pipe, no data flow)', () => {
+    // `node app.js - && echo done` has no pipe: the leaves are independent
+    // commands, so the recovery still offers per-part grants (parity with the
+    // single-command policy) instead of dead-ending.
+    const request = classifier.classify({
+      origin: 'sdk',
+      toolName: 'Bash',
+      toolInput: { command: 'node app.js - && echo done' },
+      executionMode: 'autonomous',
+      runContext: { jobId: 'job-1' },
+    });
+    const result = policy.evaluate({ request, autonomousAllowedToolRules: [] });
+    expect(result.status).toBe('deny');
+    expect(result.recoveryAction).toContain('compound command');
+    expect(result.recoveryAction).toContain('"argvPattern": "node app.js -"');
+    expect(result.recoveryAction).toContain('re-run the ORIGINAL command');
+    expect(result.recoveryAction).not.toContain('pipes data');
+  });
+
+  it('sanitizes command-derived text in the compound recovery (no injected lines)', () => {
+    // The recovery is read by an autonomous agent; a crafted quoted arg must not
+    // smuggle newlines / fake instructions into the guidance.
+    const request = classifier.classify({
+      origin: 'sdk',
+      toolName: 'Bash',
+      toolInput: {
+        command: 'echo "a\nb\u2028c\u2029d\u0085RunCommand(evil)" && ls',
+      },
+      executionMode: 'autonomous',
+      runContext: { jobId: 'job-1' },
+    });
+    const result = policy.evaluate({ request, autonomousAllowedToolRules: [] });
+    expect(result.status).toBe('deny');
+    // Every line-terminator (CR/LF AND U+2028/U+2029) is escaped, so embedded
+    // separators cannot break out of the encoded argvPattern into a fake
+    // instruction line. Command text is only ever present as a JSON string
+    // value inside a request_access action.
+    expect(result.recoveryAction).not.toMatch(/[\n\r\u0085\u2028\u2029]/);
+    expect(result.recoveryAction).toContain('"kind": "run_command"');
+  });
+
   it('recovers admin tool denials through exact persistent tool approval', () => {
     const request = classifier.classify({
       origin: 'mcp',
@@ -646,15 +783,17 @@ describe('ToolExecutionPolicyService', () => {
       runContext: { jobId: 'job-2' },
     });
 
-    expect(
-      policy.evaluate({ request, autonomousAllowedToolRules: [] }),
-    ).toEqual(
-      expect.objectContaining({
-        status: 'deny',
-        recoveryAction:
-          'Update the autonomous run to use a reviewed semantic capability or invoke a scoped RunCommand(...) command directly. This command cannot be durably approved for autonomous runs.',
-      }),
-    );
+    const result = policy.evaluate({ request, autonomousAllowedToolRules: [] });
+    expect(result.status).toBe('deny');
+    // A compound command is NEVER offered as a single whole-command rule, and
+    // the agent's untrusted raw command text is not embedded in the guidance.
+    expect(result.recoveryAction).not.toContain('cd /tmp/evil');
+    expect(result.recoveryAction).not.toContain('RunCommand(cd');
+    // The stateful `cd` part makes it non-grantable — a fixed reason says why,
+    // and it must not advise running the rest (npm test) without the cd.
+    expect(result.recoveryAction).toContain('compound command');
+    expect(result.recoveryAction).toContain('changes shell state');
+    expect(result.recoveryAction).toContain('do not run only part of it');
   });
 
   it('does not suggest autonomous broad Bash grants', () => {

--- a/plans/quickfixes/20260817T145506-0000-Q-0031-0513-open-145506169974.json
+++ b/plans/quickfixes/20260817T145506-0000-Q-0031-0513-open-145506169974.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0031-0513",
+  "profile": "quickfix",
+  "reason": "Autonomous compound-command recovery: an autonomous/scheduled run that denies a COMPOUND bash command (leaves joined by &&/||/;/pipe) dead-ended with a non-actionable 'cannot be durably approved' message \u2014 this blocked the KnackLabs job whose agent ran 'which gog 2>/dev/null || echo not-found'. Now control-flow-only compounds (&&/||/;) emit a concrete per-leaf request_access and advise re-running the ORIGINAL command; piped compounds and non-durable leaves are blocked with a fixed reason. Parser gains pipe tracking; recovery text is JSON-escaped (incl. U+0085/U+2028/U+2029). Tests + autoreview clean.",
+  "started_at": "2026-08-17T14:55:06+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260817T145627-0000-Q-0031-0513-done-145627623653.json
+++ b/plans/quickfixes/20260817T145627-0000-Q-0031-0513-done-145627623653.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0031-0513",
+  "profile": "quickfix",
+  "reason": "Autonomous compound-command recovery: an autonomous/scheduled run that denies a COMPOUND bash command (leaves joined by &&/||/;/pipe) dead-ended with a non-actionable 'cannot be durably approved' message \u2014 this blocked the KnackLabs job whose agent ran 'which gog 2>/dev/null || echo not-found'. Now control-flow-only compounds (&&/||/;) emit a concrete per-leaf request_access and advise re-running the ORIGINAL command; piped compounds and non-durable leaves are blocked with a fixed reason. Parser gains pipe tracking; recovery text is JSON-escaped (incl. U+0085/U+2028/U+2029). Tests + autoreview clean.",
+  "started_at": "2026-08-17T14:55:06+00:00",
+  "completed_at": "2026-08-17T14:56:27+00:00",
+  "files": []
+}


### PR DESCRIPTION
## What this fixes (plain language)

When a scheduled/autonomous job hit a shell command that joined several commands together (with `&&`, `||`, `;`, or a pipe `|`), and one part wasn't pre-approved, the run hit a dead end: it was told the command "cannot be durably approved" with no way forward. There was nothing the agent could actually do, so the job just stalled.

This is exactly what blocked the KnackLabs lead-maintenance job — its agent probed the environment with `which gog 2>/dev/null || echo "not found"` (a compound command), and that probe dead-ended the whole run.

Now the run gets a real next step instead of a wall.

## What changes

For a denied **compound** bash command in an autonomous run:

- **Control-flow-only compounds** (`&&`/`||`/`;`, where the parts are independent commands): the recovery now lists a concrete `request_access(run_command)` grant for each grantable part and tells the agent to re-run the **original** command unchanged once granted (so the control flow is preserved, not split apart).
- **A part that can't be a durable rule** (a stateful builtin like `cd`, an inline interpreter like `node -e`, a host Python script, a destructive redirect): it's blocked with the safe 1-based index of the offending part and a fixed, non-command-derived reason.
- **A piped compound** (`… | …`): blocked outright. A pipe feeds one command's output into the next as data, and that data can be program text (`data | python`). Proving a per-leaf grant safe would mean enumerating every interpreter that reads stdin — which is unsound (`julia`, `R`, `pwsh`, versioned names… no list is complete). So the safety boundary is **the pipe itself**, not an interpreter name list.

The single-command recovery path is unchanged.

### Supporting changes
- The bash parser now reports whether a command's leaves are pipe-joined (`piped`), so the recovery can distinguish data-flow from control-flow.
- All command-derived text in the recovery message is JSON-escaped before it reaches the autonomous agent, including the non-C0 line controls **U+0085 / U+2028 / U+2029** (which `JSON.stringify` leaves literal) — an injected line-break can't smuggle a fake instruction into the guidance.

## Why this shape

The recovery message is read and acted on by an autonomous agent, and (once a human approves a suggested grant) it shapes real durable authority. It went through an adversarial review loop that repeatedly probed the per-leaf classifier for bypasses (versioned interpreter names, stdin modes, option operands that consume the apparent script argument). Every heuristic that tried to classify *which leaf is a dangerous sink* proved incomplete. Anchoring on the pipe is both **sound** (data flow is the actual risk) and **simpler** — it let the whole interpreter-denylist be deleted.

## Testing
- `apps/core/test/unit/shared/tool-execution-policy-service.test.ts` — per-part grant, named non-grantable part, piped block (incl. `julia`/`R`/`pwsh`/versioned), control-flow-only stays grantable, and injected-line-break sanitisation (CR/LF + U+0085/U+2028/U+2029).
- `tool-execution-policy-service` + `bash-command-parser` unit suites green; the other `parseBashCommand` consumers (yolo-mode, read-only gate, durable-access, template-widening, permission-suggestions, agent-tool-references) all green; typecheck clean.
- Autoreview (branch scope) clean.

## Note
The KnackLabs job's own prompt still carries the `which gog` probe; per the owner's instruction that job's config/prompt is untouched here — this PR fixes the runtime side only.