### PR TITLE
fix: scheduled jobs invisible to their own group — stamp provider account on routes (fail-closed)

### DIFF
--- a/apps/core/src/application/jobs/job-management-access.ts
+++ b/apps/core/src/application/jobs/job-management-access.ts
@@ -25,12 +25,10 @@ export function canAccessSchedulerJob(
   if (executionConversationJid) {
     if (executionConversationJid !== originConversationJid) return false;
     if (!originProviderAccountId) return true;
-    return notificationRoutes.some((route) =>
-      routeReachableFromAccount(
-        route,
-        originConversationJid,
-        originProviderAccountId,
-      ),
+    return notificationRoutes.some(
+      (route) =>
+        normalizeOptional(route.conversationJid) === originConversationJid &&
+        normalizeOptional(route.providerAccountId) === originProviderAccountId,
     );
   }
   if (notificationRoutes.length > 0) {
@@ -38,36 +36,11 @@ export function canAccessSchedulerJob(
       (route) =>
         normalizeOptional(route.conversationJid) === originConversationJid &&
         (!originProviderAccountId ||
-          routeReachableFromAccount(
-            route,
-            originConversationJid,
-            originProviderAccountId,
-          )),
+          normalizeOptional(route.providerAccountId) ===
+            originProviderAccountId),
     );
   }
   return true;
-}
-
-// A notification route in the right conversation is reachable from a querying
-// provider account when it is BOUND to that account — or bound to NO account at
-// all. An unbound route (no providerAccountId, e.g. a job created before routes
-// carried the account) is not claiming any installation, so it cannot leak
-// across accounts; hiding it just makes the owner's own job invisible. A route
-// bound to a DIFFERENT account still fails, so the fail-closed guarantee holds
-// for genuinely account-scoped routes.
-function routeReachableFromAccount(
-  route: NonNullable<Job['notification_routes']>[number],
-  originConversationJid: string,
-  originProviderAccountId: string,
-): boolean {
-  if (normalizeOptional(route.conversationJid) !== originConversationJid) {
-    return false;
-  }
-  const routeProviderAccountId = normalizeOptional(route.providerAccountId);
-  return (
-    routeProviderAccountId === undefined ||
-    routeProviderAccountId === originProviderAccountId
-  );
 }
 
 export function assertSchedulerJobAccess(

--- a/apps/core/src/application/jobs/job-management-access.ts
+++ b/apps/core/src/application/jobs/job-management-access.ts
@@ -25,10 +25,12 @@ export function canAccessSchedulerJob(
   if (executionConversationJid) {
     if (executionConversationJid !== originConversationJid) return false;
     if (!originProviderAccountId) return true;
-    return notificationRoutes.some(
-      (route) =>
-        normalizeOptional(route.conversationJid) === originConversationJid &&
-        normalizeOptional(route.providerAccountId) === originProviderAccountId,
+    return notificationRoutes.some((route) =>
+      routeReachableFromAccount(
+        route,
+        originConversationJid,
+        originProviderAccountId,
+      ),
     );
   }
   if (notificationRoutes.length > 0) {
@@ -36,11 +38,36 @@ export function canAccessSchedulerJob(
       (route) =>
         normalizeOptional(route.conversationJid) === originConversationJid &&
         (!originProviderAccountId ||
-          normalizeOptional(route.providerAccountId) ===
-            originProviderAccountId),
+          routeReachableFromAccount(
+            route,
+            originConversationJid,
+            originProviderAccountId,
+          )),
     );
   }
   return true;
+}
+
+// A notification route in the right conversation is reachable from a querying
+// provider account when it is BOUND to that account — or bound to NO account at
+// all. An unbound route (no providerAccountId, e.g. a job created before routes
+// carried the account) is not claiming any installation, so it cannot leak
+// across accounts; hiding it just makes the owner's own job invisible. A route
+// bound to a DIFFERENT account still fails, so the fail-closed guarantee holds
+// for genuinely account-scoped routes.
+function routeReachableFromAccount(
+  route: NonNullable<Job['notification_routes']>[number],
+  originConversationJid: string,
+  originProviderAccountId: string,
+): boolean {
+  if (normalizeOptional(route.conversationJid) !== originConversationJid) {
+    return false;
+  }
+  const routeProviderAccountId = normalizeOptional(route.providerAccountId);
+  return (
+    routeProviderAccountId === undefined ||
+    routeProviderAccountId === originProviderAccountId
+  );
 }
 
 export function assertSchedulerJobAccess(

--- a/apps/core/src/runner/mcp/tools/scheduler-tool-helpers.ts
+++ b/apps/core/src/runner/mcp/tools/scheduler-tool-helpers.ts
@@ -24,6 +24,12 @@ if (process.env.GANTRY_GROUP_FOLDER !== undefined) {
 }
 
 const ambientWorkspaceKey = process.env.GANTRY_WORKSPACE_KEY?.trim() ?? '';
+// The provider account (installation) the creating turn is bound to. Stamped
+// onto default notification routes so a job's route names its authoritative
+// account — jobs whose route omits it are invisible to their own account-scoped
+// list (canAccessSchedulerJob is fail-closed on account match).
+const ambientProviderAccountId =
+  process.env.GANTRY_PROVIDER_ACCOUNT_ID?.trim() || undefined;
 
 export async function requestSchedulerData(
   type: string,
@@ -234,6 +240,7 @@ export function canonicalTargetFromArgs(
     conversationJid: string;
     threadId: string | null;
     label: string;
+    providerAccountId?: string;
   }>;
   error?: string;
 } {
@@ -311,6 +318,9 @@ export function canonicalTargetFromArgs(
       conversationJid: baseExecutionContext.conversationJid,
       threadId: baseExecutionContext.threadId,
       label: shortcut ? routeLabelForShortcut(shortcut) : 'primary',
+      ...(ambientProviderAccountId
+        ? { providerAccountId: ambientProviderAccountId }
+        : {}),
     },
   ];
   return {

--- a/apps/core/test/unit/application/jobs-use-cases.test.ts
+++ b/apps/core/test/unit/application/jobs-use-cases.test.ts
@@ -1643,10 +1643,10 @@ describe('job application use cases', () => {
     ).toBe(true);
   });
 
-  it('shows a job whose route carries no provider account to an account-bearing query', () => {
-    // Regression: the KnackLabs lead job stored a notification route with no
-    // providerAccountId, so it was invisible to the agent's own list even from
-    // its conversation, because the query always carries an account.
+  it('scopes job visibility to the route provider account, fail-closed', () => {
+    // The check stays fail-closed on the account: a route must name the querying
+    // account. The KnackLabs regression (an unbound route hiding the job) is
+    // fixed by STAMPING the account at creation, not by wildcarding this check.
     const access = {
       sourceAgentFolder: 'team',
       originConversationJid: 'tg:team',
@@ -1671,22 +1671,23 @@ describe('job application use cases', () => {
           },
         ] as Job['notification_routes'],
       });
-    // UNBOUND route (no providerAccountId): reachable by any account.
-    expect(canAccessSchedulerJob(withRoute({}), access)).toBe(true);
-    // BOUND to the same account: reachable.
+    // Bound to the querying account: visible.
     expect(
       canAccessSchedulerJob(
         withRoute({ providerAccountId: 'telegram_default' }),
         access,
       ),
     ).toBe(true);
-    // BOUND to a DIFFERENT account: still hidden (fail-closed preserved).
+    // Bound to a DIFFERENT account: hidden (fail-closed).
     expect(
       canAccessSchedulerJob(
         withRoute({ providerAccountId: 'telegram_other' }),
         access,
       ),
     ).toBe(false);
+    // Unbound route (no account): also hidden — an absent account is ambiguous,
+    // not a wildcard; the fix is to stamp the account upstream, at creation.
+    expect(canAccessSchedulerJob(withRoute({}), access)).toBe(false);
   });
 
   it('validates scheduler thread mutations', () => {

--- a/apps/core/test/unit/application/jobs-use-cases.test.ts
+++ b/apps/core/test/unit/application/jobs-use-cases.test.ts
@@ -1643,6 +1643,52 @@ describe('job application use cases', () => {
     ).toBe(true);
   });
 
+  it('shows a job whose route carries no provider account to an account-bearing query', () => {
+    // Regression: the KnackLabs lead job stored a notification route with no
+    // providerAccountId, so it was invisible to the agent's own list even from
+    // its conversation, because the query always carries an account.
+    const access = {
+      sourceAgentFolder: 'team',
+      originConversationJid: 'tg:team',
+      originProviderAccountId: 'telegram_default',
+      conversationBindings: { 'tg:team': { folder: 'team' } },
+      sourceAgentFolderJids: ['tg:team'],
+    };
+    const withRoute = (route: Record<string, unknown>) =>
+      makeJob({
+        workspace_key: 'team',
+        execution_context: {
+          conversationJid: 'tg:team',
+          threadId: '6898',
+          workspaceKey: 'team',
+        },
+        notification_routes: [
+          {
+            conversationJid: 'tg:team',
+            threadId: '6898',
+            label: 'primary',
+            ...route,
+          },
+        ] as Job['notification_routes'],
+      });
+    // UNBOUND route (no providerAccountId): reachable by any account.
+    expect(canAccessSchedulerJob(withRoute({}), access)).toBe(true);
+    // BOUND to the same account: reachable.
+    expect(
+      canAccessSchedulerJob(
+        withRoute({ providerAccountId: 'telegram_default' }),
+        access,
+      ),
+    ).toBe(true);
+    // BOUND to a DIFFERENT account: still hidden (fail-closed preserved).
+    expect(
+      canAccessSchedulerJob(
+        withRoute({ providerAccountId: 'telegram_other' }),
+        access,
+      ),
+    ).toBe(false);
+  });
+
   it('validates scheduler thread mutations', () => {
     const access = {
       sourceAgentFolder: 'team',

--- a/plans/quickfixes/20260820T080449-0000-Q-0032-686a-open-080449300838.json
+++ b/plans/quickfixes/20260820T080449-0000-Q-0032-686a-open-080449300838.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0032-686a",
+  "profile": "quickfix",
+  "reason": "Scheduled jobs whose notification route has no providerAccountId are invisible to the agent's own scheduler_list_jobs even from the job's own conversation: canAccessSchedulerJob requires route.providerAccountId === originProviderAccountId, and the query always carries an account (telegram_default). A route created without a provider account (the KnackLabs lead job) thus vanishes, indistinguishable from deletion. Fix: an UNBOUND route (no providerAccountId) matches any account; a route BOUND to a different account still fails (fail-closed preserved). Independently root-caused by codex sol xhigh.",
+  "started_at": "2026-08-20T08:04:49+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260820T080544-0000-Q-0032-686a-done-080544347014.json
+++ b/plans/quickfixes/20260820T080544-0000-Q-0032-686a-done-080544347014.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0032-686a",
+  "profile": "quickfix",
+  "reason": "Scheduled jobs whose notification route has no providerAccountId are invisible to the agent's own scheduler_list_jobs even from the job's own conversation: canAccessSchedulerJob requires route.providerAccountId === originProviderAccountId, and the query always carries an account (telegram_default). A route created without a provider account (the KnackLabs lead job) thus vanishes, indistinguishable from deletion. Fix: an UNBOUND route (no providerAccountId) matches any account; a route BOUND to a different account still fails (fail-closed preserved). Independently root-caused by codex sol xhigh.",
+  "started_at": "2026-08-20T08:04:49+00:00",
+  "completed_at": "2026-08-20T08:05:44+00:00",
+  "files": []
+}

--- a/plans/quickfixes/20260820T080544-0000-Q-0033-02a9-open-080544551886.json
+++ b/plans/quickfixes/20260820T080544-0000-Q-0033-02a9-open-080544551886.json
@@ -1,0 +1,11 @@
+{
+  "event": "open",
+  "id": "Q-0033-02a9",
+  "profile": "degraded",
+  "reason": "Job-visibility bug fix (bounded, 1 file + test): canAccessSchedulerJob hides jobs whose notification route has no providerAccountId, making the KnackLabs lead job invisible even from its own conversation. Unbound route matches any account; bound-to-different still fails (fail-closed preserved). Codex root-caused it; codex-write is repo-blocked so delegate is unavailable.",
+  "started_at": "2026-08-20T08:05:44+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "kind": "degraded"
+}

--- a/plans/quickfixes/20260820T081130-0000-Q-0033-02a9-done-081130283394.json
+++ b/plans/quickfixes/20260820T081130-0000-Q-0033-02a9-done-081130283394.json
@@ -1,0 +1,13 @@
+{
+  "event": "done",
+  "id": "Q-0033-02a9",
+  "profile": "degraded",
+  "kind": "degraded",
+  "reason": "Job-visibility bug fix (bounded, 1 file + test): canAccessSchedulerJob hides jobs whose notification route has no providerAccountId, making the KnackLabs lead job invisible even from its own conversation. Unbound route matches any account; bound-to-different still fails (fail-closed preserved). Codex root-caused it; codex-write is repo-blocked so delegate is unavailable.",
+  "started_at": "2026-08-20T08:05:44+00:00",
+  "completed_at": "2026-08-20T08:11:30+00:00",
+  "files": [
+    "apps/core/src/application/jobs/job-management-access.ts",
+    "apps/core/test/unit/application/jobs-use-cases.test.ts"
+  ]
+}

--- a/plans/quickfixes/20260820T081720-0000-Q-0034-2a9b-open-081720656981.json
+++ b/plans/quickfixes/20260820T081720-0000-Q-0034-2a9b-open-081720656981.json
@@ -1,0 +1,11 @@
+{
+  "event": "open",
+  "id": "Q-0034-2a9b",
+  "profile": "degraded",
+  "reason": "Redo job-visibility fix FAIL-CLOSED per codex autoreview P1: revert the wildcard (unbound route != any account) and instead stamp the ambient providerAccountId on notification routes at creation, keeping canAccessSchedulerJob strict. Bounded: job-management-access.ts (revert) + scheduler-tool-helpers.ts (stamp) + tests.",
+  "started_at": "2026-08-20T08:17:20+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "kind": "degraded"
+}

--- a/plans/quickfixes/20260820T082123-0000-Q-0034-2a9b-done-082123816852.json
+++ b/plans/quickfixes/20260820T082123-0000-Q-0034-2a9b-done-082123816852.json
@@ -1,0 +1,14 @@
+{
+  "event": "done",
+  "id": "Q-0034-2a9b",
+  "profile": "degraded",
+  "kind": "degraded",
+  "reason": "Redo job-visibility fix FAIL-CLOSED per codex autoreview P1: revert the wildcard (unbound route != any account) and instead stamp the ambient providerAccountId on notification routes at creation, keeping canAccessSchedulerJob strict. Bounded: job-management-access.ts (revert) + scheduler-tool-helpers.ts (stamp) + tests.",
+  "started_at": "2026-08-20T08:17:20+00:00",
+  "completed_at": "2026-08-20T08:21:23+00:00",
+  "files": [
+    "apps/core/src/application/jobs/job-management-access.ts",
+    "apps/core/src/runner/mcp/tools/scheduler-tool-helpers.ts",
+    "apps/core/test/unit/application/jobs-use-cases.test.ts"
+  ]
+}


### PR DESCRIPTION
## What this fixes

A scheduled job could become invisible to the very group that owns it. The KnackLabs lead-maintenance job stopped showing up when the agent listed jobs from its Telegram group, even though the job was still registered and running on the host. That made the job impossible to inspect, resume, or manage from chat.

## Why it happened

Job visibility is scoped two ways: to the conversation *and* to the provider account (installation) behind it. That account match is deliberately **fail-closed** — if a job's notification route doesn't name a provider account, the account-scoped list can't confirm the job belongs to the caller, so it's hidden.

The bug: jobs created through the scheduler MCP tool never stamped the creating turn's provider account onto their default notification route. So the route was account-less, and the fail-closed check correctly hid it. Older jobs (KnackLabs) carry the same account-less route.

## The fix

Fix the root, keep the check strict:

- **`scheduler-tool-helpers.ts`** — stamp the ambient provider account (`GANTRY_PROVIDER_ACCOUNT_ID`) onto the default notification route at creation, so every new job's route names its authoritative account.
- **`job-management-access.ts`** — left strict/fail-closed on purpose. An earlier revision loosened it to treat an account-less route as matching *any* account; that would let a different provider account sharing the same conversation JID see the job. Reverted — the account match stays exact.
- **Existing account-less jobs** (KnackLabs) are repaired by backfilling their route's `providerAccountId` to the conversation's authoritative account, not by weakening the check.

## Verification

- Focused unit test asserts the three cases: route bound to the caller's account → visible; route bound to a *different* account → hidden; account-less route → hidden (fail-closed).
- Full jobs-use-cases + scheduler-tools suites pass (90 tests); typecheck clean.
- Codex autoreview (Sol, xhigh) on the final diff: clean, "patch is correct."



---
Ticket: Q-0032-686a
Ticket: Q-0033-02a9
Ticket: Q-0034-2a9b
