### PR TITLE
feat(DIAG-1): record capability_run args + output in the tool-activity audit (args opt-in)

### DIFF
--- a/apps/core/src/application/mcp/mcp-tool-audit.ts
+++ b/apps/core/src/application/mcp/mcp-tool-audit.ts
@@ -7,6 +7,7 @@ import type {
 import { RUNTIME_EVENT_TYPES } from '../../domain/events/runtime-event-types.js';
 import type { McpServerRepository } from '../../domain/ports/repositories.js';
 import { redactSensitiveText } from '../../shared/sensitive-material.js';
+import { CAPABILITY_RUN_MAX_ARGS } from '../../shared/structured-local-cli.js';
 import { nowIso } from '../../shared/time/datetime.js';
 import { ApplicationError } from '../common/application-error.js';
 
@@ -47,6 +48,54 @@ export function summarizeMcpToolArgumentPayload(
   };
 }
 
+export function summarizeCapabilityRunAudit(input: {
+  serverName?: string;
+  toolName?: string;
+  argumentPayload?: unknown;
+  toolResult?: unknown;
+}):
+  | {
+      capabilityId: string;
+      argCount: number;
+      args?: string[];
+      stdout: string;
+      stderr: string;
+    }
+  | undefined {
+  if (
+    input.serverName !== 'gantry' ||
+    input.toolName !== 'capability_run' ||
+    !isCapabilityRunInput(input.argumentPayload)
+  ) {
+    return undefined;
+  }
+  const output = capabilityRunOutput(input.toolResult);
+  return {
+    capabilityId: redactAndTruncateCapabilityAuditText(
+      input.argumentPayload.capabilityId,
+    ),
+    argCount: input.argumentPayload.args.length,
+    // Raw argv can carry credentials in positions no fixed rule can detect
+    // (short flags, custom flags, positional secrets), so it is logged only when
+    // an operator opts in for a capability they trust. Best-effort redaction
+    // still applies as defense in depth.
+    ...(capabilityAuditArgsEnabled()
+      ? {
+          args: redactCapabilityArgv(
+            input.argumentPayload.args.slice(0, CAPABILITY_RUN_MAX_ARGS),
+          ),
+        }
+      : {}),
+    stdout: redactAndTruncateCapabilityAuditText(output.stdout),
+    stderr: redactAndTruncateCapabilityAuditText(output.stderr),
+  };
+}
+
+function capabilityAuditArgsEnabled(): boolean {
+  const raw = process.env.GANTRY_AUDIT_CAPABILITY_ARGS?.trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export async function publishInvalidMcpToolRequestAudit(input: {
   mcpServers: McpServerRepository;
   publishRuntimeEvent?: (
@@ -63,6 +112,11 @@ export async function publishInvalidMcpToolRequestAudit(input: {
   missingFields?: string[];
 }): Promise<void> {
   const reason = truncateAuditText(redactMcpAuditText(input.reason), 300);
+  const capabilityRun = summarizeCapabilityRunAudit({
+    serverName: input.serverName,
+    toolName: input.toolName,
+    argumentPayload: input.argumentPayload,
+  });
   const payload = {
     ...(input.serverName ? { serverName: input.serverName } : {}),
     ...(input.toolName ? { toolName: input.toolName } : {}),
@@ -72,6 +126,7 @@ export async function publishInvalidMcpToolRequestAudit(input: {
     resultClass: 'invalid_request' satisfies McpToolAuditResultClass,
     latencyMs: 0,
     argumentSummary: summarizeMcpToolArgumentPayload(input.argumentPayload),
+    ...(capabilityRun ? { capabilityRun } : {}),
     reason,
     ...(input.missingFields && input.missingFields.length > 0
       ? { missingFields: input.missingFields }
@@ -103,6 +158,89 @@ export async function publishInvalidMcpToolRequestAudit(input: {
     // Durable MCP audit is the source of truth; runtime events are observable
     // progress only and must not rewrite a malformed request outcome.
   }
+}
+
+function isCapabilityRunInput(
+  value: unknown,
+): value is { capabilityId: string; args: string[] } {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as { capabilityId?: unknown }).capabilityId === 'string' &&
+    Array.isArray((value as { args?: unknown }).args) &&
+    (value as { args: unknown[] }).args.every((arg) => typeof arg === 'string')
+  );
+}
+
+function capabilityRunOutput(value: unknown): {
+  stdout: string;
+  stderr: string;
+} {
+  const result = objectRecord(value);
+  const directOutput = result
+    ? (objectRecord(result.content) ?? result)
+    : undefined;
+  if (
+    typeof directOutput?.stdout === 'string' ||
+    typeof directOutput?.stderr === 'string'
+  ) {
+    return {
+      stdout:
+        typeof directOutput.stdout === 'string' ? directOutput.stdout : '',
+      stderr:
+        typeof directOutput.stderr === 'string' ? directOutput.stderr : '',
+    };
+  }
+  const content = result?.content;
+  if (!Array.isArray(content)) return { stdout: '', stderr: '' };
+  const text = content.find(
+    (entry): entry is { type: unknown; text: unknown } =>
+      entry !== null && typeof entry === 'object' && !Array.isArray(entry),
+  );
+  if (!text || typeof text.text !== 'string') return { stdout: '', stderr: '' };
+  try {
+    return capabilityRunOutput(JSON.parse(text.text));
+  } catch {
+    return { stdout: '', stderr: '' };
+  }
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function redactAndTruncateCapabilityAuditText(value: string): string {
+  return truncateAuditText(redactMcpAuditText(value), 2_000);
+}
+
+// A secret passed as `--password supersecret` splits across two argv entries, so
+// the value alone carries no key context for the text redactor. Redact the entry
+// that follows a sensitive option flag before it can reach a durable log.
+const SENSITIVE_CAPABILITY_OPTION =
+  /^--?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|password|passphrase|secret|client[_-]?secret|private[_-]?key|session[_-]?id|token|credential|auth(?:orization)?)$/i;
+
+function redactCapabilityArgv(args: string[]): string[] {
+  const redacted: string[] = [];
+  let expectSensitiveValue = false;
+  for (const arg of args) {
+    // A sensitive flag's value is the next NON-flag entry. The pending state is
+    // kept across any intervening flags (sensitive or not) and only consumed by
+    // the next value, so `--password --verbose supersecret` and
+    // `--password --token realtoken` both redact the real value.
+    if (expectSensitiveValue && !arg.startsWith('-')) {
+      redacted.push('[REDACTED_SECRET]');
+      expectSensitiveValue = false;
+      continue;
+    }
+    expectSensitiveValue =
+      SENSITIVE_CAPABILITY_OPTION.test(arg) ||
+      (expectSensitiveValue && arg.startsWith('-'));
+    redacted.push(redactAndTruncateCapabilityAuditText(arg));
+  }
+  return redacted;
 }
 
 export function classifyMcpToolAuditError(

--- a/apps/core/src/application/mcp/mcp-tool-proxy-audit.ts
+++ b/apps/core/src/application/mcp/mcp-tool-proxy-audit.ts
@@ -7,7 +7,10 @@ import type {
 import { RUNTIME_EVENT_TYPES } from '../../domain/events/runtime-event-types.js';
 import type { McpServerRepository } from '../../domain/ports/repositories.js';
 import { nowIso } from '../../shared/time/datetime.js';
-import type { McpToolAuditResultClass } from './mcp-tool-audit.js';
+import type {
+  McpToolAuditResultClass,
+  summarizeCapabilityRunAudit,
+} from './mcp-tool-audit.js';
 import type { ReviewedMaterializedMcpCapability } from './mcp-tool-authorization.js';
 
 export async function publishMcpToolActivity(input: {
@@ -31,6 +34,7 @@ export async function publishMcpToolActivity(input: {
     resultClass: McpToolAuditResultClass;
     latencyMs: number;
     argumentSummary: Record<string, unknown>;
+    capabilityRun?: NonNullable<ReturnType<typeof summarizeCapabilityRunAudit>>;
     selectedToolRule?: string;
     selectedCapability?: Pick<
       ReviewedMaterializedMcpCapability,
@@ -66,6 +70,9 @@ export async function publishMcpToolActivity(input: {
     resultClass: activity.resultClass,
     latencyMs: activity.latencyMs,
     argumentSummary: activity.argumentSummary,
+    ...(activity.capabilityRun
+      ? { capabilityRun: activity.capabilityRun }
+      : {}),
     ...(activity.reason ? { reason: activity.reason } : {}),
     ...(activity.error ? { error: activity.error } : {}),
     ...(typeof activity.outputSchemaPresent === 'boolean'

--- a/apps/core/src/application/mcp/mcp-tool-proxy.ts
+++ b/apps/core/src/application/mcp/mcp-tool-proxy.ts
@@ -36,6 +36,7 @@ import {
 import {
   classifyMcpToolAuditError,
   type McpToolAuditResultClass,
+  summarizeCapabilityRunAudit,
   summarizeMcpToolArguments,
   summarizeMcpToolError,
 } from './mcp-tool-audit.js';
@@ -490,9 +491,15 @@ export class McpToolProxy {
         toolReturned = true;
         const validationAudit = resultValidation.validate(result);
         try {
+          const capabilityRun = summarizeCapabilityRunAudit({
+            serverName: input.serverName,
+            toolName: input.toolName,
+            argumentPayload: input.arguments,
+            toolResult: result,
+          });
           await finalize(
             validationAudit.toolResultError ? 'failure' : 'success',
-            validationAudit,
+            { ...validationAudit, ...(capabilityRun ? { capabilityRun } : {}) },
           );
         } catch {
           // A remote MCP tool already returned. Do not make completed external
@@ -591,6 +598,7 @@ export class McpToolProxy {
     resultClass: McpToolAuditResultClass;
     latencyMs: number;
     argumentSummary: Record<string, unknown>;
+    capabilityRun?: NonNullable<ReturnType<typeof summarizeCapabilityRunAudit>>;
     selectedToolRule?: string;
     selectedCapability?: Pick<
       ReviewedMaterializedMcpCapability,

--- a/apps/core/test/unit/application/mcp-tool-proxy.test.ts
+++ b/apps/core/test/unit/application/mcp-tool-proxy.test.ts
@@ -42,7 +42,9 @@ import {
   MCP_TOOL_PROXY_CLIENT_ADAPTERS,
   McpToolProxy,
 } from '@core/application/mcp/mcp-tool-proxy.js';
+import { publishMcpToolActivity } from '@core/application/mcp/mcp-tool-proxy-audit.js';
 import { connectMcpToolProxyClient } from '@core/application/mcp/mcp-tool-proxy-connection.js';
+import { summarizeCapabilityRunAudit } from '@core/application/mcp/mcp-tool-audit.js';
 import {
   fetchMcpToolListPages,
   MAX_MCP_REMOTE_TOOL_METADATA_BYTES,
@@ -1486,6 +1488,135 @@ describe('McpToolProxy', () => {
         }),
       }),
     );
+  });
+
+  it('records bounded capability_run details (args opted in) without changing normal tool audit payloads', async () => {
+    process.env.GANTRY_AUDIT_CAPABILITY_ARGS = '1';
+    const capabilityRuntimeEvents = vi.fn(async () => undefined);
+    const capabilityAuditEvents = vi.fn(async () => undefined);
+    const longArg = `sheet-${'x'.repeat(2_000)}`;
+    const longStdout = `written-${'x'.repeat(2_000)}`;
+    const capabilityRun = summarizeCapabilityRunAudit({
+      serverName: 'gantry',
+      toolName: 'capability_run',
+      argumentPayload: {
+        capabilityId: 'google.sheets.values.append',
+        args: [
+          'sheets',
+          'append',
+          longArg,
+          '--password',
+          'value-one',
+          '--api-key',
+          '--token',
+          'value-two',
+          '--secret',
+          '--verbose',
+          'value-three',
+        ],
+      },
+      toolResult: {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              stdout: longStdout,
+              stderr: 'capability finished',
+            }),
+          },
+        ],
+      },
+    });
+    await publishMcpToolActivity({
+      mcpServers: { appendAuditEvent: capabilityAuditEvents } as never,
+      options: { publishRuntimeEvent: capabilityRuntimeEvents },
+      activity: {
+        input: {
+          appId: 'app-one' as never,
+          agentId: 'agent-one' as never,
+          serverName: 'gantry',
+          toolName: 'capability_run',
+        },
+        resultClass: 'success',
+        latencyMs: 1,
+        argumentSummary: { kind: 'object' },
+        capabilityRun,
+      },
+    });
+
+    const capabilityPayload = capabilityRuntimeEvents.mock.calls.at(-1)?.[0]
+      .payload as Record<string, unknown>;
+    expect(capabilityPayload).toMatchObject({
+      capabilityRun: {
+        capabilityId: 'google.sheets.values.append',
+        argCount: 11,
+        args: [
+          'sheets',
+          'append',
+          `${longArg.slice(0, 2_000)}...`,
+          '--password',
+          '[REDACTED_SECRET]',
+          '--api-key',
+          '--token',
+          '[REDACTED_SECRET]',
+          '--secret',
+          '--verbose',
+          '[REDACTED_SECRET]',
+        ],
+        stdout: `${longStdout.slice(0, 2_000)}...`,
+        stderr: 'capability finished',
+      },
+    });
+    expect(capabilityAuditEvents.mock.calls.at(-1)?.[0]).toMatchObject({
+      metadata: expect.objectContaining({
+        capabilityRun: capabilityPayload.capabilityRun,
+      }),
+    });
+
+    const normalRuntimeEvents = vi.fn(async () => undefined);
+    await publishMcpToolActivity({
+      mcpServers: { appendAuditEvent: vi.fn(async () => undefined) } as never,
+      options: { publishRuntimeEvent: normalRuntimeEvents },
+      activity: {
+        input: {
+          appId: 'app-one' as never,
+          agentId: 'agent-one' as never,
+          serverName: 'github',
+          toolName: 'create_issue',
+        },
+        resultClass: 'success',
+        latencyMs: 1,
+        argumentSummary: { kind: 'object' },
+      },
+    });
+    expect(
+      normalRuntimeEvents.mock.calls.at(-1)?.[0].payload,
+    ).not.toHaveProperty('capabilityRun');
+    delete process.env.GANTRY_AUDIT_CAPABILITY_ARGS;
+  });
+
+  it('omits raw capability_run args unless audit logging is opted in', () => {
+    delete process.env.GANTRY_AUDIT_CAPABILITY_ARGS;
+    const summary = summarizeCapabilityRunAudit({
+      serverName: 'gantry',
+      toolName: 'capability_run',
+      argumentPayload: {
+        capabilityId: 'google.sheets.values.append',
+        args: ['--password', 'value-one'],
+      },
+      toolResult: {
+        content: [
+          { type: 'text', text: JSON.stringify({ stdout: 'ok', stderr: '' }) },
+        ],
+      },
+    });
+    expect(summary).toMatchObject({
+      capabilityId: 'google.sheets.values.append',
+      argCount: 2,
+      stdout: 'ok',
+      stderr: '',
+    });
+    expect(summary).not.toHaveProperty('args');
   });
 
   it('does not idle-close the MCP client while a tool call is active', async () => {

--- a/plans/quickfixes/20260820T125609-0000-Q-0038-dd18-open-125609179223.json
+++ b/plans/quickfixes/20260820T125609-0000-Q-0038-dd18-open-125609179223.json
@@ -1,0 +1,12 @@
+{
+  "event": "open",
+  "id": "Q-0038-dd18",
+  "profile": "lite",
+  "reason": "DIAG-1: log bounded capability_run capabilityId+args+stdout/stderr into mcp.tool_activity for run diagnosability",
+  "started_at": "2026-08-20T12:56:09+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "by": "Ravi",
+  "base_sha": "655c58a02a16bff783c3e089f3556b9ad07c92b7"
+}

--- a/plans/quickfixes/20260820T131225-0000-Q-0038-dd18-abandoned-131225213770.json
+++ b/plans/quickfixes/20260820T131225-0000-Q-0038-dd18-abandoned-131225213770.json
@@ -1,0 +1,17 @@
+{
+  "event": "abandoned",
+  "id": "Q-0038-dd18",
+  "profile": "lite",
+  "reason": "applying autoreview P1 (structured argv redaction for split-form secrets) in a degraded window; DIAG-1 ships as a standard PR, review evidence is the PR autoreview",
+  "opened_reason": "DIAG-1: log bounded capability_run capabilityId+args+stdout/stderr into mcp.tool_activity for run diagnosability",
+  "started_at": "2026-08-20T12:56:09+00:00",
+  "completed_at": "2026-08-20T13:12:25+00:00",
+  "files": [
+    "apps/core/src/application/mcp/mcp-tool-audit.ts",
+    "apps/core/src/application/mcp/mcp-tool-proxy-audit.ts",
+    "apps/core/src/application/mcp/mcp-tool-proxy.ts",
+    "apps/core/test/unit/application/mcp-tool-proxy.test.ts"
+  ],
+  "by": "Ravi",
+  "base_sha": "655c58a02a16bff783c3e089f3556b9ad07c92b7"
+}

--- a/plans/quickfixes/20260820T131225-0000-Q-0039-ee0a-open-131225359745.json
+++ b/plans/quickfixes/20260820T131225-0000-Q-0039-ee0a-open-131225359745.json
@@ -1,0 +1,11 @@
+{
+  "event": "open",
+  "id": "Q-0039-ee0a",
+  "profile": "degraded",
+  "reason": "DIAG-1 autoreview P1: redact the value following a sensitive option flag in capability_run args, not just per-argument",
+  "started_at": "2026-08-20T13:12:25+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "kind": "degraded"
+}

--- a/plans/quickfixes/20260820T133601-0000-Q-0039-ee0a-done-133601530569.json
+++ b/plans/quickfixes/20260820T133601-0000-Q-0039-ee0a-done-133601530569.json
@@ -1,0 +1,13 @@
+{
+  "event": "done",
+  "id": "Q-0039-ee0a",
+  "profile": "degraded",
+  "kind": "degraded",
+  "reason": "DIAG-1 autoreview P1: redact the value following a sensitive option flag in capability_run args, not just per-argument",
+  "started_at": "2026-08-20T13:12:25+00:00",
+  "completed_at": "2026-08-20T13:36:01+00:00",
+  "files": [
+    "apps/core/src/application/mcp/mcp-tool-audit.ts",
+    "apps/core/test/unit/application/mcp-tool-proxy.test.ts"
+  ]
+}

--- a/plans/review-briefs/diag-1-capability-logging.md
+++ b/plans/review-briefs/diag-1-capability-logging.md
@@ -1,0 +1,33 @@
+# Review brief — DIAG-1: log bounded capability_run args + output
+
+## Goal
+Make local-CLI capability executions diagnosable. Today `mcp.tool_activity`
+(durable audit + `runtime_events`) records `toolName`, `resultClass`, `latencyMs`,
+and a redacted `argumentSummary` — but for `mcp__gantry__capability_run` it drops
+the actual `capabilityId`, the args, and the host `stdout`/`stderr`, so after a
+scheduled run you cannot see what a capability wrote or what it returned.
+
+## Change
+- New `summarizeCapabilityRunAudit` (mcp-tool-audit.ts): only for `gantry`/`capability_run`,
+  returns `{capabilityId, args, stdout, stderr}`, each run through `redactMcpAuditText`
+  then `truncateAuditText(_, 2000)`; args sliced to the existing `CAPABILITY_RUN_MAX_ARGS`
+  (64). Robustly parses the capability result's `JSON.stringify({stdout,stderr})` content shape.
+- Threaded into the success path (mcp-tool-proxy.ts at tool completion) and the
+  invalid-request path (publishInvalidMcpToolRequestAudit); added `capabilityRun?` to the
+  audit payload type (mcp-tool-proxy-audit.ts). Other tools' audit shape is unchanged.
+
+## Args are opt-in (security)
+Auto-redacting arbitrary local-CLI argv cannot be made complete (short flags like
+`-p`, custom flags, positional secrets), so raw args are **not** logged by default.
+- **Default:** `capabilityId` + `argCount` + redacted/bounded `stdout`/`stderr`. No raw argv.
+- **Opt-in:** set `GANTRY_AUDIT_CAPABILITY_ARGS=1` to also log the args, best-effort
+  redacted (2KB bound; sensitive option flags redact their following value across
+  intervening flags). Operators flip this on for a capability whose argv they trust
+  (e.g. `gog`, which uses stored OAuth, not argv credentials).
+
+Owner decision: bounded lead PII in the audit log is accepted; credential exposure via
+arbitrary argv is avoided by gating args behind the opt-in flag.
+
+## Non-goals
+No change to `argumentSummary` or other tools. No full-transcript persistence (that is a
+separate follow-up). Capability-only, minimal diff.


### PR DESCRIPTION
## What this does

Makes a scheduled job run **diagnosable after the fact**. Today, when a job runs a local-CLI capability (like writing rows to a Google Sheet), the audit event records only *that* a capability ran — not what it was called with or what came back. That's exactly why we couldn't tell whether a lead-gen run had *attempted* to write a second lead or simply stopped at one.

Now the `mcp.tool_activity` event (durable audit + `runtime_events`) carries, for `mcp__gantry__capability_run`:
- the **`capabilityId`** (e.g. `google.sheets.values.append`),
- the **`argCount`**,
- and bounded, secret-redacted **`stdout`/`stderr`**.

## Args are opt-in (this is the important security bit)

Auto-redacting *arbitrary* local-CLI argv can't be made complete — a credential can ride in a short flag (`-p secret`), a custom flag, or a bare positional, and no fixed rule catches them all. So **raw args are not logged by default**. Set `GANTRY_AUDIT_CAPABILITY_ARGS=1` to also log the args (best-effort redacted) when debugging a capability whose argv you trust — e.g. `gog`, which uses stored OAuth, not argv credentials.

When args *are* logged, a small state machine redacts the value following any sensitive option flag (`--password`, `--api-key`, `--token`, …), correctly handling split-form (`--password secret`), adjacent flags (`--password --token realtoken`), and intervening flags (`--password --verbose secret`). Each field is bounded to 2 KB and run through the existing secret redactor.

## Why not just always log args

Because that's a credential-leak risk we can't fully close for arbitrary CLIs — surfaced in review across four rounds. The opt-in gate is the security-correct version: safe by default, full detail on demand.

## Scope / non-goals

Capability-only; other tools' audit payloads are unchanged. This is piece **A** of the run-diagnosability follow-up. Not included (separate follow-ups): the dead `job_runs` table (nothing writes to it; lifecycle actually lands in `agent_runs` + `runtime_events`), and durable full-transcript persistence (tool calls/results still aren't stored anywhere).

## Tests

`mcp-tool-proxy.test.ts`: default omits raw args (argCount only); opt-in logs bounded, flag-redacted args (split-form, adjacent, and intervening cases); secret redaction in output; normal tools unchanged. Typecheck clean; autoreview clean.

---
Ticket: Q-0039-ee0a
