### PR TITLE
Fix ambient no-reply lifecycle

### DIFF
--- a/apps/core/src/runtime/agent-spawn-prompt.ts
+++ b/apps/core/src/runtime/agent-spawn-prompt.ts
@@ -14,6 +14,7 @@ import type { AgentInput } from './agent-spawn-types.js';
 const AMBIENT_NO_REPLY_SYSTEM_DIRECTIVE = [
   '## Ambient Listening',
   'This conversation uses ambient listening. Reply when the current message directly addresses you or your intervention is materially useful to the active conversation.',
+  'A plain-language greeting or vocative that uses your name or persona (for example, "hey Scout" or "Scout, can you help?") directly addresses you even when it does not contain a platform @mention. Always reply to such a message.',
   'When the current message does not need your intervention, output exactly <internal>GANTRY_NO_REPLY</internal> and nothing else. Never explain that you are staying silent.',
 ].join('\n');
 

--- a/apps/core/src/runtime/agent-spawn-prompt.ts
+++ b/apps/core/src/runtime/agent-spawn-prompt.ts
@@ -11,6 +11,12 @@ import { logger } from '../infrastructure/logging/logger.js';
 import { resolveWorkspaceFolderPath } from '../platform/workspace-folder.js';
 import type { AgentInput } from './agent-spawn-types.js';
 
+const AMBIENT_NO_REPLY_SYSTEM_DIRECTIVE = [
+  '## Ambient Listening',
+  'This conversation uses ambient listening. Reply when the current message directly addresses you or your intervention is materially useful to the active conversation.',
+  'When the current message does not need your intervention, output exactly <internal>GANTRY_NO_REPLY</internal> and nothing else. Never explain that you are staying silent.',
+].join('\n');
+
 export function resolveSpawnPromptAccessPreset(
   configured: PromptAccessPreset,
   hideAuthorityTools: boolean,
@@ -93,6 +99,14 @@ export async function compileSpawnSystemPrompt(input: {
       { err, agentFolder: input.group.folder },
       'Failed to compile prompt profile; continuing without custom system prompt',
     );
+  }
+  if (
+    input.group.requiresTrigger === false &&
+    !input.agentInput.isScheduledJob
+  ) {
+    return [compiledSystemPrompt, AMBIENT_NO_REPLY_SYSTEM_DIRECTIVE]
+      .filter(Boolean)
+      .join('\n\n');
   }
   return compiledSystemPrompt;
 }

--- a/apps/core/src/runtime/group-output-buffer.ts
+++ b/apps/core/src/runtime/group-output-buffer.ts
@@ -14,6 +14,22 @@ import {
 } from './session-resume-runtime.js';
 import type { GroupProcessingDeps } from './group-processing-types.js';
 
+const INTENTIONAL_NO_REPLY_MARKER = '<internal>GANTRY_NO_REPLY</internal>';
+const MAX_NO_REPLY_CANDIDATE_CHARS = INTENTIONAL_NO_REPLY_MARKER.length + 32;
+
+function appendIntentionalNoReplyCandidate(
+  candidate: string | null,
+  raw: string,
+): string | null {
+  if (candidate === null) return null;
+  const next = candidate + raw;
+  return next.length <= MAX_NO_REPLY_CANDIDATE_CHARS ? next : null;
+}
+
+function isIntentionalNoReplyCandidate(candidate: string | null): boolean {
+  return candidate?.trim() === INTENTIONAL_NO_REPLY_MARKER;
+}
+
 type RuntimeLogger = {
   info(input: unknown, message: string): void;
   warn(input: unknown, message: string): void;
@@ -24,6 +40,7 @@ export function createGroupOutputBuffer(input: {
   chatJid: string;
   groupName: string;
   supportsStreamingChunks: boolean;
+  allowIntentionalNoReply?: boolean;
   buildStreamingOptions: (args: { done?: boolean }) => StreamingChunkOptions;
   buildMessageOptions: () =>
     | MessageSendOptions
@@ -64,6 +81,8 @@ export function createGroupOutputBuffer(input: {
   let streamSanitizer = createRuntimeUserVisibleStreamSanitizer();
   let pendingOutputRawChars = 0;
   let pendingOutputHasParts = false;
+  let pendingNoReplyCandidate: string | null = '';
+  let intentionalNoReply = false;
 
   const runVisibleDelivery = async (
     attempt: () => Promise<DeliverySettlement>,
@@ -102,10 +121,24 @@ export function createGroupOutputBuffer(input: {
     const visibleOutput = pendingOutputVisible.snapshot();
     const finalStreamDelta = streamSanitizer.finish();
     const rawChars = pendingOutputRawChars;
+    const noReplyRequested =
+      input.allowIntentionalNoReply &&
+      isIntentionalNoReplyCandidate(pendingNoReplyCandidate);
     pendingOutputVisible = createRuntimeUserVisibleResultAccumulator();
     streamSanitizer = createRuntimeUserVisibleStreamSanitizer();
     pendingOutputRawChars = 0;
     pendingOutputHasParts = false;
+    pendingNoReplyCandidate = '';
+    if (noReplyRequested) {
+      intentionalNoReply = true;
+      generationParts = [];
+      input.resetStreamedTranscriptDeliveryStatus?.();
+      input.log.info(
+        { group: input.groupName, reason },
+        'Agent intentionally declined ambient reply',
+      );
+      return false;
+    }
     const text = visibleOutput ? formatOutboundForChannel(visibleOutput) : '';
     input.log.info(
       { group: input.groupName },
@@ -113,7 +146,7 @@ export function createGroupOutputBuffer(input: {
     );
     if (!text) return false;
     if (input.supportsStreamingChunks) {
-      const settlement = await runVisibleDelivery(
+      await runVisibleDelivery(
         () =>
           settleDeliveryAttempt(
             () =>
@@ -195,6 +228,10 @@ export function createGroupOutputBuffer(input: {
     appendRawOutput: async (raw: string) => {
       pendingOutputHasParts = true;
       pendingOutputRawChars += raw.length;
+      pendingNoReplyCandidate = appendIntentionalNoReplyCandidate(
+        pendingNoReplyCandidate,
+        raw,
+      );
       pendingOutputVisible.append(raw);
       if (!input.supportsStreamingChunks) return;
       const safeDelta = streamSanitizer.append(raw);
@@ -215,5 +252,6 @@ export function createGroupOutputBuffer(input: {
     },
     flushBufferedOutput,
     transcriptSnapshot: () => userVisibleTranscript.snapshot(),
+    intentionalNoReplyRequested: () => intentionalNoReply,
   };
 }

--- a/apps/core/src/runtime/group-output-buffer.ts
+++ b/apps/core/src/runtime/group-output-buffer.ts
@@ -41,6 +41,7 @@ export function createGroupOutputBuffer(input: {
   groupName: string;
   supportsStreamingChunks: boolean;
   allowIntentionalNoReply?: boolean;
+  onIntentionalNoReply?: () => void;
   buildStreamingOptions: (args: { done?: boolean }) => StreamingChunkOptions;
   buildMessageOptions: () =>
     | MessageSendOptions
@@ -83,6 +84,16 @@ export function createGroupOutputBuffer(input: {
   let pendingOutputHasParts = false;
   let pendingNoReplyCandidate: string | null = '';
   let intentionalNoReply = false;
+
+  const acceptIntentionalNoReply = (reason: string) => {
+    if (intentionalNoReply) return;
+    intentionalNoReply = true;
+    input.log.info(
+      { group: input.groupName, reason },
+      'Agent intentionally declined ambient reply',
+    );
+    input.onIntentionalNoReply?.();
+  };
 
   const runVisibleDelivery = async (
     attempt: () => Promise<DeliverySettlement>,
@@ -130,13 +141,9 @@ export function createGroupOutputBuffer(input: {
     pendingOutputHasParts = false;
     pendingNoReplyCandidate = '';
     if (noReplyRequested) {
-      intentionalNoReply = true;
+      acceptIntentionalNoReply(reason);
       generationParts = [];
       input.resetStreamedTranscriptDeliveryStatus?.();
-      input.log.info(
-        { group: input.groupName, reason },
-        'Agent intentionally declined ambient reply',
-      );
       return false;
     }
     const text = visibleOutput ? formatOutboundForChannel(visibleOutput) : '';
@@ -232,6 +239,12 @@ export function createGroupOutputBuffer(input: {
         pendingNoReplyCandidate,
         raw,
       );
+      if (
+        input.allowIntentionalNoReply &&
+        isIntentionalNoReplyCandidate(pendingNoReplyCandidate)
+      ) {
+        acceptIntentionalNoReply('output-complete');
+      }
       pendingOutputVisible.append(raw);
       if (!input.supportsStreamingChunks) return;
       const safeDelta = streamSanitizer.append(raw);

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -607,6 +607,17 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
             resetIdleTimer();
             return;
           }
+          if (
+            group.requiresTrigger === false &&
+            !outputBuffer.intentionalNoReplyRequested()
+          ) {
+            // Ambient turns admit unrelated top-level channel messages while
+            // the SDK runner is still waiting for same-thread steering. Once
+            // a generation has reached its terminal marker, close that idle
+            // runner so queued top-level messages can start their own turns
+            // instead of waiting for the normal idle timeout.
+            deps.queue.closeStdin(queueJid);
+          }
           if (progressGeneration === markerGeneration)
             liveness.pauseForTurnComplete();
           const markerProgressState = resolveGroupTurnFinalProgressState({

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -500,10 +500,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         groupName: group.name,
         supportsStreamingChunks,
         allowIntentionalNoReply: group.requiresTrigger === false,
-        // The runner can remain open waiting for more SDK events after it has
-        // already made a final ambient no-reply decision. Close it immediately
-        // so a message queued behind this turn can drain without waiting for
-        // the normal idle timeout.
+        // Release an intentional ambient no-reply without waiting for idle.
         onIntentionalNoReply: () => deps.queue.closeStdin(queueJid),
         buildStreamingOptions,
         buildMessageOptions,
@@ -611,11 +608,6 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
             group.requiresTrigger === false &&
             !outputBuffer.intentionalNoReplyRequested()
           ) {
-            // Ambient turns admit unrelated top-level channel messages while
-            // the SDK runner is still waiting for same-thread steering. Once
-            // a generation has reached its terminal marker, close that idle
-            // runner so queued top-level messages can start their own turns
-            // instead of waiting for the normal idle timeout.
             deps.queue.closeStdin(queueJid);
           }
           if (progressGeneration === markerGeneration)

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -500,6 +500,11 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         groupName: group.name,
         supportsStreamingChunks,
         allowIntentionalNoReply: group.requiresTrigger === false,
+        // The runner can remain open waiting for more SDK events after it has
+        // already made a final ambient no-reply decision. Close it immediately
+        // so a message queued behind this turn can drain without waiting for
+        // the normal idle timeout.
+        onIntentionalNoReply: () => deps.queue.closeStdin(queueJid),
         buildStreamingOptions,
         buildMessageOptions,
         sendMessageToChannel,

--- a/apps/core/src/runtime/group-processing.ts
+++ b/apps/core/src/runtime/group-processing.ts
@@ -499,6 +499,7 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
         chatJid,
         groupName: group.name,
         supportsStreamingChunks,
+        allowIntentionalNoReply: group.requiresTrigger === false,
         buildStreamingOptions,
         buildMessageOptions,
         sendMessageToChannel,
@@ -766,49 +767,53 @@ export function createGroupProcessor(deps: GroupProcessingDeps) {
           storeMessage: (message) => ops().storeMessage(message),
           log: logger,
         });
-        const finalization = await finalizeGroupAgentUserVisibleOutput({
-          boundedTranscript: outputBuffer.transcriptSnapshot(),
+        if (!outputBuffer.intentionalNoReplyRequested()) {
+          const finalization = await finalizeGroupAgentUserVisibleOutput({
+            boundedTranscript: outputBuffer.transcriptSnapshot(),
+            outputSentToUser,
+            undeliveredGenerations: undeliveredGenerations.join('\n\n'),
+            sawRawOutput,
+            groupName: group.name,
+            warn: (metadata, message) => logger.warn(metadata, message),
+            buildMessageOptions,
+            sendMessageToChannel: async (text, options) =>
+              settleDeliveryAttempt(() => sendMessageToChannel(text, options), {
+                scope: 'runtime-final-output-fallback',
+                target: chatJid,
+              }).catch((err) => {
+                logger.warn(
+                  { err, group: group.name },
+                  'Failed to settle fallback output delivery',
+                );
+                return 'not_delivered' as const;
+              }),
+          });
+          outputSentToUser = finalization.outputSentToUser;
+          applyDeliverySettlement(finalization.terminalSettlement, {
+            streamed: false,
+            terminal: true,
+          });
+        }
+      }
+      if (!outputBuffer.intentionalNoReplyRequested()) {
+        await sendGroupFinalProgress({
+          output,
+          hadError,
+          sawDeliveryIncomplete,
+          sawTerminalDeliveryFailure,
           outputSentToUser,
-          undeliveredGenerations: undeliveredGenerations.join('\n\n'),
-          sawRawOutput,
-          groupName: group.name,
-          warn: (metadata, message) => logger.warn(metadata, message),
-          buildMessageOptions,
-          sendMessageToChannel: async (text, options) =>
-            settleDeliveryAttempt(() => sendMessageToChannel(text, options), {
-              scope: 'runtime-final-output-fallback',
-              target: chatJid,
-            }).catch((err) => {
-              logger.warn(
-                { err, group: group.name },
-                'Failed to settle fallback output delivery',
-              );
-              return 'not_delivered' as const;
-            }),
-        });
-        outputSentToUser = finalization.outputSentToUser;
-        applyDeliverySettlement(finalization.terminalSettlement, {
-          streamed: false,
-          terminal: true,
+          options,
+          awaitingResponseReceipt,
+          sentAnyTurnDoneProgress,
+          activeGenerationHasOutput,
+          sentTurnDoneProgressGeneration,
+          progressGeneration,
+          supportsProgress,
+          buildProgressOptions,
+          sendProgress: sendProgressToChannel,
+          sendDone: sendTrackedDoneProgress,
         });
       }
-      await sendGroupFinalProgress({
-        output,
-        hadError,
-        sawDeliveryIncomplete,
-        sawTerminalDeliveryFailure,
-        outputSentToUser,
-        options,
-        awaitingResponseReceipt,
-        sentAnyTurnDoneProgress,
-        activeGenerationHasOutput,
-        sentTurnDoneProgressGeneration,
-        progressGeneration,
-        supportsProgress,
-        buildProgressOptions,
-        sendProgress: sendProgressToChannel,
-        sendDone: sendTrackedDoneProgress,
-      });
       if (resultOk && replay.hasMore) deps.queue.enqueueMessageCheck(queueJid);
       options?.onRunResult?.(output);
       return resultOk;

--- a/apps/core/test/unit/runtime/agent-spawn-prompt.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-prompt.test.ts
@@ -114,6 +114,20 @@ describe('compileSpawnSystemPrompt', () => {
     expect(prompt).not.toContain('New user messages may arrive mid-run');
   });
 
+  it('adds the no-reply contract only to ambient interactive routes', async () => {
+    const ambient = await compile({ group: { requiresTrigger: false } });
+    const triggered = await compile({ group: { requiresTrigger: true } });
+    const scheduled = await compile({
+      group: { requiresTrigger: false },
+      agentInput: { isScheduledJob: true },
+    });
+
+    expect(ambient).toContain('<internal>GANTRY_NO_REPLY</internal>');
+    expect(ambient).toContain('Never explain that you are staying silent.');
+    expect(triggered).not.toContain('GANTRY_NO_REPLY');
+    expect(scheduled).not.toContain('GANTRY_NO_REPLY');
+  });
+
   it('threads the resolved capability catalog into the compiled profile', async () => {
     // Model behavioral-corpus coverage is intentionally deferred to the
     // separate evaluation; this unit test pins only prompt projection.

--- a/apps/core/test/unit/runtime/agent-spawn-prompt.test.ts
+++ b/apps/core/test/unit/runtime/agent-spawn-prompt.test.ts
@@ -123,6 +123,10 @@ describe('compileSpawnSystemPrompt', () => {
     });
 
     expect(ambient).toContain('<internal>GANTRY_NO_REPLY</internal>');
+    expect(ambient).toContain(
+      'A plain-language greeting or vocative that uses your name or persona',
+    );
+    expect(ambient).toContain('Always reply to such a message.');
     expect(ambient).toContain('Never explain that you are staying silent.');
     expect(triggered).not.toContain('GANTRY_NO_REPLY');
     expect(scheduled).not.toContain('GANTRY_NO_REPLY');

--- a/apps/core/test/unit/runtime/group-output-buffer-generation.test.ts
+++ b/apps/core/test/unit/runtime/group-output-buffer-generation.test.ts
@@ -43,6 +43,31 @@ function makeBuffer(
 }
 
 describe('streamed generation persistence', () => {
+  it('signals the runner once when an ambient no-reply decision is finalized', async () => {
+    const onIntentionalNoReply = vi.fn();
+    const buffer = createGroupOutputBuffer({
+      channelRuntime: { sendStreamingChunk: vi.fn(async () => {}) } as never,
+      chatJid: 'sl:C1',
+      groupName: 'group',
+      supportsStreamingChunks: true,
+      allowIntentionalNoReply: true,
+      onIntentionalNoReply,
+      buildStreamingOptions: () => ({}) as never,
+      buildMessageOptions: () => undefined,
+      sendMessageToChannel: async () => {},
+      applyDeliverySettlement: vi.fn(),
+      getStreamedTranscriptDeliveryStatus: () => 'none',
+      log: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    await buffer.appendRawOutput('<internal>GANTRY_NO_REPLY</internal>');
+    await buffer.flushBufferedOutput('success-marker');
+    await buffer.appendRawOutput('<internal>GANTRY_NO_REPLY</internal>');
+    await buffer.flushBufferedOutput('turn-complete');
+
+    expect(onIntentionalNoReply).toHaveBeenCalledTimes(1);
+  });
+
   it('settles a successful delivery before running the first-visible hook', async () => {
     const order: string[] = [];
     const buffer = createGroupOutputBuffer({

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1526,6 +1526,25 @@ describe('createGroupProcessor', () => {
       );
     });
 
+    it('keeps an ambient intentional no-reply turn completely silent', async () => {
+      const agentOutput: AgentOutput = {
+        status: 'success',
+        result: '<internal>GANTRY_NO_REPLY</internal>',
+      };
+      const { deps, channel } = setupHappyPath({ agentOutput });
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await processGroupMessages('group1@g.us');
+
+      expect(channel.sendMessage).not.toHaveBeenCalled();
+      expect(channel.sendStreamingChunk).not.toHaveBeenCalled();
+      expect(channel.sendProgressUpdate).not.toHaveBeenCalledWith(
+        'group1@g.us',
+        'Done.',
+        expect.anything(),
+      );
+    });
+
     it('calls setTyping true before and false after agent run', async () => {
       const { deps, channel } = setupHappyPath();
 

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1762,8 +1762,11 @@ describe('createGroupProcessor', () => {
       },
     );
 
-    it('notifies idle without closing stdin on final success marker from onOutput callback', async () => {
-      const { deps } = setupHappyPath();
+    it('notifies idle without closing stdin on final success marker for trigger-required routes', async () => {
+      const { deps } = setupHappyPath({
+        group: makeGroup({ requiresTrigger: true }),
+        messages: [makeMessage({ content: '@Andy hello' })],
+      });
       mockSpawnAgent.mockImplementation(
         async (
           _group: ConversationRoute,
@@ -1784,13 +1787,45 @@ describe('createGroupProcessor', () => {
       expect(deps.queue.closeStdin).not.toHaveBeenCalled();
     });
 
+    it('closes an ambient runner after its final visible success marker', async () => {
+      const { deps, channel } = setupHappyPath();
+      const runnerClosed = deferred<AgentOutput>();
+      const terminalOutput: AgentOutput = { status: 'success', result: null };
+      deps.queue.closeStdin = vi.fn(() => runnerClosed.resolve(terminalOutput));
+      mockSpawnAgent.mockImplementation(
+        async (
+          _group: ConversationRoute,
+          _prompt: string,
+          _chatJid: string,
+          onOutput?: (output: AgentOutput) => Promise<void>,
+        ) => {
+          await onOutput?.({ status: 'success', result: 'ambient reply' });
+          await onOutput?.(terminalOutput);
+          return runnerClosed.promise;
+        },
+      );
+
+      const { processGroupMessages } = createGroupProcessor(deps);
+      await processGroupMessages('group1@g.us');
+
+      expect(channel.sendMessage).toHaveBeenCalledWith(
+        'group1@g.us',
+        'ambient reply',
+      );
+      expect(deps.queue.closeStdin).toHaveBeenCalledWith('group1@g.us');
+      expect(deps.queue.notifyIdle).toHaveBeenCalledWith('group1@g.us');
+    });
+
     it('sends done progress at a terminal marker without restarting typing during finalization', async () => {
       const liveRun = deferred<AgentOutput>();
       const terminalMarkerHandled = deferred();
       const channel = makeChannel({
         sendProgressUpdate: vi.fn().mockResolvedValue(undefined),
       });
-      const { deps } = setupHappyPath();
+      const { deps } = setupHappyPath({
+        group: makeGroup({ requiresTrigger: true }),
+        messages: [makeMessage({ content: '@Andy hello' })],
+      });
       deps.channelRuntime = channel;
       mockSpawnAgent.mockImplementation(
         async (

--- a/apps/core/test/unit/runtime/group-processing.test.ts
+++ b/apps/core/test/unit/runtime/group-processing.test.ts
@@ -1532,6 +1532,19 @@ describe('createGroupProcessor', () => {
         result: '<internal>GANTRY_NO_REPLY</internal>',
       };
       const { deps, channel } = setupHappyPath({ agentOutput });
+      const runnerClosed = deferred<AgentOutput>();
+      deps.queue.closeStdin = vi.fn(() => runnerClosed.resolve(agentOutput));
+      mockSpawnAgent.mockImplementation(
+        async (
+          _group: ConversationRoute,
+          _input: unknown,
+          _onProc: unknown,
+          onOutput?: (output: AgentOutput) => Promise<void>,
+        ) => {
+          if (onOutput) await onOutput(agentOutput);
+          return runnerClosed.promise;
+        },
+      );
 
       const { processGroupMessages } = createGroupProcessor(deps);
       await processGroupMessages('group1@g.us');
@@ -1543,6 +1556,7 @@ describe('createGroupProcessor', () => {
         'Done.',
         expect.anything(),
       );
+      expect(deps.queue.closeStdin).toHaveBeenCalledWith('group1@g.us');
     });
 
     it('calls setTyping true before and false after agent run', async () => {

--- a/plans/quickfixes/20260825T111911-0000-Q-0061-db72-open-111911546095.json
+++ b/plans/quickfixes/20260825T111911-0000-Q-0061-db72-open-111911546095.json
@@ -1,0 +1,12 @@
+{
+  "event": "open",
+  "id": "Q-0061-db72",
+  "profile": "lite",
+  "reason": "Suppress intentional no-reply outcomes for ambient channel conversations",
+  "started_at": "2026-08-25T11:19:11+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "by": "Codex",
+  "base_sha": "595bd4ff69dd0e2a6e9c34628652815db8f5d7f9"
+}

--- a/plans/quickfixes/20260825T114114-0000-Q-0061-db72-done-114114270625.json
+++ b/plans/quickfixes/20260825T114114-0000-Q-0061-db72-done-114114270625.json
@@ -1,0 +1,79 @@
+{
+  "event": "done",
+  "id": "Q-0061-db72",
+  "profile": "lite",
+  "by": "Codex",
+  "reason": "Suppress intentional no-reply outcomes for ambient channel conversations",
+  "base_sha": "595bd4ff69dd0e2a6e9c34628652815db8f5d7f9",
+  "started_at": "2026-08-25T11:19:11+00:00",
+  "completed_at": "2026-08-25T11:41:14+00:00",
+  "files": [
+    "apps/core/src/runtime/agent-spawn-prompt.ts",
+    "apps/core/src/runtime/group-output-buffer.ts",
+    "apps/core/src/runtime/group-processing.ts",
+    "apps/core/test/unit/runtime/agent-spawn-prompt.test.ts",
+    "apps/core/test/unit/runtime/group-processing.test.ts"
+  ],
+  "reviews": {
+    "quality": {
+      "generated_by": "autoreview",
+      "score": 9,
+      "summary": "The route guard is scoped to non-scheduled ambient conversations, the marker must be the complete bounded output, and ordinary internal-only or visible responses retain existing finalization behavior.",
+      "blocking_findings": [],
+      "non_blocking_findings": [],
+      "residual_risks": [
+        "Semantic relevance remains model-decided, so behavior quality depends on the active model following the ambient-listening contract."
+      ],
+      "reviewed_scope": [
+        "ambient prompt projection",
+        "streamed output suppression",
+        "fallback and progress finalization",
+        "route and scheduled-job isolation"
+      ],
+      "skills_used": [
+        "autoreview"
+      ],
+      "commit": "60cab00f62291a82c631dd067d372a1d00bb1a6e"
+    },
+    "performance": {
+      "generated_by": "autoreview",
+      "score": 9,
+      "summary": "The runtime overhead is a bounded string accumulator capped near the marker length and a constant-time route check; it adds no database, network, or unbounded memory work.",
+      "blocking_findings": [],
+      "non_blocking_findings": [],
+      "residual_risks": [
+        "Ambient relevance still requires one model invocation and therefore cannot have zero model-token cost."
+      ],
+      "reviewed_scope": [
+        "prompt-size impact",
+        "streaming hot path",
+        "memory bounds",
+        "delivery short-circuit"
+      ],
+      "skills_used": [
+        "autoreview"
+      ],
+      "commit": "60cab00f62291a82c631dd067d372a1d00bb1a6e"
+    },
+    "security": {
+      "generated_by": "autoreview",
+      "score": 9,
+      "summary": "Suppression is restricted to an exact internal marker on ambient routes, does not broaden permissions or tool access, and never exposes marker content to the channel.",
+      "blocking_findings": [],
+      "non_blocking_findings": [],
+      "residual_risks": [
+        "A model induced to emit the exact internal marker can suppress one ambient response; triggered routes and scheduled jobs are not opted into the contract."
+      ],
+      "reviewed_scope": [
+        "route authorization boundary",
+        "marker matching",
+        "channel output exposure",
+        "tool and credential impact"
+      ],
+      "skills_used": [
+        "autoreview"
+      ],
+      "commit": "60cab00f62291a82c631dd067d372a1d00bb1a6e"
+    }
+  }
+}


### PR DESCRIPTION
Ticket: Q-0061-db72

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Make ambient channel participation silent and non-blocking when an agent is configured with `requires_trigger: false`.

- Treat natural name-based greetings such as `hey <agent name>` as direct address without hardcoding a specific agent.
- Introduce an internal `GANTRY_NO_REPLY` marker for irrelevant ambient conversation and suppress it before channel delivery.
- Close intentionally silent runs promptly instead of leaving the host runner open.
- Release completed visible ambient turns after the final success marker so subsequent top-level messages are not blocked behind the prior runner.
- Preserve explicit-trigger routes and genuine same-run follow-up continuation behavior.

## Verification

- `npm run check:architecture`
- `npm run test:unit -- apps/core/test/unit/runtime/agent-spawn-prompt.test.ts apps/core/test/unit/runtime/group-output-buffer-generation.test.ts apps/core/test/unit/runtime/group-processing.test.ts` (264 tests passed)
- `npm run typecheck`
- `git diff --check`
- Verified in dev Slack: relevant ambient messages replied, irrelevant ambient message stayed silent, and the next relevant message started without the previous ~4 minute delay.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone