### PR TITLE
fix: host card taps carry verifiable provenance for the scheduler mutation-authority gate

### DIFF
--- a/apps/core/src/app/bootstrap/runtime-live-stop-message-action.ts
+++ b/apps/core/src/app/bootstrap/runtime-live-stop-message-action.ts
@@ -6,6 +6,10 @@ import {
   createIpcAuthEnvelope,
   revokeIpcResponseSigningKey,
 } from '../../runtime/ipc-auth.js';
+import {
+  registerPermissionRunRestriction,
+  unregisterPermissionRunRestriction,
+} from '../../runtime/permission-decision-coordinator.js';
 import { taskIpcResponsePath } from '../../jobs/ipc-shared.js';
 import type { IpcDeps } from '../../runtime/ipc-domain-types.js';
 import { requestSchedulerSync } from '../../jobs/scheduler.js';
@@ -115,6 +119,18 @@ async function runSchedulerTaskThroughIpc(
     input.authThreadId,
   );
   const responsePath = taskIpcResponsePath(input.sourceAgentFolder, taskId);
+  // The scheduler mutation-authority gate verifies source provenance against a
+  // registered run restriction. This lane is host-originated (a human tapped a
+  // card; the same-channel approver gate already passed), so register an
+  // interactive restriction for this one task and present matching provenance.
+  registerPermissionRunRestriction({
+    sourceAgentFolder: input.sourceAgentFolder,
+    responseKeyId: ipcAuth.responseKeyId,
+    hideAuthorityTools: false,
+    runKind: 'interactive',
+    jobId: input.jobId,
+    runId: taskId,
+  });
   try {
     await processTaskIpc(
       {
@@ -125,6 +141,9 @@ async function runSchedulerTaskThroughIpc(
         targetJid: input.originConversationJid,
         authThreadId: input.authThreadId,
         responseKeyId: ipcAuth.responseKeyId,
+        sourceRunKind: 'interactive',
+        sourceJobId: input.jobId,
+        sourceRunId: taskId,
       },
       input.sourceAgentFolder,
       {
@@ -158,6 +177,10 @@ async function runSchedulerTaskThroughIpc(
     }
     return result.message || `Scheduler job queued (${input.jobId}).`;
   } finally {
+    unregisterPermissionRunRestriction({
+      sourceAgentFolder: input.sourceAgentFolder,
+      responseKeyId: ipcAuth.responseKeyId,
+    });
     await fs.unlink(responsePath).catch(() => undefined);
     revokeIpcResponseSigningKey(
       ipcAuth.responseKeyId,

--- a/apps/core/test/unit/application/scheduler-message-actions.test.ts
+++ b/apps/core/test/unit/application/scheduler-message-actions.test.ts
@@ -15,6 +15,7 @@ import { JobManagementService } from '@core/application/jobs/job-management-serv
 import { SETUP_REQUIRED_PAUSE_REASON } from '@core/application/jobs/job-readiness-service.js';
 import { runtimeJobSchedulePlanner } from '@core/jobs/job-schedule-planner.js';
 import { writeTaskIpcResponse } from '@core/jobs/ipc-shared.js';
+import { permissionRunRestriction } from '@core/runtime/permission-decision-coordinator.js';
 
 function makeJob(overrides: Record<string, unknown> = {}) {
   return {
@@ -254,5 +255,83 @@ describe('scheduler message actions (CARDFIX-1)', () => {
       jobId: 'job-1',
     });
     expect(processTaskIpcMock).not.toHaveBeenCalled();
+  });
+
+  it('host card taps present verifiable interactive provenance to the mutation-authority gate', async () => {
+    let observed: {
+      data?: Record<string, unknown>;
+      restriction?: unknown;
+      responseKeyId?: string;
+    } = {};
+    processTaskIpcMock.mockImplementation(
+      async (
+        data: {
+          taskId?: string;
+          authThreadId?: string;
+          responseKeyId?: string;
+        },
+        sourceAgentFolder: string,
+      ) => {
+        observed = {
+          data: data as Record<string, unknown>,
+          responseKeyId: data.responseKeyId,
+          restriction: data.responseKeyId
+            ? permissionRunRestriction({
+                sourceAgentFolder,
+                responseKeyId: data.responseKeyId,
+              })
+            : undefined,
+        };
+        writeTaskIpcResponse(
+          sourceAgentFolder,
+          data.taskId,
+          { ok: true, message: 'queued' },
+          data.authThreadId,
+          data.responseKeyId,
+        );
+      },
+    );
+    let handler: any;
+    const channelWiring = {
+      setMessageActionHandler: vi.fn((next: unknown) => {
+        handler = next;
+      }),
+      isControlApproverAllowed: vi.fn(async () => true),
+      sendMessage: vi.fn(async () => undefined),
+    };
+    registerRuntimeLiveStopMessageAction(
+      channelWiring as never,
+      {
+        getConversationRoutes: () => ({
+          'sl:C123': { folder: 'main_agent' },
+        }),
+      } as never,
+      { stopGroup: vi.fn() },
+    );
+    await handler?.({
+      kind: 'scheduler_retry_ask',
+      conversationJid: 'sl:C123',
+      userId: 'U123',
+      jobId: 'job-1',
+    });
+    // The gate compares data.sourceRun* against the restriction registered for
+    // (sourceAgentFolder, responseKeyId); both sides must exist and match.
+    expect(observed.data).toMatchObject({
+      sourceRunKind: 'interactive',
+      sourceJobId: 'job-1',
+    });
+    expect(observed.data?.sourceRunId).toBe(observed.data?.taskId);
+    expect(observed.restriction).toMatchObject({
+      runKind: 'interactive',
+      jobId: 'job-1',
+      runId: observed.data?.taskId,
+    });
+    // The one-task restriction is unregistered once the tap settles.
+    expect(
+      permissionRunRestriction({
+        sourceAgentFolder: 'main_agent',
+        responseKeyId: observed.responseKeyId as string,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/plans/quickfixes/20260831T171117-0000-Q-0131-9363-open-171117595386.json
+++ b/plans/quickfixes/20260831T171117-0000-Q-0131-9363-open-171117595386.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0131-9363",
+  "profile": "quickfix",
+  "reason": "Live check bug: pause-card taps (Allow once / Pause job / Run now class) are rejected with 'Scheduler mutation source could not be verified' \u2014 the host card lane never registers a permission run restriction nor passes source provenance, so the SCHED-1 mutation-authority gate fails closed on every host-originated scheduler card action. Fix: register an interactive restriction for the lane's responseKeyId and pass matching sourceRunKind/sourceJobId/sourceRunId.",
+  "started_at": "2026-08-31T17:11:17+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260831T171359-0000-Q-0131-9363-done-171359900914.json
+++ b/plans/quickfixes/20260831T171359-0000-Q-0131-9363-done-171359900914.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0131-9363",
+  "profile": "quickfix",
+  "reason": "Live check bug: pause-card taps (Allow once / Pause job / Run now class) are rejected with 'Scheduler mutation source could not be verified' \u2014 the host card lane never registers a permission run restriction nor passes source provenance, so the SCHED-1 mutation-authority gate fails closed on every host-originated scheduler card action. Fix: register an interactive restriction for the lane's responseKeyId and pass matching sourceRunKind/sourceJobId/sourceRunId.",
+  "started_at": "2026-08-31T17:11:17+00:00",
+  "completed_at": "2026-08-31T17:13:59+00:00",
+  "files": []
+}


### PR DESCRIPTION
## What this gives you

The buttons on paused-job cards actually work now. In the live check after #460, tapping "Allow once for this run" (or "Pause job") on Slack answered "Scheduler mutation source could not be verified" and did nothing.

## Why it broke

The SCHED-1 mutation-authority gate (#386) verifies every scheduler mutation against a registered run restriction — designed to stop scheduled runs from mutating their own scheduler. The host card lane (a human tapping a card) never registered a restriction nor presented source provenance, so the gate correctly failed closed on every host-originated card action — including the pre-existing "Run now" button path, which shares this lane.

## Technical delta

`runtime-live-stop-message-action.ts` (the shared host card lane for `scheduler_run_now` / `scheduler_pause_job` / `scheduler_retry_ask`):
- registers a one-task `interactive` permission run restriction for the lane's `responseKeyId` (the tap is human and already behind the same-channel-approver gate),
- presents matching `sourceRunKind: 'interactive'`, `sourceJobId`, `sourceRunId` (the task id) in the IPC payload,
- unregisters the restriction in `finally`.

The runner-originated lane is untouched: scheduled runs still cannot mutate scheduler jobs.

## Proof

- New leaf: `host card taps present verifiable interactive provenance to the mutation-authority gate` — asserts the restriction exists and matches at IPC call time and is unregistered after settlement.
- tsc, check:architecture, bootstrap+application+jobs unit dirs (2083 tests) green.
- Agent-e2e delta: live Slack re-tap check follows the deploy (same protocol as #460's live check).

Ticket: CARDFIX-1
Ticket: Q-0131-9363
