### PR TITLE
fix: apply Debian security upgrades in the runtime image layer

### DIFF
--- a/ops/docker/Dockerfile
+++ b/ops/docker/Dockerfile
@@ -70,6 +70,10 @@ ENV NODE_ENV=production \
 # package installs belong to a future bake lane, see TODOS.md) and the Go
 # toolchain (Go-built tools ship as binaries: add the binary here per tool).
 RUN apt-get update \
+    # Pull in pending Debian security updates for base-image packages; the
+    # digest-pinned base goes stale between upstream rebuilds (e.g. libexpat1
+    # CVE-2026-56408 failed the Trivy gate before its base refresh).
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
       python3 \
       python3-venv \

--- a/plans/quickfixes/20260901T072820-0000-Q-0148-2f7d-open-072820227892.json
+++ b/plans/quickfixes/20260901T072820-0000-Q-0148-2f7d-open-072820227892.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0148-2f7d",
+  "profile": "quickfix",
+  "reason": "image lane red on main: apply security upgrades in the runtime apt layer (libexpat CVE-2026-56408)",
+  "started_at": "2026-09-01T07:28:20+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260901T072909-0000-Q-0148-2f7d-done-072909529689.json
+++ b/plans/quickfixes/20260901T072909-0000-Q-0148-2f7d-done-072909529689.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0148-2f7d",
+  "profile": "quickfix",
+  "reason": "image lane red on main: apply security upgrades in the runtime apt layer (libexpat CVE-2026-56408)",
+  "started_at": "2026-09-01T07:28:20+00:00",
+  "completed_at": "2026-09-01T07:29:09+00:00",
+  "files": []
+}


### PR DESCRIPTION
Unblocks CI for every open PR: the image security scan started failing this morning on all branches (including main) because a new CVE was published for a package inside our pinned base image, and our pin means we don't get Debian's fix until upstream rebuilds.

Technical delta: add `apt-get upgrade -y` to the existing runtime-stage apt layer in ops/docker/Dockerfile, so each image build applies pending Debian security updates (today: libexpat1 2.5.0-1+deb12u3 fixing CVE-2026-56408) regardless of base-image staleness. No runtime behavior change; no agent-e2e delta (infra-only).

Ticket: Q-0148-2f7d
Ticket: Q-0145-a3ea
