### PR TITLE
fix: a stale stored grant no longer disables all of an agent's durable grants

### DIFF
--- a/apps/core/src/application/agents/agent-tool-runtime-rules.ts
+++ b/apps/core/src/application/agents/agent-tool-runtime-rules.ts
@@ -185,7 +185,10 @@ function projectAgentToolRuntimePolicy(input: {
   // semantic rejections below still throw.
   const projectedRules = rules.filter(
     (rule) =>
-      !(rule.startsWith('RunCommand(') && !validateReadableAgentToolRule(rule).ok),
+      !(
+        rule.startsWith('RunCommand(') &&
+        !validateReadableAgentToolRule(rule).ok
+      ),
   );
   validateAgentToolRuntimeRules({
     rules: projectedRules,

--- a/apps/core/src/application/agents/agent-tool-runtime-rules.ts
+++ b/apps/core/src/application/agents/agent-tool-runtime-rules.ts
@@ -174,14 +174,27 @@ function projectAgentToolRuntimePolicy(input: {
         })
       : [];
   });
+  // Stored RunCommand grants are machine-minted (Allow for future); a later,
+  // stricter durable-rule validator can retroactively reject one (e.g. an npx
+  // wildcard after the family hardening). Dropping just that rule keeps the
+  // agent's OTHER grants projecting — throwing here would make the whole
+  // policy resolution fail, and the caller swallows that to `undefined`, so a
+  // single stale grant would silently disable EVERY durable grant for the
+  // agent. A dropped rule simply grants nothing durable (the command re-asks),
+  // which is the intended fail-closed behavior. Structural MCP/browser/
+  // semantic rejections below still throw.
+  const projectedRules = rules.filter(
+    (rule) =>
+      !(rule.startsWith('RunCommand(') && !validateReadableAgentToolRule(rule).ok),
+  );
   validateAgentToolRuntimeRules({
-    rules,
+    rules: projectedRules,
     errorSubject: input.errorSubject,
     allowProjectedThirdPartyMcpTools: true,
     makeError: input.makeError,
   });
   return {
-    rules,
+    rules: projectedRules,
     runtimeAccess,
     semanticCapabilities,
     reviewedMcpReadBindings: reviewedMcpReadBindingsForRuntimeAccess({

--- a/apps/core/test/unit/application/agents/agent-tool-runtime-rules.test.ts
+++ b/apps/core/test/unit/application/agents/agent-tool-runtime-rules.test.ts
@@ -38,7 +38,7 @@ describe('resolveAgentToolRuntimePolicy', () => {
     expect(getTool).not.toHaveBeenCalledWith('tool:bob');
   });
 
-  it('drops a stale RunCommand grant a stricter validator rejects without losing the agent\'s other grants', async () => {
+  it("drops a stale RunCommand grant a stricter validator rejects without losing the agent's other grants", async () => {
     // Regression: a stored `RunCommand(npx remotion *)` grant (valid when
     // minted, rejected after the npx family hardening) must not throw and take
     // down every other durable grant for the agent.

--- a/apps/core/test/unit/application/agents/agent-tool-runtime-rules.test.ts
+++ b/apps/core/test/unit/application/agents/agent-tool-runtime-rules.test.ts
@@ -37,4 +37,35 @@ describe('resolveAgentToolRuntimePolicy', () => {
     expect(sharedPolicy.rules).toEqual(['WebSearch']);
     expect(getTool).not.toHaveBeenCalledWith('tool:bob');
   });
+
+  it('drops a stale RunCommand grant a stricter validator rejects without losing the agent\'s other grants', async () => {
+    // Regression: a stored `RunCommand(npx remotion *)` grant (valid when
+    // minted, rejected after the npx family hardening) must not throw and take
+    // down every other durable grant for the agent.
+    const tools = new Map<string, { appId: string; name: string }>([
+      ['tool:curl', { appId: 'app:test', name: 'RunCommand(curl *)' }],
+      ['tool:npx', { appId: 'app:test', name: 'RunCommand(npx remotion *)' }],
+      ['tool:web', { appId: 'app:test', name: 'WebSearch' }],
+    ]);
+    const getTool = vi.fn(async (toolId: string) => tools.get(toolId) ?? null);
+    const repository = {
+      listAgentToolBindings: vi.fn(async () => [
+        { status: 'active', toolId: 'tool:curl', personId: null },
+        { status: 'active', toolId: 'tool:npx', personId: null },
+        { status: 'active', toolId: 'tool:web', personId: null },
+      ]),
+      getTool,
+    };
+
+    const policy = await resolveAgentToolRuntimePolicy({
+      repository: repository as never,
+      appId: 'app:test',
+      agentId: 'agent:test',
+      errorSubject: 'Configured agent tool',
+    });
+
+    // Valid grants survive; the invalid npx family grant is dropped (so npx
+    // re-asks) rather than throwing and nuking the whole policy.
+    expect(policy.rules).toEqual(['RunCommand(curl *)', 'WebSearch']);
+  });
 });

--- a/apps/core/test/unit/application/job-tool-policy.test.ts
+++ b/apps/core/test/unit/application/job-tool-policy.test.ts
@@ -123,15 +123,19 @@ describe('job tool policy', () => {
     ).rejects.toThrowError(/wildcard grants are not supported/);
   });
 
-  it('rejects stale inherited RunCommand wildcard rules from agent tool bindings', async () => {
-    await expect(
-      resolveJobToolPolicy({
-        job: makeJob(),
-        appId: 'default',
-        agentId: 'agent:team',
-        toolRepository: toolRepositoryFor(['RunCommand(*)']),
-      }),
-    ).rejects.toThrowError(/Persistent RunCommand scope is too broad/);
+  it('drops stale inherited over-broad RunCommand rules instead of failing the whole policy', async () => {
+    // A stale/over-broad RunCommand grant (e.g. RunCommand(*)) is now dropped
+    // from the projection rather than throwing: throwing would take down every
+    // other durable grant for the agent (the caller swallows it to undefined).
+    // Dropped means it grants nothing — the command re-asks (fail-closed).
+    const policy = await resolveJobToolPolicy({
+      job: makeJob(),
+      appId: 'default',
+      agentId: 'agent:team',
+      toolRepository: toolRepositoryFor(['RunCommand(*)']),
+    });
+    expect(policy.effectiveAllowedTools).not.toContain('RunCommand(*)');
+    expect(policy.effectiveAllowedTools).toEqual([]);
   });
 
   it('rejects stale inherited third-party MCP wildcard rules from agent tool bindings', async () => {

--- a/apps/core/test/unit/runtime/configured-agent-tools.test.ts
+++ b/apps/core/test/unit/runtime/configured-agent-tools.test.ts
@@ -582,7 +582,11 @@ describe('configured agent tools', () => {
     ).rejects.toThrow('wildcard grants are not supported');
   });
 
-  it('fails closed for stale active RunCommand wildcard bindings', async () => {
+  it('drops a stale active over-broad RunCommand binding instead of failing closed', async () => {
+    // A stale/over-broad RunCommand grant is dropped from the projection (it
+    // grants nothing - the command re-asks) rather than throwing: throwing
+    // would take down every other durable grant for the agent via the caller's
+    // catch-to-undefined. Structural rejections (SDK sandbox, MCP) still throw.
     const repository = {
       listAgentToolBindings: async () => [
         {
@@ -602,7 +606,7 @@ describe('configured agent tools', () => {
         appId: 'default',
         agentId: 'agent:one',
       }),
-    ).rejects.toThrow('Persistent RunCommand scope is too broad');
+    ).resolves.toEqual([]);
   });
 
   it('fails closed for stale active SDK sandbox network bindings', async () => {

--- a/plans/quickfixes/20260901T083428-0000-Q-0151-eb15-open-083428848463.json
+++ b/plans/quickfixes/20260901T083428-0000-Q-0151-eb15-open-083428848463.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0151-eb15",
+  "profile": "quickfix",
+  "reason": "LIVE regression: one stale RunCommand grant throws in resolveAgentToolRuntimePolicy \u2192 caught as undefined \u2192 ALL grants for that agent stop applying; drop invalid RunCommand rules from projection instead",
+  "started_at": "2026-09-01T08:34:28+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260901T083552-0000-Q-0151-eb15-done-083552657659.json
+++ b/plans/quickfixes/20260901T083552-0000-Q-0151-eb15-done-083552657659.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0151-eb15",
+  "profile": "quickfix",
+  "reason": "LIVE regression: one stale RunCommand grant throws in resolveAgentToolRuntimePolicy \u2192 caught as undefined \u2192 ALL grants for that agent stop applying; drop invalid RunCommand rules from projection instead",
+  "started_at": "2026-09-01T08:34:28+00:00",
+  "completed_at": "2026-09-01T08:35:52+00:00",
+  "files": []
+}

--- a/plans/quickfixes/20260901T085527-0000-Q-0152-6658-open-085527329181.json
+++ b/plans/quickfixes/20260901T085527-0000-Q-0152-6658-open-085527329181.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0152-6658",
+  "profile": "quickfix",
+  "reason": "flip runtime configured-agent-tools stale-wildcard test to drop-contract (sibling of Q-0151)",
+  "started_at": "2026-09-01T08:55:27+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260901T085627-0000-Q-0152-6658-done-085627740072.json
+++ b/plans/quickfixes/20260901T085627-0000-Q-0152-6658-done-085627740072.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0152-6658",
+  "profile": "quickfix",
+  "reason": "flip runtime configured-agent-tools stale-wildcard test to drop-contract (sibling of Q-0151)",
+  "started_at": "2026-09-01T08:55:27+00:00",
+  "completed_at": "2026-09-01T08:56:27+00:00",
+  "files": []
+}


### PR DESCRIPTION
Fixes a live regression from tonight's permission work: after we tightened which commands may hold a durable "Allow for future" grant, an agent that already had one now-invalid saved grant (real case: main_agent's `RunCommand(npx remotion *)`) had ALL of its saved permissions silently stop working — every command started re-asking, defeating the whole family-grant feature we just shipped.

Root cause: `resolveAgentToolRuntimePolicy` threw on the first stored RunCommand rule the tightened validator rejects, and its only caller swallows that throw to `undefined` — so one stale grant collapsed the agent's entire reviewed-rule policy. Verified live: main_agent has active tool bindings for the invalid npx rules.

Technical delta: `projectAgentToolRuntimePolicy` now drops just the invalid RunCommand rule from the projection (it grants nothing durable, so that one command re-asks — intended fail-closed) and projects the rest; structural MCP/browser/semantic rejections still throw. Stale over-broad RunCommand rules (e.g. `RunCommand(*)`) are likewise ignored rather than fatal. Regression test added; application unit lane 991/991 + tsc green.

Agent-e2e delta: none run — startup/permission-projection fix; proof is the live-binding reproduction plus unit coverage.

Ticket: Q-0151-eb15
Ticket: Q-0152-6658
