### PR TITLE
chore(forge): vendor symphony-forge #156 (companion read-only guard fixes)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 6e4d95e4b91014590f8efa161c80cd3eadc39eff
+symphony-forge @ 16041dcb620a88a52ee3e50ddb706a9eb4cf1c84
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "6e4d95e4b91014590f8efa161c80cd3eadc39eff",
+  "harness_commit": "16041dcb620a88a52ee3e50ddb706a9eb4cf1c84",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -16,7 +16,7 @@
     "factory/scripts/forge_cli/adopt.py": "b6d34e97ba5967447d5aa8dfa2c7ae5dfffcf0aea2d34f16c7d11839bf11a63c",
     "factory/scripts/forge_cli/assumptions.py": "474ce594e8d1348487d12545310894eebd60b382ef969ce9cdce049c56e7b8a6",
     "factory/scripts/forge_cli/audit.py": "125d9b853b5a45a1a5783b6f9d7ac4b3be86eef367ec34edfc5144da1c21c12c",
-    "factory/scripts/forge_cli/board.py": "403e8fc66c7ecbe43fccefb4a06c1b823aab4ab00a618712502f0d502574638e",
+    "factory/scripts/forge_cli/board.py": "0c593fca9be02ab0ceb5cdc18547b1f08ab52bd910f061ff7de11f3583356dfb",
     "factory/scripts/forge_cli/ceremony.py": "f31653141a89562c84e04ecdc5cd438d68353230f364149301c367e2e91aa7fd",
     "factory/scripts/forge_cli/codex_status.py": "9bb92d099f86e3943236a4b583edaf8d94a72fdda78f8983392b867a282b03ba",
     "factory/scripts/forge_cli/common.py": "a5db9b7c577f869a0c856b3d9c9a20b34ea764b1e4439b5ad40f583119414e17",
@@ -55,7 +55,7 @@
     "factory/scripts/post_tool_use.py": "b56fcb933df3b1c43f6ad13fd4ae320c147e8cce5cfd948d34fb096be7684e20",
     "factory/scripts/pr_ready.py": "0a51cabc77693c3bb8522b08027b7b81b3bbdd6e900bdb0f53cb5c94f094adfd",
     "factory/scripts/pre_compact.py": "ad65f7caae8510711e334d0254a42fbb0df1a314fb1ea635b088f000862a8486",
-    "factory/scripts/pre_tool_use.py": "79f1051ffcad0ee5eb5b1cc1abacf2bbbd077577e37ecb675342947541363b18",
+    "factory/scripts/pre_tool_use.py": "c35c0f819ce0bf60fc6b5cd5bd890b3a5b2cc69e34121cb4b55b6c6ab727797c",
     "factory/scripts/record_decomposition_from_json.py": "bb0b6a961927bcaf88cae1c62d6de2cb26fa460cfc3beddd0cf6155f0d3e0838",
     "factory/scripts/record_grill_from_json.py": "376a96f4eb29a1a6dfb218727ba26ad662bca807422b3c699207e11054e26e2c",
     "factory/scripts/record_review_from_json.py": "4827b6fbbdf0168720fcaba9818584bade5dd2743ad9f16b6bac2b7a852384dc",

--- a/factory/scripts/forge_cli/board.py
+++ b/factory/scripts/forge_cli/board.py
@@ -85,17 +85,25 @@ def merge_task_detail(
 
 
 def _plan_evidence(
-    base: Path, plan: dict | None, derived_rows: list[dict] | None = None,
+    base: Path, story_key: str, plan: dict | None,
+    derived_rows: list[dict] | None = None,
 ) -> tuple[dict | None, dict, list]:
     """Stage progress, gate evidence, and the story's real task list.
 
-    Tasks exist only once a story's plan is approved and decomposed, so an
-    unplanned story returns none rather than inventing children.
+    Tasks exist once a story is decomposed. A live story reads them via its plan
+    record; a SHIPPED story's plan has moved out of plans/active|completed (to
+    completed/, debt/, or elsewhere), so fall back to the story key and read the
+    archived decomposition directly — otherwise a shipped story's task graph
+    silently disappears from the board. An unplanned story (no plan AND no
+    recorded decomposition) returns none rather than inventing children.
     """
     empty_reviews = {aspect: False for aspect in ("quality", "performance", "security")}
-    if not plan:
+    story = str((plan or {}).get("story") or (plan or {}).get("issue")
+                or story_key or "")
+    decomposition = (load_json(evidence_path(base, story, "decomposition.json"),
+                               default={}) if story else {})
+    if not plan and not decomposition.get("tasks"):
         return None, {"verify": False, "tests": False, "reviews": empty_reviews}, []
-    story = str(plan.get("story") or plan.get("issue") or "")
     stages_data = load_json(evidence_path(base, story, "stages.json"), default={})
     stages = stages_data.get("stages", [])
     progress = None
@@ -104,10 +112,7 @@ def _plan_evidence(
             "done": sum(1 for stage in stages if stage.get("status") == "done"),
             "total": len(stages),
         }
-    tasks = merge_task_detail(
-        load_json(evidence_path(base, story, "decomposition.json"), default={}),
-        stages, derived_rows,
-    )
+    tasks = merge_task_detail(decomposition, stages, derived_rows)
     # The same predicates pr_ready gates on: a tick here must mean the gate
     # would open, not merely that a file is on disk.
     recorded = load_json(evidence_path(base, story, "tests.json"), default={})
@@ -291,7 +296,8 @@ def aggregate_state(base: Path) -> dict:
         story = dict(item)
         plan = plan_by_story.get(item.get("key"))
         progress, evidence, tasks = _plan_evidence(
-            base, plan, live_task_rows if item.get("key") == active else None,
+            base, item.get("key"), plan,
+            live_task_rows if item.get("key") == active else None,
         )
         story["ready_to_plan"] = item.get("key") in frontier
         story["plan"] = plan
@@ -304,7 +310,7 @@ def aggregate_state(base: Path) -> dict:
         story["lifecycle"] = {
             "spec": spec_status.get(item.get("spec"), "missing"),
             "roadmap": True,
-            "planned": plan is not None,
+            "planned": plan is not None or bool(tasks),
             "stages": progress,
             "verify": evidence["verify"],
             "tests": evidence["tests"],

--- a/factory/scripts/pre_tool_use.py
+++ b/factory/scripts/pre_tool_use.py
@@ -678,11 +678,40 @@ for candidate in write_targets:
 # for the plan UI, never for product or canon writes.
 guard_product_writes(write_targets, root,
                      command=command if tool_name == "Bash" else "")
-literal_command = command.replace("''", "").replace('""', "")
+# A heredoc whose ONLY consumer is a data sink (cat/tee/printf/echo writing
+# to a file) is data, never argv: its body is dropped before the companion
+# classification so a note that mentions the companion, or holds a quote or
+# backtick that breaks shlex, is not mistaken for a launch. Every other shape
+# keeps its body and is classified as before — a body fed to sh/node/xargs,
+# through a pipe, or followed by more text CAN carry a launch (`sh <<EOF`,
+# `cat <<EOF | sh`), so nothing outside this exact shape is stripped.
+HEREDOC_SINK_ARGV0 = {"cat", "tee", "printf", "echo"}
+HEREDOC_NOTE = re.compile(
+    r"\A(?P<head>[^\n]*?)<<-?[ \t]*(?P<q>['\"]?)(?P<word>\w+)(?P=q)"
+    r"(?P<tail>[^\n]*)\n(?P<body>.*?)\n(?P=word)[ \t]*\n?\Z", re.DOTALL)
+
+
+def _strip_note_heredoc(text: str) -> str:
+    match = HEREDOC_NOTE.match(text)
+    if match is None:
+        return text
+    head, tail = match.group("head"), match.group("tail")
+    argv0 = re.match(r"[ \t]*(?:\w+=\S*[ \t]+)*([^\s<>|;&]+)", head)
+    if (
+        argv0 is None
+        or Path(argv0.group(1)).name not in HEREDOC_SINK_ARGV0
+        or re.search(r"[|;&`]|\$\(", head + tail)
+    ):
+        return text
+    return text[:match.start("body")] + text[match.end("body"):]
+
+
+classify_command = _strip_note_heredoc(command)
+literal_command = classify_command.replace("''", "").replace('""', "")
 shell_shape = re.sub(
     r"\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*", "", literal_command)
 try:
-    shell_tokens = shlex.split(command)
+    shell_tokens = shlex.split(classify_command)
 except ValueError:
     if (
         tool_name == "Bash"
@@ -700,7 +729,7 @@ compact_command = re.sub(r"[^a-z0-9]", "", shell_shape.lower())
 has_companion = (
     re.search(r"\bcodex-companion(?:\.mjs)?\b", shell_shape) is not None
     or re.search(r"\$(?:\{)?(?=[A-Za-z_])[A-Za-z0-9_]*companion[A-Za-z0-9_]*",
-                 command, re.IGNORECASE) is not None
+                 classify_command, re.IGNORECASE) is not None
     or any(re.fullmatch(r"codex-companion(?:\.mjs)?", Path(token).name)
            for token in shell_tokens)
     or "codexcompanion" in compact_command
@@ -712,8 +741,12 @@ has_companion = (
 # the companion is either a safe display command (rg/cat/...) or an
 # unverifiable launch, which is denied: shell text cannot bound a child
 # interpreter's computed argv, so we never try.
-READONLY_COMPANION_VERBS = {"status", "task", "task-resume-candidate"}
-READONLY_COMPANION_FLAGS = {"--model", "--effort", "--json"}
+# `result <job-id>` only prints a stored job's output — the fetch path for a
+# backgrounded read-only /codex:rescue run; `--background` merely detaches a
+# read-only `task`. Neither can write (writes need --write, never allowlisted).
+# `cancel`, `setup` and `task-worker` mutate state and stay denied.
+READONLY_COMPANION_VERBS = {"status", "task", "task-resume-candidate", "result"}
+READONLY_COMPANION_FLAGS = {"--model", "--effort", "--json", "--background"}
 COMPANION_NAME = re.compile(r"codex-companion(?:\.mjs)?")
 # No shell-capable pagers (less/more run "+!cmd" startup commands).
 DISPLAY_SAFE_ARGV0 = {
@@ -722,10 +755,24 @@ DISPLAY_SAFE_ARGV0 = {
 }
 
 
+# Exec-capable or non-terminating options among DISPLAY_SAFE_ARGV0 tools,
+# per tool: rg --pre / --pre-glob run a preprocessor command; tail -f / -F /
+# --follow / --pid follow forever. Every other flag (grep -n, rg -i, tail -n,
+# ls -la, head -c ...) only reads or formats, so a display command that
+# merely MENTIONS the companion may carry them. Pager-style `+` tokens stay
+# denied. Per tool, because `-f` is a harmless read flag for grep/stat.
+DISPLAY_EXEC_OPTIONS = {
+    "rg": ("--pre",),
+    "tail": ("-f", "-F", "--follow", "--pid"),
+}
+
+
 def _display_safe(tokens):
-    """Display command with NO option tokens: some display tools grow
-    exec options (rg --pre, tail --pid); bare invocations have none."""
-    return not any(t.startswith(("-", "+")) for t in tokens[1:])
+    """Display command whose options cannot execute or hang."""
+    denied = DISPLAY_EXEC_OPTIONS.get(Path(tokens[0]).name, ())
+    return not any(
+        t.startswith("+") or t.startswith(denied) for t in tokens[1:]
+    )
 
 
 def _has_active_shell_syntax(value: str) -> bool:

--- a/factory/tests/test_gates.py
+++ b/factory/tests/test_gates.py
@@ -1047,6 +1047,37 @@ def test_board_and_history_read_shipped_story_dir(repo, tmp_path):
     assert "shipped" in out and "Story: ENG-1" in out
 
 
+def test_board_shows_shipped_story_tasks_when_plan_left_active_and_completed(
+    repo, tmp_path,
+):
+    # A shipped story's plan can move out of plans/active|completed (to debt/, or
+    # be archived) while its decomposition stays under .factory/stories/<key>/.
+    # The board must still render its task graph from the archived decomposition,
+    # never silently drop it to zero tasks (the "no task graph for a completed
+    # story" board bug).
+    from forge_cli.board import aggregate_state
+
+    prepare_pr_ready_story(repo, tmp_path, scoped_layout=True)
+    code, out = run(repo, "pr_ready.py")
+    assert code == 0, out
+
+    def eng1():
+        return next(s for s in aggregate_state(repo)["stories"] if s["key"] == "ENG-1")
+
+    assert eng1()["state"] == "shipped" and eng1()["tasks"], "tasks present at ship"
+
+    # Move the plan entirely out of the dirs the board scans for plan records.
+    (repo / "plans" / "debt").mkdir(exist_ok=True)
+    for location in ("active", "completed"):
+        for plan_file in (repo / "plans" / location).glob("*.md"):
+            plan_file.rename(repo / "plans" / "debt" / plan_file.name)
+
+    story = eng1()
+    assert story["state"] == "shipped"
+    assert story["tasks"], "shipped story's task graph must survive the plan moving"
+    assert story["lifecycle"]["planned"] is True
+
+
 def test_pr_ready_legacy_story_still_archives_to_history(repo, tmp_path):
     sign_off(repo)
     assert signed_off(repo)
@@ -7388,6 +7419,86 @@ def test_hook_allows_readonly_companion_task_launch(repo):
         code, out = hook(repo, {"tool_name": "Bash", "permission_mode": "default",
                                 "tool_input": {"command": command}})
         assert code == 0 and "deny" not in out, command
+
+
+def test_hook_allows_display_options_on_companion_mentions(repo):
+    # grep -n / rg -i / ls -la / tail -n only read or format: a display
+    # command that merely mentions the companion may carry them.
+    for command in (
+        "grep -n codex-companion factory/scripts",
+        "rg -n --ignore-case codex-companion .",
+        "ls -la /x/codex-companion.mjs",
+        "tail -n 20 /x/codex-companion.log",
+        "head -c 400 /x/codex-companion.mjs",
+    ):
+        code, out = hook(repo, {"tool_name": "Bash", "permission_mode": "default",
+                                "tool_input": {"command": command}})
+        assert code == 0 and "deny" not in out, command
+
+
+def test_hook_still_denies_exec_capable_options_on_companion_mentions(repo):
+    # rg --pre / --pre-glob run a preprocessor and tail -f follows forever:
+    # the pinned exec-capable display options stay off-contract even though
+    # read/format flags are now allowed.
+    for command in (
+        "rg --pre ./decode codex-companion .",
+        "rg --pre-glob '*.gz' --pre gunzip codex-companion .",
+        "tail -f /x/codex-companion.log",
+        "tail --follow=name /x/codex-companion.log",
+    ):
+        code, out = hook(repo, {"tool_name": "Bash", "permission_mode": "default",
+                                "tool_input": {"command": command}})
+        assert code == 0 and "deny" in out and "forge delegate" in out, command
+
+
+def test_hook_allows_readonly_companion_result_and_background(repo):
+    # `result` only prints a stored job (the fetch path for a backgrounded
+    # rescue run); `--background` detaches a read-only task. Neither writes.
+    for command in (
+        "node /x/codex-companion.mjs result task-abc123 --json",
+        "node /x/codex-companion.mjs result --json",
+        COMPANION + " --background 'explore the sender chain'",
+        "node /x/codex-companion.mjs task --background --effort high 'explore'",
+    ):
+        code, out = hook(repo, {"tool_name": "Bash", "permission_mode": "default",
+                                "tool_input": {"command": command}})
+        assert code == 0 and "deny" not in out, command
+    for command in (
+        "node /x/codex-companion.mjs cancel task-abc123 --json",
+        "node /x/codex-companion.mjs task --background --write 'explore'",
+        "node /x/codex-companion.mjs setup --json",
+    ):
+        code, out = hook(repo, {"tool_name": "Bash", "permission_mode": "default",
+                                "tool_input": {"command": command}})
+        assert code == 0 and "deny" in out and "forge delegate" in out, command
+
+
+def test_hook_allows_note_heredoc_that_mentions_the_companion(repo):
+    # A heredoc whose only consumer is a data sink is data: a note may name
+    # the companion and hold a quote/backtick that breaks shlex.
+    note = (
+        "cat >> plans/exploration/notes.md <<'EOF'\n"
+        "it's the codex-companion.mjs `task` launcher; see $CODEX_COMPANION\n"
+        "EOF\n"
+    )
+    code, out = hook(repo, {"tool_name": "Bash", "permission_mode": "default",
+                            "tool_input": {"command": note}})
+    assert code == 0 and "deny" not in out, out
+
+
+def test_hook_keeps_heredoc_bodies_fed_to_executors(repo):
+    # A body that reaches sh, a pipe, a separator, or trailing text can
+    # carry a launch: nothing outside the exact sink shape is stripped.
+    launch = "node /x/codex-companion.mjs task --write\n"
+    for command in (
+        "sh <<'EOF'\n" + launch + "EOF",
+        "cat <<'EOF' | sh\n" + launch + "EOF",
+        "cat >> plans/notes.md <<'EOF'\n" + launch + "EOF\nsh plans/notes.md",
+        "cat <<'EOF'; sh plans/notes.md\n" + launch + "EOF",
+    ):
+        code, out = hook(repo, {"tool_name": "Bash", "permission_mode": "default",
+                                "tool_input": {"command": command}})
+        assert code == 0 and "deny" in out and "forge delegate" in out, command
 
 
 def test_hook_routes_absolute_and_quoted_node_companion_invocations(repo):


### PR DESCRIPTION
## Why

Agents working in this repo could not get the output back from a **read-only** Codex rescue run once the runtime backgrounded it, and ordinary read-only commands that merely *mentioned* the companion (`grep -n …`, a note written with a heredoc) were refused as if they were launches. We hit all of it in one CARDSIMPLE-2 session and had to recover a finished plan grill by reading the raw Codex rollout off disk.

This PR re-vendors the harness at the commit that fixes the guard — **symphony-forge #156** (tracking issue #157). No product code changes; only vendored harness-owned paths and the vendor manifest.

## What the new guard does differently (`factory/scripts/pre_tool_use.py`)

- **Fetch path restored.** The companion's read-only `result <job-id> --json` verb and the `task --background` flag are on the read-only allowlist, so a backgrounded rescue run's output can be fetched with a bare companion call.
- **Harmless mentions allowed.** Display commands that only mention the companion may carry read/format options (`grep -n`, `rg -i`, `ls -la`, `tail -n`). The pinned exec-capable options stay denied per tool — rg `--pre*` and tail `-f`/`-F`/`--follow`/`--pid` — as do pager-style `+` tokens.
- **Note heredocs.** A heredoc body is ignored **only** for the exact data-sink note shape (`cat`/`tee`/`printf`/`echo` → file, no pipe/separator/backtick/`$(` outside the body, nothing after the terminator). `sh <<EOF`, `cat <<EOF | sh`, separators and trailing text keep their body and are classified as before.

Unchanged boundary: writes still require `--write` (never allowlisted); `cancel`/`setup`/`task-worker` still deny; backtick/`<()`/newline-smuggled launches still deny.

## Proof

Upstream: every hook-driven gate test (`-k hook`) green — 51 passed, 1 skipped, 0 failed — with all pre-existing must-deny cases unchanged; symphony-forge CI green before merge.

Here, after the bump: all green — check_factory_scaffold, check_agents_hygiene, check_dual_runtime, check_encoding_hygiene, context scan --check, check_repo_budget, compileall, plus check_vendor_integrity.

Practical rule this restores for agents: invoke the read-only companion as a **bare argv** (no pipe, no redirect, no `$var`) — the guard refuses shell metacharacters on a launch by design, which is what actually caused the earlier "denials"; only the three gaps above were real.
