### PR TITLE
chore(harness): re-vendor symphony-forge to 1e525d2 (#166)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 4bac95e9df7d360a127add9edc9f25056e30b1b4
+symphony-forge @ 1e525d24de715292e14a2b5e7844cd376e70d892
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "4bac95e9df7d360a127add9edc9f25056e30b1b4",
+  "harness_commit": "1e525d24de715292e14a2b5e7844cd376e70d892",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -41,8 +41,8 @@
     "factory/scripts/forge_cli/quickfix.py": "a58e468d9cc8a89d7ffb45094807a05f4f275a2dbf88add9b827d6b854c59fb4",
     "factory/scripts/forge_cli/readiness.py": "7b18cacce293cce2e760c1c5ebdb8331d4ff5ca354f58e9a01a435a71b94882d",
     "factory/scripts/forge_cli/repo_kind.py": "427043c49817f650c77eb20dbc368914822e31e028a9bd1c5042ff64cd475c97",
-    "factory/scripts/forge_cli/review.py": "5d2f21e3f78a34896933c48b6a57b8b3ff5982ea4eb4e6d0f239cf84d0653f94",
-    "factory/scripts/forge_cli/review_brief.py": "eb2c988d3e067844770213ad7f5f38cce6b41cee745fc326d868a3a52b6fa92a",
+    "factory/scripts/forge_cli/review.py": "438f8c6ae93e37151479becb97333df5885696d2f4ea1e466d42690671488e99",
+    "factory/scripts/forge_cli/review_brief.py": "c1efb8a4c8b9fce1c25f868626bb7731702953b2d41ef862e68c7ca576eef465",
     "factory/scripts/forge_cli/roadmap.py": "c33f5e9fde96f620962354114cf93a6ebb3bbc130ebb70719f09f6e286b91756",
     "factory/scripts/forge_cli/sanitise.py": "f8fe1115caf6ed19a63d400ca8e9688e5b267e6f284f280969edace274300d91",
     "factory/scripts/forge_cli/scaffold.py": "06d682c882011e5eef2ce4a41ffbbcc0c8bbdec97c1f35da0550b50943230666",

--- a/factory/scripts/forge_cli/review.py
+++ b/factory/scripts/forge_cli/review.py
@@ -131,13 +131,48 @@ def _product_dirty(base: Path) -> list[str]:
     return dirty
 
 
-def _lens_prompt(task: dict, lens: str) -> bytes:
+def _lens_prompt(task: dict, lens: str, base: Path | None = None) -> bytes:
     lines = [f"# Review brief — {task.get('id', '')} — {lens} lens", "",
              COMMON_PREAMBLE, LENS_FOCUS[lens]]
     if lens == "quality":
         lines += [QUALITY_VERDICT_FORMAT, VERDICT_INSTRUCTION, ""]
-    lines += _task_section(task)
+    lines += _task_section(task, base)
     return ("\n".join(lines).rstrip() + "\n").encode()
+
+
+def resolve_review_base(base: Path, stage: dict, state: dict, tip_sha: str) -> str:
+    """The commit the task diff is measured from.
+
+    The stage records the trunk commit the task started on. When the trunk is
+    merged INTO the task branch later (a harness re-vendor, a sibling task
+    landing), everything the trunk gained since that recorded base is reachable
+    from HEAD but is not the task's work — reviewing `base...HEAD` then bundles
+    the whole trunk delta, chunks the pass, and returns findings on code the
+    task never touched (observed 2026-09-04: a per-task review scored 0 on five
+    vendored-harness findings and recorded every contract as partial because
+    the chunked reviewer never reached the verdict lines). The task's own delta
+    is `merge-base(origin/<trunk>, HEAD)...HEAD`; use that point whenever it
+    descends from the recorded base, and keep the recorded base otherwise (no
+    trunk merge happened, or the trunk moved without being merged — then the
+    diff still starts where the task did)."""
+    from factory_lib import default_trunk_branch
+    trunk = default_trunk_branch(base)
+    recorded = stage.get("base_sha") or state.get("base_main_sha")
+    base_sha = recorded if isinstance(recorded, str) and recorded else None
+    if base_sha is None:
+        base_sha = _require_git(base, "resolving the task base", "merge-base",
+                                f"origin/{trunk}", "HEAD")
+    if _git(base, "merge-base", "--is-ancestor", base_sha, tip_sha).returncode != 0:
+        fail(f"task base {base_sha[:12]} is not an ancestor of HEAD")
+    merged = _git(base, "merge-base", f"origin/{trunk}", tip_sha)
+    trunk_point = merged.stdout.strip() if merged.returncode == 0 else ""
+    if (trunk_point and trunk_point != base_sha
+            and _git(base, "merge-base", "--is-ancestor", base_sha, trunk_point).returncode == 0):
+        print(f"task base advanced {base_sha[:12]} -> {trunk_point[:12]}: the trunk was "
+              "merged into this branch after the stage began; only the task's own "
+              "delta is reviewed")
+        return trunk_point
+    return base_sha
 
 
 def _area(path: str) -> str:
@@ -305,14 +340,7 @@ def cmd_review(args: argparse.Namespace) -> None:
                  "`record_test_from_json.py --kind automated`")
 
     tip_sha = _require_git(base, "resolving HEAD", "rev-parse", "--verify", "HEAD^{commit}")
-    base_sha = stage.get("base_sha") or state.get("base_main_sha")
-    if not isinstance(base_sha, str) or not base_sha:
-        from factory_lib import default_trunk_branch
-        trunk = default_trunk_branch(base)
-        base_sha = _require_git(base, "resolving the task base", "merge-base",
-                                f"origin/{trunk}", "HEAD")
-    if _git(base, "merge-base", "--is-ancestor", base_sha, tip_sha).returncode != 0:
-        fail(f"task base {base_sha[:12]} is not an ancestor of HEAD")
+    base_sha = resolve_review_base(base, stage, state, tip_sha)
     scope = sorted(
         p for p in _require_git(base, "listing the task diff", "diff",
                                 "--name-only", f"{base_sha}...HEAD").splitlines()
@@ -337,7 +365,7 @@ def cmd_review(args: argparse.Namespace) -> None:
     prompts: dict[str, tuple[str, bytes]] = {}
     for lens in lenses:
         rel = f"review-briefs/{args.id}.{lens}.md"
-        body = _lens_prompt(task, lens)
+        body = _lens_prompt(task, lens, base)
         if not safe_factory_write_bytes(base, rel, body):
             fail(f"could not write .factory/{rel}")
         prompts[lens] = (f".factory/{rel}", body)

--- a/factory/scripts/forge_cli/review_brief.py
+++ b/factory/scripts/forge_cli/review_brief.py
@@ -36,7 +36,35 @@ def declared_contracts(decomposition: dict) -> list[dict]:
     return contracts
 
 
-def _task_section(task: dict) -> list[str]:
+def _lessons_section(base: Path, task: dict) -> list[str]:
+    """Lessons whose `applies_to` globs hit the task's write scope — the
+    reviewer must not re-raise a finding the ledger already settled (the
+    2026-09-04 case: a per-task review re-flagged as P1 the exact behaviour a
+    recorded lesson pins as deliberate, because the brief never carried it)."""
+    from .lessons import relevant_lessons
+    scope = [p for p in task.get("write_scope", []) if isinstance(p, str)]
+    if not scope:
+        return []
+    try:
+        hits = relevant_lessons(base, scope)
+    except SystemExit:
+        return []
+    if not hits:
+        return []
+    lines = ["### Lessons in force", "",
+             "Recorded lessons that apply to this task's paths. A finding that "
+             "contradicts one is not a defect unless it shows the lesson itself "
+             "is wrong; say so explicitly instead of re-raising it.", ""]
+    for lesson in hits:
+        topic = str(lesson.get("topic", "")).strip()
+        body = str(lesson.get("lesson", "")).strip()
+        severity = str(lesson.get("severity", "")).strip()
+        lines.append(f"- [{severity}] {topic}: {body}")
+    lines.append("")
+    return lines
+
+
+def _task_section(task: dict, base: Path | None = None) -> list[str]:
     task_id = task.get("id", "")
     lines = [f"## Task {task_id}", "", "### Plan contracts", ""]
     contracts = task.get("plan_contracts", [])
@@ -59,6 +87,8 @@ def _task_section(task: dict) -> list[str]:
         reviewer_focus,
         "",
     ])
+    if base is not None:
+        lines.extend(_lessons_section(base, task))
     return lines
 
 
@@ -86,7 +116,7 @@ def cmd_review_brief(args: argparse.Namespace) -> None:
 
     lines = [title, "", VERDICT_INSTRUCTION, ""]
     for task in selected:
-        lines.extend(_task_section(task))
+        lines.extend(_task_section(task, base))
     relative = f"review-briefs/{filename}"
     body = ("\n".join(lines).rstrip() + "\n").encode()
     if not safe_factory_write_bytes(base, relative, body):

--- a/factory/tests/test_review_task_delta.py
+++ b/factory/tests/test_review_task_delta.py
@@ -1,0 +1,103 @@
+"""Per-task review measures the TASK's delta and carries the lessons in force.
+
+Two 2026-09-04 defects from the first per-task review on a client repo:
+- the trunk had been merged into the task branch after the stage began, and
+  `forge review` diffed from the stage's recorded base, so the bundle carried
+  the whole vendored-harness delta, chunked into three passes, scored 0 on
+  findings against code the task never touched, and recorded every contract
+  as `partial` because the chunked reviewer never reached the verdict lines;
+- the brief carried no lessons, so the reviewer re-raised as P1 the exact
+  behaviour a recorded lesson pins as deliberate.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from test_gates import (  # noqa: I001 — test_gates puts factory/scripts on sys.path
+    DECOMP, git, head, intake, repo, run, save_plan, sign_off, skeletal_stage_task,
+    task_skeleton,
+)
+from forge_cli.review import resolve_review_base  # noqa: E402
+
+__all__ = ["repo"]
+
+
+def _commit(repo, name: str, content: str) -> str:
+    (repo / name).parent.mkdir(parents=True, exist_ok=True)
+    (repo / name).write_text(content)
+    git(repo, "add", name)
+    git(repo, "commit", "-q", "-m", f"add {name}")
+    return head(repo)
+
+
+def test_review_base_advances_past_a_trunk_merged_after_the_stage_began(repo):
+    recorded = head(repo)                       # the stage's recorded base
+    git(repo, "checkout", "-q", "-b", "feat/ENG-1-T1")
+    task_commit = _commit(repo, "src/task.py", "task work\n")
+
+    # No trunk merge: the recorded base stands.
+    assert resolve_review_base(repo, {"base_sha": recorded}, {}, head(repo)) == recorded
+
+    # The trunk moves and is merged INTO the task branch.
+    git(repo, "checkout", "-q", "-b", "trunk-work", recorded)
+    trunk_commit = _commit(repo, "factory/vendored.py", "harness delta\n")
+    git(repo, "update-ref", "refs/remotes/origin/main", trunk_commit)
+    git(repo, "checkout", "-q", "feat/ENG-1-T1")
+    git(repo, "merge", "-q", "--no-edit", "origin/main")
+    tip = head(repo)
+
+    advanced = resolve_review_base(repo, {"base_sha": recorded}, {}, tip)
+    assert advanced == trunk_commit
+    # The reviewed delta is the task's own work only.
+    delta = git(repo, "diff", "--name-only", f"{advanced}...{tip}").splitlines()
+    assert delta == ["src/task.py"]
+    assert task_commit != tip
+
+    # A trunk that moved WITHOUT being merged does not move the base.
+    git(repo, "checkout", "-q", "trunk-work")
+    unmerged = _commit(repo, "factory/later.py", "later\n")
+    git(repo, "update-ref", "refs/remotes/origin/main", unmerged)
+    git(repo, "checkout", "-q", "feat/ENG-1-T1")
+    assert resolve_review_base(repo, {"base_sha": recorded}, {}, tip) == trunk_commit
+
+    # A recorded base that is not an ancestor of HEAD is refused, not guessed.
+    with pytest.raises(SystemExit):
+        resolve_review_base(repo, {"base_sha": unmerged}, {}, tip)
+
+
+def test_review_brief_carries_the_lessons_in_force_for_the_task_paths(repo, tmp_path):
+    sign_off(repo)
+    intake(repo)
+    save_plan(repo, tmp_path)
+    first = {**DECOMP["tasks"][0], "id": "T1", "reviewer_focus": "focus one",
+             "write_scope": ["src/permission/gate.py", "test/gate_test.py"],
+             "plan_contracts": [{"id": "C1", "statement": "first statement",
+                                  "source": "plan.md#first"}]}
+    second = {**skeletal_stage_task("T2", "second slice"), "dependencies": ["T1"]}
+    skeletons = [task_skeleton(first), task_skeleton(second)]
+    code, out = run(repo, "record_decomposition_from_json.py", stdin=json.dumps(
+        {**DECOMP, "tasks": skeletons}))
+    assert code == 0, out
+    code, out = run(repo, "record_decomposition_from_json.py", stdin=json.dumps(
+        {**DECOMP, "tasks": [first, skeletons[1]]}))
+    assert code == 0, out
+
+    for topic, applies_to in (
+        ("soft rail asks keep classifier eligibility", "src/permission/**"),
+        ("unrelated discord lesson", "src/channels/discord/**"),
+    ):
+        code, out = run(repo, "forge.py", "lesson", "add", "--topic", topic,
+                        "--lesson", f"{topic} — pinned by test", "--source", "review r1",
+                        "--applies-to", applies_to, "--severity", "high",
+                        "--by", "orchestrator", "--repo", str(repo))
+        assert code == 0, out
+
+    code, out = run(repo, "forge.py", "review-brief", "T1", "--repo", str(repo))
+    assert code == 0, out
+    brief = (repo / out.strip()).read_text()
+    assert "### Lessons in force" in brief
+    assert "soft rail asks keep classifier eligibility" in brief
+    assert "pinned by test" in brief
+    assert "unrelated discord lesson" not in brief


### PR DESCRIPTION
## Goal

Pick up the per-task review fix so a task's three-lens review judges only the task's own work and carries the lessons in force.

## What changed

Pure re-vendor via `forge upgrade` from a clean `symphony-forge` `origin/main` (4bac95e -> 1e525d2, upstream #166): `forge review` advances its base past a trunk merged into the task branch after the stage began, and the review brief ends with a "Lessons in force" section for the task's write scope. Four harness files. `harness.yaml` untouched.

## Verification

Seven client checks green: check_factory_scaffold, check_agents_hygiene, check_dual_runtime, check_encoding_hygiene, check_repo_budget, `forge context scan --check`, `compileall factory/scripts`.

No runtime behaviour change; no agent-e2e delta.