### PR TITLE
chore(harness): re-vendor symphony-forge to 9d9aefe (#167)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 1e525d24de715292e14a2b5e7844cd376e70d892
+symphony-forge @ 9d9aefe8e9cfadd374de96ac8402b6112bd62d3b
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "1e525d24de715292e14a2b5e7844cd376e70d892",
+  "harness_commit": "9d9aefe8e9cfadd374de96ac8402b6112bd62d3b",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -41,7 +41,7 @@
     "factory/scripts/forge_cli/quickfix.py": "a58e468d9cc8a89d7ffb45094807a05f4f275a2dbf88add9b827d6b854c59fb4",
     "factory/scripts/forge_cli/readiness.py": "7b18cacce293cce2e760c1c5ebdb8331d4ff5ca354f58e9a01a435a71b94882d",
     "factory/scripts/forge_cli/repo_kind.py": "427043c49817f650c77eb20dbc368914822e31e028a9bd1c5042ff64cd475c97",
-    "factory/scripts/forge_cli/review.py": "438f8c6ae93e37151479becb97333df5885696d2f4ea1e466d42690671488e99",
+    "factory/scripts/forge_cli/review.py": "b35b936a130d68e6dba0928936e9e11c0f7f3b240f8643a896775b1e306f06d6",
     "factory/scripts/forge_cli/review_brief.py": "c1efb8a4c8b9fce1c25f868626bb7731702953b2d41ef862e68c7ca576eef465",
     "factory/scripts/forge_cli/roadmap.py": "c33f5e9fde96f620962354114cf93a6ebb3bbc130ebb70719f09f6e286b91756",
     "factory/scripts/forge_cli/sanitise.py": "f8fe1115caf6ed19a63d400ca8e9688e5b267e6f284f280969edace274300d91",

--- a/factory/scripts/forge_cli/review.py
+++ b/factory/scripts/forge_cli/review.py
@@ -151,10 +151,17 @@ def resolve_review_base(base: Path, stage: dict, state: dict, tip_sha: str) -> s
     task never touched (observed 2026-09-04: a per-task review scored 0 on five
     vendored-harness findings and recorded every contract as partial because
     the chunked reviewer never reached the verdict lines). The task's own delta
-    is `merge-base(origin/<trunk>, HEAD)...HEAD`; use that point whenever it
-    descends from the recorded base, and keep the recorded base otherwise (no
-    trunk merge happened, or the trunk moved without being merged — then the
-    diff still starts where the task did)."""
+    is `merge-base(origin/<trunk>, HEAD)...HEAD`. Use that point unless it is
+    an ancestor of the recorded base — i.e. no trunk landed in the branch since
+    the stage began (the trunk may have moved without being merged; then the
+    diff still starts where the task did). The recorded base may itself be a
+    branch commit (a story branch that carried planning commits before the
+    stage started, then merged the trunk): it is then neither ancestor nor
+    descendant of the trunk point, no single commit means "base plus trunk",
+    and the trunk point is still the right base — the branch's own commits
+    since divergence are the task under the per-task flow, and on a legacy
+    story branch they are the story's earlier planning artifacts, which the
+    harness-path filter drops."""
     from factory_lib import default_trunk_branch
     trunk = default_trunk_branch(base)
     recorded = stage.get("base_sha") or state.get("base_main_sha")
@@ -167,10 +174,10 @@ def resolve_review_base(base: Path, stage: dict, state: dict, tip_sha: str) -> s
     merged = _git(base, "merge-base", f"origin/{trunk}", tip_sha)
     trunk_point = merged.stdout.strip() if merged.returncode == 0 else ""
     if (trunk_point and trunk_point != base_sha
-            and _git(base, "merge-base", "--is-ancestor", base_sha, trunk_point).returncode == 0):
+            and _git(base, "merge-base", "--is-ancestor", trunk_point, base_sha).returncode != 0):
         print(f"task base advanced {base_sha[:12]} -> {trunk_point[:12]}: the trunk was "
-              "merged into this branch after the stage began; only the task's own "
-              "delta is reviewed")
+              "merged into this branch after the stage began; only the branch's own "
+              "delta since it diverged from the trunk is reviewed")
         return trunk_point
     return base_sha
 

--- a/factory/tests/test_review_task_delta.py
+++ b/factory/tests/test_review_task_delta.py
@@ -67,6 +67,31 @@ def test_review_base_advances_past_a_trunk_merged_after_the_stage_began(repo):
         resolve_review_base(repo, {"base_sha": unmerged}, {}, tip)
 
 
+def test_review_base_advances_when_the_recorded_base_is_a_branch_commit(repo):
+    """A story branch carried planning commits BEFORE the stage started, so the
+    recorded base is a branch commit — neither ancestor nor descendant of the
+    trunk point once the trunk is merged in. The trunk point is still the base:
+    the branch's own delta since divergence is reviewed, never the trunk's."""
+    fork = head(repo)
+    git(repo, "checkout", "-q", "-b", "feat/ENG-1-story")
+    _commit(repo, "plans/story-plan.md", "planning\n")
+    recorded = head(repo)                       # stage started here, on the branch
+    _commit(repo, "src/task.py", "task work\n")
+
+    git(repo, "checkout", "-q", "-b", "trunk-work", fork)
+    trunk_commit = _commit(repo, "factory/vendored.py", "harness delta\n")
+    git(repo, "update-ref", "refs/remotes/origin/main", trunk_commit)
+    git(repo, "checkout", "-q", "feat/ENG-1-story")
+    git(repo, "merge", "-q", "--no-edit", "origin/main")
+    tip = head(repo)
+
+    advanced = resolve_review_base(repo, {"base_sha": recorded}, {}, tip)
+    assert advanced == trunk_commit
+    delta = sorted(git(repo, "diff", "--name-only", f"{advanced}...{tip}").splitlines())
+    assert delta == ["plans/story-plan.md", "src/task.py"]
+    assert "factory/vendored.py" not in delta
+
+
 def test_review_brief_carries_the_lessons_in_force_for_the_task_paths(repo, tmp_path):
     sign_off(repo)
     intake(repo)


### PR DESCRIPTION
## Goal

Finish the per-task review base fix: a task review measures the branch's own delta after a trunk merge even when the stage's recorded base is a branch commit.

## What changed

Pure re-vendor via `forge upgrade` from a clean `symphony-forge` `origin/main` (1e525d2 -> 9d9aefe, upstream #167). `harness.yaml` untouched.

## Verification

Seven client checks green: check_factory_scaffold, check_agents_hygiene, check_dual_runtime, check_encoding_hygiene, check_repo_budget, `forge context scan --check`, `compileall factory/scripts`.

No runtime behaviour change; no agent-e2e delta.