### PR TITLE
chore(harness): re-vendor symphony-forge to 1872b47 (#172)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 9d9aefe8e9cfadd374de96ac8402b6112bd62d3b
+symphony-forge @ 1872b476fada5dc17afdf8e01f9ddac438ef13c9
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "9d9aefe8e9cfadd374de96ac8402b6112bd62d3b",
+  "harness_commit": "1872b476fada5dc17afdf8e01f9ddac438ef13c9",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -12,7 +12,7 @@
     "factory/scripts/check_task_proof.py": "228f1e893db557a9f5b24543f839f8265844249af7b2d723af5b3ba4de5274bf",
     "factory/scripts/check_vendor_integrity.py": "f8a6d0f0ecf2440334944c7c3c9395024c15d9e76b44ac524cdf2592d513d931",
     "factory/scripts/factory_lib.py": "dff10ed80b11def6b53e6b7b1d5c2ec72620c881fae78f5b67833bede45542e9",
-    "factory/scripts/forge.py": "ce7f05e55a72fb239b2e56635aa5582f0db5bce86020d292595d59d75839462d",
+    "factory/scripts/forge.py": "ca691806c0cd83f357a67831d507b9e8ec4181af57f28bfb1827ed49a3b6dc24",
     "factory/scripts/forge_cli/__init__.py": "4ab03bbb8200c9ec1fcba0ec1b326bd8de4352d024f5cfdd6a1f46755e0dc0b4",
     "factory/scripts/forge_cli/adopt.py": "b6d34e97ba5967447d5aa8dfa2c7ae5dfffcf0aea2d34f16c7d11839bf11a63c",
     "factory/scripts/forge_cli/assumptions.py": "474ce594e8d1348487d12545310894eebd60b382ef969ce9cdce049c56e7b8a6",
@@ -49,9 +49,9 @@
     "factory/scripts/forge_cli/scratchpad.py": "6b5b57ba5c9a558d5fdfe8d48c835490eaaf48ef29097d05ce4c18da3a03f510",
     "factory/scripts/forge_cli/signal.py": "751fdc0e021f7a137a82ded23755db8b4540fa531df2c49186cc0b3bfbe7591b",
     "factory/scripts/forge_cli/specs.py": "bd66ffdca2ee89a14e17e86acb24f5a8ec2aa3a86cb3ce2b3b9d06e9821e34c0",
-    "factory/scripts/forge_cli/stages.py": "f369c1abd7c0f906f79a3789d1b7fdc8a54ec9c051e387d8685dc71289a55206",
+    "factory/scripts/forge_cli/stages.py": "e468a7523c07f048119194f396ecd625ee45a08f06220a26f487dda301f616f0",
     "factory/scripts/forge_cli/story.py": "dba9eaf5974a535b51c04944753cb37ebcaf6239a58d869c7be4099bb12cf7e8",
-    "factory/scripts/forge_cli/tasks.py": "3f96ce722c859048fc63a6a28f1d4881f55cb72877aaf27a93d02e1c95bfc7f9",
+    "factory/scripts/forge_cli/tasks.py": "90b835e89a0a22357e5b8fe086a2be293e8028178d5b0f8ccd419a5e5541b305",
     "factory/scripts/forge_cli/team.py": "499ca14519cb96529f2371e03ec213e1341c8e1bbe8d98555937c76a2131a471",
     "factory/scripts/forge_cli/upgrade.py": "45e05b1fbc3cfc15fa8f408b60717fe0039bf6e0dde4b21f5e6228caa45f417e",
     "factory/scripts/intake.py": "ccd4879f87d5d5037dc4e8c302fb172390deb31b37525ab574aab5affca8068f",

--- a/factory/scripts/forge.py
+++ b/factory/scripts/forge.py
@@ -202,6 +202,12 @@ def main() -> None:
         help="reopen a done-but-unshipped task (move the frontier back to it)",
     )
     p_task_reopen.add_argument("id", help="task id")
+    p_task_reopen.add_argument(
+        "--base",
+        help="the commit the task's work started from (default: the stage's recorded "
+             "base); `stage start` pins the reopened stage to it so the diff is the "
+             "task's real delta, not an empty diff from today's HEAD",
+    )
     p_task_reopen.add_argument("--repo")
     p_task_reopen.set_defaults(func=tasks_mod.cmd_task_reopen)
     p_task_reconcile = task_sub.add_parser(

--- a/factory/scripts/forge_cli/stages.py
+++ b/factory/scripts/forge_cli/stages.py
@@ -179,10 +179,15 @@ def write_skeleton(base: Path, issue: str, tasks: list[dict]) -> None:
         stage = {"id": task["id"], "title": task["title"], "status": "pending"}
         old = previous.get(task["id"])
         if old:
+            # Every seal token survives a re-record: the NEXT task's contract is
+            # recorded while this one is done-but-unshipped, and dropping the
+            # stage-local review stamp here left `task pr-ready` unable to seal
+            # a task whose stage had closed clean (symphony-forge #171).
             stage.update({k: v for k, v in old.items()
                           if k in ("status", "started_at", "completed_at",
                                    "base_sha", "dirty_at_start", "task_sha256",
-                                   "incomplete")})
+                                   "incomplete", "local_review_stamp",
+                                   "contract_changed", "reopen_base_sha")})
             stage["title"] = task["title"]
         stages.append(stage)
     write_stages(base, {"issue": issue, "stages": stages})
@@ -905,7 +910,24 @@ def _cmd_start_locked(args: argparse.Namespace, base: Path) -> None:
     # rewritten by the next `stage start`, which is how re-recording a contract
     # once destroyed the delta it was supposed to protect. A ref is written
     # once per stage and survives commits, rebases and worktree switches.
-    stage["base_sha"] = write_stage_ref(base, args.id) or ""
+    # A REOPENED task keeps the base its work started from: measuring a
+    # reopened stage from today's HEAD reports an empty diff for work that is
+    # already on the branch, and the stage can then neither close nor seal
+    # (symphony-forge #171). `task reopen` records that base; it must still be
+    # an ancestor of HEAD, else the ref pins HEAD as for a fresh stage.
+    reopen_base = stage.pop("reopen_base_sha", None)
+    pinned = ""
+    if isinstance(reopen_base, str) and reopen_base:
+        if _git(base, "merge-base", "--is-ancestor", reopen_base,
+                head_sha(base) or "HEAD").returncode == 0:
+            _git(base, "update-ref", stage_ref(args.id), reopen_base)
+            pinned = reopen_base
+            print(f"Stage baseline restored to {reopen_base[:12]} (reopened task): "
+                  "the diff is measured from where the task's work started")
+        else:
+            print(f"WARNING: reopened base {reopen_base[:12]} is not an ancestor of "
+                  "HEAD; measuring from HEAD instead")
+    stage["base_sha"] = pinned or write_stage_ref(base, args.id) or ""
     stage["dirty_at_start"] = dirty_digests(base)
     stage["task_sha256"] = task_digest(current_task)
     append_event(base, "stage-start", actor="implementer", story=data.get("issue", ""),

--- a/factory/scripts/forge_cli/tasks.py
+++ b/factory/scripts/forge_cli/tasks.py
@@ -327,10 +327,28 @@ def cmd_task_reopen(args: argparse.Namespace) -> None:
     if idx is None:
         fail(f"task {args.id} is not in the current decomposition")
     target = stages[idx]
-    if target.get("status") != "done":
-        fail(f"task {args.id} is '{target.get('status')}', not done. Only a done "
-             "task is reopened: an active task's contract is amended in place, and "
-             "a pending task has not started.")
+    # A done task reopens. So does an ACTIVE task that closed `--incomplete`: the
+    # harness's own "partial work" marker leaves the stage active on purpose,
+    # and the only way forward from a stage that cannot close (an empty
+    # measured diff after a reopen) is to reopen it with the right base.
+    status = target.get("status")
+    if not (status == "done" or (status == "active" and target.get("incomplete"))):
+        fail(f"task {args.id} is '{status}', not done (or active-and-incomplete). "
+             "An active task's contract is amended in place, and a pending task "
+             "has not started.")
+    # The base the task's work started from survives the reopen: `stage start`
+    # pins the stage ref to it, so the reopened stage measures the task's real
+    # delta instead of an empty diff from today's HEAD (symphony-forge #171).
+    # `--base` names it explicitly when the record no longer carries it.
+    explicit = (getattr(args, "base", None) or "").strip()
+    if explicit:
+        resolved = _git(base, "rev-parse", "--verify", "--quiet", f"{explicit}^{{commit}}")
+        if resolved.returncode != 0:
+            fail(f"--base {explicit} is not a commit in this repository")
+        explicit = resolved.stdout.strip()
+        if _git(base, "merge-base", "--is-ancestor", explicit, "HEAD").returncode != 0:
+            fail(f"--base {explicit[:12]} is not an ancestor of HEAD")
+    reopen_base = explicit or target.get("reopen_base_sha") or target.get("base_sha") or ""
     # Shipped work is immutable. The task marker rides onto the integration branch
     # at merge; if it is there, the work is shipped — add a follow-up task instead.
     default_branch = _default_branch(base)
@@ -360,6 +378,8 @@ def cmd_task_reopen(args: argparse.Namespace) -> None:
             stage.pop(field, None)
         stage["status"] = "pending"
         reopened.append(stage.get("id"))
+    if reopen_base:
+        stages[idx]["reopen_base_sha"] = reopen_base
     write_stages(base, data)
     print(
         f"Reopened {', '.join(reopened)} -> pending; the frontier is back at "

--- a/factory/tests/test_reopen_keeps_base_and_stamp.py
+++ b/factory/tests/test_reopen_keeps_base_and_stamp.py
@@ -1,0 +1,126 @@
+"""Issue #171: a done-but-unshipped task must stay sealable, and a reopened
+task must measure its real delta.
+
+- Re-recording the decomposition (the NEXT task's JIT contract) regenerates
+  stages.json; it dropped the done stage's `local_review_stamp`, so `task
+  pr-ready` could no longer seal a task whose stage had closed clean.
+- `task reopen` popped the stage base, so `stage start` pinned today's HEAD and
+  the reopened stage measured an EMPTY diff for work already on the branch —
+  it could neither close nor seal. Reopen now keeps the base (or takes
+  `--base`), `stage start` pins it, and an active stage that closed
+  `--incomplete` may be reopened.
+"""
+from __future__ import annotations
+
+import json
+
+from test_gates import (  # noqa: I001 — test_gates puts factory/scripts on sys.path
+    DECOMP, git, head, intake, record_skeleton_then_frontier, repo, run, save_plan,
+    sign_off, skeletal_stage_task, write_stages,
+)
+from factory_lib import load_json, protected_decomposition_state_path  # noqa: E402
+from forge_cli.stages import load_stages, task_digest  # noqa: E402
+
+__all__ = ["repo"]
+
+
+def _stage(repo, task_id: str) -> dict:
+    return next(s for s in load_stages(repo)["stages"] if s["id"] == task_id)
+
+
+def test_re_recording_the_decomposition_keeps_a_done_stage_seal_tokens(repo, tmp_path):
+    sign_off(repo)
+    intake(repo)
+    save_plan(repo, tmp_path)
+    record_skeleton_then_frontier(
+        repo, [skeletal_stage_task("T1"), skeletal_stage_task("T2")])
+    stamp = {"score": 9, "brief_sha256": "b" * 64, "product_tree_digest": "p" * 64}
+    recorded = load_json(protected_decomposition_state_path(repo), default={})
+    t1_contract = next(t for t in recorded["tasks"] if t["id"] == "T1")
+    write_stages(repo, {
+        "issue": "ENG-1",
+        "stages": [
+            {"id": "T1", "title": "first", "status": "done",
+             "task_sha256": task_digest(t1_contract),
+             "base_sha": "c" * 40, "local_review_stamp": stamp,
+             "contract_changed": {"from": "a" * 64, "to": "b" * 64}},
+            {"id": "T2", "title": "second", "status": "pending"},
+        ],
+    })
+    # Author the next task's contract: the decomposition is re-recorded.
+    code, out = run(repo, "record_decomposition_from_json.py", stdin=json.dumps(
+        {**DECOMP, "tasks": [skeletal_stage_task("T1"),
+                             {**skeletal_stage_task("T2"), "title": "second slice"}]}))
+    assert code == 0, out
+    t1 = _stage(repo, "T1")
+    assert t1["status"] == "done"
+    assert t1["local_review_stamp"] == stamp
+    assert t1["contract_changed"] == {"from": "a" * 64, "to": "b" * 64}
+    assert t1["base_sha"] == "c" * 40
+
+
+def test_reopen_keeps_the_base_and_stage_start_pins_it(repo, tmp_path):
+    sign_off(repo)
+    intake(repo)
+    save_plan(repo, tmp_path)
+    record_skeleton_then_frontier(repo, [skeletal_stage_task("T1")])
+    original_base = head(repo)
+    (repo / "src").mkdir(exist_ok=True)
+    (repo / "src" / "work.py").write_text("task work\n")
+    git(repo, "add", "src/work.py")
+    git(repo, "commit", "-q", "-m", "T1 work")
+    write_stages(repo, {
+        "issue": "ENG-1",
+        "stages": [
+            {"id": "T1", "title": "first", "status": "done", "task_sha256": "abc",
+             "base_sha": original_base, "local_review_stamp": {"score": 9}},
+        ],
+    })
+    code, out = run(repo, "forge.py", "task", "reopen", "T1")
+    assert code == 0 and "Reopened" in out, out
+    t1 = _stage(repo, "T1")
+    assert t1["status"] == "pending"
+    assert t1["reopen_base_sha"] == original_base
+    assert "base_sha" not in t1
+
+    # An explicit --base wins and must be an ancestor of HEAD.
+    write_stages(repo, {
+        "issue": "ENG-1",
+        "stages": [{"id": "T1", "title": "first", "status": "done", "task_sha256": "abc"}],
+    })
+    code, out = run(repo, "forge.py", "task", "reopen", "T1", "--base", "deadbeef")
+    assert code != 0 and "not a commit" in out, out
+    write_stages(repo, {
+        "issue": "ENG-1",
+        "stages": [{"id": "T1", "title": "first", "status": "done", "task_sha256": "abc"}],
+    })
+    code, out = run(repo, "forge.py", "task", "reopen", "T1", "--base", original_base)
+    assert code == 0, out
+    assert _stage(repo, "T1")["reopen_base_sha"] == original_base
+
+
+def test_reopen_accepts_an_active_stage_that_closed_incomplete(repo, tmp_path):
+    sign_off(repo)
+    intake(repo)
+    save_plan(repo, tmp_path)
+    record_skeleton_then_frontier(repo, [skeletal_stage_task("T1")])
+    base_sha = head(repo)
+    write_stages(repo, {
+        "issue": "ENG-1",
+        "stages": [
+            {"id": "T1", "title": "first", "status": "active", "task_sha256": "abc",
+             "base_sha": base_sha, "incomplete": "empty diff after a reopen"},
+        ],
+    })
+    code, out = run(repo, "forge.py", "task", "reopen", "T1")
+    assert code == 0 and "Reopened" in out, out
+    assert _stage(repo, "T1")["status"] == "pending"
+    assert _stage(repo, "T1")["reopen_base_sha"] == base_sha
+
+    # A plainly active stage (no incomplete marker) still refuses.
+    write_stages(repo, {
+        "issue": "ENG-1",
+        "stages": [{"id": "T1", "title": "first", "status": "active", "task_sha256": "abc"}],
+    })
+    code, out = run(repo, "forge.py", "task", "reopen", "T1")
+    assert code != 0 and "not done" in out, out


### PR DESCRIPTION
## Goal

Let a done-but-unshipped task stay sealable while the next task's contract is authored, and let a reopened task close on its real delta (symphony-forge #171).

## What changed

Pure re-vendor via `forge upgrade` from a clean `symphony-forge` `origin/main` (9d9aefe -> 1872b47, upstream #172): `write_skeleton` keeps `local_review_stamp` / `contract_changed` / `reopen_base_sha` on re-record; `task reopen` keeps the task base or takes `--base`; `stage start` pins a reopened base; reopen accepts an active `--incomplete` stage. Five harness files. `harness.yaml` untouched.

## Verification

Seven client checks green: check_factory_scaffold, check_agents_hygiene, check_dual_runtime, check_encoding_hygiene, check_repo_budget, `forge context scan --check`, `compileall factory/scripts`.

No runtime behaviour change; no agent-e2e delta.