### PR TITLE
chore(harness): re-vendor symphony-forge to 36f41cd (#173)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 1872b476fada5dc17afdf8e01f9ddac438ef13c9
+symphony-forge @ 36f41cdde01f1776ae191682a28c86615f2ddd8c
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "1872b476fada5dc17afdf8e01f9ddac438ef13c9",
+  "harness_commit": "36f41cdde01f1776ae191682a28c86615f2ddd8c",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -49,7 +49,7 @@
     "factory/scripts/forge_cli/scratchpad.py": "6b5b57ba5c9a558d5fdfe8d48c835490eaaf48ef29097d05ce4c18da3a03f510",
     "factory/scripts/forge_cli/signal.py": "751fdc0e021f7a137a82ded23755db8b4540fa531df2c49186cc0b3bfbe7591b",
     "factory/scripts/forge_cli/specs.py": "bd66ffdca2ee89a14e17e86acb24f5a8ec2aa3a86cb3ce2b3b9d06e9821e34c0",
-    "factory/scripts/forge_cli/stages.py": "e468a7523c07f048119194f396ecd625ee45a08f06220a26f487dda301f616f0",
+    "factory/scripts/forge_cli/stages.py": "9bffff60fa27d7dff23748a6473ef77e8069f847a95cb6d62b7d8973ab45c9d0",
     "factory/scripts/forge_cli/story.py": "dba9eaf5974a535b51c04944753cb37ebcaf6239a58d869c7be4099bb12cf7e8",
     "factory/scripts/forge_cli/tasks.py": "90b835e89a0a22357e5b8fe086a2be293e8028178d5b0f8ccd419a5e5541b305",
     "factory/scripts/forge_cli/team.py": "499ca14519cb96529f2371e03ec213e1341c8e1bbe8d98555937c76a2131a471",

--- a/factory/scripts/forge_cli/stages.py
+++ b/factory/scripts/forge_cli/stages.py
@@ -918,8 +918,14 @@ def _cmd_start_locked(args: argparse.Namespace, base: Path) -> None:
     reopen_base = stage.pop("reopen_base_sha", None)
     pinned = ""
     if isinstance(reopen_base, str) and reopen_base:
-        if _git(base, "merge-base", "--is-ancestor", reopen_base,
-                head_sha(base) or "HEAD").returncode == 0:
+        # stages' `_git` returns stdout (empty on failure); an ancestor check is
+        # a return code, so ask subprocess directly, as the done path does.
+        ancestor = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", reopen_base, "HEAD"],
+            cwd=base, capture_output=True, text=True, encoding="utf-8",
+            env=clean_git_env(),
+        ).returncode == 0
+        if ancestor:
             _git(base, "update-ref", stage_ref(args.id), reopen_base)
             pinned = reopen_base
             print(f"Stage baseline restored to {reopen_base[:12]} (reopened task): "

--- a/factory/tests/test_stage_start_after_reopen.py
+++ b/factory/tests/test_stage_start_after_reopen.py
@@ -1,0 +1,56 @@
+"""`stage start` on a reopened task pins the stage ref to the base the task's
+work started from (#171 follow-up: the first cut called `.returncode` on a
+helper that returns stdout, and crashed the first real `stage start`)."""
+from __future__ import annotations
+
+from test_gates import (  # noqa: I001 — test_gates puts factory/scripts on sys.path
+    STAGE_TASK, git, head, record_task_grill, repo, run, start_stage,
+    write_in_scope, write_stages,
+)
+from forge_cli.stages import load_stages  # noqa: E402
+
+__all__ = ["repo"]
+
+
+def test_stage_start_pins_a_reopened_base_and_measures_the_real_delta(repo, tmp_path):
+    start_stage(repo, tmp_path, STAGE_TASK, launch=False)
+    original = git(repo, "rev-parse", "refs/forge/stage/T1")
+    write_in_scope(repo, "src/core.py")
+    git(repo, "add", "src/core.py")
+    git(repo, "commit", "-qm", "the task's work")
+    worked = head(repo)
+
+    # The stage closed done (fixture), then something moved HEAD on the branch.
+    data = load_stages(repo)
+    stage = next(s for s in data["stages"] if s["id"] == "T1")
+    stage.update({"status": "done", "local_review_stamp": {"score": 9}})
+    write_stages(repo, data)
+    (repo / "NOTES.md").write_text("later commit\n")
+    git(repo, "add", "NOTES.md")
+    git(repo, "commit", "-qm", "later, unrelated")
+
+    code, out = run(repo, "forge.py", "task", "reopen", "T1")
+    assert code == 0 and "Reopened" in out, out
+    code, out = record_task_grill(repo, STAGE_TASK)
+    assert code == 0, out
+    code, out = run(repo, "forge.py", "stage", "start", "T1")
+    assert code == 0 and "Stage baseline restored" in out, out
+    assert git(repo, "rev-parse", "refs/forge/stage/T1") == original
+    delta = git(repo, "diff", "--name-only", f"{original}..HEAD").splitlines()
+    assert "src/core.py" in delta and worked != original
+
+    # A reopened base that is not an ancestor falls back to HEAD with a warning.
+    data = load_stages(repo)
+    stage = next(s for s in data["stages"] if s["id"] == "T1")
+    stage.update({"status": "done", "local_review_stamp": {"score": 9}})
+    write_stages(repo, data)
+    code, out = run(repo, "forge.py", "task", "reopen", "T1")
+    assert code == 0, out
+    data = load_stages(repo)
+    next(s for s in data["stages"] if s["id"] == "T1")["reopen_base_sha"] = "0" * 40
+    write_stages(repo, data)
+    code, out = record_task_grill(repo, STAGE_TASK)
+    assert code == 0, out
+    code, out = run(repo, "forge.py", "stage", "start", "T1")
+    assert code == 0 and "not an ancestor of HEAD" in out, out
+    assert git(repo, "rev-parse", "refs/forge/stage/T1") == head(repo)


### PR DESCRIPTION
## Goal

Finish the reopen fix (symphony-forge #171): `stage start` on a reopened task pins the stage ref to the base the task's work started from, so the stage measures the task's real delta and can close and seal.

## What changed

Pure re-vendor via `forge upgrade` from a clean `symphony-forge` `origin/main` (upstream #173: return-code capture for the ancestor check, end-to-end test). `harness.yaml` untouched.

## Verification

Seven client checks green: check_factory_scaffold, check_agents_hygiene, check_dual_runtime, check_encoding_hygiene, check_repo_budget, `forge context scan --check`, `compileall factory/scripts`.

No runtime behaviour change; no agent-e2e delta.