### PR TITLE
chore(harness): re-vendor symphony-forge to fc09793 (#175, #176)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 36f41cdde01f1776ae191682a28c86615f2ddd8c
+symphony-forge @ fc09793e39fb7c0b60599d8cda4598a34846a2e7
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "36f41cdde01f1776ae191682a28c86615f2ddd8c",
+  "harness_commit": "fc09793e39fb7c0b60599d8cda4598a34846a2e7",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -17,7 +17,7 @@
     "factory/scripts/forge_cli/adopt.py": "b6d34e97ba5967447d5aa8dfa2c7ae5dfffcf0aea2d34f16c7d11839bf11a63c",
     "factory/scripts/forge_cli/assumptions.py": "474ce594e8d1348487d12545310894eebd60b382ef969ce9cdce049c56e7b8a6",
     "factory/scripts/forge_cli/audit.py": "3ee18c67985328831d706fac9415fb488f5efffa84eb82c60925b9df6c7b0e4d",
-    "factory/scripts/forge_cli/board.py": "c00219d9c075f27ce1c6f75664c4a28814ed11086de86bf4222139af607d67df",
+    "factory/scripts/forge_cli/board.py": "c9fcb7dca33379c27e96e8efaea23ea7ba55c2215a18006edfa65e9b61312f93",
     "factory/scripts/forge_cli/ceremony.py": "f31653141a89562c84e04ecdc5cd438d68353230f364149301c367e2e91aa7fd",
     "factory/scripts/forge_cli/codex_status.py": "f62ea21fe6b73a590b8d3051a287041079b9c83cd3f99fff2bd1903d4367be79",
     "factory/scripts/forge_cli/common.py": "a5db9b7c577f869a0c856b3d9c9a20b34ea764b1e4439b5ad40f583119414e17",
@@ -41,7 +41,7 @@
     "factory/scripts/forge_cli/quickfix.py": "a58e468d9cc8a89d7ffb45094807a05f4f275a2dbf88add9b827d6b854c59fb4",
     "factory/scripts/forge_cli/readiness.py": "7b18cacce293cce2e760c1c5ebdb8331d4ff5ca354f58e9a01a435a71b94882d",
     "factory/scripts/forge_cli/repo_kind.py": "427043c49817f650c77eb20dbc368914822e31e028a9bd1c5042ff64cd475c97",
-    "factory/scripts/forge_cli/review.py": "b35b936a130d68e6dba0928936e9e11c0f7f3b240f8643a896775b1e306f06d6",
+    "factory/scripts/forge_cli/review.py": "87ca481c62d586ce5cf52c1172d584f8eee9eadca1ec45e798b7036ce2368cb5",
     "factory/scripts/forge_cli/review_brief.py": "c1efb8a4c8b9fce1c25f868626bb7731702953b2d41ef862e68c7ca576eef465",
     "factory/scripts/forge_cli/roadmap.py": "c33f5e9fde96f620962354114cf93a6ebb3bbc130ebb70719f09f6e286b91756",
     "factory/scripts/forge_cli/sanitise.py": "f8fe1115caf6ed19a63d400ca8e9688e5b267e6f284f280969edace274300d91",

--- a/factory/board/index.html
+++ b/factory/board/index.html
@@ -1732,6 +1732,24 @@ function renderProgress(state) {
     (sum.waiting ? cell("waiting", "·", sum.waiting, "waiting") : "");
 }
 
+// Accepted decisions govern; PROPOSED ones are still questions, and the work
+// resting on them is resting on an unanswered one. Listing only the accepted
+// made the board quietest exactly where it should have been loudest.
+function decisionSection(decisions) {
+  const accepted = decisions.filter(d => d.status === "accepted");
+  const proposed = decisions.filter(d => d.status === "proposed");
+  const rows = (list) => `<div class="ledger">${list.map(d => `<div>
+      <span class="id">${esc(d.id)}</span><span>${esc(d.title)}</span>${openFile(d.path)}
+    </div>`).join("")}</div>`;
+  return `${proposed.length ? `<h3>Decisions awaiting you
+      <span class="meta">${proposed.length}</span></h3>
+      <p class="quiet">Proposed, not yet accepted — they govern nothing until
+        you confirm them in chat.</p>${rows(proposed)}` : ""}
+    <h3>Active decisions <span class="meta">${accepted.length}</span></h3>
+    ${accepted.length ? rows(accepted)
+      : `<p class="quiet">No accepted decisions yet. They are recorded when you confirm one in chat.</p>`}`;
+}
+
 function renderBanner(state) {
   const rows = [];
   for (const sig of state.signals || []) {
@@ -1746,6 +1764,20 @@ function renderBanner(state) {
       <b>Quickfix window open</b>
       <span>${esc(q.id)} — ${esc(q.reason || "")} (${(q.files || []).length}/${esc(q.max_files)} files)</span>
       <span class="do">Close it in your session once the fix lands.</span></div>`);
+  }
+  const so = state.signoff || {};
+  if (so.signed_off === false) {
+    rows.push(`<div class="flag urgent"><em>\u25c6</em>
+      <b>Client sign-off is not recorded</b>
+      <span>${esc(so.reason || "planning is refused until it is")}</span>
+      <span class="do">Confirm the sign-off decision in chat, then
+        <code>record_signoff.py</code>.</span></div>`);
+  }
+  const proposedDecisions = (state.decisions || []).filter(d => d.status === "proposed");
+  if (proposedDecisions.length) {
+    rows.push(`<div class="flag"><em>\u00b7</em><span>${
+      plural(proposedDecisions.length, "decision")} proposed and awaiting you —
+      ${proposedDecisions.map(d => esc(d.id)).join(", ")}</span></div>`);
   }
   const a = (state.summary || {}).attention || {};
   const quiet = [];
@@ -3823,12 +3855,7 @@ function libraryBody(state) {
     </div>`).join("");
   const active = planRows("active"), completed = planRows("completed");
   return `<h3>Specs <span class="meta">${specs.length}</span></h3>${specRows}
-    <h3>Active decisions <span class="meta">${decisions.length}</span></h3>
-    ${decisions.length
-      ? `<div class="ledger">${decisions.map(d => `<div>
-          <span class="id">${esc(d.id)}</span><span>${esc(d.title)}</span>${openFile(d.path)}
-        </div>`).join("")}</div>`
-      : `<p class="quiet">No accepted decisions yet. They are recorded when you confirm one in chat.</p>`}
+    ${decisionSection(decisions)}
     <h3>Plans ledger</h3>
     ${active ? `<p class="quiet">Active</p><div class="ledger">${active}</div>` : ""}
     ${completed ? `<p class="quiet">Completed</p><div class="ledger">${completed}</div>` : ""}

--- a/factory/scripts/forge_cli/board.py
+++ b/factory/scripts/forge_cli/board.py
@@ -381,6 +381,7 @@ def aggregate_state(base: Path) -> dict:
         "quickfix_ledger": quickfix_ledger(base),
         "next": next_actions(base),
         "decisions": active_decisions(base),
+        "signoff": signoff_state(base),
     }
 
 
@@ -459,14 +460,45 @@ def next_actions(base: Path) -> dict:
 
 
 def active_decisions(base: Path) -> list[dict]:
+    """Accepted decisions AND the ones still waiting on a human.
+
+    Only accepted records used to reach the board, which hid the only decision
+    state a person can act on: a PROPOSED decision governs nothing until it is
+    accepted, and until then the work resting on it is resting on a question
+    nobody answered. Showing only the settled ones made the board quietest
+    exactly where it should have been loudest.
+    """
     records = decision_records(base)
     return [
         {"id": str(r.get("id") or r.get("slug") or ""),
          "title": str(r.get("title") or ""),
          "status": str(r.get("status") or ""),
          "path": Path(str(r["path"])).relative_to(base).as_posix() if r.get("path") else ""}
-        for r in records if r.get("status") == "accepted"
+        for r in records if r.get("status") in ("accepted", "proposed")
     ]
+
+
+def signoff_state(base: Path) -> dict:
+    """Whether the project is signed off, and what its handover grill said.
+
+    The sign-off grill is project-level (`.factory/grills/signoff.json`), not
+    story-scoped, so the board -- which reads grills from the STORY directory
+    -- never saw it. It is the gate every other gate sits behind: before it
+    passes, planning is refused outright.
+    """
+    from factory_lib import client_signoff
+
+    signed, reason = client_signoff(base)
+    grill = load_json(base / ".factory" / "grills" / "signoff.json", default={})
+    return {
+        "signed_off": bool(signed),
+        "reason": "" if signed else str(reason or ""),
+        "grill": {
+            "verdict": str(grill.get("verdict") or ""),
+            "at": str(grill.get("at") or grill.get("recorded_at") or ""),
+            "gaps": len(grill.get("gaps") or []),
+        } if grill else None,
+    }
 
 
 def approval_readiness(base: Path, detail: dict) -> list[dict]:

--- a/factory/scripts/forge_cli/review.py
+++ b/factory/scripts/forge_cli/review.py
@@ -301,6 +301,48 @@ def _artifact(
     return artifact
 
 
+def product_only_tip(worktree: Path, base_sha: str) -> str:
+    """Commit a review tip in the detached worktree with every harness
+    bookkeeping path (`.factory/`, `plans/`, `docs/decisions/`, the context
+    ledger) put back to the task base, and return its sha.
+
+    The scope list already drops those paths, but the autoreview skill builds
+    its own bundle from `base..HEAD`, so a story branch carrying hundreds of
+    planning artifacts handed the reviewer a >1 MB bundle: chunked into several
+    passes, the reviewer never reached the contract VERDICT lines, every
+    contract was recorded `partial` (fail-closed -> blocking), and the task-proof
+    gate refused a task whose product review was clean (observed 2026-09-04,
+    issue #171). With the bookkeeping at the base, the bundle is the product
+    delta only. The base is untouched and stays an ancestor of the new tip."""
+    from .stages import WORKFLOW_PATHS
+    prefixes = tuple(sorted(set(HARNESS_PREFIXES) | set(WORKFLOW_PATHS)))
+    changed = [
+        p for p in _require_git(worktree, "listing the review diff", "diff",
+                                "--name-only", f"{base_sha}..HEAD").splitlines()
+        if p.strip() and p.startswith(prefixes)
+    ]
+    if not changed:
+        return _require_git(worktree, "resolving the review tip", "rev-parse", "HEAD")
+    for rel in changed:
+        at_base = _git(worktree, "cat-file", "-e", f"{base_sha}:{rel}").returncode == 0
+        if at_base:
+            _require_git(worktree, f"restoring {rel} to the task base",
+                         "checkout", base_sha, "--", rel)
+        else:
+            _require_git(worktree, f"dropping {rel} from the review tip",
+                         "rm", "-q", "--cached", "--", rel)
+            path = worktree / rel
+            if path.is_file():
+                path.unlink()
+    _require_git(worktree, "committing the review tip",
+                 "-c", "user.name=forge-review", "-c", "user.email=forge-review@local",
+                 "commit", "-q", "--no-verify", "-m",
+                 f"review tip: harness bookkeeping at task base {base_sha[:12]}")
+    print(f"review tip excludes {len(changed)} harness bookkeeping path(s); the "
+          "bundle is the product delta only")
+    return _require_git(worktree, "resolving the review tip", "rev-parse", "HEAD")
+
+
 def _run_skill(skill: Path, worktree: Path, base_sha: str, prompt_rel: str,
                json_out: Path, engine: str, max_priority: str) -> dict:
     argv = [
@@ -387,6 +429,7 @@ def cmd_review(args: argparse.Namespace) -> None:
         # scoped to the committed task diff.
         _require_git(base, "creating the review worktree", "worktree", "add",
                      "--detach", str(worktree), tip_sha)
+        review_tip = product_only_tip(worktree, base_sha)
         for lens in lenses:
             rel, body = prompts[lens]
             target = worktree / rel
@@ -394,8 +437,8 @@ def cmd_review(args: argparse.Namespace) -> None:
             target.write_bytes(body)
         for lens in lenses:
             print(f"== {lens} lens: releasing Codex over {len(scope)} path(s) "
-                  f"({base_sha[:7]}..{tip_sha[:7]}) — watch the heartbeat below ==",
-                  flush=True)
+                  f"({base_sha[:7]}..{review_tip[:7]}, task tip {tip_sha[:7]}) — "
+                  "watch the heartbeat below ==", flush=True)
             reports[lens] = _run_skill(
                 skill, worktree, base_sha, prompts[lens][0], tmp / f"{lens}.json",
                 args.engine, args.max_priority,

--- a/factory/tests/test_gates.py
+++ b/factory/tests/test_gates.py
@@ -12503,6 +12503,44 @@ def test_board_separates_never_grilled_from_grilled_then_edited(repo, tmp_path):
     assert task_plan_view(repo, key, task, passing)["plan_state"] == "stale"
 
 
+def test_board_shows_proposed_decisions_and_the_signoff_gate(repo, tmp_path):
+    # Two things the board could not show. A PROPOSED decision governs nothing
+    # until a human accepts it, so the work resting on it rests on an open
+    # question — yet only accepted records reached the board, which made it
+    # quietest exactly where it should have been loudest. And the sign-off
+    # grill is project-level (.factory/grills/signoff.json), while the board
+    # reads grills from the STORY directory, so the gate every other gate sits
+    # behind was invisible.
+    sys.path.insert(0, str(repo / "factory" / "scripts"))
+    from forge_cli.board import active_decisions, signoff_state  # noqa: E402
+
+    decisions = repo / "docs" / "decisions"
+    decisions.mkdir(parents=True, exist_ok=True)
+    (decisions / "0001-accepted-thing.md").write_text(
+        "---\nid: 0001-accepted-thing\ntitle: Accepted thing\n"
+        "status: accepted\n---\n\nBody.\n", encoding="utf-8")
+    (decisions / "0002-open-question.md").write_text(
+        "---\nid: 0002-open-question\ntitle: Open question\n"
+        "status: proposed\n---\n\nBody.\n", encoding="utf-8")
+
+    listed = {d["id"]: d["status"] for d in active_decisions(repo)}
+    assert listed.get("0002-open-question") == "proposed", (
+        "a decision awaiting a human must reach the board")
+    assert listed.get("0001-accepted-thing") == "accepted"
+
+    state = signoff_state(repo)
+    assert "signed_off" in state
+    # Unsigned must carry the REASON, not just a false: the board explains a
+    # gate rather than only reporting it.
+    if state["signed_off"] is False:
+        assert state["reason"]
+
+    page = (HARNESS / "factory" / "board" / "index.html").read_text(
+        encoding="utf-8")
+    assert "Decisions awaiting you" in page
+    assert "Client sign-off is not recorded" in page
+
+
 def test_state_audit_reports_a_stage_split_between_working_copies(repo, tmp_path):
     # The harness gates TRANSITIONS and never re-validates STATE, so a record
     # that stopped being true is invisible. This is the split that made a

--- a/factory/tests/test_review_task_delta.py
+++ b/factory/tests/test_review_task_delta.py
@@ -126,3 +126,28 @@ def test_review_brief_carries_the_lessons_in_force_for_the_task_paths(repo, tmp_
     assert "soft rail asks keep classifier eligibility" in brief
     assert "pinned by test" in brief
     assert "unrelated discord lesson" not in brief
+
+
+def test_review_tip_puts_harness_bookkeeping_back_at_the_task_base(repo, tmp_path):
+    from forge_cli.review import product_only_tip
+
+    base_sha = head(repo)
+    git(repo, "checkout", "-q", "-b", "feat/ENG-1-T1")
+    (repo / "plans" / "exploration").mkdir(parents=True, exist_ok=True)
+    (repo / "plans" / "exploration" / "grill-r1.md").write_text("x" * 5000)
+    (repo / ".factory" / "stories" / "ENG-1").mkdir(parents=True, exist_ok=True)
+    (repo / ".factory" / "stories" / "ENG-1" / "verify.json").write_text("{}")
+    _commit(repo, "src/task.py", "task work\n")
+    git(repo, "add", "-A", "plans", ".factory")
+    git(repo, "commit", "-q", "-m", "planning artifacts")
+    tip = head(repo)
+
+    worktree = tmp_path / "review-wt"
+    git(repo, "worktree", "add", "--detach", str(worktree), tip)
+    review_tip = product_only_tip(worktree, base_sha)
+    assert review_tip != tip
+    delta = sorted(git(worktree, "diff", "--name-only", f"{base_sha}..{review_tip}").splitlines())
+    assert delta == ["src/task.py"]
+    # The task branch itself is untouched.
+    assert head(repo) == tip
+    git(repo, "worktree", "remove", "--force", str(worktree))


### PR DESCRIPTION
## Goal

Let the per-task review reach its contract verdicts: the review bundle becomes the task's product delta only, so a story branch full of planning artifacts no longer chunks the pass and records every contract as partial (symphony-forge #171).

## What changed

Pure re-vendor via `forge upgrade` from a clean `symphony-forge` `origin/main` (upstream #175 board fix, #176 product-only review tip). `harness.yaml` untouched.

## Verification

Seven client checks green: check_factory_scaffold, check_agents_hygiene, check_dual_runtime, check_encoding_hygiene, check_repo_budget, `forge context scan --check`, `compileall factory/scripts`.

No runtime behaviour change; no agent-e2e delta.