### PR TITLE
chore(harness): re-vendor symphony-forge to b03ed74 (#177)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ fc09793e39fb7c0b60599d8cda4598a34846a2e7
+symphony-forge @ b03ed74e9e439e6d61139bfd3e1f49a3b312e6c1
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "fc09793e39fb7c0b60599d8cda4598a34846a2e7",
+  "harness_commit": "b03ed74e9e439e6d61139bfd3e1f49a3b312e6c1",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -42,7 +42,7 @@
     "factory/scripts/forge_cli/readiness.py": "7b18cacce293cce2e760c1c5ebdb8331d4ff5ca354f58e9a01a435a71b94882d",
     "factory/scripts/forge_cli/repo_kind.py": "427043c49817f650c77eb20dbc368914822e31e028a9bd1c5042ff64cd475c97",
     "factory/scripts/forge_cli/review.py": "87ca481c62d586ce5cf52c1172d584f8eee9eadca1ec45e798b7036ce2368cb5",
-    "factory/scripts/forge_cli/review_brief.py": "c1efb8a4c8b9fce1c25f868626bb7731702953b2d41ef862e68c7ca576eef465",
+    "factory/scripts/forge_cli/review_brief.py": "af56282c0e90301fd2b62d45467bd3aa951558e2cd0f76fc621a210bd03622b5",
     "factory/scripts/forge_cli/roadmap.py": "c33f5e9fde96f620962354114cf93a6ebb3bbc130ebb70719f09f6e286b91756",
     "factory/scripts/forge_cli/sanitise.py": "f8fe1115caf6ed19a63d400ca8e9688e5b267e6f284f280969edace274300d91",
     "factory/scripts/forge_cli/scaffold.py": "06d682c882011e5eef2ce4a41ffbbcc0c8bbdec97c1f35da0550b50943230666",
@@ -58,7 +58,7 @@
     "factory/scripts/post_tool_use.py": "b56fcb933df3b1c43f6ad13fd4ae320c147e8cce5cfd948d34fb096be7684e20",
     "factory/scripts/pr_ready.py": "0a51cabc77693c3bb8522b08027b7b81b3bbdd6e900bdb0f53cb5c94f094adfd",
     "factory/scripts/pre_compact.py": "ad65f7caae8510711e334d0254a42fbb0df1a314fb1ea635b088f000862a8486",
-    "factory/scripts/pre_tool_use.py": "c35c0f819ce0bf60fc6b5cd5bd890b3a5b2cc69e34121cb4b55b6c6ab727797c",
+    "factory/scripts/pre_tool_use.py": "15ce41a057e9e60bdf997f7048d3ff6a9e7e9ec5ea1cc51d89eca839e32d384b",
     "factory/scripts/record_decomposition_from_json.py": "bb0b6a961927bcaf88cae1c62d6de2cb26fa460cfc3beddd0cf6155f0d3e0838",
     "factory/scripts/record_grill_from_json.py": "97f165857722cfd53eef06e731d3ee5280be8278f6ea9dc10c1ae17a256ce81a",
     "factory/scripts/record_review_from_json.py": "98e8080b2b85374b4cda11f3b7e340ad2efcbc09b9dde242e84fc20e04d15f4e",

--- a/factory/scripts/forge_cli/review_brief.py
+++ b/factory/scripts/forge_cli/review_brief.py
@@ -64,6 +64,48 @@ def _lessons_section(base: Path, task: dict) -> list[str]:
     return lines
 
 
+def _evidence_section(base: Path) -> list[str]:
+    """The story's recorded verification evidence, summarised for the reviewer.
+
+    The review bundle is the product delta only (bookkeeping paths sit at the
+    task base), so the reviewer no longer sees `verify.json` / `tests.json`
+    in the diff — and a contract like "suites pass; tsc and architecture
+    green" was recorded `partial` for lack of execution evidence (issue #171).
+    The brief carries the summary instead: what verify ran and whether it was
+    green, and what the automated-test record says."""
+    from factory_lib import evidence_path
+    state = load_json(run_state_path(base), default={})
+    story = state.get("issue_key") or state.get("story")
+    if not isinstance(story, str) or not story:
+        return []
+    lines: list[str] = []
+    verify = load_json(evidence_path(base, story, "verify.json"), default={})
+    if verify:
+        ok = "ok" if verify.get("ok") is True else "FAILED"
+        commit = str(verify.get("commit", ""))[:12]
+        lines.append(f"- verify.py: {ok}" + (f" at {commit}" if commit else ""))
+        for result in verify.get("results") or []:
+            if isinstance(result, dict) and result.get("command"):
+                code = result.get("exit_code")
+                lines.append(f"  - `{result['command']}` -> exit {code}")
+    tests = load_json(evidence_path(base, story, "tests.json"), default={})
+    automated = (tests or {}).get("automated")
+    if isinstance(automated, dict):
+        lines.append(f"- automated tests: {automated.get('status', 'unknown')}")
+        summary = str(automated.get("summary", "")).strip()
+        if summary:
+            lines.append(f"  - {summary}")
+        commands = automated.get("commands_run") or []
+        if commands:
+            lines.append(f"  - {len(commands)} command(s) recorded, e.g. `{commands[0]}`")
+    if not lines:
+        return []
+    return ["### Recorded evidence", "",
+            "Recorded by the harness for this story (not in the diff). Use it to "
+            "verdict verification contracts; do not mark them partial for lack "
+            "of execution evidence in the bundle.", "", *lines, ""]
+
+
 def _task_section(task: dict, base: Path | None = None) -> list[str]:
     task_id = task.get("id", "")
     lines = [f"## Task {task_id}", "", "### Plan contracts", ""]
@@ -89,6 +131,7 @@ def _task_section(task: dict, base: Path | None = None) -> list[str]:
     ])
     if base is not None:
         lines.extend(_lessons_section(base, task))
+        lines.extend(_evidence_section(base))
     return lines
 
 

--- a/factory/scripts/pre_tool_use.py
+++ b/factory/scripts/pre_tool_use.py
@@ -121,9 +121,38 @@ def _static_locked(raw: str, root: Path) -> bool:
             .resolve().relative_to(root.resolve()).as_posix()
     except ValueError:
         return False
-    return rel not in STATIC_WRITE_EXEMPT_FILES and not any(
-        rel == prefix.rstrip("/") or rel.startswith(prefix)
-        for prefix in STATIC_WRITE_EXEMPT_PREFIXES)
+    if rel in STATIC_WRITE_EXEMPT_FILES or any(
+            rel == prefix.rstrip("/") or rel.startswith(prefix)
+            for prefix in STATIC_WRITE_EXEMPT_PREFIXES):
+        return False
+    return not _ignored_and_untracked(rel, root)
+
+
+def _ignored_and_untracked(rel: str, root: Path) -> bool:
+    """A path git ignores AND does not track is not product or canon.
+
+    The exemption list named `.envrc` but not `.env`, so editing local service
+    config to run verify was refused as a product write. Enumerating filenames
+    always misses one; the question is what the file IS. Git already answers
+    it, and the answer costs nothing on the common path because this is only
+    consulted for a path that would otherwise be refused.
+
+    BOTH conditions matter. A tracked file stays guarded even if someone adds
+    it to .gitignore, so the lock cannot be lifted off product by editing an
+    ignore rule.
+    """
+    try:
+        ignored = subprocess.run(
+            ["git", "check-ignore", "-q", "--", rel], cwd=root,
+            capture_output=True, timeout=5)
+        if ignored.returncode != 0:
+            return False
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", rel], cwd=root,
+            capture_output=True, timeout=5)
+        return tracked.returncode != 0
+    except (OSError, subprocess.SubprocessError):
+        return False   # cannot tell: keep the lock on
 
 
 def _fallback_readonly(command: str) -> bool:

--- a/factory/tests/test_gates.py
+++ b/factory/tests/test_gates.py
@@ -12541,6 +12541,27 @@ def test_board_shows_proposed_decisions_and_the_signoff_gate(repo, tmp_path):
     assert "Client sign-off is not recorded" in page
 
 
+# Every gate, and what it requires. A gate may only require things PRODUCED
+# EARLIER in this order. The scope deadlock and the grill deadlock were both
+# the same shape: a gate demanding something its own refusal had just made
+# impossible, with no escape but a false record.
+GATE_ORDER = ["plan", "grill", "approve", "task_start", "stage_start",
+              "delegate", "verify", "review", "stage_done", "task_pr_ready",
+              "story_closeout"]
+GATE_REQUIRES = {
+    "grill": ["plan"],
+    "approve": ["plan", "grill"],
+    "task_start": ["approve"],
+    "stage_start": ["task_start"],
+    "delegate": ["stage_start"],
+    "verify": [],
+    "review": ["delegate"],
+    "stage_done": ["delegate"],
+    "task_pr_ready": ["stage_done", "verify", "review"],
+    "story_closeout": ["task_pr_ready"],
+}
+
+
 def test_state_audit_reports_a_stage_split_between_working_copies(repo, tmp_path):
     # The harness gates TRANSITIONS and never re-validates STATE, so a record
     # that stopped being true is invisible. This is the split that made a
@@ -19491,3 +19512,60 @@ def test_ceremony_target_redirects_rounds_and_markers(repo, tmp_path):
     bare.mkdir()
     code, out = run(repo, "forge.py", "ceremony", "target", "set", str(bare))
     assert code != 0 and "not an adopted factory repo" in out
+
+
+def test_write_lock_exempts_ignored_local_config_but_not_tracked_product(repo):
+    # The exemption list named .envrc but not .env, so editing local service
+    # config to run verify was refused as a product write. Enumerating
+    # filenames always misses one; git already knows what a file IS.
+    sys.path.insert(0, str(repo / "factory" / "scripts"))
+    from pre_tool_use import _static_locked  # noqa: E402
+
+    (repo / ".gitignore").write_text(".env\nsrc/generated.py\n", encoding="utf-8")
+    (repo / ".env").write_text("SMTP_HOST=127.0.0.1\n", encoding="utf-8")
+    (repo / "src").mkdir(exist_ok=True)
+    (repo / "src" / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / "src" / "generated.py").write_text("y = 2\n", encoding="utf-8")
+    git(repo, "add", "-A")
+    # Tracked AND ignored: the loophole. Git tracks it regardless of the rule.
+    git(repo, "add", "-f", "src/generated.py")
+    git(repo, "commit", "-qm", "lock fixture")
+
+    assert _static_locked(".env", repo) is False
+    assert _static_locked("src/app.py", repo) is True
+    # A tracked file stays guarded even when someone adds it to .gitignore, so
+    # the lock cannot be lifted off product by editing an ignore rule.
+    assert _static_locked("src/generated.py", repo) is True
+
+
+def test_the_gate_graph_has_no_cycles(repo):
+    # A deadlock is not a bug in one gate; it is an edge pointing forward. Two
+    # shipped this month: `stage done` demanded a launch bound to a contract
+    # its own refusal told you to change, and a grill was staled by the fix it
+    # asked for. Both were only escapable by recording something false.
+    position = {gate: index for index, gate in enumerate(GATE_ORDER)}
+    for gate, requires in GATE_REQUIRES.items():
+        for needed in requires:
+            assert needed in position, f"{gate} requires unknown gate {needed}"
+            assert position[needed] < position[gate], (
+                f"{gate} requires {needed}, which comes AFTER it — that is a "
+                "cycle, and the only way through it is a false record")
+
+    # Reachability: no gate may require itself, directly or transitively.
+    def reaches(start, target, seen=None):
+        seen = seen or set()
+        for needed in GATE_REQUIRES.get(start, []):
+            if needed == target:
+                return True
+            if needed not in seen and reaches(needed, target, seen | {needed}):
+                return True
+        return False
+
+    for gate in GATE_REQUIRES:
+        assert not reaches(gate, gate), f"{gate} transitively requires itself"
+
+    # The graph must describe the gates that actually exist: a gate added to
+    # the harness and not to this map would be unchecked by this test.
+    lib = (HARNESS / "factory" / "scripts" / "factory_lib.py").read_text(
+        encoding="utf-8")
+    assert "def require_closeout_order" in lib

--- a/factory/tests/test_review_task_delta.py
+++ b/factory/tests/test_review_task_delta.py
@@ -151,3 +151,29 @@ def test_review_tip_puts_harness_bookkeeping_back_at_the_task_base(repo, tmp_pat
     # The task branch itself is untouched.
     assert head(repo) == tip
     git(repo, "worktree", "remove", "--force", str(worktree))
+
+
+def test_review_brief_carries_the_recorded_verification_evidence(repo, tmp_path):
+    from test_gates import write_passing_artifacts
+
+    sign_off(repo)
+    intake(repo)
+    save_plan(repo, tmp_path)
+    first = {**DECOMP["tasks"][0], "id": "T1", "reviewer_focus": "focus one",
+             "write_scope": ["src/gate.py"],
+             "plan_contracts": [{"id": "C1", "statement": "unit suites pass; tsc green",
+                                  "source": "plan.md#first"}]}
+    code, out = run(repo, "record_decomposition_from_json.py", stdin=json.dumps(
+        {**DECOMP, "tasks": [task_skeleton(first)]}))
+    assert code == 0, out
+    code, out = run(repo, "record_decomposition_from_json.py", stdin=json.dumps(
+        {**DECOMP, "tasks": [first]}))
+    assert code == 0, out
+    write_passing_artifacts(repo)
+
+    code, out = run(repo, "forge.py", "review-brief", "T1", "--repo", str(repo))
+    assert code == 0, out
+    brief = (repo / out.strip()).read_text()
+    assert "### Recorded evidence" in brief
+    assert "verify.py: ok" in brief
+    assert "automated tests: passed" in brief


### PR DESCRIPTION
## Goal

Let the per-task review verdict verification contracts on a product-only bundle: the brief now carries the story's recorded verify and test evidence (symphony-forge #171 follow-up).

## What changed

Pure re-vendor via `forge upgrade` from a clean `symphony-forge` `origin/main` (upstream #177). `harness.yaml` untouched.

## Verification

Seven client checks green: check_factory_scaffold, check_agents_hygiene, check_dual_runtime, check_encoding_hygiene, check_repo_budget, `forge context scan --check`, `compileall factory/scripts`.

No runtime behaviour change; no agent-e2e delta.