### PR TITLE
fix: Postgres-lane reds — live waiting admission query + inline runtime fixtures (Q-0154)

### DIFF
--- a/apps/core/src/adapters/storage/postgres/repositories/live-waiting-admission-query.postgres.ts
+++ b/apps/core/src/adapters/storage/postgres/repositories/live-waiting-admission-query.postgres.ts
@@ -19,9 +19,12 @@ export async function getOldestWaitingLiveAdmission(
 ): Promise<OldestWaitingLiveAdmission | null> {
   if (input.conversationJids.length === 0) return null;
   const now = input.now ?? currentIso();
-  // messages.conversation_id is `conversation:<jid>`; live_turns.conversation_id
-  // is the raw jid. Normalize the routed input once so live_turns predicates stay
-  // plain-column comparisons instead of expression joins.
+  // messages.conversation_id is `conversation:<jid>` for legacy rows and
+  // `conversation:<providerAccountId>:<jid>` for current writes (0091/0092), with
+  // the raw jid kept in external_ref_json.chat_jid — the same two-axis match as
+  // messageConversationFilter. live_turns.conversation_id is the raw jid.
+  // Normalize the routed input once so live_turns predicates stay plain-column
+  // comparisons instead of expression joins.
   const routed = sql.join(
     input.conversationJids.map(
       (jid) => sql`(${jid}::text, ${`conversation:${jid}`}::text)`,
@@ -42,7 +45,9 @@ export async function getOldestWaitingLiveAdmission(
            m.created_at AS waiting_since,
            floor(extract(epoch FROM (${now}::timestamptz - m.created_at)))::int AS age_seconds
     FROM routed
-    INNER JOIN messages m ON m.conversation_id = routed.conversation_id
+    INNER JOIN messages m
+      ON m.conversation_id = routed.conversation_id
+      OR m.external_ref_json::jsonb->>'chat_jid' = routed.raw_jid
     WHERE m.direction = 'inbound'
       AND NOT EXISTS (
         SELECT 1 FROM live_turns lt

--- a/apps/core/test/integration/inline-agent-runtime.integration.test.ts
+++ b/apps/core/test/integration/inline-agent-runtime.integration.test.ts
@@ -1180,11 +1180,13 @@ maybeDescribe('inline session turns through the control API', () => {
       app,
       channelWiring: {
         sendMessage: channelEffects.runtime.sendMessage,
-        requestPermissionApproval: (request) =>
-          channelEffects.runtime.requestPermissionApproval(
+        requestPermissionApproval: async (request) => ({
+          kind: 'decision' as const,
+          decision: await channelEffects.runtime.requestPermissionApproval(
             request.targetJid ?? baseInput.chatJid,
             request,
           ),
+        }),
         requestUserAnswer: (request) =>
           channelEffects.runtime.requestUserAnswer(
             request.targetJid ?? baseInput.chatJid,
@@ -1451,18 +1453,24 @@ maybeDescribe('inline session turns through the control API', () => {
     const { makeAgentThreadQueueKey } =
       await import('@core/shared/thread-queue-key.js');
     const conversationJid = 'app:default:delegation';
+    // Delegation scopes targets to the caller's canonical conversation, so
+    // every route in the map carries the same conversationId.
+    const conversationId = 'conversation:delegation';
     const parentGroup = {
       ...group,
+      conversationId,
       folder: 'parent_inline',
       agentConfig: { runtime: 'inline' },
     } as ConversationRoute;
     const inlineTarget = {
       ...group,
+      conversationId,
       folder: 'child_inline',
       agentConfig: { runtime: 'inline' },
     } as ConversationRoute;
     const workerTarget = {
       ...group,
+      conversationId,
       folder: 'child_worker',
       agentConfig: { runtime: 'worker' },
     } as ConversationRoute;

--- a/plans/quickfixes/20260905T172104-0000-Q-0154-3718-open-172104335444.json
+++ b/plans/quickfixes/20260905T172104-0000-Q-0154-3718-open-172104335444.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0154-3718",
+  "profile": "quickfix",
+  "reason": "four pre-existing integration reds on main that block ASKFLOOR-1-T3a's Postgres verify gate: live-waiting-admission x2 (getOldestWaitingLiveAdmission null under provider-account-qualified ids) and inline-agent-runtime x2 (run never reaches completed; child runs stay running)",
+  "started_at": "2026-09-05T17:21:04+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260905T173241-0000-Q-0154-3718-done-173241855636.json
+++ b/plans/quickfixes/20260905T173241-0000-Q-0154-3718-done-173241855636.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0154-3718",
+  "profile": "quickfix",
+  "reason": "four pre-existing integration reds on main that block ASKFLOOR-1-T3a's Postgres verify gate: live-waiting-admission x2 (getOldestWaitingLiveAdmission null under provider-account-qualified ids) and inline-agent-runtime x2 (run never reaches completed; child runs stay running)",
+  "started_at": "2026-09-05T17:21:04+00:00",
+  "completed_at": "2026-09-05T17:32:41+00:00",
+  "files": []
+}

--- a/vitest.integration.postgres.config.ts
+++ b/vitest.integration.postgres.config.ts
@@ -25,7 +25,7 @@ export default makeVitestConfig({
           // ponytail: these match the convention but were never in the old
           // hard-coded script list and have never run in CI with a live
           // database. Excluded to keep behavior; delete a line to adopt one.
-          '**/live-waiting-admission.postgres.integration.test.ts',
+          // (live-waiting-admission adopted by Q-0154 once its query was fixed.)
           '**/pattern-candidate-atomic-claim.postgres.integration.test.ts',
           '**/toolchain-bake-reconciler.postgres.integration.test.ts',
           '**/worker-coordination.postgres.integration.test.ts',

--- a/vitest.integration.postgres.config.ts
+++ b/vitest.integration.postgres.config.ts
@@ -15,7 +15,9 @@ export default makeVitestConfig({
           'apps/core/test/integration/fleet-capability-chaos-combo.postgres.integration.test.ts',
         ]
       : lane === 'hot-path'
-        ? ['apps/core/test/integration/**/*-explain.postgres.integration.test.ts']
+        ? [
+            'apps/core/test/integration/**/*-explain.postgres.integration.test.ts',
+          ]
         : ['apps/core/test/integration/**/*.postgres.integration.test.ts'],
   exclude:
     lane === 'default'


### PR DESCRIPTION
## Goal

Four integration tests have been red on main for weeks whenever a test database is configured, and nothing in CI runs them, so nobody noticed. The next ASKFLOOR-1 task (T3a) is the first storage task whose verify gate must run the Postgres lane, so these have to be green first. One of the four is a real production bug: the "oldest waiting live admission" signal never fired.

## What changed

- **Production fix, live waiting admission.** The query that finds the oldest inbound message with no covering live turn still joined messages on the legacy `conversation:<jid>` id. Since provider-account keying (decisions 0091/0092) messages are stored as `conversation:<providerAccountId>:<jid>` with the raw jid in `external_ref_json.chat_jid`, so the join matched nothing and the signal was dead. The join now matches either axis, the same way the sibling message filter already does.
- **Postgres lane adoption.** `live-waiting-admission.postgres.integration.test.ts` was deliberately excluded from the Postgres lane because it had never run against a live database. It now passes and is adopted into the default lane.
- **Test drift, inline runtime.** Two fixtures in `inline-agent-runtime.integration.test.ts` predated current contracts: the permission-approval wiring returned a bare decision instead of `{ kind: 'decision', decision }`, so the run failed; and the delegation routes lacked the caller's `conversationId`, so target resolution failed before any child run was created. Both fixtures now match the contracts; no product code changed for these.

## Proof

- `live-waiting-admission` 5/5 through both the general and the Postgres configs; the neighbouring `live-admission-work-items` suite 20/20.
- `inline-agent-runtime` 8/8 solo, twice.
- tsc and prettier green; autoreview of the branch diff clean.
- Known residual, out of scope: running the two files together under the general integration config (file-parallel) can drop the second lane's message in the mocked-providers test. It passes solo and the Postgres lane is serial, so the T3a gate is unaffected. Tracked with the other parallel-load timeouts in that lane.
- Agent-e2e delta: none. Query fix plus test fixtures; no runner behaviour change.

Quickfix window Q-0154-3718 (4 product files).

Ticket: Q-0154-3718
