### PR TITLE
chore(forge): vendor symphony-forge #194 (review scope excludes vendored harness machinery)

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 6babcda24292f1702ec53f63d53e94f2aa1897e3
+symphony-forge @ 221ab027368f6c130e84fe373304ac09f1bee58f
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "6babcda24292f1702ec53f63d53e94f2aa1897e3",
+  "harness_commit": "221ab027368f6c130e84fe373304ac09f1bee58f",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -42,7 +42,7 @@
     "factory/scripts/forge_cli/quickfix.py": "dd8ef80baa7378edafcb9897e537b7173746b3577b5871edbaec726c59aa97c1",
     "factory/scripts/forge_cli/readiness.py": "7b18cacce293cce2e760c1c5ebdb8331d4ff5ca354f58e9a01a435a71b94882d",
     "factory/scripts/forge_cli/repo_kind.py": "427043c49817f650c77eb20dbc368914822e31e028a9bd1c5042ff64cd475c97",
-    "factory/scripts/forge_cli/review.py": "776d44fcfe2019396e229a3004cd6b1b386a871cf14f0c26b41b005cd00f5d15",
+    "factory/scripts/forge_cli/review.py": "2c6fe97c25188f2998fe2c6936fb7e790aafab7c75b07a4363e826523a1ee0c8",
     "factory/scripts/forge_cli/review_brief.py": "c1a8c10fb037ed8b947057c2f9adbf98cef93729769cafc60a5ebf53e02a49d4",
     "factory/scripts/forge_cli/roadmap.py": "a8e659d83c0e24e64f76b16075836a7cd73114f379e8478664028366deed1e4d",
     "factory/scripts/forge_cli/sanitise.py": "f8fe1115caf6ed19a63d400ca8e9688e5b267e6f284f280969edace274300d91",

--- a/factory/scripts/forge_cli/review.py
+++ b/factory/scripts/forge_cli/review.py
@@ -123,14 +123,30 @@ def resolve_skill(explicit: str | None) -> Path:
     raise AssertionError("unreachable")
 
 
+def review_excluded_prefixes(base: Path) -> tuple[str, ...]:
+    """Paths a product review never judges: harness bookkeeping, the workflow
+    ledgers, and — in a VENDORED client — the harness machinery itself
+    (`factory/`, `.claude/`, `constitution/`, ...), which `forge upgrade`
+    rewrites mid-task and which the stage measure already exempts
+    (`workflow_prefixes`). A re-vendor commit on a task branch once put 36
+    harness files into a client's review bundle and the quality lens raised
+    P1s against harness code the task never touched."""
+    from .stages import HARNESS_MACHINERY_PATHS, WORKFLOW_PATHS
+    from factory_lib import vendored_client
+    prefixes = set(HARNESS_PREFIXES) | set(WORKFLOW_PATHS)
+    if vendored_client(base):
+        prefixes |= set(HARNESS_MACHINERY_PATHS)
+    return tuple(sorted(prefixes))
+
+
 def _product_dirty(base: Path) -> list[str]:
-    from .stages import WORKFLOW_PATHS
+    excluded = review_excluded_prefixes(base)
     status = _require_git(base, "reading working tree status", "status",
                           "--porcelain", "--untracked-files=all")
     dirty = []
     for line in status.splitlines():
         path = line[3:].strip()
-        if path and not path.startswith(WORKFLOW_PATHS):
+        if path and not path.startswith(excluded):
             dirty.append(path)
     return dirty
 
@@ -324,13 +340,13 @@ def _contract_verdicts(
 def _artifact(
     lens: str, task: dict, report: dict, scope: list[str], base_sha: str,
     tip_sha: str, skills_used: list[str], all_tasks: list[dict],
-    started: dict[str, str],
+    started: dict[str, str], excluded: tuple[str, ...] = HARNESS_PREFIXES,
 ) -> dict:
     findings = [
         f for f in report.get("findings", [])
         if isinstance(f, dict) and not str(
             (f.get("code_location") or {}).get("file_path", "")
-        ).startswith(HARNESS_PREFIXES)
+        ).startswith(excluded)
     ]
     blocking = [f for f in findings if f.get("priority") in ("P0", "P1")]
     non_blocking = [f for f in findings if f.get("priority") not in ("P0", "P1")]
@@ -372,8 +388,7 @@ def product_only_tip(worktree: Path, base_sha: str) -> str:
     gate refused a task whose product review was clean (observed 2026-09-04,
     issue #171). With the bookkeeping at the base, the bundle is the product
     delta only. The base is untouched and stays an ancestor of the new tip."""
-    from .stages import WORKFLOW_PATHS
-    prefixes = tuple(sorted(set(HARNESS_PREFIXES) | set(WORKFLOW_PATHS)))
+    prefixes = review_excluded_prefixes(worktree)
     changed = [
         p for p in _require_git(worktree, "listing the review diff", "diff",
                                 "--name-only", f"{base_sha}..HEAD").splitlines()
@@ -724,7 +739,7 @@ def _shared_terms(finding: dict | str, source: str) -> list[str]:
 
 
 def cmd_review(args: argparse.Namespace) -> None:
-    from .stages import WORKFLOW_PATHS, load_stages, task_for
+    from .stages import load_stages, task_for
 
     base = Path(args.repo).resolve() if args.repo else repo_root()
     if getattr(args, "reject", None):
@@ -759,11 +774,11 @@ def cmd_review(args: argparse.Namespace) -> None:
 
     tip_sha = _require_git(base, "resolving HEAD", "rev-parse", "--verify", "HEAD^{commit}")
     base_sha = resolve_review_base(base, stage, state, tip_sha)
+    excluded = review_excluded_prefixes(base)
     scope = sorted(
         p for p in _require_git(base, "listing the task diff", "diff",
                                 "--name-only", f"{base_sha}...HEAD").splitlines()
-        if p.strip() and not p.startswith(WORKFLOW_PATHS)
-        and not p.startswith(HARNESS_PREFIXES)
+        if p.strip() and not p.startswith(excluded)
     )
     if not scope:
         fail(f"no product paths changed between {base_sha[:12]} and HEAD — nothing to review")
@@ -820,7 +835,7 @@ def cmd_review(args: argparse.Namespace) -> None:
     outcome: dict[str, dict] = {}
     for lens in lenses:
         artifact = _artifact(lens, task, reports[lens], scope, base_sha, tip_sha,
-                             skills_used, all_tasks, started)
+                             skills_used, all_tasks, started, excluded)
         # A rejection is part of the task's review record: a later round must
         # not erase it (the ledgered lesson keeps the reviewer from re-raising
         # it; the artifact keeps the human able to see it was set aside).

--- a/factory/tests/test_review_task_delta.py
+++ b/factory/tests/test_review_task_delta.py
@@ -228,3 +228,22 @@ def test_every_lens_brief_hunts_for_compatibility_leftovers():
         text = _lens_prompt(task, lens).decode()
         assert LEFTOVER_INSTRUCTION in text, lens
         assert "BLOCKING" in LEFTOVER_INSTRUCTION
+
+
+def test_vendored_client_review_excludes_the_harness_machinery(repo):
+    """A re-vendor commit on a task branch put 36 harness files into a client's
+    review bundle and the quality lens raised P1s against harness code the task
+    never touched. In a vendored client the review drops the same machinery
+    prefixes the stage measure already exempts."""
+    from forge_cli.review import HARNESS_PREFIXES, review_excluded_prefixes
+    from forge_cli.stages import HARNESS_MACHINERY_PATHS, WORKFLOW_PATHS
+    marker = repo / "constitution" / "VENDORED_FROM"
+    marker.parent.mkdir(exist_ok=True)
+    marker.write_text("symphony-forge @ deadbeef\n")
+    vendored = review_excluded_prefixes(repo)
+    assert "factory/" in vendored and ".claude/" in vendored and "constitution/" in vendored
+    assert set(vendored) == set(HARNESS_PREFIXES) | set(WORKFLOW_PATHS) | set(HARNESS_MACHINERY_PATHS)
+    marker.unlink()
+    harness_only = review_excluded_prefixes(repo)
+    assert set(harness_only) == set(HARNESS_PREFIXES) | set(WORKFLOW_PATHS)
+    assert "factory/" not in harness_only


### PR DESCRIPTION
## Goal

Task reviews in gantry should judge the task's product code only. Under the previous vendor (6babcda) a re-vendor commit on a task branch put 36 harness files into the review bundle and the three lenses blocked on harness code the task never touched (ASKFLOOR-1-T5a, run 4).

## What changes

Vendors symphony-forge #194: `review_excluded_prefixes` drops the harness machinery prefixes from every review scope site whenever `constitution/VENDORED_FROM` exists. Four files: the two vendor markers, `review.py`, and its test.

Checks run locally: vendor integrity OK (95 gate files), dual-runtime clean apart from an untracked local lock file.

https://claude.ai/code/session_01XRQFmriS18TCQJNffT5qja