### PR TITLE
fix(runner): state each granted CLI capability's argv shape in context

### DIFF
--- a/apps/core/src/jobs/structured-local-cli-invocation.ts
+++ b/apps/core/src/jobs/structured-local-cli-invocation.ts
@@ -1,3 +1,4 @@
+import { localCliArgPatterns } from '../shared/semantic-capabilities.js';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -165,17 +166,7 @@ async function resolveGrantedLocalCliInvocation(input: {
   // template string got pasted into a shell on the first live run). The
   // templates are not secret - they appear verbatim on approval cards -
   // and the runtime, not the job prompt, owns call-shape recovery.
-  const reviewedArgPatterns = capability.implementationBindings
-    .filter((binding) => binding.kind === 'local_cli')
-    .flatMap((binding) =>
-      (binding.commandTemplates ?? []).map((template) => {
-        const executable = binding.executablePath?.trim() ?? '';
-        const rest = template.startsWith(executable)
-          ? template.slice(executable.length).trim()
-          : template.trim();
-        return JSON.stringify(rest.split(/\s+/));
-      }),
-    );
+  const reviewedArgPatterns = localCliArgPatterns(capability);
   throw new StructuredLocalCliInvocationError(
     'capability_template_mismatch',
     `Arguments are outside the reviewed pattern for capability "${capabilityId}". Reviewed args patterns: ${reviewedArgPatterns.join(' or ')}. Re-call capability_run with an args array matching one pattern (a terminal standalone "*" covers the remaining args; a non-terminal "*" covers one non-flag positional value). Never run this capability through Bash/RunCommand.`,

--- a/apps/core/src/runner/mcp/context.ts
+++ b/apps/core/src/runner/mcp/context.ts
@@ -23,6 +23,7 @@ import {
 import {
   parseSemanticCapabilityDefinitionsRecord,
   type SemanticCapabilityDefinition,
+  localCliArgPatterns,
 } from '../../shared/semantic-capabilities.js';
 
 function requirePathEnv(name: string): string {
@@ -287,6 +288,7 @@ export function capabilityStatusText(): string {
           '- Use admin_permission_list (read-only, no grant needed) to review current permissions, suggest cleanup of unused or overly broad access, or spot missing access; report findings in plain language.',
           '- Treat skill commands, MCP tool names, local CLI commands, browser internals, and network hosts as review/audit metadata unless a reviewed capability grants the action.',
         ]),
+    ...grantedCliCapabilityLines(currentAllowedTools),
     // Scheduler guidance only when scheduler tools are actually mounted; the
     // locked fail-closed tool set excludes them, so locked agents are never
     // told about tools they cannot call.
@@ -405,6 +407,31 @@ export function capabilityStatusText(): string {
       'settings.yaml selected capabilities plus action-first runtime defaults',
   });
   return [...lines, '', formatAgentToolAccess(view)].join('\n');
+}
+
+// A granted CLI capability is called through capability_run with the argv
+// after the executable. The reviewed shapes are not secret (approval cards
+// show them verbatim); stating them here spares every run the failed probe
+// that otherwise teaches the shape through a denial.
+function grantedCliCapabilityLines(currentAllowedTools: string[]): string[] {
+  const lines = availableSemanticCapabilities
+    .filter((capability) =>
+      currentAllowedTools.includes(`capability:${capability.capabilityId}`),
+    )
+    .map((capability) => ({
+      id: capability.capabilityId,
+      patterns: localCliArgPatterns(capability),
+    }))
+    .filter((entry) => entry.patterns.length > 0)
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((entry) => `- ${entry.id}: args ${entry.patterns.join(' or ')}`);
+  return lines.length === 0
+    ? []
+    : [
+        '',
+        'Granted CLI capabilities (call mcp__gantry__capability_run with capabilityId and args after the executable; never an MCP server or RunCommand):',
+        ...lines,
+      ];
 }
 
 function displayMcpSourceName(sourceId: string): string {

--- a/apps/core/src/runner/mcp/tools/capability-run.ts
+++ b/apps/core/src/runner/mcp/tools/capability-run.ts
@@ -13,7 +13,7 @@ const CAPABILITY_RUN_RESPONSE_TIMEOUT_MS = 125_000;
 export function registerCapabilityRunTool(server: McpServer): void {
   server.tool(
     'capability_run',
-    'Run a granted local CLI capability with structured arguments. Pass only argv entries after the executable. Gantry validates them against the reviewed capability pattern and runs without an agent-authored shell command. If rejected, the error lists the reviewed patterns; re-call with args matching one pattern.',
+    'Run a granted local CLI capability with structured arguments. Pass only argv entries after the executable. The reviewed args pattern of each granted capability is listed in the runtime capability context under "Granted CLI capabilities"; a granted capability is never reached through an MCP server or RunCommand. Gantry validates the args against that reviewed pattern and runs without an agent-authored shell command. If rejected, the error lists the reviewed patterns; re-call with args matching one pattern.',
     {
       capabilityId: z
         .string()

--- a/apps/core/src/shared/semantic-capabilities.ts
+++ b/apps/core/src/shared/semantic-capabilities.ts
@@ -533,6 +533,27 @@ function validateLocalCliBinding(
   return { ok: true };
 }
 
+/**
+ * The reviewed argv shapes of a local CLI capability, as JSON arrays of the
+ * entries after the executable. This is the vocabulary of capability_run, so
+ * the runtime context and the mismatch denial teach one identical shape.
+ */
+export function localCliArgPatterns(
+  capability: Pick<SemanticCapabilityDefinition, 'implementationBindings'>,
+): string[] {
+  return capability.implementationBindings
+    .filter((binding) => binding.kind === 'local_cli')
+    .flatMap((binding) =>
+      (binding.commandTemplates ?? []).map((template) => {
+        const executable = binding.executablePath?.trim() ?? '';
+        const rest = template.startsWith(executable)
+          ? template.slice(executable.length).trim()
+          : template.trim();
+        return JSON.stringify(rest.split(/\s+/));
+      }),
+    );
+}
+
 export function validateLocalCliCommandTemplate(
   executablePath: string,
   commandTemplate: string,

--- a/apps/core/test/unit/runner/mcp/locked-introspection.test.ts
+++ b/apps/core/test/unit/runner/mcp/locked-introspection.test.ts
@@ -179,6 +179,64 @@ describe('capabilityStatusText access projection', () => {
       'selected capabilities: mcp.crm.lookup',
     );
   });
+
+  it('states the reviewed args pattern of every granted CLI capability up front', async () => {
+    const sheetsCapability = {
+      capabilityId: 'google.sheets.values.get',
+      version: '1',
+      displayName: 'Sheets read',
+      category: 'Google',
+      risk: 'read',
+      can: 'Read a range from a spreadsheet.',
+      cannot: 'Write to a spreadsheet.',
+      credentialSource: 'local_cli',
+      implementationBindings: [
+        {
+          kind: 'local_cli',
+          executablePath: '/opt/homebrew/bin/gog',
+          executableVersion: '1.0.0',
+          executableHash: 'sha256:abc',
+          commandTemplates: [
+            '/opt/homebrew/bin/gog sheets get *',
+            '/opt/homebrew/bin/gog sheets get * *',
+          ],
+        },
+      ],
+    };
+    setRunnerEnv({
+      GANTRY_AGENT_ACCESS_PRESET: 'full',
+      GANTRY_SEMANTIC_CAPABILITIES_JSON: JSON.stringify([sheetsCapability]),
+      GANTRY_CONFIGURED_ALLOWED_TOOLS_JSON: JSON.stringify([]),
+    });
+    vi.resetModules();
+    const ungranted = await import('@core/runner/mcp/context.js');
+    expect(ungranted.capabilityStatusText()).not.toContain(
+      'Granted CLI capabilities',
+    );
+
+    setRunnerEnv({
+      GANTRY_AGENT_ACCESS_PRESET: 'full',
+      GANTRY_SEMANTIC_CAPABILITIES_JSON: JSON.stringify([sheetsCapability]),
+      GANTRY_CONFIGURED_ALLOWED_TOOLS_JSON: JSON.stringify([
+        'capability:google.sheets.values.get',
+      ]),
+    });
+    vi.resetModules();
+    const granted = await import('@core/runner/mcp/context.js');
+    const { localCliArgPatterns } =
+      await import('@core/shared/semantic-capabilities.js');
+    const text = granted.capabilityStatusText();
+    expect(text).toContain(
+      'Granted CLI capabilities (call mcp__gantry__capability_run',
+    );
+    expect(text).toContain(
+      '- google.sheets.values.get: args ["sheets","get","*"] or ["sheets","get","*","*"]',
+    );
+    expect(localCliArgPatterns(sheetsCapability)).toEqual([
+      '["sheets","get","*"]',
+      '["sheets","get","*","*"]',
+    ]);
+  });
 });
 
 describe('locked MCP listing and tool descriptions', () => {

--- a/plans/quickfixes/20260910T082727-0000-Q-0180-33de-open-082727899849.json
+++ b/plans/quickfixes/20260910T082727-0000-Q-0180-33de-open-082727899849.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0180-33de",
+  "profile": "quickfix",
+  "reason": "Granted CLI capabilities never tell the model their argv shape up front: the capability context lists ids only and capability_run's description names a reviewed pattern without stating it, so every scheduled run pays failed probing calls before the first successful sheets read. Render each granted capability's reviewed args pattern in the capability context from the same helper the mismatch denial uses, and point the tool description at it.",
+  "started_at": "2026-09-10T08:27:27+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260910T085423-0000-Q-0180-33de-done-085423749595.json
+++ b/plans/quickfixes/20260910T085423-0000-Q-0180-33de-done-085423749595.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0180-33de",
+  "profile": "quickfix",
+  "reason": "Granted CLI capabilities never tell the model their argv shape up front: the capability context lists ids only and capability_run's description names a reviewed pattern without stating it, so every scheduled run pays failed probing calls before the first successful sheets read. Render each granted capability's reviewed args pattern in the capability context from the same helper the mismatch denial uses, and point the tool description at it.",
+  "started_at": "2026-09-10T08:27:27+00:00",
+  "completed_at": "2026-09-10T08:54:23+00:00",
+  "files": []
+}


### PR DESCRIPTION
## Why

The agent could not see how to call a granted capability.

`google.sheets.values.get` is a capability that wraps the `gog` CLI. The runner only accepts arguments matching one of the reviewed command templates, but nothing told the model what those templates are: the capability context listed the id alone, and `capability_run`'s description said a reviewed pattern exists without stating it. So the agent guessed. Every scheduled KnackLabs lead-maintenance run opened with two or three denied calls (an MCP server that does not exist, a `capability_call` tool that does not exist, then off-pattern args) before the first sheets read landed. Those show up on the job card as red crosses on a run that otherwise succeeded.

## What changes

The mismatch denial already knew the answer, so this exposes it instead of computing it twice.

- `localCliArgPatterns` moves the template-to-argv formatting out of the denial path into `shared/semantic-capabilities.ts`, and the denial message now calls it.
- The runtime capability context renders a "Granted CLI capabilities" block listing each granted capability's reviewed args patterns, so the argv shape is on the page before the first call. Ungranted capabilities are not listed.
- `capability_run`'s description points at that block and says plainly that a granted capability is never reached through an MCP server or `RunCommand`.

No behaviour change in what the runner accepts or denies.

## Proof

- New case in `locked-introspection.test.ts` pins the rendered line for a `local_cli` fixture, its absence when the capability is not granted, and equality with the helper. 26/26 in that suite plus the structured-invocation suite pass.
- `tsc --noEmit` and `npm run check:architecture` green.
- Local three-lens autoreview (`--mode local`, Codex, P2 floor): no accepted or actionable findings.

Ticket: Q-0180-33de

https://claude.ai/code/session_01XRQFmriS18TCQJNffT5qja
