### PR TITLE
fix(scheduler): return the job prompt verbatim from scheduler_get_job

### DIFF
--- a/apps/core/src/runner/mcp/tools/scheduler-formatters.ts
+++ b/apps/core/src/runner/mcp/tools/scheduler-formatters.ts
@@ -115,7 +115,6 @@ export function schedulerJobSummary(job: unknown): string {
     `Next action: ${nextActionLabelText}`,
     `Health: ${String(health.state ?? 'unknown')} | latest ${String(health.latestRunStatus ?? 'none')} | action ${nextAction}`,
     `Recovery: ${recoverySummary(recovery)}`,
-    ...(prompt ? [`Prompt: ${prompt}`] : []),
     `Notification routes: ${notificationRoutes.length}`,
     `Kind/status: ${String(record.schedule_type ?? 'unknown')} / ${String(record.status ?? 'unknown')}`,
     `Next/last run: ${String(record.next_run ?? 'none')} / ${String(record.last_run ?? 'none')}`,
@@ -127,6 +126,8 @@ export function schedulerJobSummary(job: unknown): string {
     })}`,
     ...(toolAccessMissing ? ['Tool access: missing canonical toolAccess'] : []),
     `Recent run errors: ${recentErrors}`,
+    // Last, so a multi-line prompt cannot be mistaken for the fields above.
+    ...(prompt ? [`Prompt: ${prompt}`] : []),
   ].join('\n');
 }
 
@@ -134,10 +135,15 @@ function promptSummary(
   record: Record<string, any>,
   visibility: Record<string, any>,
 ): string | undefined {
-  return compactText(
-    visibility.fullPrompt ?? record.prompt ?? visibility.promptPreview,
-    600,
-  );
+  // The detail view is what an agent reads before scheduler_update_job, which
+  // replaces the prompt wholesale: it must round-trip verbatim, newlines and
+  // all. Only the list view compacts (see schedulerJobsSummary).
+  const raw =
+    visibility.fullPrompt ?? record.prompt ?? visibility.promptPreview;
+  if (typeof raw !== 'string') return undefined;
+  const text = redactSensitiveText(raw);
+  // Emit untrimmed: boundary whitespace is part of what a write-back replaces.
+  return text.trim() ? text : undefined;
 }
 
 function preferredOwnerLabel(input: {

--- a/apps/core/src/runner/mcp/tools/scheduler.ts
+++ b/apps/core/src/runner/mcp/tools/scheduler.ts
@@ -336,7 +336,7 @@ export function registerSchedulerTools(server: McpServer): void {
   );
   server.tool(
     'scheduler_get_job',
-    'Get one scheduler job by ID from the host scheduler.',
+    'Get one scheduler job by ID from the host scheduler. The Prompt section is last and holds the job prompt verbatim, so it can be read, edited and written back whole.',
     { job_id: z.string() },
     async (args) => {
       const response = await requestSchedulerData('scheduler_get_job', {
@@ -402,7 +402,7 @@ export function registerSchedulerTools(server: McpServer): void {
   );
   server.tool(
     'scheduler_update_job',
-    'Update mutable fields on a scheduler job.',
+    'Update mutable fields on a scheduler job. A prompt here replaces the stored prompt entirely, so send the full text from scheduler_get_job, not an excerpt.',
     {
       job_id: z.string(),
       name: z.string().optional(),

--- a/apps/core/test/unit/runner/mcp/scheduler-tools.test.ts
+++ b/apps/core/test/unit/runner/mcp/scheduler-tools.test.ts
@@ -897,6 +897,42 @@ describe('scheduler MCP tools', () => {
     );
   });
 
+  it('returns the job prompt verbatim so an update can round-trip it', async () => {
+    const { schedulerJobSummary, schedulerJobsSummary } =
+      await import('../../../../src/runner/mcp/tools/scheduler-formatters.js');
+    const prompt = `\n  ${[
+      'KNACKLABS FDE LEAD MAINTENANCE',
+      '',
+      `GOAL ${'find companies that just raised. '.repeat(30)}`,
+      '',
+      'RULE never overwrite an existing row.',
+    ].join('\n')}\n\n`;
+    const job = {
+      id: 'job-1',
+      name: 'Lead maintenance',
+      schedule_type: 'recurring',
+      status: 'active',
+      visibility: {
+        target: { agentId: 'agent:main', conversationJids: ['tg:team'] },
+        recentRunErrors: [],
+        fullPrompt: prompt,
+        promptPreview: 'KNACKLABS FDE LEAD MAINTENANCE GOAL find companies…',
+      },
+    };
+    const summary = schedulerJobSummary(job);
+    expect(prompt.length).toBeGreaterThan(600);
+    expect(summary).toContain(`Prompt: ${prompt}`);
+    expect(summary).not.toContain('…');
+    // The prompt is the tail, so its newlines cannot be read as further fields,
+    // and leading/trailing whitespace survives for a byte-exact write-back.
+    expect(summary.endsWith(prompt)).toBe(true);
+    expect(prompt.startsWith('\n  ')).toBe(true);
+    expect(prompt.endsWith('\n\n')).toBe(true);
+    // The list view still compacts to a single line.
+    const listed = schedulerJobsSummary([job]);
+    expect(listed).not.toContain('RULE never overwrite an existing row.');
+  });
+
   it('renders notification targets with shortcut and routing values', async () => {
     const { schedulerNotificationTargetsSummary } =
       await import('../../../../src/runner/mcp/tools/scheduler-formatters.js');

--- a/plans/quickfixes/20260910T092917-0000-Q-0181-c406-open-092917756436.json
+++ b/plans/quickfixes/20260910T092917-0000-Q-0181-c406-open-092917756436.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0181-c406",
+  "profile": "quickfix",
+  "reason": "GitHub #447: scheduler_get_job collapses newlines and truncates the job prompt at 600 characters, so an agent reading a job before scheduler_update_job (which replaces the prompt wholesale) silently drops everything past the cut. The full prompt already reaches the formatter as visibility.fullPrompt. Emit it verbatim and redacted as the final section of the detail view, keeping the compacted preview for the list view.",
+  "started_at": "2026-09-10T09:29:17+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260910T093630-0000-Q-0181-c406-done-093630439985.json
+++ b/plans/quickfixes/20260910T093630-0000-Q-0181-c406-done-093630439985.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0181-c406",
+  "profile": "quickfix",
+  "reason": "GitHub #447: scheduler_get_job collapses newlines and truncates the job prompt at 600 characters, so an agent reading a job before scheduler_update_job (which replaces the prompt wholesale) silently drops everything past the cut. The full prompt already reaches the formatter as visibility.fullPrompt. Emit it verbatim and redacted as the final section of the detail view, keeping the compacted preview for the list view.",
+  "started_at": "2026-09-10T09:29:17+00:00",
+  "completed_at": "2026-09-10T09:36:30+00:00",
+  "files": []
+}


### PR DESCRIPTION
## Why

An agent could not safely edit its own scheduled job.

`scheduler_get_job` had the whole prompt in hand and then destroyed it for display. A shared helper collapsed every run of whitespace into a single space and cut the text at 600 characters with an ellipsis. Because `scheduler_update_job` replaces the prompt wholesale, any agent doing a read-modify-write silently dropped everything past the cut and every line break before it, with nothing to signal the loss. The only workarounds were to rewrite the prompt from scratch and lose rules that were never visible, or to ask the person to paste the prompt back into chat for every small change.

## What changes

- The detail view emits the redacted prompt untouched: newlines, indentation and boundary whitespace all survive, so a write-back is byte-exact.
- The prompt moves to the end of the detail view. A multi-line prompt in the middle of a block of `key: value` lines would be ambiguous; at the tail it cannot be misread as further fields.
- The list view is unchanged and still shows the compact one-line preview, which is what a listing wants.
- Both tool descriptions now say what they do. `scheduler_get_job` states that the trailing prompt section is verbatim, and `scheduler_update_job` states that a prompt replaces the stored one entirely, so send the full text rather than an excerpt. Neither warned about this before, which is what made the trap silent.

No change to what is stored, only to what is shown.

## Proof

- New test builds a multi-line prompt over 600 characters with leading and trailing whitespace, and pins that it returns byte-for-byte with no ellipsis, that it sits at the tail, and that the list view still compacts.
- 2210 tests across the runner, runtime and access-policy suites pass. Type checking and the architecture gate are green.
- Two rounds of local three-lens review. Round one caught a real defect: my first version trimmed the prompt, which broke the very round-trip guarantee the change claims. Round two is clean.

Ticket: Q-0181-c406

Closes #447

https://claude.ai/code/session_01XRQFmriS18TCQJNffT5qja
