### PR TITLE
Repin the three workflow models; correct the plan and spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,10 @@ Testing has no separate agent: the implementer writes and records the tests.
 
 - planning / decomposition / architecture reconciliation: `high`
 - code exploration: `gpt-5.6-terra` @ `high` (`/codex:rescue`, read-only)
-- implementation: `gpt-5.6-sol` (`high` for migrations/cross-domain/security)
+- implementation: `gpt-6-astra` @ `low` (raise to `high`/`xhigh` for
+  migrations, cross-domain or security work). The pin that actually runs lives
+  in `harness.yaml`, which `delegate.py` reads; the model in
+  `.codex/config.toml` is shadowed by `~/.codex` and never reaches the CLI.
 - review and testing agents: explicit per-agent overrides
 
 Do not default the entire repo to `high` reasoning for every task.

--- a/docs/specs/cache-bug.md
+++ b/docs/specs/cache-bug.md
@@ -123,12 +123,17 @@ final cold read amended once per the one-read rule):
    and alerts (0025 skew contract) instead of failing. A lowered value takes
    effect on the next resume evaluated by a worker that has applied that
    revision. No environment variable, no per-agent override.
-5. **Atomic retirement returning the retired reference.**
-   `expireProviderSession` becomes one atomic `active`→`expired` transition
+5. **Atomic retirement returning the retired reference.** A NEW
+   `retireProviderSession` is one atomic `active`→`expired` transition
    fenced on provider-session id, `agent_session_id` ownership, status
    `active`, and `agent_sessions.reset_at`; it returns the retired
    `{ providerSessionId, externalSessionId, executionProviderId }` or nothing
-   if no row transitioned. On a lost transition the host re-reads the turn
+   if no row transitioned. The existing `expireProviderSession` REMAINS for
+   the compaction-delta degradation path, which operates on a `ready` row and
+   is unchanged: no release, no retirement event (0159 §4). Three callers move
+   to the new operation — the access-fingerprint change, the missing-session
+   retry, and the ops-service facade.
+   On a lost transition the host re-reads the turn
    context and proceeds with what it finds; it does not persist a replacement
    handle for a generation it does not own. Covered retirement paths:
    ceiling (new), missing-session, access-fingerprint change, and `/new`,

--- a/harness.yaml
+++ b/harness.yaml
@@ -16,16 +16,22 @@ precedence:
 
 modes:
   lite:
-    model: "gpt-5.6-terra"
-    reasoning: "high"
+    model: "gpt-5.6-luna"
+    # Ravi, 2026-09-10. `max` sits above the harness's own ALLOWED_EFFORTS
+    # (low/medium/high/xhigh), which gates only the `--effort` OVERRIDE flag:
+    # a pin here is passed through by mode_run_config unvalidated and the CLI
+    # accepts it (enabled-reasoning-efforts carries ultra and max). So the pin
+    # works, but `forge delegate --effort max` would still be refused.
+    reasoning: "max"
     bound: 5
-  # The harness's cold reader for `forge grill` (its gate test pins this exact
-  # model). The per-task contract grills this project runs go out through the
-  # codex companion on gpt-5.6-sol at xhigh — owner policy 2026-09-05, one
+  # The cold reader for `forge grill`. Repinned by Ravi 2026-09-10 to sol at
+  # high, which also settles a drift: the note here used to claim the per-task
+  # grills ran on sol at xhigh while the pin below said terra at xhigh, and
+  # the pin is what mode_run_config actually reads (grill.py:400). Still one
   # grill per round, no parallel second model.
   grill:
-    model: "gpt-5.6-terra"
-    reasoning: "xhigh"
+    model: "gpt-5.6-sol"
+    reasoning: "high"
     bound: 0
 
 phases:
@@ -102,11 +108,14 @@ phases:
     notes: "Per-task task graph; records the user_facing flag the ship gate reads."
   implementation:
     owner: "codex:/codex:rescue"
-    model: "gpt-5.6-terra"
-    # Floor, not a ceiling; this project runs its implementers at xhigh. Raise
-    # a single run with `./forge delegate <id> --effort high` when a pin lower
-    # than that is ever chosen for migrations, cross-domain or security work.
-    reasoning: "xhigh"
+    model: "gpt-6-astra"
+    # Ravi, 2026-09-10: astra at low is fast, and this pin rides on that being
+    # good enough — judged per task by verify plus the three-lens review, not
+    # by feel. It replaces terra at xhigh, so it is a deliberate drop from the
+    # old floor: raise a single run with `./forge delegate <id> --effort high`
+    # (or xhigh) for migrations, cross-domain or security work, which is where
+    # that floor was aimed.
+    reasoning: "low"
     prompts: "factory/prompts/implementer.md"
     required_skills: # ENFORCED by feature type — the decomposition's user_facing flag:
       # the recorder refuses a user-facing testing artifact unless skills_used

--- a/plans/active/cache-bug-bound-provider-session-context-growth-across-runner-restarts.md
+++ b/plans/active/cache-bug-bound-provider-session-context-growth-across-runner-restarts.md
@@ -226,7 +226,8 @@ that serves it.
   and timing per reason, carries `sessionId` or `runId` as stated, and is
   not dropped.
 - S10 (T1, T2, T3) scheduled-job tests untouched and green.
-- S11 (all) `verify.py` green, now including `npm run lint`.
+- S11 (all) `verify.py` green, now including the diff-scoped
+  `npm run lint:changed`.
 - S12 (T2) operator procedures and recipe in `docs/memory/`; the query is
   executed by a Postgres test against the current schema.
 - R1 (T1) null-safe generation fence: null/null succeeds, null vs non-null
@@ -282,16 +283,18 @@ DISTINCT FROM $gen` and returns `rowCount > 0`. A typed domain error
 `ProviderSessionMeasurementError` rejects non-integer or negative values
 before SQL. `providerSessionContext` returns `contextHighWaterMark`.
 
-**Retirement (0158 §3).** `expireProviderSession` becomes
-`retireProviderSession`: `UPDATE ... SET status='expired', updated_at=now()
+**Retirement (0158 §3).** A NEW `retireProviderSession` joins the existing
+`expireProviderSession`: `UPDATE ... SET status='expired', updated_at=now()
 FROM agent_sessions WHERE id AND agent_session_id AND provider AND
 external_session_id AND status='active' AND reset_at IS NOT DISTINCT FROM
 $gen RETURNING id, external_session_id, provider`, returning the retired
-reference or `undefined`. All four existing callers switch: fingerprint
-(`group-agent-runner.ts:391`), missing-session (`:503`), the compaction-delta
-degradation path (`group-agent-runner-compaction-delta.ts:104`, keeps its
-behaviour, discards the reference, uncovered per 0159), and the
-`canonical-session-ops-service.ts` facade. New ceiling preflight in
+reference or `undefined`. THREE callers switch to it: fingerprint
+(`group-agent-runner.ts:391`), missing-session (`:503`), and the
+`canonical-session-ops-service.ts` facade with its
+`canonical-ops-repo.postgres.ts` twin. The compaction-delta degradation path
+(`group-agent-runner-compaction-delta.ts:104`) does NOT switch: it operates on
+a `ready` row and keeps calling `expireProviderSession` unchanged, performing
+no release and emitting no retirement event, per decision 0159 §4. New ceiling preflight in
 `group-agent-runner.ts` after `prepareCompactionDeltaReplay` and the
 fingerprint check: if `turnContext.contextHighWaterMark > cap` and the row is
 `active`, call `retireProviderSession`; on success clear the resume ids,
@@ -349,9 +352,13 @@ projection (the run listing consumers ignore the new family cleanly). Hash:
 `createHash('sha256').update(id).digest('hex')`.
 
 **Quality gate.** Core ESLint exists (`npm run lint`) but neither `verify.py`
-(`.envrc` `FACTORY_STRUCTURAL_CMD`) nor CI runs it. T1 adds `npm run lint` to
-`FACTORY_STRUCTURAL_CMD` and to the CI workflow's check step, and fixes any
-lint debt its own diff exposes.
+(`.envrc` `FACTORY_STRUCTURAL_CMD`) nor CI runs it. T1 adds a diff-scoped
+`npm run lint:changed` — ESLint over the TypeScript files changed against the
+merge-base with origin/main — to `FACTORY_STRUCTURAL_CMD` and as the BLOCKING
+CI check step, while full `npm run lint` runs as an advisory
+continue-on-error CI step. Gating on full lint would fail every branch on the
+82 pre-existing errors, so the diff-scoped gate is what blocks and the debt
+is a recorded deferral.
 
 **Docs.** `docs/memory/provider-session-ceiling-operations.md` carries the
 pre-deploy reset (drain, stop workers, select interactive sessions by
@@ -389,7 +396,7 @@ configured — all installed and the only fit for this repo.
 | Runtime behaviour | Changed | over-cap sessions retire on next resume; DeepAgents retired threads released after reply; both `/new` paths release |
 | API | Unchanged by design | no control-API route changes; the setting rides the existing desired-state CRUD and revision document for `limits` |
 | Data/schema | Changed | `provider_sessions.context_high_water_mark` (generated migration); `resetScope` return type; `retireProviderSession` return type |
-| CLI/ops | Changed | new `limits.provider_session_max_input_tokens` key with defaults/export; reader version 16; operator procedures in docs/memory; `npm run lint` in verify and CI |
+| CLI/ops | Changed | new `limits.provider_session_max_input_tokens` key with defaults/export; reader version 16; operator procedures in docs/memory; `npm run lint:changed` blocking in verify and CI, full lint advisory |
 | UI | N-A | no console surface |
 | Docs | Changed | docs/memory procedures + executed recipe; `runtime-components.md` and `canonical-domain-model.md` aligned |
 | Tests | Changed | unit, repository, settings, event and Postgres integration tests per task; four pinned tests untouched |
@@ -407,7 +414,7 @@ configured — all installed and the only fit for this repo.
    the reference with all four callers switched (fingerprint, missing-session,
    compaction-delta, ops-service facade); `resetScope` returning references
    through `canonical-session-ops-service.ts` and `clearSessionForChatJid`;
-   turn-context projection; `npm run lint` in `.envrc` and CI. Serves S1, S2,
+   turn-context projection; `npm run lint:changed` in `.envrc` and CI. Serves S1, S2,
    S3, S10, S11, R1, R2, R3, R4 (return type). Write scope:
    `apps/core/src/shared/model-usage.ts`,
    `apps/core/src/shared/model-provider-registry*.ts`,
@@ -472,9 +479,9 @@ no task exists for later.
   alert until upgraded; documented in the operator procedure.
 - Orphaned DeepAgents rows on process loss between commit and release, and
   from the uncovered paths: accepted (0159); operator scan documented.
-- Lint debt exposed by adding `npm run lint` to verify: T1 fixes what its
-  diff touches; pre-existing debt outside the diff is recorded as a deferral
-  with a trigger, not silently fixed.
+- Lint debt exposed by adding a lint gate to verify at all: T1 fixes what its
+  diff touches; the 82 pre-existing errors outside the diff are recorded as a
+  deferral with a trigger, not silently fixed, baselined or suppressed.
 - Recurring finding class `plan-contract-partial` touches repository
   contracts: tripwire — if review flags it on T1, escalate per WORKFLOW.md
   Recurring Findings rather than patching.
@@ -482,7 +489,7 @@ no task exists for later.
 ## Verify Plan
 
 - `python3 factory/scripts/verify.py` after each task (never bypassed);
-  from T1 on it includes `npm run lint`.
+  from T1 on it includes `npm run lint:changed`.
 - T1: `npm run db:migrations:check` clean; repository Postgres tests against
   `GANTRY_TEST_DATABASE_URL` (raise, retire, resetScope references, R1
   fences); unit tests for derivation, registry validation, normaliser route,

--- a/plans/quickfixes/20260910T181917-0000-Q-0162-6c03-open-181917186167.json
+++ b/plans/quickfixes/20260910T181917-0000-Q-0162-6c03-open-181917186167.json
@@ -1,0 +1,11 @@
+{
+  "event": "open",
+  "id": "Q-0162-6c03",
+  "profile": "degraded",
+  "reason": "Pin the implementation model per Ravi (2026-09-10): harness.yaml currently pins gpt-5.6-terra @ xhigh while AGENTS.md documents gpt-5.6-sol, and .codex/config.toml's sol/medium never reaches the CLI (shadowed by ~/.codex). Switching the effective pin to gpt-6-astra @ low and aligning the stale AGENTS.md line. Two client-owned config files, neither vendor-tracked.",
+  "started_at": "2026-09-10T18:19:17+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "kind": "degraded"
+}

--- a/plans/quickfixes/20260910T181948-0000-Q-0162-6c03-done-181948997426.json
+++ b/plans/quickfixes/20260910T181948-0000-Q-0162-6c03-done-181948997426.json
@@ -1,0 +1,13 @@
+{
+  "event": "done",
+  "id": "Q-0162-6c03",
+  "profile": "degraded",
+  "kind": "degraded",
+  "reason": "Pin the implementation model per Ravi (2026-09-10): harness.yaml currently pins gpt-5.6-terra @ xhigh while AGENTS.md documents gpt-5.6-sol, and .codex/config.toml's sol/medium never reaches the CLI (shadowed by ~/.codex). Switching the effective pin to gpt-6-astra @ low and aligning the stale AGENTS.md line. Two client-owned config files, neither vendor-tracked.",
+  "started_at": "2026-09-10T18:19:17+00:00",
+  "completed_at": "2026-09-10T18:19:48+00:00",
+  "files": [
+    "harness.yaml",
+    "AGENTS.md"
+  ]
+}

--- a/plans/quickfixes/20260910T182517-0000-Q-0163-741d-open-182517951347.json
+++ b/plans/quickfixes/20260910T182517-0000-Q-0163-741d-open-182517951347.json
@@ -1,0 +1,11 @@
+{
+  "event": "open",
+  "id": "Q-0163-741d",
+  "profile": "degraded",
+  "reason": "Ravi 2026-09-10: repin the two workflow modes in harness.yaml \u2014 grill to gpt-5.6-sol @ high (was gpt-5.6-terra @ xhigh) and lite to gpt-5.6-luna @ max (was gpt-5.6-terra @ high). Both are read by mode_run_config (grill.py:400, fix.py:36) and reach the companion argv. max is a valid effort per ~/.codex enabled-reasoning-efforts. One client-owned file, not vendor-tracked; the gate tests that assert terra/xhigh run against a forge.py init scaffold in tmp_path, not this repo.",
+  "started_at": "2026-09-10T18:25:17+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "kind": "degraded"
+}

--- a/plans/quickfixes/20260910T182556-0000-Q-0163-741d-done-182556244992.json
+++ b/plans/quickfixes/20260910T182556-0000-Q-0163-741d-done-182556244992.json
@@ -1,0 +1,12 @@
+{
+  "event": "done",
+  "id": "Q-0163-741d",
+  "profile": "degraded",
+  "kind": "degraded",
+  "reason": "Ravi 2026-09-10: repin the two workflow modes in harness.yaml \u2014 grill to gpt-5.6-sol @ high (was gpt-5.6-terra @ xhigh) and lite to gpt-5.6-luna @ max (was gpt-5.6-terra @ high). Both are read by mode_run_config (grill.py:400, fix.py:36) and reach the companion argv. max is a valid effort per ~/.codex enabled-reasoning-efforts. One client-owned file, not vendor-tracked; the gate tests that assert terra/xhigh run against a forge.py init scaffold in tmp_path, not this repo.",
+  "started_at": "2026-09-10T18:25:17+00:00",
+  "completed_at": "2026-09-10T18:25:56+00:00",
+  "files": [
+    "harness.yaml"
+  ]
+}

--- a/plans/quickfixes/20260911T023809-0000-Q-0164-f02d-open-023809428176.json
+++ b/plans/quickfixes/20260911T023809-0000-Q-0164-f02d-open-023809428176.json
@@ -1,0 +1,11 @@
+{
+  "event": "open",
+  "id": "Q-0164-f02d",
+  "profile": "degraded",
+  "reason": "D-0082 and D-0084: correct the approved cache-bug story plan and the confirmed spec, which both still say expireProviderSession becomes the atomic fenced transition and prescribe blocking full npm run lint. Decision 0159 \u00a74 keeps compaction-delta on expireProviderSession and introduces retireProviderSession for the three switched callers; the settled lint ruling is lint:changed blocking with full lint advisory. Scheduled by Ravi for after T1 merges and before T2 starts; T1 merged as PR 501. Two documents.",
+  "started_at": "2026-09-11T02:38:09+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "kind": "degraded"
+}

--- a/plans/quickfixes/20260911T023918-0000-Q-0164-f02d-done-023918467258.json
+++ b/plans/quickfixes/20260911T023918-0000-Q-0164-f02d-done-023918467258.json
@@ -1,0 +1,10 @@
+{
+  "event": "done",
+  "id": "Q-0164-f02d",
+  "profile": "degraded",
+  "kind": "degraded",
+  "reason": "D-0082 and D-0084: correct the approved cache-bug story plan and the confirmed spec, which both still say expireProviderSession becomes the atomic fenced transition and prescribe blocking full npm run lint. Decision 0159 \u00a74 keeps compaction-delta on expireProviderSession and introduces retireProviderSession for the three switched callers; the settled lint ruling is lint:changed blocking with full lint advisory. Scheduled by Ravi for after T1 merges and before T2 starts; T1 merged as PR 501. Two documents.",
+  "started_at": "2026-09-11T02:38:09+00:00",
+  "completed_at": "2026-09-11T02:39:18+00:00",
+  "files": []
+}

--- a/plans/quickfixes/20260911T024138-0000-Q-0197-d6a7-open-024138582621.json
+++ b/plans/quickfixes/20260911T024138-0000-Q-0197-d6a7-open-024138582621.json
@@ -1,0 +1,11 @@
+{
+  "event": "open",
+  "id": "Q-0197-d6a7",
+  "profile": "degraded",
+  "reason": "Reapply onto main: the three model pins in harness.yaml (implementation gpt-6-astra low, grill gpt-5.6-sol high, lite gpt-5.6-luna max), the stale AGENTS.md reasoning-defaults line, and the D-0082/D-0084 corrections to the story plan and confirmed spec. These were first made on the stale feat/cache-bug-... branch, which is 164 commits behind main; redone here on a branch cut from origin/main.",
+  "started_at": "2026-09-11T02:41:38+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false,
+  "kind": "degraded"
+}

--- a/plans/quickfixes/20260911T024341-0000-Q-0197-d6a7-done-024341041518.json
+++ b/plans/quickfixes/20260911T024341-0000-Q-0197-d6a7-done-024341041518.json
@@ -1,0 +1,13 @@
+{
+  "event": "done",
+  "id": "Q-0197-d6a7",
+  "profile": "degraded",
+  "kind": "degraded",
+  "reason": "Reapply onto main: the three model pins in harness.yaml (implementation gpt-6-astra low, grill gpt-5.6-sol high, lite gpt-5.6-luna max), the stale AGENTS.md reasoning-defaults line, and the D-0082/D-0084 corrections to the story plan and confirmed spec. These were first made on the stale feat/cache-bug-... branch, which is 164 commits behind main; redone here on a branch cut from origin/main.",
+  "started_at": "2026-09-11T02:41:38+00:00",
+  "completed_at": "2026-09-11T02:43:41+00:00",
+  "files": [
+    "harness.yaml",
+    "AGENTS.md"
+  ]
+}


### PR DESCRIPTION
## Goal

Two unrelated-looking changes that share one cause: configuration and prose
that no longer match what actually runs.

## Model pins

`harness.yaml` is the only source that reaches the Codex CLI for these lanes —
`delegate.py` reads it and passes `--model`/`--effort` on the companion argv.
The model in `.codex/config.toml` is shadowed by `~/.codex` and reaches
nothing, which is why it had drifted unnoticed.

| Lane | Was | Now | Read by |
|---|---|---|---|
| implementation | `gpt-5.6-terra` @ `xhigh` | `gpt-6-astra` @ `low` | `pinned_run_config` → `forge delegate` |
| grill | `gpt-5.6-terra` @ `xhigh` | `gpt-5.6-sol` @ `high` | `mode_run_config(…, "grill")` → `grill.py:400` |
| lite | `gpt-5.6-terra` @ `high` | `gpt-5.6-luna` @ `max` | `mode_run_config(…, LITE)` → `fix.py:36` |

The implementation drop is deliberate and below a floor the old comment
recorded, so the new comment keeps the escalation route that floor named:
raise a single run with `--effort high`/`xhigh` for migrations, cross-domain
or security work. `max` is a valid effort (`enabled-reasoning-efforts` carries
`ultra` and `max`) and a pin is passed through unvalidated, but
`ALLOWED_EFFORTS` still caps the `--effort` OVERRIDE at `xhigh` — noted in
place, since `forge delegate --effort max` would be refused.

Repinning the grill also settles a drift: its comment claimed the per-task
grills ran on sol at xhigh while the pin said terra at xhigh, and the pin is
what executes. `AGENTS.md` was stale too, naming a model matching neither.

## Plan and spec corrections (D-0082, D-0084)

Both still said `expireProviderSession` BECOMES the atomic fenced transition,
and both prescribed blocking full `npm run lint`. Decision 0159 §4 keeps
compaction-delta on `expireProviderSession` and adds `retireProviderSession`
for the three switched callers; the settled ruling is `lint:changed` blocking
with full lint advisory.

These documents outrank task contracts for anyone reading them, and T2 owns
exactly those callers — which is why this was scheduled between T1's merge and
T2's start.

## Follow-up required

Editing the approved plan body invalidates `approved_plan_sha256`. The plan
needs its re-grill and a fresh human approval before T2 starts; the spec edit
may likewise re-stale its confirmation record.

## Work windows

Four ledgered windows, each opened with a stated reason and closed inside
its file bound: Q-0162 and Q-0163 for the model pins, Q-0164 for the plan
and spec corrections, Q-0197 for reapplying onto a branch cut from main
after the first pass landed on the stale story branch.

Ticket: Q-0162-6c03
Ticket: Q-0163-741d
Ticket: Q-0164-f02d
Ticket: Q-0197-d6a7
