### PR TITLE
Re-vendor the harness: make the task-proof gate passable for chunked reviews

### DIFF
--- a/constitution/VENDORED_FROM
+++ b/constitution/VENDORED_FROM
@@ -1,2 +1,2 @@
-symphony-forge @ 7bab4934134b7986ff858f62277b7d2f0e6817cf
+symphony-forge @ 790e0d590d1bf7754122e4ca3ffd75292d8f4950
 Update by re-vendoring from the harness repo; do not edit in place.

--- a/constitution/VENDOR_MANIFEST.json
+++ b/constitution/VENDOR_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "harness_commit": "7bab4934134b7986ff858f62277b7d2f0e6817cf",
+  "harness_commit": "790e0d590d1bf7754122e4ca3ffd75292d8f4950",
   "files": {
     "factory/scripts/check_agents_hygiene.py": "63b5db9b788ebc55d3542af506566ab8d45ba7c7f588a6f93e78d3811d0003c4",
     "factory/scripts/check_board_complete.py": "75022051af7cc2928039641ba2ef1a5f31e45e6b5c1651e15c2213cca6c6a7a0",
@@ -42,7 +42,7 @@
     "factory/scripts/forge_cli/quickfix.py": "dd8ef80baa7378edafcb9897e537b7173746b3577b5871edbaec726c59aa97c1",
     "factory/scripts/forge_cli/readiness.py": "7b18cacce293cce2e760c1c5ebdb8331d4ff5ca354f58e9a01a435a71b94882d",
     "factory/scripts/forge_cli/repo_kind.py": "427043c49817f650c77eb20dbc368914822e31e028a9bd1c5042ff64cd475c97",
-    "factory/scripts/forge_cli/review.py": "f6a890fd10de61a26570bb945582eb34c1276ed826a27803fd36f189a009b8b0",
+    "factory/scripts/forge_cli/review.py": "2db52531a88fecc0b8a6dd3b13b9491bd185b197201d8ebaed171a4cb6df3864",
     "factory/scripts/forge_cli/review_brief.py": "c1a8c10fb037ed8b947057c2f9adbf98cef93729769cafc60a5ebf53e02a49d4",
     "factory/scripts/forge_cli/roadmap.py": "a8e659d83c0e24e64f76b16075836a7cd73114f379e8478664028366deed1e4d",
     "factory/scripts/forge_cli/sanitise.py": "f8fe1115caf6ed19a63d400ca8e9688e5b267e6f284f280969edace274300d91",
@@ -63,7 +63,7 @@
     "factory/scripts/pre_tool_use.py": "fdccdb021e4b2cc58ea87a23fa217e0a200328531a76b573c96c2a36b73cb050",
     "factory/scripts/record_decomposition_from_json.py": "7f2c9707f360b41a15d6a6645631f5835682c5f03680a36fc4598d116224d97d",
     "factory/scripts/record_grill_from_json.py": "e37f2fbd8faf57a99a3f2f8aed8f3efa5b27274eeb67e3159ec436f9ed1b49a2",
-    "factory/scripts/record_review_from_json.py": "90fa00cf2efdaea5fb53ca67468114194afd9f8d26d51033164e9e3eb7054789",
+    "factory/scripts/record_review_from_json.py": "e6db966f7df3c3e0b635deed33f35f931cb7e7501e3c80306b55b29f2187b1b3",
     "factory/scripts/record_signoff.py": "2abe32da30d8c0fbe91815be683c57b65bea19a3d45b89d301178b22422774a0",
     "factory/scripts/record_test_from_json.py": "e2b690a9a1050d03c0931bdaecbe7d3f079152434fae5a56c6f773379e14a1e6",
     "factory/scripts/session_start.py": "57f8fe0ea7f1fb08f5b5aae51098437208a50572d6ffde622350513987c62b64",
@@ -78,7 +78,7 @@
     "factory/schemas/lesson.json": "82bbc5664e6179ca826fd7a29011fc5e07790dfec03d78492c454fe3a96ed787",
     "factory/schemas/outcome.json": "5d29647862de90a21ab7c28395c883c4647c3b8686926b26eaee86940789f554",
     "factory/schemas/plan-mode-marker.json": "573f2e24b527f30505a04ce03c2558e2aca6e52e49f836274d56f56379b24869",
-    "factory/schemas/review.json": "39c4678c70632cf045a790f8905fef55feb73976bd72562a1a848ca345acd2d0",
+    "factory/schemas/review.json": "cbd83f9c0da32fa0f1ca92110b697d04ae61056a2546bd0d98efd80e713e6c2f",
     "factory/schemas/roadmap.json": "ce0779be13e38c51776fc6cf8b3ff12bfb38fbde321ec7acab725ca7c2a76df0",
     "factory/schemas/signal.json": "b9a11b942bd54945eb634d9fa95774f87e319403124de5e3ca603ef686cb8bcf",
     "factory/schemas/test-automated.json": "11872553dca48f269cd6cb67e144abadb8dd58e015d5bab169886731818ed9d2",

--- a/factory/schemas/review.json
+++ b/factory/schemas/review.json
@@ -29,5 +29,5 @@
     "score": [0, 10]
   },
   "findings_note": "Finding entries SHOULD be objects {category: kebab-case defect class, area: module/dir, summary} so `forge findings patterns` can cluster recurring classes across tasks; plain strings are accepted but cluster on exact text only. The quality lens ALWAYS assesses cyclomatic complexity: excessively tangled control flow is a blocking finding under the stable `cyclomatic-complexity` category (see factory/prompts/reviewer.md).",
-  "contract_verdicts_note": "Quality reviews for decompositions that declare plan_contracts require entries {contract_id, verdict: implemented|partial|missing, evidence}; evidence is a non-empty file:line explanation."
+  "contract_verdicts_note": "Quality reviews for decompositions that declare plan_contracts require entries {contract_id, verdict: implemented|partial|missing|unverified, evidence}; evidence is a non-empty file:line explanation."
 }

--- a/factory/scripts/forge_cli/review.py
+++ b/factory/scripts/forge_cli/review.py
@@ -374,9 +374,17 @@ def _contract_verdicts(
         if cid in parsed:
             verdict, evidence = parsed[cid]
         else:
-            verdict, evidence = "partial", (
-                "the reviewer emitted no VERDICT line for this contract; "
-                "recorded as partial (fail-closed) — re-review or verdict it")
+            # No pass verdicted this contract. That is NOT the reviewer
+            # asserting a defect: a chunked review gives each pass part of the
+            # diff, and a contract whose implementation spans slices can be
+            # judged by none of them. Recording it as `partial` made it a
+            # blocking finding, which left the task-proof gate unpassable for
+            # any task large enough to chunk. `unverified` keeps it visible as
+            # a non-blocking gap while `partial`/`missing` stay reserved for a
+            # defect a pass actually saw.
+            verdict, evidence = "unverified", (
+                "no review pass emitted a VERDICT line for this contract — "
+                "its implementation was not judged by any chunk")
         out.append({"contract_id": cid, "verdict": verdict, "evidence": evidence})
     for other in all_tasks:
         oid = other.get("id")

--- a/factory/scripts/record_review_from_json.py
+++ b/factory/scripts/record_review_from_json.py
@@ -144,10 +144,10 @@ if args.aspect == "quality" and state.get("decomposition_status") == "recorded":
                 )
             seen.add(contract_id)
             value = verdict.get("verdict")
-            if value not in {"implemented", "partial", "missing"}:
+            if value not in {"implemented", "partial", "missing", "unverified"}:
                 raise SystemExit(
                     f"contract_verdicts[{pos}] for {contract_id}: verdict must be "
-                    "implemented, partial, or missing"
+                    "implemented, partial, missing, or unverified"
                 )
             evidence = verdict.get("evidence")
             if not isinstance(evidence, str) or not evidence.strip():
@@ -155,12 +155,27 @@ if args.aspect == "quality" and state.get("decomposition_status") == "recorded":
                     f"contract_verdicts[{pos}] for {contract_id}: evidence must "
                     "be a non-empty string"
                 )
+            # `partial`/`missing` are the reviewer ASSERTING a defect, so they
+            # block. `unverified` says only that no pass attested the contract
+            # — a chunked review hands each pass part of the diff, and a
+            # contract whose implementation spans slices can end up judged by
+            # none of them. Recording that as a defect made the gate
+            # unpassable for any task big enough to chunk, so it is surfaced
+            # as a non-blocking gap instead: visible to the human, not a claim
+            # the code is wrong.
+            contract = expected[contract_id]
             if value in {"partial", "missing"}:
-                contract = expected[contract_id]
                 review["blocking_findings"].append({
                     "category": f"plan-contract-{value}",
                     "area": contract["source"],
                     "summary": f"{contract_id}: {contract['statement']}",
+                })
+            elif value == "unverified":
+                review.setdefault("non_blocking_findings", []).append({
+                    "category": "plan-contract-unverified",
+                    "area": contract["source"],
+                    "summary": f"{contract_id} was not attested by any review "
+                               f"pass: {contract['statement']}",
                 })
         missing_ids = [contract["id"] for contract in contracts
                        if contract["id"] not in seen]

--- a/factory/tests/test_gates.py
+++ b/factory/tests/test_gates.py
@@ -18016,7 +18016,8 @@ def test_quality_review_requires_contract_verdicts(repo, tmp_path):
         ([verdict("C1")], "C2"),
         ([verdict("C1"), verdict("UNKNOWN")], "unknown contract id"),
         ([verdict("C1"), verdict("C1")], "duplicate contract id"),
-        ([verdict("C1", "almost"), verdict("C2")], "implemented, partial, or missing"),
+        ([verdict("C1", "almost"), verdict("C2")],
+         "implemented, partial, missing, or unverified"),
         ([verdict("C1", evidence=""), verdict("C2")], "evidence"),
     ]
     for contract_verdicts, expected in refused:
@@ -18034,6 +18035,26 @@ def test_quality_review_requires_contract_verdicts(repo, tmp_path):
         "category": "plan-contract-partial",
         "area": "plan.md#first",
         "summary": "C1: first statement",
+    }]
+
+    # `unverified` is not the reviewer asserting a defect — it says no pass
+    # attested the contract, which a chunked review produces whenever a
+    # contract's implementation spans slices. It must be VISIBLE but must not
+    # block, or the task-proof gate is unpassable for any task big enough to
+    # chunk.
+    unverified = [verdict("C1", "unverified", "no pass judged it"),
+                  verdict("C2")]
+    code, out = run(repo, "record_review_from_json.py", "--aspect", "quality",
+                    stdin=json.dumps(review_payload(
+                        contract_verdicts=unverified)))
+    assert code == 0, out
+    quality = json.loads(
+        (story_state(repo) / "reviews" / "quality.json").read_text())
+    assert quality["blocking_findings"] == []
+    assert quality["non_blocking_findings"] == [{
+        "category": "plan-contract-unverified",
+        "area": "plan.md#first",
+        "summary": "C1 was not attested by any review pass: first statement",
     }]
 
     code, out = run(repo, "record_review_from_json.py", "--aspect", "performance",


### PR DESCRIPTION
## Goal

`forge review` reported zero blocking findings and stamped the stage, while
the artifact it wrote in the same run recorded six blocking findings — and
`check_task_proof` reads the artifact. So a task could pass review and still
be refused at the PR gate, with nothing wrong with the code.

Observed on cache-bug-T1: 47 changed paths, ten plan contracts, two review
chunks. Every lens scored 10 with zero real findings across five rounds while
six of ten contracts were recorded as blocking.

## Cause

Two meanings collapsed into one word. A chunked review hands each pass part of
the diff, and the brief ordered every pass to verdict every contract — so each
pass had to say something about code it never saw. Those guesses arrived as
`partial`, the merge took the worst verdict across passes, and the recorder
turned every `partial` into a blocking finding. "No pass could judge this" and
"the reviewer found this defective" became indistinguishable.

## Fix

Five commits upstream, each because the previous was insufficient:

| Commit | Change |
|---|---|
| `0bde0a8` | `not_in_chunk` never outvotes a real verdict |
| `3799896` | read blindness from the evidence prose too — the engine ignored the token |
| `b32bab8` | detect it semantically (chunk reference AND absence cue); the prose wording varies every run |
| `7bab493` | each pass verdicts only what its slice shows, instead of guessing |
| `790e0d5` | an unattested contract is `unverified` — visible, non-blocking — while `partial`/`missing` still block |

Fail-closed is intact: a real `partial` still beats `implemented`, `missing`
still dominates, and a contract no pass attested is surfaced rather than
silently passed. `test_gates` extended to pin the new semantics.

## Why now

T1 shipped on the first steps. T2 needs the last one, or its reviews get
blocked by bookkeeping the same way.

Vendor integrity: 95/95 match the manifest. The ticket gate exempts a pure
re-vendor (vendored paths only, manifest rewritten).