### PR TITLE
Pull the MinIO images from quay, which is where they still exist

### DIFF
--- a/ops/docker/docker-compose.fleet.yml
+++ b/ops/docker/docker-compose.fleet.yml
@@ -140,7 +140,7 @@ services:
   # S3-compatible artifact store for local fleet rehearsal. Production uses real
   # S3 with split IAM (bake:rw, worker:ro); here one root credential is enough.
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e
+    image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e
     container_name: gantry-fleet-minio
     restart: unless-stopped
     command: server /data --console-address ':9001'
@@ -163,7 +163,7 @@ services:
   # One-shot bucket bootstrap: create the artifact bucket, then exit. All roles
   # wait on service_completed_successfully before booting.
   minio-bootstrap:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z@sha256:aead63c77f9db9107f1696fb08ecb0faeda23729cde94b0f663edf4fe09728e3
+    image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z@sha256:aead63c77f9db9107f1696fb08ecb0faeda23729cde94b0f663edf4fe09728e3
     container_name: gantry-fleet-minio-bootstrap
     depends_on:
       minio:

--- a/plans/quickfixes/20260912T062127-0000-Q-0206-d56e-open-062127791362.json
+++ b/plans/quickfixes/20260912T062127-0000-Q-0206-d56e-open-062127791362.json
@@ -1,0 +1,10 @@
+{
+  "event": "open",
+  "id": "Q-0206-d56e",
+  "profile": "quickfix",
+  "reason": "MinIO deleted both minio/minio and minio/mc from Docker Hub, so every PR fails CI at 'Check runtime images' with 'pull access denied ... repository does not exist'. Repoint the fleet compose at the vendor's own quay.io registry; the manifest digests there are byte-identical to the ones already pinned, so the pin that actually guards content is unchanged.",
+  "started_at": "2026-09-12T06:21:27+00:00",
+  "max_files": 5,
+  "files": [],
+  "harness_source": false
+}

--- a/plans/quickfixes/20260912T062207-0000-Q-0206-d56e-done-062207328129.json
+++ b/plans/quickfixes/20260912T062207-0000-Q-0206-d56e-done-062207328129.json
@@ -1,0 +1,9 @@
+{
+  "event": "done",
+  "id": "Q-0206-d56e",
+  "profile": "quickfix",
+  "reason": "MinIO deleted both minio/minio and minio/mc from Docker Hub, so every PR fails CI at 'Check runtime images' with 'pull access denied ... repository does not exist'. Repoint the fleet compose at the vendor's own quay.io registry; the manifest digests there are byte-identical to the ones already pinned, so the pin that actually guards content is unchanged.",
+  "started_at": "2026-09-12T06:21:27+00:00",
+  "completed_at": "2026-09-12T06:22:07+00:00",
+  "files": []
+}


### PR DESCRIPTION
## What broke

Every pull request is failing CI at `Check runtime images`, whatever it changes:

```
Error response from daemon: pull access denied for minio/mc,
repository does not exist or may require 'docker login': denied
```

MinIO deleted both `minio/minio` and `minio/mc` from Docker Hub. Both repository
pages now return 404 to anonymous callers, so this is not rate limiting and it
will not clear on a re-run. I re-ran a failed job first to confirm that.

## The fix

The images are still published on `quay.io`, MinIO's own registry. This repoints
the two pinned images in `ops/docker/docker-compose.fleet.yml` at that host.

The part worth checking: **the digests do not change.** Quay serves the exact
manifest digests already pinned here — `sha256:aead63c7…` for `mc` and
`sha256:a1ea29fa…` for `minio` — so the images are byte-identical to what this
repo was already pulling. The digest pin is what actually guards content, and it
is untouched; only the host name in front of it moves.

I verified both digests resolve anonymously on quay before changing anything:

```
quay.io/minio/mc     @ sha256:aead63c7… -> HTTP 200
quay.io/minio/minio  @ sha256:a1ea29fa… -> HTTP 200
```

## Scope

Two lines. The occurrences in `scripts/tests/test_supply_chain_gates.py` are
synthetic fixture strings for the gate's own tests and pull nothing, so they stay
as they are.

Ticket: Q-0206-d56e
